### PR TITLE
Add basic code to support multi-dimensional (2/3D) unstructured mesh

### DIFF
--- a/include/modmesh/base.hpp
+++ b/include/modmesh/base.hpp
@@ -47,13 +47,13 @@ namespace modmesh
  * Spatial table basic information.  Any table-based data store for spatial
  * data should inherit this class template.
  */
-template <size_t ND>
+template <uint8_t ND>
 class SpaceBase
 {
 
 public:
 
-    static constexpr const size_t NDIM = ND;
+    static constexpr const uint8_t NDIM = ND;
 
     using int_type = int32_t;
     using uint_type = uint32_t;

--- a/include/modmesh/grid.hpp
+++ b/include/modmesh/grid.hpp
@@ -180,6 +180,217 @@ class StaticGrid3d
 {
 }; /* end class StaticGrid3d */
 
+struct CellTypeBase
+{
+    /* symbols for type id codes */
+    static constexpr const uint8_t NONCELLTYPE   = 0; /* not a cell type */
+    static constexpr const uint8_t POINT         = 1;
+    static constexpr const uint8_t LINE          = 2;
+    static constexpr const uint8_t QUADRILATERAL = 3;
+    static constexpr const uint8_t TRIANGLE      = 4;
+    static constexpr const uint8_t HEXAHEDRON    = 5;
+    static constexpr const uint8_t TETRAHEDRON   = 6;
+    static constexpr const uint8_t PRISM         = 7;
+    static constexpr const uint8_t PYRAMID       = 8;
+    /* number of all types; one larger than the last type id code */
+    static constexpr const uint8_t NTYPE         = 8;
+
+    //< Maximum number of nodes in a face.
+    static constexpr const uint8_t FCNND_MAX = 4;
+    //< Maximum number of cells in a face.
+    static constexpr const uint8_t FCNCL_MAX = 2;
+    //< Maximum number of nodes in a cell.
+    static constexpr const uint8_t CLNND_MAX = 8;
+    //< Maximum number of faces in a cell.
+    static constexpr const uint8_t CLNFC_MAX = 6;
+}; /* end struct CellTypeBase */
+
+/**
+ * Cell type for unstructured mesh.
+ */
+template < uint8_t ND > struct CellType
+  : public CellTypeBase
+  , public SpaceBase<ND>
+{
+
+    static constexpr const uint8_t NDIM = SpaceBase<ND>::NDIM;
+
+    /* NOLINTNEXTLINE(bugprone-easily-swappable-parameters) */
+    CellType(uint8_t id_in, uint8_t nnode_in, uint8_t nedge_in, uint8_t nsurface_in)
+      : m_id(id_in), m_nnode(nnode_in), m_nedge(nedge_in), m_nsurface(nsurface_in) {}
+
+    uint8_t id() const { return m_id; }
+    uint8_t ndim() const { return NDIM; }
+    uint8_t nnode() const { return m_nnode; }
+    uint8_t nedge() const { return m_nedge; }
+    uint8_t nsurface() const { return m_nsurface; }
+
+    uint8_t nface() const
+    {
+        if      constexpr (2 == NDIM) { return nedge()   ; }
+        else if constexpr (3 == NDIM) { return nsurface(); }
+        else                          { return 0         ; }
+    }
+
+    const char * name() const
+    {
+        switch (id()) {
+        case POINT         /* 1 */: return "point"         ; break;
+        case LINE          /* 2 */: return "line"          ; break;
+        case QUADRILATERAL /* 3 */: return "quadrilateral" ; break;
+        case TRIANGLE      /* 4 */: return "triangle"      ; break;
+        case HEXAHEDRON    /* 5 */: return "hexahedron"    ; break;
+        case TETRAHEDRON   /* 6 */: return "tetrahedron"   ; break;
+        case PRISM         /* 7 */: return "prism"         ; break;
+        case PYRAMID       /* 8 */: return "pyramid"       ; break;
+        case NONCELLTYPE   /* 0 */:
+        default        /* other */: return "noncelltype"   ; break;
+        }
+    }
+
+private:
+
+    uint8_t m_id = NONCELLTYPE;
+    uint8_t m_nnode = 0;
+    uint8_t m_nedge = 0;
+    uint8_t m_nsurface = 0;
+
+}; /* end struct CellType */
+
+#define MM_DECL_CELL_TYPE(NAME, TYPE, NDIM, NNODE, NEDGE, NSURFACE) \
+struct NAME##CellType : public CellType<NDIM> { \
+    NAME##CellType() : CellType<NDIM>(TYPE, NNODE, NEDGE, NSURFACE) {} \
+}; \
+static_assert(sizeof(NAME##CellType) == 4);
+//                                 id, ndim, nnode, nedge, nsurface
+MM_DECL_CELL_TYPE(Point        ,    1,    0,     1,     0,        0 ) // point/node/vertex
+MM_DECL_CELL_TYPE(Line         ,    2,    1,     2,     0,        0 ) // line/edge
+MM_DECL_CELL_TYPE(Quadrilateral,    3,    2,     4,     4,        0 )
+MM_DECL_CELL_TYPE(Triangle     ,    4,    2,     3,     3,        0 )
+MM_DECL_CELL_TYPE(Hexahedron   ,    5,    3,     8,    12,        6 ) // hexahedron/brick
+MM_DECL_CELL_TYPE(Tetrahedron  ,    6,    3,     4,     6,        4 )
+MM_DECL_CELL_TYPE(Prism        ,    7,    3,     6,     9,        5 )
+MM_DECL_CELL_TYPE(Pyramid      ,    8,    3,     5,     8,        5 )
+#undef MH_DECL_CELL_TYPE
+
+template < typename D /* derived type */, uint8_t ND >
+class StaticMeshBase
+  : public SpaceBase<ND>
+  , public std::enable_shared_from_this<D>
+{
+
+private:
+
+    class ctor_passkey {};
+
+public:
+
+    using space_base = SpaceBase<ND>;
+    using int_type = typename space_base::int_type;
+    using uint_type = typename space_base::uint_type;
+    using real_type = typename space_base::real_type;
+
+    static constexpr const auto NDIM = space_base::NDIM;
+    static constexpr const uint8_t FCMND = CellTypeBase::FCNND_MAX;
+    static constexpr const uint8_t FCMCL = CellTypeBase::FCNCL_MAX;
+    static constexpr const uint8_t CLMND = CellTypeBase::CLNND_MAX;
+    static constexpr const uint8_t CLMFC = CellTypeBase::CLNFC_MAX;
+    static constexpr const uint8_t FCNCL = 4;
+    static constexpr const uint8_t FCREL = 4;
+    static constexpr const uint8_t BFREL = 3;
+
+    template < typename ... Args >
+    static std::shared_ptr<D> construct(Args && ... args)
+    {
+        return std::make_shared<D>(std::forward<Args>(args) ..., ctor_passkey());
+    }
+
+    StaticMeshBase(uint_type nnode, ctor_passkey const &)
+      : m_nnode(nnode), m_nface(0), m_ncell(0)
+      , m_nbound(0), m_ngstnode(0), m_ngstface(0), m_ngstcell(0)
+      , m_ndcrd(std::vector<size_t>{nnode, NDIM})
+      , m_fccnd(std::vector<size_t>{0, NDIM})
+      , m_fcnml(std::vector<size_t>{0, NDIM})
+      , m_fcara(std::vector<size_t>{0})
+      , m_clcnd(std::vector<size_t>{0, NDIM})
+      , m_clvol(std::vector<size_t>{0})
+      , m_fctpn(std::vector<size_t>{0})
+      , m_cltpn(std::vector<size_t>{0})
+      , m_clgrp(std::vector<size_t>{0})
+      , m_fcnds(std::vector<size_t>{0, FCMND})
+      , m_fccls(std::vector<size_t>{0, FCMCL})
+      , m_clnds(std::vector<size_t>{0, CLMND})
+      , m_clfcs(std::vector<size_t>{0, CLMFC})
+    {}
+    StaticMeshBase() = delete;
+    StaticMeshBase(StaticMeshBase const & ) = delete;
+    StaticMeshBase(StaticMeshBase       &&) = delete;
+    StaticMeshBase & operator=(StaticMeshBase const & ) = delete;
+    StaticMeshBase & operator=(StaticMeshBase       &&) = delete;
+    ~StaticMeshBase() = default;
+
+    uint_type nnode() const { return m_nnode; }
+    uint_type nface() const { return m_nface; }
+    uint_type ncell() const { return m_ncell; }
+    uint_type nbound() const { return m_nbound; }
+    uint_type ngstnode() const { return m_ngstnode; }
+    uint_type ngstface() const { return m_ngstface; }
+    uint_type ngstcell() const { return m_ngstcell; }
+
+// Shape data.
+private:
+
+    uint_type m_nnode = 0; ///< Number of nodes (interior).
+    uint_type m_nface = 0; ///< Number of faces (interior).
+    uint_type m_ncell = 0; ///< Number of cells (interior).
+    uint_type m_nbound = 0; ///< Number of boundary faces.
+    uint_type m_ngstnode = 0; ///< Number of ghost nodes.
+    uint_type m_ngstface = 0; ///< Number of ghost faces.
+    uint_type m_ngstcell = 0; ///< Number of ghost cells.
+    // other block information.
+    bool m_use_incenter = false; ///< While true, m_clcnd uses in-center for simplices.
+
+// Data arrays.
+#define MM_DECL_StaticMesh_ARRAY(TYPE, NAME) \
+public: \
+    SimpleArray<TYPE> const & NAME() const { return m_ ## NAME; } \
+    SimpleArray<TYPE>       & NAME()       { return m_ ## NAME; } \
+private: \
+    SimpleArray<TYPE> m_ ## NAME
+
+    // geometry arrays.
+    MM_DECL_StaticMesh_ARRAY(real_type, ndcrd);
+    MM_DECL_StaticMesh_ARRAY(real_type, fccnd);
+    MM_DECL_StaticMesh_ARRAY(real_type, fcnml);
+    MM_DECL_StaticMesh_ARRAY(real_type, fcara);
+    MM_DECL_StaticMesh_ARRAY(real_type, clcnd);
+    MM_DECL_StaticMesh_ARRAY(real_type, clvol);
+    // meta arrays.
+    MM_DECL_StaticMesh_ARRAY(int_type, fctpn);
+    MM_DECL_StaticMesh_ARRAY(int_type, cltpn);
+    MM_DECL_StaticMesh_ARRAY(int_type, clgrp);
+    // connectivity arrays.
+    MM_DECL_StaticMesh_ARRAY(int_type, fcnds);
+    MM_DECL_StaticMesh_ARRAY(int_type, fccls);
+    MM_DECL_StaticMesh_ARRAY(int_type, clnds);
+    MM_DECL_StaticMesh_ARRAY(int_type, clfcs);
+
+#undef MM_DECL_StaticMesh_ARRAY
+
+}; /* end class StaticMeshBase */
+
+class StaticMesh2d
+  : public StaticMeshBase<StaticMesh2d, 2>
+{
+    using StaticMeshBase::StaticMeshBase;
+}; /* end class StaticGrid2d */
+
+class StaticMesh3d
+  : public StaticMeshBase<StaticMesh3d, 3>
+{
+    using StaticMeshBase::StaticMeshBase;
+}; /* end class StaticGrid3d */
+
 } /* end namespace modmesh */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/include/modmesh/python/python.hpp
+++ b/include/modmesh/python/python.hpp
@@ -504,45 +504,143 @@ protected:
 
 }; /* end class WrapStaticGrid1d */
 
+#define MM_DECL_StaticGridMD(NDIM) \
+class \
+MODMESH_PYTHON_WRAPPER_VISIBILITY \
+WrapStaticGrid ## NDIM ## d \
+  : public WrapStaticGridBase< WrapStaticGrid ## NDIM ## d, StaticGrid ## NDIM ## d > \
+{ \
+\
+public: \
+\
+    friend root_base_type; \
+\
+    using base_type = WrapStaticGridBase< WrapStaticGrid ## NDIM ## d, StaticGrid ## NDIM ## d >; \
+\
+protected: \
+\
+    explicit WrapStaticGrid ## NDIM ## d(pybind11::module & mod, char const * pyname, char const * pydoc) \
+      : base_type(mod, pyname, pydoc) \
+    {} \
+\
+}
+
+MM_DECL_StaticGridMD(2);
+MM_DECL_StaticGridMD(3);
+
+#undef MM_DECL_StaticGridMD
+
+template< typename Wrapper, typename GT >
 class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
-WrapStaticGrid2d
-  : public WrapStaticGridBase< WrapStaticGrid2d, StaticGrid2d >
+WrapStaticMeshBase
+  : public WrapBase< Wrapper, GT, std::shared_ptr<GT> >
 {
 
 public:
 
-    friend root_base_type;
+    using base_type = WrapBase< Wrapper, GT, std::shared_ptr<GT> >;
+    using wrapped_type = typename base_type::wrapped_type;
 
-    using base_type = WrapStaticGridBase< WrapStaticGrid2d, StaticGrid2d >;
+    using int_type = typename wrapped_type::int_type;
+    using uint_type = typename wrapped_type::uint_type;
+    using serial_type = typename wrapped_type::serial_type;
+    using real_type = typename wrapped_type::real_type;
 
-protected:
-
-    explicit WrapStaticGrid2d(pybind11::module & mod, char const * pyname, char const * pydoc)
-      : base_type(mod, pyname, pydoc)
-    {}
-
-}; /* end class WrapStaticGrid2d */
-
-class
-MODMESH_PYTHON_WRAPPER_VISIBILITY
-WrapStaticGrid3d
-  : public WrapStaticGridBase< WrapStaticGrid3d, StaticGrid3d >
-{
-
-public:
-
-    friend root_base_type;
-
-    using base_type = WrapStaticGridBase< WrapStaticGrid3d, StaticGrid3d >;
+    friend typename base_type::root_base_type;
 
 protected:
 
-    WrapStaticGrid3d(pybind11::module & mod, char const * pyname, char const * pydoc)
+    WrapStaticMeshBase(pybind11::module & mod, char const * pyname, char const * pydoc)
       : base_type(mod, pyname, pydoc)
-    {}
+    {
 
-}; /* end class WrapStaticGrid3d */
+        namespace py = pybind11;
+
+        (*this)
+            .def_timed
+            (
+                py::init([](uint_type nnode) { return wrapped_type::construct(nnode); })
+              , py::arg("nnode")
+            )
+        ;
+
+#define MM_DECL_STATIC(NAME) \
+.def_property_readonly_static(#NAME, [](py::object const &) { return wrapped_type::NAME; })
+
+        (*this)
+            MM_DECL_STATIC(NDIM)
+            MM_DECL_STATIC(FCMND)
+            MM_DECL_STATIC(FCMCL)
+            MM_DECL_STATIC(CLMND)
+            MM_DECL_STATIC(CLMFC)
+            MM_DECL_STATIC(FCNCL)
+            MM_DECL_STATIC(FCREL)
+            MM_DECL_STATIC(BFREL)
+        ;
+
+#undef MM_DECL_STATIC
+
+        (*this)
+            .def_property_readonly("nnode", &wrapped_type::nnode)
+            .def_property_readonly("nface", &wrapped_type::nface)
+            .def_property_readonly("ncell", &wrapped_type::ncell)
+            .def_property_readonly("nbound", &wrapped_type::nbound)
+            .def_property_readonly("ngstnode", &wrapped_type::ngstnode)
+            .def_property_readonly("ngstface", &wrapped_type::ngstface)
+            .def_property_readonly("ngstcell", &wrapped_type::ngstcell)
+        ;
+
+#define MM_DECL_ARRAY(NAME) \
+.expose_SimpleArrayAsNdarray(#NAME, [](wrapped_type & self) -> decltype(auto) { return self.NAME(); })
+
+        (*this)
+            MM_DECL_ARRAY(ndcrd)
+            MM_DECL_ARRAY(fccnd)
+            MM_DECL_ARRAY(fcnml)
+            MM_DECL_ARRAY(fcara)
+            MM_DECL_ARRAY(clcnd)
+            MM_DECL_ARRAY(clvol)
+            MM_DECL_ARRAY(fctpn)
+            MM_DECL_ARRAY(cltpn)
+            MM_DECL_ARRAY(clgrp)
+            MM_DECL_ARRAY(fcnds)
+            MM_DECL_ARRAY(fccls)
+            MM_DECL_ARRAY(clnds)
+            MM_DECL_ARRAY(clfcs)
+        ;
+
+#undef MM_DECL_ARRAY
+
+    }
+
+}; /* end class WrapStaticMeshBase */
+
+#define MM_DECL_StaticMeshMD(NDIM) \
+class \
+MODMESH_PYTHON_WRAPPER_VISIBILITY \
+WrapStaticMesh ## NDIM ## d \
+  : public WrapStaticMeshBase< WrapStaticMesh ## NDIM ## d, StaticMesh ## NDIM ## d > \
+{ \
+\
+public: \
+\
+    friend root_base_type; \
+\
+    using base_type = WrapStaticMeshBase< WrapStaticMesh ## NDIM ## d, StaticMesh ## NDIM ## d >; \
+\
+protected: \
+\
+    explicit WrapStaticMesh ## NDIM ## d(pybind11::module & mod, char const * pyname, char const * pydoc) \
+      : base_type(mod, pyname, pydoc) \
+    {} \
+\
+}
+
+MM_DECL_StaticMeshMD(2);
+MM_DECL_StaticMeshMD(3);
+
+#undef MM_DECL_StaticMeshMD
 
 #pragma GCC diagnostic push
 // Suppress the warning "greater visibility than the type of its field"
@@ -645,6 +743,9 @@ inline void initialize_impl(pybind11::module & mod)
     WrapStaticGrid1d::commit(mod, "StaticGrid1d", "StaticGrid1d");
     WrapStaticGrid2d::commit(mod, "StaticGrid2d", "StaticGrid2d");
     WrapStaticGrid3d::commit(mod, "StaticGrid3d", "StaticGrid3d");
+
+    WrapStaticMesh2d::commit(mod, "StaticMesh2d", "StaticMesh2d");
+    WrapStaticMesh3d::commit(mod, "StaticMesh3d", "StaticMesh3d");
 
 }
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
+# Copyright (c) 2021, Yung-Yu Chen <yyc@solvcon.net>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -25,71 +25,45 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
-"""
-General mesh data definition and manipulation in one, two, and
-three-dimensional space.
-"""
+import unittest
+
+import modmesh
 
 
-# Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
+class StaticMeshTC(unittest.TestCase):
 
+    def test_construct(self):
+        def _test(cls, ndim):
 
-__all__ = [
-    'WrapperProfilerStatus',
-    'wrapper_profiler_status',
-    'StopWatch',
-    'stop_watch',
-    'TimeRegistry',
-    'time_registry',
-    'ConcreteBuffer',
-    'SimpleArrayBool',
-    'SimpleArrayInt8',
-    'SimpleArrayInt16',
-    'SimpleArrayInt32',
-    'SimpleArrayInt64',
-    'SimpleArrayUint8',
-    'SimpleArrayUint16',
-    'SimpleArrayUint32',
-    'SimpleArrayUint64',
-    'SimpleArrayFloat32',
-    'SimpleArrayFloat64',
-    'StaticGrid1d',
-    'StaticGrid2d',
-    'StaticGrid3d',
-    'StaticMesh2d',
-    'StaticMesh3d',
-]
+            mh = cls(nnode=0)
 
+            self.assertEqual(ndim, cls.NDIM)
 
-# A hidden loophole to impolementation; it should only be used for testing
-# during development.
-from . import _modmesh as _impl  # noqa: F401
+            self.assertEqual(0, mh.nnode)
+            self.assertEqual(0, mh.nface)
+            self.assertEqual(0, mh.ncell)
+            self.assertEqual(0, mh.nbound)
+            self.assertEqual(0, mh.ngstnode)
+            self.assertEqual(0, mh.ngstface)
+            self.assertEqual(0, mh.ngstcell)
 
+            self.assertEqual((mh.nnode, ndim), mh.ndcrd.shape)
+            self.assertEqual((mh.nface, ndim), mh.fccnd.shape)
+            self.assertEqual((mh.nface, ndim), mh.fcnml.shape)
+            self.assertEqual((mh.nface,), mh.fcara.shape)
+            self.assertEqual((mh.ncell, ndim), mh.clcnd.shape)
+            self.assertEqual((mh.ncell,), mh.clvol.shape)
 
-from ._modmesh import (
-    WrapperProfilerStatus,
-    wrapper_profiler_status,
-    StopWatch,
-    stop_watch,
-    TimeRegistry,
-    time_registry,
-    ConcreteBuffer,
-    SimpleArrayBool,
-    SimpleArrayInt8,
-    SimpleArrayInt16,
-    SimpleArrayInt32,
-    SimpleArrayInt64,
-    SimpleArrayUint8,
-    SimpleArrayUint16,
-    SimpleArrayUint32,
-    SimpleArrayUint64,
-    SimpleArrayFloat32,
-    SimpleArrayFloat64,
-    StaticGrid1d,
-    StaticGrid2d,
-    StaticGrid3d,
-    StaticMesh2d,
-    StaticMesh3d,
-)
+            self.assertEqual((mh.ncell,), mh.fctpn.shape)
+            self.assertEqual((mh.ncell,), mh.cltpn.shape)
+            self.assertEqual((mh.ncell,), mh.clgrp.shape)
+
+            self.assertEqual((mh.nface, cls.FCMND), mh.fcnds.shape)
+            self.assertEqual((mh.nface, cls.FCMCL), mh.fccls.shape)
+            self.assertEqual((mh.ncell, cls.CLMND), mh.clnds.shape)
+            self.assertEqual((mh.ncell, cls.CLMFC), mh.clfcs.shape)
+
+        _test(modmesh.StaticMesh2d, 2)
+        _test(modmesh.StaticMesh3d, 3)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Add multi-dimensional (2/3D) unstructured mesh object without any verification

The mesh is named StaticMesh* because it does not change when being used.

1. The code was copied from SOLVCON (https://github.com/solvcon/solvcon).
2. Add basic shape tests for the mesh object.
3. Add CellType but it is not used nor tested at all.