### PR TITLE
Allow negative value for the ghost index in the first dimension of SimpleArray

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ifeq ($(PYTEST),)
 	PYTEST := $(shell which pytest)
 endif
 ifneq ($(VERBOSE),)
-	PYTEST_OPTS ?= -v
+	PYTEST_OPTS ?= -v -s
 else
 	PYTEST_OPTS ?=
 endif

--- a/include/modmesh/SimpleArray.hpp
+++ b/include/modmesh/SimpleArray.hpp
@@ -88,6 +88,7 @@ public:
 
     using value_type = T;
     using shape_type = small_vector<size_t>;
+    using sshape_type = small_vector<ssize_t>;
     using buffer_type = ConcreteBuffer;
 
     static constexpr size_t ITEMSIZE = sizeof(value_type);
@@ -98,6 +99,7 @@ public:
       : m_buffer(buffer_type::construct(length * ITEMSIZE))
       , m_shape{length}
       , m_stride{1}
+      , m_body(m_buffer->data<T>())
     {}
 
     template< class InputIt > SimpleArray(InputIt first, InputIt last)
@@ -110,7 +112,20 @@ public:
     explicit SimpleArray(small_vector<size_t> const & shape)
       : m_shape(shape), m_stride(calc_stride(m_shape))
     {
-        if (!m_shape.empty()) { m_buffer = buffer_type::construct(m_shape[0] * m_stride[0] * ITEMSIZE); }
+        if (!m_shape.empty())
+        {
+            m_buffer = buffer_type::construct(m_shape[0] * m_stride[0] * ITEMSIZE);
+            m_body = m_buffer->data<T>();
+        }
+    }
+
+    explicit SimpleArray(std::vector<size_t> const & shape)
+      : m_shape(shape), m_stride(calc_stride(m_shape))
+    {
+        if (!m_shape.empty()) {
+            m_buffer = buffer_type::construct(m_shape[0] * m_stride[0] * ITEMSIZE);
+            m_body = m_buffer->data<T>();
+        }
     }
 
     explicit SimpleArray(std::shared_ptr<buffer_type> const & buffer)
@@ -125,6 +140,7 @@ public:
             m_shape = shape_type{nitem};
             m_stride = shape_type{1};
             m_buffer = buffer;
+            m_body = m_buffer->data<T>();
         }
         else
         {
@@ -153,12 +169,6 @@ public:
         }
     }
 
-    explicit SimpleArray(std::vector<size_t> const & shape)
-      : m_shape(shape), m_stride(calc_stride(m_shape))
-    {
-        if (!m_shape.empty()) { m_buffer = buffer_type::construct(m_shape[0] * m_stride[0] * ITEMSIZE); }
-    }
-
     static shape_type calc_stride(shape_type const & shape)
     {
         shape_type stride(shape.size());
@@ -185,7 +195,24 @@ public:
       : m_buffer(other.m_buffer->clone())
       , m_shape(other.m_shape)
       , m_stride(other.m_stride)
+      , m_nghost(other.m_nghost)
+      , m_body(calc_body(m_buffer->data<T>(), m_stride, other.m_nghost))
     {}
+
+    static T * calc_body(T * data, shape_type const & stride, size_t nghost)
+    {
+        if (nullptr == data || 0 == stride.size() || 0 == nghost)
+        {
+            // Do nothing.
+        }
+        else
+        {
+            shape_type shape(stride.size(), 0);
+            shape[0] = nghost;
+            data += buffer_offset(stride, shape);
+        }
+        return data;
+    }
 
     SimpleArray(SimpleArray && other) noexcept
       : m_buffer(std::move(other.m_buffer))
@@ -198,6 +225,10 @@ public:
         if (this != &other)
         {
             *m_buffer = *(other.m_buffer); // Size is checked inside.
+            m_shape = other.m_shape;
+            m_stride = other.m_stride;
+            m_nghost = other.m_nghost;
+            m_body = calc_body(m_buffer->data<T>(), m_stride, other.m_nghost);
         }
         return *this;
     }
@@ -209,6 +240,8 @@ public:
             m_buffer = std::move(other.m_buffer);
             m_shape = std::move(other.m_shape);
             m_stride = std::move(other.m_stride);
+            m_nghost = other.m_nghost;
+            m_body = other.m_body;
         }
         return *this;
     }
@@ -236,6 +269,9 @@ public:
     value_type const & at(size_t it) const { validate_range(it); return data(it); }
     value_type       & at(size_t it)       { validate_range(it); return data(it); }
 
+    value_type const & at(ssize_t it) const { validate_range(it); it += m_nghost; return data(it); }
+    value_type       & at(ssize_t it)       { validate_range(it); it += m_nghost; return data(it); }
+
     value_type const & at(std::vector<size_t> const & idx) const { return at(shape_type(idx)); }
     value_type       & at(std::vector<size_t> const & idx)       { return at(shape_type(idx)); }
 
@@ -252,6 +288,26 @@ public:
         return data(offset);
     }
 
+    value_type const & at(std::vector<ssize_t> const & idx) const { return at(sshape_type(idx)); }
+    value_type       & at(std::vector<ssize_t> const & idx)       { return at(sshape_type(idx)); }
+
+    value_type const & at(sshape_type sidx) const
+    {
+        validate_shape(sidx);
+        sidx[0] += m_nghost;
+        shape_type const idx(sidx.begin(), sidx.end());
+        const size_t offset = buffer_offset(m_stride, idx);
+        return data(offset);
+    }
+    value_type & at(sshape_type sidx)
+    {
+        validate_shape(sidx);
+        sidx[0] += m_nghost;
+        shape_type const idx(sidx.begin(), sidx.end());
+        const size_t offset = buffer_offset(m_stride, idx);
+        return data(offset);
+    }
+
     size_t ndim() const noexcept { return m_shape.size(); }
     shape_type const & shape() const { return m_shape; }
     size_t   shape(size_t it) const noexcept { return m_shape[it]; }
@@ -259,6 +315,33 @@ public:
     shape_type const & stride() const { return m_stride; }
     size_t   stride(size_t it) const noexcept { return m_stride[it]; }
     size_t & stride(size_t it)       noexcept { return m_stride[it]; }
+
+    size_t nghost() const { return m_nghost; }
+    size_t nbody() const { return 0 == m_shape.size() ? 0 : m_shape[0] - m_nghost; }
+    bool has_ghost() const { return m_nghost != 0; }
+    void set_nghost(size_t nghost)
+    {
+        if (0 != nghost)
+        {
+            if (0 == ndim())
+            {
+                std::ostringstream ms;
+                ms << "SimpleArray: cannot set nghost " << nghost << " > 0 to an empty array";
+                throw std::out_of_range(ms.str());
+            }
+            if (nghost > shape(0))
+            {
+                std::ostringstream ms;
+                ms << "SimpleArray: cannt set nghost " << nghost << " > shape(0) " << shape(0);
+                throw std::out_of_range(ms.str());
+            }
+        }
+        m_nghost = nghost;
+        if (bool(*this))
+        {
+            m_body = calc_body(m_buffer->data<T>(), m_stride, m_nghost);
+        }
+    }
 
     template < typename U >
     SimpleArray<U> reshape(shape_type const & shape) const
@@ -277,10 +360,10 @@ public:
     }
 
     template < typename ... Args >
-    value_type const & operator()(Args ... args) const { return data(buffer_offset(m_stride, args...)); }
+    value_type const & operator()(Args ... args) const { return m_body[buffer_offset(m_stride, args...)]; }
 
     template < typename ... Args >
-    value_type       & operator()(Args ... args)       { return data(buffer_offset(m_stride, args...)); }
+    value_type       & operator()(Args ... args)       { return m_body[buffer_offset(m_stride, args...)]; }
 
     /* Backdoor */
     value_type const & data(size_t it) const { return data()[it]; }
@@ -291,15 +374,92 @@ public:
     buffer_type const & buffer() const { return *m_buffer; }
     buffer_type       & buffer()       { return *m_buffer; }
 
+    value_type const * body() const { return m_body; }
+    value_type       * body()       { return m_body; }
+
 private:
 
-    void validate_range(size_t it) const
+    void validate_range(ssize_t it) const
     {
-        if (it >= size())
+        if (m_nghost != 0 && ndim() != 1)
         {
             std::ostringstream ms;
-            ms << "SimpleArray: index " << it << " is out of bounds with size " << size();
+            ms << "SimpleArray::validate_range(): cannot handle "
+               << ndim() << "-dimensional (more than 1) array with non-zero nghost: " << m_nghost;
             throw std::out_of_range(ms.str());
+        }
+        else if (it < -static_cast<ssize_t>(m_nghost))
+        {
+            std::ostringstream ms;
+            ms << "SimpleArray: index " << it << " < -nghost: " << -static_cast<ssize_t>(m_nghost);
+            throw std::out_of_range(ms.str());
+        }
+        else if (it >= static_cast<ssize_t>(size() - m_nghost))
+        {
+            std::ostringstream ms;
+            ms << "SimpleArray: index " << it << " >= " << size() - m_nghost
+               << " (size: " << size() << " - nghost: " << m_nghost << ")";
+            throw std::out_of_range(ms.str());
+        }
+    }
+
+    void validate_shape(small_vector<ssize_t> const & idx) const
+    {
+        auto index2string = [&idx]()
+        {
+            std::ostringstream ms;
+            ms << "[";
+            for (size_t it = 0 ; it < idx.size() ; ++it)
+            {
+                ms << idx[it];
+                if (it != idx.size()-1) { ms << ", "; }
+            }
+            ms << "]";
+            return ms.str();
+        };
+
+        if (0 == idx.size())
+        {
+            throw std::out_of_range("SimpleArray::validate_shape(): empty index");
+        }
+        else if (idx.size() != m_shape.size())
+        {
+            std::ostringstream ms;
+            ms << "SimpleArray: dimension of input indices " << index2string() << " != array dimension " << m_shape.size();
+            throw std::out_of_range(ms.str());
+        }
+        else
+        {
+            if (idx[0] < -static_cast<ssize_t>(m_nghost))
+            {
+                std::ostringstream ms;
+                ms << "SimpleArray: dim 0 in " << index2string() << " < -nghost: " << -static_cast<ssize_t>(m_nghost);
+                throw std::out_of_range(ms.str());
+            }
+            else if (idx[0] >= static_cast<ssize_t>(nbody()))
+            {
+                std::ostringstream ms;
+                ms << "SimpleArray: dim 0 in " << index2string() << " >= nbody: " << nbody()
+                   << " (shape[0]: " << m_shape[0] << " - nghost: " << nghost() << ")";
+                throw std::out_of_range(ms.str());
+            }
+
+            for (size_t it = 1 ; it < m_shape.size() ; ++it)
+            {
+                if (idx[it] < 0)
+                {
+                    std::ostringstream ms;
+                    ms << "SimpleArray: dim " << it << " in " << index2string() << " < 0";
+                    throw std::out_of_range(ms.str());
+                }
+                else if (idx[it] >= static_cast<ssize_t>(m_shape[it]))
+                {
+                    std::ostringstream ms;
+                    ms << "SimpleArray: dim " << it << " in " << index2string()
+                       << " >= shape[" << it << "]: " << m_shape[it];
+                    throw std::out_of_range(ms.str());
+                }
+            }
         }
     }
 
@@ -311,6 +471,9 @@ private:
     /// Each element in this vector is the number of elements (not number of
     /// bytes) to skip for advancing an index in the corresponding dimension.
     shape_type m_stride;
+
+    size_t m_nghost = 0;
+    value_type * m_body = nullptr;
 
 }; /* end class SimpleArray */
 

--- a/include/modmesh/base.hpp
+++ b/include/modmesh/base.hpp
@@ -55,7 +55,9 @@ public:
 
     static constexpr const size_t NDIM = ND;
 
-    using serial_type = uint32_t;
+    using int_type = int32_t;
+    using uint_type = uint32_t;
+    using serial_type = uint_type;
     using real_type = double;
 
 }; /* end class SpaceBase */

--- a/include/modmesh/python/python.hpp
+++ b/include/modmesh/python/python.hpp
@@ -461,40 +461,10 @@ WrapSimpleArray
                 }
             )
             .def("__len__", &wrapped_type::size)
-            .def_timed
-            (
-                "__getitem__"
-              , [](wrapped_type const & self, py::object const & key)
-                {
-                    try
-                    {
-                        auto const it = key.cast<size_t>();
-                        return self.at(it);
-                    }
-                    catch (const py::cast_error &)
-                    {
-                        shape_type const idx(key.cast<std::vector<size_t>>());
-                        return self.at(idx);
-                    }
-                }
-            )
-            .def_timed
-            (
-                "__setitem__"
-              , [](wrapped_type & self, py::object const & key, T val)
-                {
-                    try
-                    {
-                        auto const it = key.cast<size_t>();
-                        self.at(it) = val;
-                    }
-                    catch (const py::cast_error &)
-                    {
-                        shape_type const idx(key.cast<std::vector<size_t>>());
-                        self.at(idx) = val;
-                    }
-                }
-            )
+            .def("__getitem__", [](wrapped_type const & self, ssize_t key) { return self.at(key); })
+            .def("__getitem__", [](wrapped_type const & self, std::vector<ssize_t> const & key) { return self.at(key); })
+            .def("__setitem__", [](wrapped_type & self, ssize_t key, T val) { self.at(key) = val; })
+            .def("__setitem__", [](wrapped_type & self, std::vector<ssize_t> const & key, T val) { self.at(key) = val; })
             .def_timed
             (
                 "reshape"
@@ -503,6 +473,9 @@ WrapSimpleArray
                     return self.reshape(make_shape(shape));
                 }
             )
+            .def_property_readonly("has_ghost", &wrapped_type::has_ghost)
+            .def_property("nghost", &wrapped_type::nghost, &wrapped_type::set_nghost)
+            .def_property_readonly("nbody", &wrapped_type::nbody)
         ;
 
     }

--- a/include/modmesh/small_vector.hpp
+++ b/include/modmesh/small_vector.hpp
@@ -60,6 +60,12 @@ public:
         }
     }
 
+    explicit small_vector(size_t size, T const & v)
+      : small_vector(size)
+    {
+        std::fill(begin(), end(), v);
+    }
+
     explicit small_vector(std::vector<T> const & vector)
       : small_vector(vector.size())
     {


### PR DESCRIPTION
The ghost index works like the negative index in the POD array.  In SimpleArray, it is only enabled in the first (leading dimension).

ref #20 