### PR TITLE
Enable external ownership of ConcreteBuffer

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,7 +19,8 @@ Checks: >
     -llvm-include-order,
     -performance-noexcept-move-constructor,
     -readability-named-parameter,
-    -readability-magic-numbers
+    -readability-magic-numbers,
+    -misc-non-private-member-variables-in-classes
 WarningsAsErrors: ''
 HeaderFilterRegex: 'modmesh.*'
 AnalyzeTemporaryDtors: false

--- a/include/modmesh/ConcreteBuffer.hpp
+++ b/include/modmesh/ConcreteBuffer.hpp
@@ -43,9 +43,9 @@ namespace detail
 // https://bugzilla.redhat.com/show_bug.cgi?id=1569374
 
 /**
- * The base class of memory deallocator for ConcreteBuffer.  When the
- * object exists in the unique_ptr deleter, the deleter calls it to release
- * the ConcreteBuffer memory.
+ * The base class of memory deallocator for ConcreteBuffer.  When the object
+ * exists in ConcreteBufferDataDeleter (the unique_ptr deleter), the deleter
+ * calls it to release the memory of the ConcreteBuffer data buffer.
  */
 struct ConcreteBufferRemover
 {
@@ -71,11 +71,12 @@ struct ConcreteBufferDataDeleter
 
     using remover_type = ConcreteBufferRemover;
 
-    ConcreteBufferDataDeleter() = default;
     ConcreteBufferDataDeleter(ConcreteBufferDataDeleter const & ) = delete;
-    ConcreteBufferDataDeleter(ConcreteBufferDataDeleter       &&) = default;
     ConcreteBufferDataDeleter & operator=(ConcreteBufferDataDeleter const & ) = delete;
-    ConcreteBufferDataDeleter & operator=(ConcreteBufferDataDeleter       &&) = default;
+
+    ConcreteBufferDataDeleter() = default;
+    ConcreteBufferDataDeleter(ConcreteBufferDataDeleter &&) = default;
+    ConcreteBufferDataDeleter & operator=(ConcreteBufferDataDeleter &&) = default;
     ~ConcreteBufferDataDeleter() = default;
     explicit ConcreteBufferDataDeleter(std::unique_ptr<remover_type> && remover_in) : remover(std::move(remover_in)) {}
 
@@ -108,9 +109,9 @@ class ConcreteBuffer
 
 private:
 
-    using data_deleter_type = detail::ConcreteBufferDataDeleter;
-
     struct ctor_passkey {};
+
+    using data_deleter_type = detail::ConcreteBufferDataDeleter;
 
 public:
 
@@ -147,7 +148,8 @@ public:
     }
 
     /**
-     * \param[in] nbytes Size of the memory buffer in bytes.
+     * \param[in] nbytes
+     *      Size of the memory buffer in bytes.
      */
     ConcreteBuffer(size_t nbytes, const ctor_passkey &)
       : m_nbytes(nbytes)
@@ -155,7 +157,8 @@ public:
     {}
 
     /**
-     * \param[in] nbytes Size of the memory buffer in bytes.
+     * \param[in] nbytes
+     *      Size of the memory buffer in bytes.
      * \param[in] data
      *      Pointer to the memory buffer that is not supposed to be owned by
      *      this ConcreteBuffer.

--- a/include/modmesh/ConcreteBuffer.hpp
+++ b/include/modmesh/ConcreteBuffer.hpp
@@ -36,11 +36,15 @@
 namespace modmesh
 {
 
+// NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+using ConcreteBufferDefaultDelete = std::default_delete<int8_t[]>;
+
 /**
  * Untyped and unresizeable memory buffer for contiguous data storage.
  */
+template < typename D = ConcreteBufferDefaultDelete >
 class ConcreteBuffer
-  : public std::enable_shared_from_this<ConcreteBuffer>
+  : public std::enable_shared_from_this<ConcreteBuffer<D>>
 {
 
 private:
@@ -140,7 +144,7 @@ public:
 private:
 
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
-    using unique_ptr_type = std::unique_ptr<int8_t, std::default_delete<int8_t[]>>;
+    using unique_ptr_type = std::unique_ptr<int8_t, D>;
     static_assert(sizeof(size_t) == sizeof(unique_ptr_type), "sizeof(Buffer::m_data) must be a word");
 
     void validate_range(size_t it) const

--- a/include/modmesh/SimpleArray.hpp
+++ b/include/modmesh/SimpleArray.hpp
@@ -80,7 +80,7 @@ inline size_t buffer_offset(small_vector<size_t> const & stride, small_vector<si
  * copy semantics performs data copy. The move semantics invalidates the
  * existing memory buffer.
  */
-template < typename T, typename D = ConcreteBufferDefaultDelete >
+template < typename T, typename D = ConcreteBufferDeleter >
 class SimpleArray
 {
 

--- a/include/modmesh/SimpleArray.hpp
+++ b/include/modmesh/SimpleArray.hpp
@@ -80,7 +80,7 @@ inline size_t buffer_offset(small_vector<size_t> const & stride, small_vector<si
  * copy semantics performs data copy. The move semantics invalidates the
  * existing memory buffer.
  */
-template < typename T, typename D = ConcreteBufferDeleter >
+template < typename T >
 class SimpleArray
 {
 
@@ -88,7 +88,7 @@ public:
 
     using value_type = T;
     using shape_type = small_vector<size_t>;
-    using buffer_type = ConcreteBuffer<D>;
+    using buffer_type = ConcreteBuffer;
 
     static constexpr size_t ITEMSIZE = sizeof(value_type);
 

--- a/include/modmesh/python/common.hpp
+++ b/include/modmesh/python/common.hpp
@@ -49,6 +49,12 @@ namespace modmesh
 namespace python
 {
 
+template < typename T >
+bool dtype_is_type(pybind11::array const & arr)
+{
+    return pybind11::detail::npy_format_descriptor<T>::dtype().is(arr.dtype());
+}
+
 class WrapperProfilerStatus
 {
 

--- a/include/modmesh/python/python.hpp
+++ b/include/modmesh/python/python.hpp
@@ -196,13 +196,17 @@ protected:
 
 }; /* end class WrapTimeRegistry */
 
-struct ConcreteBufferNdarrayRemover : ConcreteBuffer::remover_type
+struct
+MODMESH_PYTHON_WRAPPER_VISIBILITY
+ConcreteBufferNdarrayRemover : ConcreteBuffer::remover_type
 {
 
     static bool is_same_type(ConcreteBuffer::remover_type const & other)
     {
         return typeid(other) == typeid(ConcreteBufferNdarrayRemover);
     }
+
+    ConcreteBufferNdarrayRemover() = delete;
 
     explicit ConcreteBufferNdarrayRemover(pybind11::array arr_in)
       : ndarray(std::move(arr_in))

--- a/include/modmesh/python/python.hpp
+++ b/include/modmesh/python/python.hpp
@@ -199,7 +199,7 @@ protected:
 class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapConcreteBuffer
-  : public WrapBase< WrapConcreteBuffer, ConcreteBuffer, std::shared_ptr<ConcreteBuffer> >
+  : public WrapBase< WrapConcreteBuffer, ConcreteBuffer<>, std::shared_ptr<ConcreteBuffer<>> >
 {
 
     friend root_base_type;
@@ -217,7 +217,7 @@ WrapConcreteBuffer
                 (
                     [](size_t nbytes)
                     {
-                        return ConcreteBuffer::construct(nbytes);
+                        return wrapped_type::construct(nbytes);
                     }
                 )
               , py::arg("nbytes")
@@ -225,11 +225,13 @@ WrapConcreteBuffer
             .def_timed("clone", &wrapped_type::clone)
             .def_property_readonly("nbytes", &wrapped_type::nbytes)
             .def("__len__", &wrapped_type::size)
-            .def_timed(
+            .def_timed
+            (
                 "__getitem__"
               , [](wrapped_type const & self, size_t it) { return self.at(it); }
             )
-            .def_timed(
+            .def_timed
+            (
                 "__setitem__"
               , [](wrapped_type & self, size_t it, int8_t val)
                 {

--- a/include/modmesh/python/python.hpp
+++ b/include/modmesh/python/python.hpp
@@ -305,6 +305,26 @@ WrapSimpleArray
                 )
               , py::arg("shape")
             )
+            .def
+            (
+                py::init
+                (
+                    [](py::array & arr_in)
+                    {
+                        if (!py::detail::npy_format_descriptor<T>::dtype().is(arr_in.dtype()))
+                        {
+                            throw std::runtime_error("dtype mismatch");
+                        }
+                        shape_type shape;
+                        for (ssize_t i = 0 ; i < arr_in.ndim() ; ++i)
+                        {
+                            shape.push_back(arr_in.shape(i));
+                        }
+                        return wrapped_type(shape);
+                    }
+                )
+              , py::arg("array")
+            )
             .def_buffer
             (
                 [](wrapped_type & self)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -69,6 +69,18 @@ class BasicTC(unittest.TestCase):
         buf2[5] = 19
         self.assertEqual(19, ndarr2[5])
 
+    def test_ConcreteBuffer_from_ndarray(self):
+
+        ndarr = np.arange(24, dtype='float64').reshape((2, 3, 4))
+
+        buf = modmesh.ConcreteBuffer(array=ndarr)
+        self.assertEqual(ndarr.nbytes, buf.nbytes)
+
+        # The data buffer is shared.
+        self.assertFalse((ndarr == 0).all())
+        buf.ndarray.fill(0)
+        self.assertTrue((ndarr == 0).all())
+
     def test_SimpleArray(self):
 
         sarr = modmesh.SimpleArrayFloat64((2, 3, 4))

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -146,9 +146,12 @@ class BasicTC(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, r"dtype mismatch"):
             modmesh.SimpleArrayFloat32(array=ndarr)
 
-        modmesh.SimpleArrayFloat64(array=ndarr)
+        sarr_from_py = modmesh.SimpleArrayFloat64(array=ndarr)
+        self.assertTrue(sarr_from_py.is_from_python)
 
-    @unittest.expectedFailure
+        sarr_from_cpp = modmesh.SimpleArrayFloat64(shape=(2, 3, 4))
+        self.assertFalse(sarr_from_cpp.is_from_python)
+
     def test_SimpleArray_from_ndarray_content(self):
 
         ndarr = np.arange(24, dtype='float64').reshape((2, 3, 4))

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -135,4 +135,25 @@ class BasicTC(unittest.TestCase):
         self.assertEqual(13*8,
                          modmesh.SimpleArrayFloat64(13).nbytes)
 
+    def test_SimpleArray_from_ndarray(self):
+
+        ndarr = np.arange(24, dtype='float64').reshape((2, 3, 4))
+
+        with self.assertRaisesRegex(RuntimeError, r"dtype mismatch"):
+            modmesh.SimpleArrayInt8(array=ndarr)
+        with self.assertRaisesRegex(RuntimeError, r"dtype mismatch"):
+            modmesh.SimpleArrayUint64(array=ndarr)
+        with self.assertRaisesRegex(RuntimeError, r"dtype mismatch"):
+            modmesh.SimpleArrayFloat32(array=ndarr)
+
+        modmesh.SimpleArrayFloat64(array=ndarr)
+
+    @unittest.expectedFailure
+    def test_SimpleArray_from_ndarray_content(self):
+
+        ndarr = np.arange(24, dtype='float64').reshape((2, 3, 4))
+        sarr = modmesh.SimpleArrayFloat64(array=ndarr)
+        sarr.ndarray.fill(100)
+        self.assertTrue((ndarr == 100).all())
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
This PR suggests to allow the internal data buffer of `ConcreteBuffer` to be owned outside the shared-pointer-controlled object.  Before the change, creation of `ConcreteBuffer` mandates dynamic memory allocation.

A custom `std::unique_ptr` `Deleter` is added to support memory management of the internal buffer of `ConcreteBuffer`.  The customer `Deleter` uses a polymorphic "remover" to control the lifecycle of the internal buffer.  By default, the remover is null, and the `Deleter` behaves the same as `std::default_delete<T>`.

The `remover` makes it possible to bind the lifecycle of the internal data buffer outside.  For example, `struct ConcreteBufferNdarrayRemover` is derived from `ConcreteBuffer::remover_type` and bind the lifecycle of the buffer to a `PyArrayObject` (i.e., `pybind11::array`).