### PR TITLE
Turn off scheduled Github Actions in forked repository

### DIFF
--- a/.github/workflows/modmesh_install.yml
+++ b/.github/workflows/modmesh_install.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
 
+    if: ${{ github.event_name != '' || github.repository_owner == 'solvcon' }}
+
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/modmesh_pytest.yml
+++ b/.github/workflows/modmesh_pytest.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
 
+    if: ${{ github.event_name != '' || github.repository_owner == 'solvcon' }}
+
     runs-on: ${{ matrix.os }}
 
     strategy:


### PR DESCRIPTION
Add a check for the owner of the repository to turn off the scheduled jobs on forked repositories.