### PR TITLE
[refactor] Add helpers to wrap member SimpleArray

### DIFF
--- a/include/modmesh/SimpleArray.hpp
+++ b/include/modmesh/SimpleArray.hpp
@@ -359,6 +359,18 @@ public:
         return SimpleArray(m_shape, m_buffer);
     }
 
+    void swap(SimpleArray<T> && other)
+    {
+        if (this != &other)
+        {
+            std::swap(m_buffer, other.m_buffer);
+            std::swap(m_shape, other.m_shape);
+            std::swap(m_stride, other.m_stride);
+            std::swap(m_nghost, other.m_nghost);
+            std::swap(m_body, other.m_body);
+        }
+    }
+
     template < typename ... Args >
     value_type const & operator()(Args ... args) const { return m_body[buffer_offset(m_stride, args...)]; }
 

--- a/tests/test_grid1d.py
+++ b/tests/test_grid1d.py
@@ -67,7 +67,7 @@ class StaticGrid1dTC(unittest.TestCase):
         # Cannot set coord with a different shape.
         with self.assertRaisesRegex(
             ValueError,
-            r"StaticGrid1d: input array size differs from internal"
+            r"80 bytes of input array differ from 88 bytes of internal array"
         ):
             gd.coord = np.arange(10, dtype='float64')
 


### PR DESCRIPTION
* Add SimpleArray::swap().
* Create `modmesh::python::makeSimpleArray` to create SimpleArray from ndarray (`pybind11::array_t`) buffer.
  * Use a more concise declaration to return reference from lambda.