### PR TITLE
Update compiler warning options

### DIFF
--- a/.github/workflows/modmesh_install.yml
+++ b/.github/workflows/modmesh_install.yml
@@ -48,19 +48,19 @@ jobs:
 
     - name: show dependency
       run: |
-        which gcc
-        gcc --version
-        which cmake
-        cmake --version
-        which python3
-        python3 --version
+        echo "gcc path: $(which gcc)"
+        echo "gcc version: $(gcc --version)"
+        echo "cmake path: $(which cmake)"
+        echo "cmake version: $(cmake --version)"
+        echo "python3 path: $(which python3)"
+        echo "python3 version: $(python3 --version)"
         python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
-        which pytest
-        pytest --version
-        which clang-tidy
-        clang-tidy -version
-        which flake8
-        flake8 --version
+        echo "pytest path: $(which pytest)"
+        echo "pytest version: $(pytest --version)"
+        echo "clang-tidy path: $(which clang-tidy)"
+        echo "clang-tidy version: $(clang-tidy -version)"
+        echo "flake8 path: $(which flake8)"
+        echo "flake8 version: $(flake8 --version)"
 
     - name: build_ext
       run: python3 setup.py build_ext --cmake-args="-DCMAKE_BUILD_TYPE=Release" --make-args="VERBOSE=1"

--- a/.github/workflows/modmesh_install.yml
+++ b/.github/workflows/modmesh_install.yml
@@ -38,10 +38,10 @@ jobs:
     - name: dependency (macos)
       if: matrix.os == 'macos-latest'
       run: |
-        brew install python3 numpy llvm
+        brew install python3 llvm
         ln -s "$(brew --prefix llvm)/bin/clang-format" "/usr/local/bin/clang-format"
         ln -s "$(brew --prefix llvm)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
-        pip3 install -U setuptools pytest flake8
+        pip3 install -U numpy setuptools pytest flake8
 
     - name: dependency (manual)
       run: sudo ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11

--- a/.github/workflows/modmesh_pytest.yml
+++ b/.github/workflows/modmesh_pytest.yml
@@ -39,10 +39,10 @@ jobs:
     - name: dependency (macos)
       if: matrix.os == 'macos-latest'
       run: |
-        brew install python3 numpy llvm
+        brew install python3 llvm
         ln -s "$(brew --prefix llvm)/bin/clang-format" "/usr/local/bin/clang-format"
         ln -s "$(brew --prefix llvm)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
-        pip3 install -U pytest flake8
+        pip3 install -U numpy pytest flake8
 
     - name: dependency (manual)
       run: sudo ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11

--- a/.github/workflows/modmesh_pytest.yml
+++ b/.github/workflows/modmesh_pytest.yml
@@ -49,19 +49,19 @@ jobs:
 
     - name: show dependency
       run: |
-        which gcc
-        gcc --version
-        which cmake
-        cmake --version
-        which python3
-        python3 --version
+        echo "gcc path: $(which gcc)"
+        echo "gcc version: $(gcc --version)"
+        echo "cmake path: $(which cmake)"
+        echo "cmake version: $(cmake --version)"
+        echo "python3 path: $(which python3)"
+        echo "python3 version: $(python3 --version)"
         python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
-        which pytest
-        pytest --version
-        which clang-tidy
-        clang-tidy -version
-        which flake8
-        flake8 --version
+        echo "pytest path: $(which pytest)"
+        echo "pytest version: $(pytest --version)"
+        echo "clang-tidy path: $(which clang-tidy)"
+        echo "clang-tidy version: $(clang-tidy -version)"
+        echo "flake8 path: $(which flake8)"
+        echo "flake8 version: $(flake8 --version)"
 
     - name: buildext
       run: make buildext VERBOSE=1 USE_CLANG_TIDY=ON CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ target_compile_options(
     _modmesh PRIVATE
     -Werror -Wall -Wextra
     -Wno-unused-value # for PYBIND11_EXPAND_SIDE_EFFECTS in pybind11.h
+    -Wno-noexcept-type # GCC
 )
 
 if(CLANG_TIDY_EXE AND USE_CLANG_TIDY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,12 @@ else()
     set_target_properties(_modmesh PROPERTIES CXX_VISIBILITY_PRESET "default")
 endif()
 
+target_compile_options(
+    _modmesh PRIVATE
+    -Werror -Wall -Wextra
+    -Wno-unused-value # for PYBIND11_EXPAND_SIDE_EFFECTS in pybind11.h
+)
+
 if(CLANG_TIDY_EXE AND USE_CLANG_TIDY)
     set_target_properties(
         _modmesh PROPERTIES

--- a/include/modmesh/ConcreteBuffer.hpp
+++ b/include/modmesh/ConcreteBuffer.hpp
@@ -77,6 +77,8 @@ public:
     ConcreteBuffer(ConcreteBuffer &&) = delete;
     ConcreteBuffer & operator=(ConcreteBuffer &&) = delete;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wextra"
     // Avoid enabled_shared_from_this copy constructor
     // NOLINTNEXTLINE(bugprone-copy-constructor-init)
     ConcreteBuffer(ConcreteBuffer const & other)
@@ -89,6 +91,7 @@ public:
         }
         std::copy_n(other.data(), size(), data());
     }
+#pragma GCC diagnostic pop
 
     ConcreteBuffer & operator=(ConcreteBuffer const & other)
     {

--- a/include/modmesh/grid.hpp
+++ b/include/modmesh/grid.hpp
@@ -152,8 +152,8 @@ public:
 
     size_t nx() const { return m_nx; }
     //NOLINTNEXTLINE(readability-const-return-type)
-    real_type * const coord() const { return m_coord.get(); }
-    real_type *       coord()       { return m_coord.get(); }
+    real_type * coord() const { return m_coord.get(); }
+    real_type * coord()       { return m_coord.get(); }
 
     size_t size() const { return m_nx; }
     real_type   operator[] (size_t it) const noexcept { return m_coord[it]; }


### PR DESCRIPTION
GitHub Action seemed to update its macOS image and the way I installed numpy does not work any more.  Taking this opportunity I update the CI script as well as some other things:

* Use pip to install numpy on macOS.
* Add `-Werror -Wall -Wextra` to build the Python extension.
* Add `-Wno-unused-value` for PYBIND11_EXPAND_SIDE_EFFECTS in `pybind11.h`
* Add `-Wno-noexcept-type` for GCC
* Ignore `-Wextra` for allowing calling the base default constructor for ConcreteBuffer (use `#pragma`).