### PR TITLE
Refactor SimpleArray

### DIFF
--- a/include/modmesh/SimpleArray.hpp
+++ b/include/modmesh/SimpleArray.hpp
@@ -189,7 +189,7 @@ public:
         std::copy_n(init.begin(), init.size(), data());
     }
 
-    SimpleArray() = default;
+    SimpleArray() : SimpleArray(0) {}
 
     SimpleArray(SimpleArray const & other)
       : m_buffer(other.m_buffer->clone())

--- a/include/modmesh/python/common.hpp
+++ b/include/modmesh/python/common.hpp
@@ -274,7 +274,7 @@ public:
 #undef DECL_MM_PYBIND_CLASS_METHOD
 
     template < typename Func >
-    wrapper_type & expose_SimpleArray(char const * name, Func && f)
+    wrapper_type & expose_SimpleArrayAsNdarray(char const * name, Func && f)
     {
         namespace py = pybind11;
 

--- a/include/modmesh/python/python.hpp
+++ b/include/modmesh/python/python.hpp
@@ -496,7 +496,7 @@ protected:
             .def("__getitem__", [](wrapped_type const & self, size_t it) { return self.at(it); })
             .def("__setitem__", [](wrapped_type & self, size_t it, wrapped_type::real_type val) { self.at(it) = val; })
             .def_property_readonly("nx", [](wrapped_type const & self) { return self.nx(); })
-            .expose_SimpleArray("coord", [](wrapped_type & self) -> decltype(auto) { return self.coord(); })
+            .expose_SimpleArrayAsNdarray("coord", [](wrapped_type & self) -> decltype(auto) { return self.coord(); })
             .def_timed("fill", &wrapped_type::fill, py::arg("value"))
         ;
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -278,22 +278,26 @@ class SimpleArrayBasicTC(unittest.TestCase):
 
     def test_SimpleArray_types(self):
 
-        def _check(sarr, nbytes, dtype):
+        def _check(sarr, nbytes, dtype, get=True):
             self.assertEqual(nbytes, sarr.nbytes)
             self.assertEqual(dtype, sarr.ndarray.dtype)
+            if get:
+                dtype = getattr(np, dtype)
+                self.assertEqual(dtype, sarr.ndarray.dtype)
 
         # Boolean.
-        _check(modmesh.SimpleArrayBool((2, 3, 4)), 24, np.bool_)
+        _check(modmesh.SimpleArrayBool((2, 3, 4)), 24, 'bool', get=False)
+        _check(modmesh.SimpleArrayBool((2, 3, 4)), 24, 'bool_')
 
         # Integer types.
-        _check(modmesh.SimpleArrayInt8((2, 3)), 6, np.int8)
-        _check(modmesh.SimpleArrayUint8((2, 3)), 6, np.uint8)
-        _check(modmesh.SimpleArrayInt16((3, 5)), 30, np.int16)
-        _check(modmesh.SimpleArrayUint16((3, 5)), 30, np.uint16)
-        _check(modmesh.SimpleArrayInt32(7), 28, np.int32)
-        _check(modmesh.SimpleArrayUint32(7), 28, np.uint32)
-        _check(modmesh.SimpleArrayInt64((2, 3, 4)), 2*3*4*8, np.int64)
-        _check(modmesh.SimpleArrayUint64((2, 3, 4)), 2*3*4*8, np.uint64)
+        _check(modmesh.SimpleArrayInt8((2, 3)), 6, 'int8')
+        _check(modmesh.SimpleArrayUint8((2, 3)), 6, 'uint8')
+        _check(modmesh.SimpleArrayInt16((3, 5)), 30, 'int16')
+        _check(modmesh.SimpleArrayUint16((3, 5)), 30, 'uint16')
+        _check(modmesh.SimpleArrayInt32(7), 28, 'int32')
+        _check(modmesh.SimpleArrayUint32(7), 28, 'uint32')
+        _check(modmesh.SimpleArrayInt64((2, 3, 4)), 2*3*4*8, 'int64')
+        _check(modmesh.SimpleArrayUint64((2, 3, 4)), 2*3*4*8, 'uint64')
 
         # Real-number types.
         _check(modmesh.SimpleArrayFloat32((2, 3, 4, 5)), 2*3*4*5*4, 'float32')


### PR DESCRIPTION
* Rename `expose_SimpleArray` to `expose_SimpleArrayAsNdarray`.
* Use custom implementation for the default constructor of `SimpleArray`.
* Make it more comprehensive to test for the types of `SimpleArray`.