### PR TITLE
Refactor build_faces_from_cells() to save some lines of code

### DIFF
--- a/include/modmesh/SimpleArray.hpp
+++ b/include/modmesh/SimpleArray.hpp
@@ -386,10 +386,14 @@ public:
     }
 
     template < typename ... Args >
-    value_type const & operator()(Args ... args) const { return m_body[buffer_offset(m_stride, args...)]; }
+    value_type const & operator()(Args ... args) const { return *vptr(args...); }
+    template < typename ... Args >
+    value_type       & operator()(Args ... args)       { return *vptr(args...); }
 
     template < typename ... Args >
-    value_type       & operator()(Args ... args)       { return m_body[buffer_offset(m_stride, args...)]; }
+    value_type const * vptr(Args ... args) const { return m_body + buffer_offset(m_stride, args...); }
+    template < typename ... Args >
+    value_type       * vptr(Args ... args)       { return m_body + buffer_offset(m_stride, args...); }
 
     /* Backdoor */
     value_type const & data(size_t it) const { return data()[it]; }

--- a/include/modmesh/mesh/StaticMesh_decl.hpp
+++ b/include/modmesh/mesh/StaticMesh_decl.hpp
@@ -237,7 +237,6 @@ public:
     static constexpr const uint8_t FCMND = CellType::FCNND_MAX;
     static constexpr const uint8_t CLMND = CellType::CLNND_MAX;
     static constexpr const uint8_t CLMFC = CellType::CLNFC_MAX;
-    static constexpr const uint8_t FCNCL = 4;
     static constexpr const uint8_t FCREL = 4;
     static constexpr const uint8_t BFREL = 3;
 
@@ -261,7 +260,7 @@ public:
       , m_cltpn(std::vector<size_t>{ncell})
       , m_clgrp(std::vector<size_t>{ncell})
       , m_fcnds(std::vector<size_t>{nface, FCMND+1})
-      , m_fccls(std::vector<size_t>{nface, FCNCL})
+      , m_fccls(std::vector<size_t>{nface, FCREL})
       , m_clnds(std::vector<size_t>{ncell, CLMND+1})
       , m_clfcs(std::vector<size_t>{ncell, CLMFC+1})
       , m_bndfcs(std::vector<size_t>{0, StaticMeshBC::BFREL})

--- a/include/modmesh/mesh/boundary.hpp
+++ b/include/modmesh/mesh/boundary.hpp
@@ -167,7 +167,7 @@ void StaticMeshBase<D, ND>::build_ghost()
     MM_DECL_GHOST_SWAP1(clgrp, int_type, cell, -1)
     // connectivity arrays.
     MM_DECL_GHOST_SWAP2(fcnds, int_type, face, FCMND+1, -1)
-    MM_DECL_GHOST_SWAP2(fccls, int_type, face, FCNCL, -1)
+    MM_DECL_GHOST_SWAP2(fccls, int_type, face, FCREL, -1)
     MM_DECL_GHOST_SWAP2(clnds, int_type, cell, CLMND+1, -1)
     MM_DECL_GHOST_SWAP2(clfcs, int_type, cell, CLMFC+1, -1)
 

--- a/include/modmesh/python/python.hpp
+++ b/include/modmesh/python/python.hpp
@@ -557,10 +557,8 @@ protected:
         (*this)
             MM_DECL_STATIC(NDIM)
             MM_DECL_STATIC(FCMND)
-            MM_DECL_STATIC(FCNCL)
             MM_DECL_STATIC(CLMND)
             MM_DECL_STATIC(CLMFC)
-            MM_DECL_STATIC(FCNCL)
             MM_DECL_STATIC(FCREL)
             MM_DECL_STATIC(BFREL)
         ;

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -58,7 +58,7 @@ class StaticMeshTC(unittest.TestCase):
         self.assertEqual((mh.ngstcell + mh.ncell,), mh.clgrp.shape)
 
         self.assertEqual((mh.ngstface + mh.nface, mh.FCMND+1), mh.fcnds.shape)
-        self.assertEqual((mh.ngstface + mh.nface, mh.FCNCL), mh.fccls.shape)
+        self.assertEqual((mh.ngstface + mh.nface, mh.FCREL), mh.fccls.shape)
         self.assertEqual((mh.ngstcell + mh.ncell, mh.CLMND+1), mh.clnds.shape)
         self.assertEqual((mh.ngstcell + mh.ncell, mh.CLMFC+1), mh.clfcs.shape)
 


### PR DESCRIPTION
* Add `SimpleArray::vptr()` API to return the pointer to an element.
* Change the use of some local pointers with `SimpleArray` API.
* Remove the constexpr `FCNCL` which is duplicated with `FCREL`.