### PR TITLE
Provide a workaround of macos SIP in the build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 build/
 dist/
 tmp/
+setup.mk
 *.egg-info/
 *.pyc
 *.pyo

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@
 # Build with clang-tidy
 #   make USE_CLANG_TIDY=ON
 
+SETUP_FILE ?= ./setup.mk
+
+ifneq (,$(wildcard $(SETUP_FILE)))
+	include $(SETUP_FILE)
+endif
+
 SKIP_PYTHON_EXECUTABLE ?= OFF
 HIDE_SYMBOL ?= OFF
 DEBUG_SYMBOL ?= ON
@@ -19,6 +25,7 @@ CMAKE_INSTALL_PREFIX ?= $(MODMESH_ROOT)/build/fakeinstall
 CMAKE_LIBRARY_OUTPUT_DIRECTORY ?= $(MODMESH_ROOT)/modmesh
 CMAKE_ARGS ?=
 VERBOSE ?=
+RUNENV += PYTHONPATH=$(MODMESH_ROOT)
 
 pyextsuffix := $(shell python3-config --extension-suffix)
 pyvminor := $(shell python3 -c 'import sys; print("%d%d" % sys.version_info[0:2])')
@@ -54,7 +61,8 @@ cmakeclean:
 
 .PHONY: pytest
 pytest: $(MODMESH_ROOT)/modmesh/_modmesh$(pyextsuffix)
-	env PYTHONPATH=$(MODMESH_ROOT) $(PYTEST) $(PYTEST_OPTS) tests/
+	env $(RUNENV) \
+		$(PYTEST) $(PYTEST_OPTS) tests/
 
 .PHONY: flake8
 flake8:
@@ -77,7 +85,8 @@ $(MODMESH_ROOT)/modmesh/_modmesh$(pyextsuffix): $(BUILD_PATH)/Makefile
 $(BUILD_PATH)/Makefile: CMakeLists.txt Makefile
 	mkdir -p $(BUILD_PATH) ; \
 	cd $(BUILD_PATH) ; \
-	cmake $(MODMESH_ROOT) \
+	env $(RUNENV) \
+		cmake $(MODMESH_ROOT) \
 		-DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX) \
 		-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(CMAKE_LIBRARY_OUTPUT_DIRECTORY) \
 		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \


### PR DESCRIPTION
Mac SIP (System Integrity Protection) was introduced in El Capitan (10.11) in 2015 and it [disabled `DYLD_*LIBRARY_PATH`](https://developer.apple.com/library/archive/documentation/Security/Conceptual/System_Integrity_Protection_Guide/RuntimeProtections/RuntimeProtections.html) for some protected binaries (the `DYLD_LIBRARY_PATH` and `DYLD_FALLBACK_LIBRARY_PATH` are purged when launching the processes).

`make` is among the binaries influenced by SIP.  Assume that we have a `Makefile`:

```make
.PHONY:
default:
	@echo "NORMALVAR=$$NORMALVAR"
	@echo "DYLD_LIBRARY_PATH=$$DYLD_LIBRARY_PATH"
	@echo "DYLD_FALLBACK_LIBRARY_PATH=$$DYLD_FALLBACK_LIBRARY_PATH"
```

and run it by supplying the environment variables.  The `dyld` environment variables are not gone, surprisingly:

```console
$ env NORMALVAR=content DYLD_LIBRARY_PATH=. DYLD_FALLBACK_LIBRARY_PATH=. make
NORMALVAR=content
DYLD_LIBRARY_PATH=
DYLD_FALLBACK_LIBRARY_PATH=
```

Consequently, we no longer can set the `dyld` variables outside `make` and send them to processes spawned in `make`.  A workaround is to use an include file in `Makefile`.  Assume we have a file name `setup.mk`:

```makefile
RUNENV ?= DYLD_LIBRARY_PATH=. DYLD_FALLBACK_LIBRARY_PATH=.
```

The `Makefile` is modified to:

```makefile
ifneq (,$(wildcard ./setup.mk))
	include ./setup.mk
endif

.PHONY:
default:
	env $(RUNENV) python3 -c "import os; print(os.environ.get('NORMALVAR'))"
	env $(RUNENV) python3 -c "import os; print(os.environ.get('DYLD_LIBRARY_PATH'))"
	env $(RUNENV) python3 -c "import os; print(os.environ.get('DYLD_FALLBACK_LIBRARY_PATH'))"
```

`python3` is a custom installed Python binary.  (If you use the system `python`, which is a protected binary, this trick won't work.)  Running make and the value stored in the include file can be passed to the `python3` sub-processes:

```console
$ make
env DYLD_LIBRARY_PATH=. DYLD_FALLBACK_LIBRARY_PATH=. python3 -c "import os; print(os.environ.get('NORMALVAR'))"
None
env DYLD_LIBRARY_PATH=. DYLD_FALLBACK_LIBRARY_PATH=. python3 -c "import os; print(os.environ.get('DYLD_LIBRARY_PATH'))"
.
env DYLD_LIBRARY_PATH=. DYLD_FALLBACK_LIBRARY_PATH=. python3 -c "import os; print(os.environ.get('DYLD_FALLBACK_LIBRARY_PATH'))"
.
```