### PR TITLE
Use clang-format to control coding style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,178 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+# Formatting options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Allman
+BreakBeforeInheritanceComma: true
+BreakInheritanceList: BeforeComma
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Leave
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Middle
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+ShortNamespaceLines: 1
+SortIncludes:    Never
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        c++14
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...

--- a/.github/workflows/modmesh_format.yml
+++ b/.github/workflows/modmesh_format.yml
@@ -1,0 +1,24 @@
+# Run clang-format
+name: modmesh_format.yml
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  clang-format-check:
+    name: clang format check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        path:
+          - 'include'
+          - 'src'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check for C/C++/Protobuf programs.
+      uses: jidicula/clang-format-action@v4.5.0
+      with:
+        clang-format-version: '13'
+        check-path: ${{ matrix.path }}
+        fallback-style: 'LLVM' # optional

--- a/include/modmesh/ConcreteBuffer.hpp
+++ b/include/modmesh/ConcreteBuffer.hpp
@@ -53,10 +53,10 @@ struct ConcreteBufferRemover
 {
 
     ConcreteBufferRemover() = default;
-    ConcreteBufferRemover(ConcreteBufferRemover const & ) = default;
-    ConcreteBufferRemover(ConcreteBufferRemover       &&) = default;
-    ConcreteBufferRemover & operator=(ConcreteBufferRemover const & ) = default;
-    ConcreteBufferRemover & operator=(ConcreteBufferRemover       &&) = default;
+    ConcreteBufferRemover(ConcreteBufferRemover const &) = default;
+    ConcreteBufferRemover(ConcreteBufferRemover &&) = default;
+    ConcreteBufferRemover & operator=(ConcreteBufferRemover const &) = default;
+    ConcreteBufferRemover & operator=(ConcreteBufferRemover &&) = default;
     virtual ~ConcreteBufferRemover() = default;
 
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays,readability-non-const-parameter)
@@ -73,14 +73,17 @@ struct ConcreteBufferDataDeleter
 
     using remover_type = ConcreteBufferRemover;
 
-    ConcreteBufferDataDeleter(ConcreteBufferDataDeleter const & ) = delete;
-    ConcreteBufferDataDeleter & operator=(ConcreteBufferDataDeleter const & ) = delete;
+    ConcreteBufferDataDeleter(ConcreteBufferDataDeleter const &) = delete;
+    ConcreteBufferDataDeleter & operator=(ConcreteBufferDataDeleter const &) = delete;
 
     ConcreteBufferDataDeleter() = default;
     ConcreteBufferDataDeleter(ConcreteBufferDataDeleter &&) = default;
     ConcreteBufferDataDeleter & operator=(ConcreteBufferDataDeleter &&) = default;
     ~ConcreteBufferDataDeleter() = default;
-    explicit ConcreteBufferDataDeleter(std::unique_ptr<remover_type> && remover_in) : remover(std::move(remover_in)) {}
+    explicit ConcreteBufferDataDeleter(std::unique_ptr<remover_type> && remover_in)
+        : remover(std::move(remover_in))
+    {
+    }
 
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays,readability-non-const-parameter)
     void operator()(int8_t * p) const
@@ -96,7 +99,7 @@ struct ConcreteBufferDataDeleter
         }
     }
 
-    std::unique_ptr<remover_type> remover {nullptr};
+    std::unique_ptr<remover_type> remover{nullptr};
 
 }; /* end struct ConcreteBufferDataDeleter */
 
@@ -106,12 +109,14 @@ struct ConcreteBufferDataDeleter
  * Untyped and unresizeable memory buffer for contiguous data storage.
  */
 class ConcreteBuffer
-  : public std::enable_shared_from_this<ConcreteBuffer>
+    : public std::enable_shared_from_this<ConcreteBuffer>
 {
 
 private:
 
-    struct ctor_passkey {};
+    struct ctor_passkey
+    {
+    };
 
     using data_deleter_type = detail::ConcreteBufferDataDeleter;
 
@@ -137,7 +142,7 @@ public:
 
     static std::shared_ptr<ConcreteBuffer> construct(size_t nbytes, void * data, std::unique_ptr<remover_type> && remover)
     {
-        return construct(nbytes, static_cast<int8_t*>(data), std::move(remover));
+        return construct(nbytes, static_cast<int8_t *>(data), std::move(remover));
     }
 
     static std::shared_ptr<ConcreteBuffer> construct() { return construct(0); }
@@ -154,9 +159,10 @@ public:
      *      Size of the memory buffer in bytes.
      */
     ConcreteBuffer(size_t nbytes, const ctor_passkey &)
-      : m_nbytes(nbytes)
-      , m_data(allocate(nbytes))
-    {}
+        : m_nbytes(nbytes)
+        , m_data(allocate(nbytes))
+    {
+    }
 
     /**
      * \param[in] nbytes
@@ -169,9 +175,10 @@ public:
      */
     // NOLINTNEXTLINE(readability-non-const-parameter)
     ConcreteBuffer(size_t nbytes, int8_t * data, std::unique_ptr<remover_type> && remover, const ctor_passkey &)
-      : m_nbytes(nbytes)
-      , m_data(data, data_deleter_type(std::move(remover)))
-    {}
+        : m_nbytes(nbytes)
+        , m_data(data, data_deleter_type(std::move(remover)))
+    {
+    }
 
     ~ConcreteBuffer() = default;
 
@@ -184,8 +191,8 @@ public:
     // Avoid enabled_shared_from_this copy constructor
     // NOLINTNEXTLINE(bugprone-copy-constructor-init)
     ConcreteBuffer(ConcreteBuffer const & other)
-      : m_nbytes(other.m_nbytes)
-      , m_data(allocate(other.m_nbytes))
+        : m_nbytes(other.m_nbytes)
+        , m_data(allocate(other.m_nbytes))
     {
         if (size() != other.size())
         {
@@ -223,25 +230,35 @@ public:
     const_iterator cbegin() const noexcept { return begin(); }
     const_iterator cend() const noexcept { return end(); }
 
-    int8_t   operator[](size_t it) const { return data(it); }
-    int8_t & operator[](size_t it)       { return data(it); }
+    int8_t operator[](size_t it) const { return data(it); }
+    int8_t & operator[](size_t it) { return data(it); }
 
-    int8_t   at(size_t it) const { validate_range(it); return data(it); }
-    int8_t & at(size_t it)       { validate_range(it); return data(it); }
+    int8_t at(size_t it) const
+    {
+        validate_range(it);
+        return data(it);
+    }
+    int8_t & at(size_t it)
+    {
+        validate_range(it);
+        return data(it);
+    }
 
     /* Backdoor */
-    int8_t   data(size_t it) const { return data()[it]; }
-    int8_t & data(size_t it)       { return data()[it]; }
+    int8_t data(size_t it) const { return data()[it]; }
+    int8_t & data(size_t it) { return data()[it]; }
     int8_t const * data() const noexcept { return data<int8_t>(); }
-    int8_t       * data()       noexcept { return data<int8_t>(); }
+    int8_t * data() noexcept { return data<int8_t>(); }
+    // clang-format off
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    template<typename T> T const * data() const noexcept { return reinterpret_cast<T*>(m_data.get()); }
+    template <typename T> T const * data() const noexcept { return reinterpret_cast<T *>(m_data.get()); }
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    template<typename T> T       * data()       noexcept { return reinterpret_cast<T*>(m_data.get()); }
+    template <typename T> T * data() noexcept { return reinterpret_cast<T *>(m_data.get()); }
+    // clang-format on
 
     bool has_remover() const noexcept { return bool(m_data.get_deleter().remover); }
     remover_type const & get_remover() const { return *m_data.get_deleter().remover; }
-    remover_type       & get_remover()       { return *m_data.get_deleter().remover; }
+    remover_type & get_remover() { return *m_data.get_deleter().remover; }
 
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     using unique_ptr_type = std::unique_ptr<int8_t, data_deleter_type>;

--- a/include/modmesh/SimpleArray.hpp
+++ b/include/modmesh/SimpleArray.hpp
@@ -38,22 +38,22 @@ namespace modmesh
 namespace detail
 {
 
-template < size_t D, typename S >
+template <size_t D, typename S>
 size_t buffer_offset_impl(S const &)
 {
     return 0;
 }
 
-template < size_t D, typename S, typename Arg, typename ... Args >
-size_t buffer_offset_impl(S const & strides, Arg arg, Args ... args)
+template <size_t D, typename S, typename Arg, typename... Args>
+size_t buffer_offset_impl(S const & strides, Arg arg, Args... args)
 {
-    return arg * strides[D] + buffer_offset_impl<D+1>(strides, args...);
+    return arg * strides[D] + buffer_offset_impl<D + 1>(strides, args...);
 }
 
 } /* end namespace detail */
 
-template < typename S, typename ... Args >
-size_t buffer_offset(S const & strides, Args ... args)
+template <typename S, typename... Args>
+size_t buffer_offset(S const & strides, Args... args)
 {
     return detail::buffer_offset_impl<0>(strides, args...);
 }
@@ -69,20 +69,19 @@ inline size_t buffer_offset(small_vector<size_t> const & stride, small_vector<si
         throw std::out_of_range(ms.str());
     }
     size_t offset = 0;
-    for (size_t it = 0 ; it < stride.size() ; ++it)
+    for (size_t it = 0; it < stride.size(); ++it)
     {
         offset += stride[it] * idx[it];
     }
     return offset;
 }
 
-
 /**
  * Simple array type for contiguous memory storage. Size does not change. The
  * copy semantics performs data copy. The move semantics invalidates the
  * existing memory buffer.
  */
-template < typename T >
+template <typename T>
 class SimpleArray
 {
 
@@ -98,21 +97,24 @@ public:
     static constexpr size_t itemsize() { return ITEMSIZE; }
 
     explicit SimpleArray(size_t length)
-      : m_buffer(buffer_type::construct(length * ITEMSIZE))
-      , m_shape{length}
-      , m_stride{1}
-      , m_body(m_buffer->data<T>())
-    {}
+        : m_buffer(buffer_type::construct(length * ITEMSIZE))
+        , m_shape{length}
+        , m_stride{1}
+        , m_body(m_buffer->data<T>())
+    {
+    }
 
-    template< class InputIt > SimpleArray(InputIt first, InputIt last)
-      : SimpleArray(last-first)
+    template <class InputIt>
+    SimpleArray(InputIt first, InputIt last)
+        : SimpleArray(last - first)
     {
         std::copy(first, last, data());
     }
 
     // NOLINTNEXTLINE(modernize-pass-by-value)
     explicit SimpleArray(small_vector<size_t> const & shape)
-      : m_shape(shape), m_stride(calc_stride(m_shape))
+        : m_shape(shape)
+        , m_stride(calc_stride(m_shape))
     {
         if (!m_shape.empty())
         {
@@ -123,13 +125,14 @@ public:
 
     // NOLINTNEXTLINE(modernize-pass-by-value)
     explicit SimpleArray(small_vector<size_t> const & shape, value_type const & value)
-      : SimpleArray(shape)
+        : SimpleArray(shape)
     {
         std::fill(begin(), end(), value);
     }
 
     explicit SimpleArray(std::vector<size_t> const & shape)
-      : m_shape(shape), m_stride(calc_stride(m_shape))
+        : m_shape(shape)
+        , m_stride(calc_stride(m_shape))
     {
         if (!m_shape.empty())
         {
@@ -139,7 +142,7 @@ public:
     }
 
     explicit SimpleArray(std::vector<size_t> const & shape, value_type const & value)
-      : SimpleArray(shape)
+        : SimpleArray(shape)
     {
         std::fill(begin(), end(), value);
     }
@@ -164,12 +167,9 @@ public:
         }
     }
 
-    explicit SimpleArray
-    (
-        small_vector<size_t> const & shape
-      , std::shared_ptr<buffer_type> const & buffer
-    )
-      : SimpleArray(buffer)
+    explicit SimpleArray(
+        small_vector<size_t> const & shape, std::shared_ptr<buffer_type> const & buffer)
+        : SimpleArray(buffer)
     {
         if (buffer)
         {
@@ -186,26 +186,31 @@ public:
     }
 
     SimpleArray(std::initializer_list<T> init)
-      : SimpleArray(init.size())
+        : SimpleArray(init.size())
     {
         std::copy_n(init.begin(), init.size(), data());
     }
 
-    SimpleArray() : SimpleArray(0) {}
+    SimpleArray()
+        : SimpleArray(0)
+    {
+    }
 
     SimpleArray(SimpleArray const & other)
-      : m_buffer(other.m_buffer->clone())
-      , m_shape(other.m_shape)
-      , m_stride(other.m_stride)
-      , m_nghost(other.m_nghost)
-      , m_body(calc_body(m_buffer->data<T>(), m_stride, other.m_nghost))
-    {}
+        : m_buffer(other.m_buffer->clone())
+        , m_shape(other.m_shape)
+        , m_stride(other.m_stride)
+        , m_nghost(other.m_nghost)
+        , m_body(calc_body(m_buffer->data<T>(), m_stride, other.m_nghost))
+    {
+    }
 
     SimpleArray(SimpleArray && other) noexcept
-      : m_buffer(std::move(other.m_buffer))
-      , m_shape(std::move(other.m_shape))
-      , m_stride(std::move(other.m_stride))
-    {}
+        : m_buffer(std::move(other.m_buffer))
+        , m_shape(std::move(other.m_shape))
+        , m_stride(std::move(other.m_stride))
+    {
+    }
 
     SimpleArray & operator=(SimpleArray const & other)
     {
@@ -235,10 +240,10 @@ public:
 
     ~SimpleArray() = default;
 
-    template < typename ... Args >
-    SimpleArray & remake(Args && ... args)
+    template <typename... Args>
+    SimpleArray & remake(Args &&... args)
     {
-        SimpleArray(args ...).swap(*this);
+        SimpleArray(args...).swap(*this);
         return *this;
     }
 
@@ -247,10 +252,10 @@ public:
         shape_type stride(shape.size());
         if (!shape.empty())
         {
-            stride[shape.size()-1] = 1;
-            for (size_t it=shape.size()-1; it>0; --it)
+            stride[shape.size() - 1] = 1;
+            for (size_t it = shape.size() - 1; it > 0; --it)
             {
-                stride[it-1] = stride[it] * shape[it];
+                stride[it - 1] = stride[it] * shape[it];
             }
         }
         return stride;
@@ -287,16 +292,34 @@ public:
     const_iterator cend() const noexcept { return end(); }
 
     value_type const & operator[](size_t it) const noexcept { return data(it); }
-    value_type       & operator[](size_t it)       noexcept { return data(it); }
+    value_type & operator[](size_t it) noexcept { return data(it); }
 
-    value_type const & at(size_t it) const { validate_range(it); return data(it); }
-    value_type       & at(size_t it)       { validate_range(it); return data(it); }
+    value_type const & at(size_t it) const
+    {
+        validate_range(it);
+        return data(it);
+    }
+    value_type & at(size_t it)
+    {
+        validate_range(it);
+        return data(it);
+    }
 
-    value_type const & at(ssize_t it) const { validate_range(it); it += m_nghost; return data(it); }
-    value_type       & at(ssize_t it)       { validate_range(it); it += m_nghost; return data(it); }
+    value_type const & at(ssize_t it) const
+    {
+        validate_range(it);
+        it += m_nghost;
+        return data(it);
+    }
+    value_type & at(ssize_t it)
+    {
+        validate_range(it);
+        it += m_nghost;
+        return data(it);
+    }
 
     value_type const & at(std::vector<size_t> const & idx) const { return at(shape_type(idx)); }
-    value_type       & at(std::vector<size_t> const & idx)       { return at(shape_type(idx)); }
+    value_type & at(std::vector<size_t> const & idx) { return at(shape_type(idx)); }
 
     value_type const & at(shape_type const & idx) const
     {
@@ -312,7 +335,7 @@ public:
     }
 
     value_type const & at(std::vector<ssize_t> const & idx) const { return at(sshape_type(idx)); }
-    value_type       & at(std::vector<ssize_t> const & idx)       { return at(sshape_type(idx)); }
+    value_type & at(std::vector<ssize_t> const & idx) { return at(sshape_type(idx)); }
 
     value_type const & at(sshape_type sidx) const
     {
@@ -333,11 +356,11 @@ public:
 
     size_t ndim() const noexcept { return m_shape.size(); }
     shape_type const & shape() const { return m_shape; }
-    size_t   shape(size_t it) const noexcept { return m_shape[it]; }
-    size_t & shape(size_t it)       noexcept { return m_shape[it]; }
+    size_t shape(size_t it) const noexcept { return m_shape[it]; }
+    size_t & shape(size_t it) noexcept { return m_shape[it]; }
     shape_type const & stride() const { return m_stride; }
-    size_t   stride(size_t it) const noexcept { return m_stride[it]; }
-    size_t & stride(size_t it)       noexcept { return m_stride[it]; }
+    size_t stride(size_t it) const noexcept { return m_stride[it]; }
+    size_t & stride(size_t it) noexcept { return m_stride[it]; }
 
     size_t nghost() const { return m_nghost; }
     size_t nbody() const { return m_shape.empty() ? 0 : m_shape[0] - m_nghost; }
@@ -366,7 +389,7 @@ public:
         }
     }
 
-    template < typename U >
+    template <typename U>
     SimpleArray<U> reshape(shape_type const & shape) const
     {
         return SimpleArray<U>(shape, m_buffer);
@@ -394,27 +417,27 @@ public:
         }
     }
 
-    template < typename ... Args >
-    value_type const & operator()(Args ... args) const { return *vptr(args...); }
-    template < typename ... Args >
-    value_type       & operator()(Args ... args)       { return *vptr(args...); }
+    template <typename... Args>
+    value_type const & operator()(Args... args) const { return *vptr(args...); }
+    template <typename... Args>
+    value_type & operator()(Args... args) { return *vptr(args...); }
 
-    template < typename ... Args >
-    value_type const * vptr(Args ... args) const { return m_body + buffer_offset(m_stride, args...); }
-    template < typename ... Args >
-    value_type       * vptr(Args ... args)       { return m_body + buffer_offset(m_stride, args...); }
+    template <typename... Args>
+    value_type const * vptr(Args... args) const { return m_body + buffer_offset(m_stride, args...); }
+    template <typename... Args>
+    value_type * vptr(Args... args) { return m_body + buffer_offset(m_stride, args...); }
 
     /* Backdoor */
     value_type const & data(size_t it) const { return data()[it]; }
-    value_type       & data(size_t it)       { return data()[it]; }
+    value_type & data(size_t it) { return data()[it]; }
     value_type const * data() const { return buffer().template data<value_type>(); }
-    value_type       * data()       { return buffer().template data<value_type>(); }
+    value_type * data() { return buffer().template data<value_type>(); }
 
     buffer_type const & buffer() const { return *m_buffer; }
-    buffer_type       & buffer()       { return *m_buffer; }
+    buffer_type & buffer() { return *m_buffer; }
 
     value_type const * body() const { return m_body; }
-    value_type       * body()       { return m_body; }
+    value_type * body() { return m_body; }
 
 private:
 
@@ -448,10 +471,13 @@ private:
         {
             std::ostringstream ms;
             ms << "[";
-            for (size_t it = 0 ; it < idx.size() ; ++it)
+            for (size_t it = 0; it < idx.size(); ++it)
             {
                 ms << idx[it];
-                if (it != idx.size()-1) { ms << ", "; }
+                if (it != idx.size() - 1)
+                {
+                    ms << ", ";
+                }
             }
             ms << "]";
             return ms.str();
@@ -487,7 +513,7 @@ private:
         }
 
         // Test the rest of the dimensions.
-        for (size_t it = 1 ; it < m_shape.size() ; ++it)
+        for (size_t it = 1; it < m_shape.size(); ++it)
         {
             if (idx[it] < 0)
             {

--- a/include/modmesh/SimpleArray.hpp
+++ b/include/modmesh/SimpleArray.hpp
@@ -63,7 +63,9 @@ inline size_t buffer_offset(small_vector<size_t> const & stride, small_vector<si
     if (stride.size() != idx.size())
     {
         std::ostringstream ms;
+        // clang-format off
         ms << "stride size " << stride.size() << " != " << "index size " << idx.size();
+        // clang-format on
         throw std::out_of_range(ms.str());
     }
     size_t offset = 0;
@@ -477,8 +479,10 @@ private:
         if (idx[0] >= static_cast<ssize_t>(nbody()))
         {
             std::ostringstream ms;
+            // clang-format off
             ms << "SimpleArray: dim 0 in " << index2string() << " >= nbody: " << nbody()
                 << " (shape[0]: " << m_shape[0] << " - nghost: " << nghost() << ")";
+            // clang-format on
             throw std::out_of_range(ms.str());
         }
 

--- a/include/modmesh/base.hpp
+++ b/include/modmesh/base.hpp
@@ -61,8 +61,7 @@ public:
  * data should inherit this class template.
  */
 template <uint8_t ND, typename I, typename R>
-class SpaceBase
-  : public NumberBase<I, R>
+class SpaceBase : public NumberBase<I, R>
 {
 
 public:

--- a/include/modmesh/grid.hpp
+++ b/include/modmesh/grid.hpp
@@ -59,32 +59,33 @@ public:
     using array_type = SimpleArray<value_type>;
 
     explicit AscendantGrid1d(size_t ncoord)
-      : m_coord(ncoord)
-      , m_idmax(ncoord-1)
-    {}
+        : m_coord(ncoord)
+        , m_idmax(ncoord - 1)
+    {
+    }
 
     AscendantGrid1d() = default;
-    AscendantGrid1d(AscendantGrid1d const & ) = default;
-    AscendantGrid1d(AscendantGrid1d       &&) = default;
-    AscendantGrid1d & operator=(AscendantGrid1d const & ) = default;
-    AscendantGrid1d & operator=(AscendantGrid1d       &&) = default;
+    AscendantGrid1d(AscendantGrid1d const &) = default;
+    AscendantGrid1d(AscendantGrid1d &&) = default;
+    AscendantGrid1d & operator=(AscendantGrid1d const &) = default;
+    AscendantGrid1d & operator=(AscendantGrid1d &&) = default;
     ~AscendantGrid1d() = default;
 
-    explicit operator bool () const { return bool(m_coord); }
+    explicit operator bool() const { return bool(m_coord); }
 
     size_t ncoord() const { return m_idmax - m_idmin + 1; }
 
     size_t size() const { return m_coord.size(); }
-    value_type const & operator[] (size_t it) const { return m_coord[it]; }
-    value_type       & operator[] (size_t it)       { return m_coord[it]; }
+    value_type const & operator[](size_t it) const { return m_coord[it]; }
+    value_type & operator[](size_t it) { return m_coord[it]; }
     value_type const & at(size_t it) const { return m_coord.at(it); }
-    value_type       & at(size_t it)       { return m_coord.at(it); }
+    value_type & at(size_t it) { return m_coord.at(it); }
 
     array_type const & coord() const { return m_coord; }
-    array_type       & coord()       { return m_coord; }
+    array_type & coord() { return m_coord; }
 
     value_type const * data() const { return m_coord.data(); }
-    value_type       * data()       { return m_coord.data(); }
+    value_type * data() { return m_coord.data(); }
 
 private:
 
@@ -105,17 +106,22 @@ public:
     using value_type = double;
     using array_type = SimpleArray<value_type>;
 
-    StaticGrid1d() : m_coord(nullptr) {}
+    StaticGrid1d()
+        : m_coord(nullptr)
+    {
+    }
 
     explicit StaticGrid1d(serial_type nx)
-      : m_nx(nx)
-      , m_coord(nx)
-    {}
+        : m_nx(nx)
+        , m_coord(nx)
+    {
+    }
 
     StaticGrid1d(StaticGrid1d const & other)
-      : m_nx(other.m_nx)
-      , m_coord(other.m_coord)
-    {}
+        : m_nx(other.m_nx)
+        , m_coord(other.m_coord)
+    {
+    }
 
     StaticGrid1d & operator=(StaticGrid1d const & other)
     {
@@ -128,9 +134,10 @@ public:
     }
 
     StaticGrid1d(StaticGrid1d && other) noexcept
-      : m_nx(other.m_nx)
-      , m_coord(std::move(other.m_coord))
-    {}
+        : m_nx(other.m_nx)
+        , m_coord(std::move(other.m_coord))
+    {
+    }
 
     StaticGrid1d & operator=(StaticGrid1d && other) noexcept
     {
@@ -146,13 +153,13 @@ public:
 
     size_t nx() const { return m_nx; }
     array_type const & coord() const { return m_coord; }
-    array_type       & coord()       { return m_coord; }
+    array_type & coord() { return m_coord; }
 
     size_t size() const { return m_nx; }
-    real_type   operator[] (size_t it) const noexcept { return m_coord[it]; }
-    real_type & operator[] (size_t it)       noexcept { return m_coord[it]; }
-    real_type   at (size_t it) const { return m_coord.at(it); }
-    real_type & at (size_t it)       { return m_coord.at(it); }
+    real_type operator[](size_t it) const noexcept { return m_coord[it]; }
+    real_type & operator[](size_t it) noexcept { return m_coord[it]; }
+    real_type at(size_t it) const { return m_coord.at(it); }
+    real_type & at(size_t it) { return m_coord.at(it); }
 
     void fill(real_type val)
     {

--- a/include/modmesh/grid.hpp
+++ b/include/modmesh/grid.hpp
@@ -43,16 +43,14 @@ namespace modmesh
  * Base class template for structured grid.
  */
 template <uint8_t ND>
-class StaticGridBase
-  : public SpaceBase<ND, int32_t, double>
+class StaticGridBase : public SpaceBase<ND, int32_t, double>
 {
 }; /* end class StaticGridBase */
 
 /**
  * 1D grid whose coordnate ascends with index.
  */
-class AscendantGrid1d
-  : public StaticGridBase<1>
+class AscendantGrid1d : public StaticGridBase<1>
 {
 
 public:
@@ -99,8 +97,7 @@ private:
 /**
  * 1D grid.
  */
-class StaticGrid1d
-  : public StaticGridBase<1>
+class StaticGrid1d : public StaticGridBase<1>
 {
 
 public:
@@ -170,13 +167,11 @@ private:
 
 }; /* end class StaticGrid1d */
 
-class StaticGrid2d
-  : public StaticGridBase<2>
+class StaticGrid2d : public StaticGridBase<2>
 {
 }; /* end class StaticGrid2d */
 
-class StaticGrid3d
-  : public StaticGridBase<3>
+class StaticGrid3d : public StaticGridBase<3>
 {
 }; /* end class StaticGrid3d */
 

--- a/include/modmesh/mesh/StaticMesh_decl.hpp
+++ b/include/modmesh/mesh/StaticMesh_decl.hpp
@@ -46,17 +46,17 @@ struct CellType : NumberBase<int32_t, double>
 {
 
     /* symbols for type id codes */
-    static constexpr const uint8_t NONCELLTYPE   = 0; /* not a cell type */
-    static constexpr const uint8_t POINT         = 1;
-    static constexpr const uint8_t LINE          = 2;
+    static constexpr const uint8_t NONCELLTYPE = 0; /* not a cell type */
+    static constexpr const uint8_t POINT = 1;
+    static constexpr const uint8_t LINE = 2;
     static constexpr const uint8_t QUADRILATERAL = 3;
-    static constexpr const uint8_t TRIANGLE      = 4;
-    static constexpr const uint8_t HEXAHEDRON    = 5;
-    static constexpr const uint8_t TETRAHEDRON   = 6;
-    static constexpr const uint8_t PRISM         = 7;
-    static constexpr const uint8_t PYRAMID       = 8;
+    static constexpr const uint8_t TRIANGLE = 4;
+    static constexpr const uint8_t HEXAHEDRON = 5;
+    static constexpr const uint8_t TETRAHEDRON = 6;
+    static constexpr const uint8_t PRISM = 7;
+    static constexpr const uint8_t PYRAMID = 8;
     /* number of all types; the same as the last type id code */
-    static constexpr const uint8_t NTYPE         = 8;
+    static constexpr const uint8_t NTYPE = 8;
 
     //< Maximum number of nodes in a face.
     static constexpr const uint8_t FCNND_MAX = 4;
@@ -69,9 +69,18 @@ struct CellType : NumberBase<int32_t, double>
 
     /* NOLINTNEXTLINE(bugprone-easily-swappable-parameters) */
     CellType(uint8_t id_in, uint8_t ndim_in, uint8_t nnode_in, uint8_t nedge_in, uint8_t nsurface_in)
-      : m_id(id_in), m_ndim(ndim_in), m_nnode(nnode_in), m_nedge(nedge_in), m_nsurface(nsurface_in) {}
+        : m_id(id_in)
+        , m_ndim(ndim_in)
+        , m_nnode(nnode_in)
+        , m_nedge(nedge_in)
+        , m_nsurface(nsurface_in)
+    {
+    }
 
-    CellType() : CellType(NONCELLTYPE, 0, 0, 0, 0) {}
+    CellType()
+        : CellType(NONCELLTYPE, 0, 0, 0, 0)
+    {
+    }
 
     uint8_t id() const { return m_id; }
     uint8_t ndim() const { return m_ndim; }
@@ -85,16 +94,16 @@ struct CellType : NumberBase<int32_t, double>
     {
         switch (id())
         {
-        case POINT         /* 1 */: return "point"         ; break;
-        case LINE          /* 2 */: return "line"          ; break;
-        case QUADRILATERAL /* 3 */: return "quadrilateral" ; break;
-        case TRIANGLE      /* 4 */: return "triangle"      ; break;
-        case HEXAHEDRON    /* 5 */: return "hexahedron"    ; break;
-        case TETRAHEDRON   /* 6 */: return "tetrahedron"   ; break;
-        case PRISM         /* 7 */: return "prism"         ; break;
-        case PYRAMID       /* 8 */: return "pyramid"       ; break;
-        case NONCELLTYPE   /* 0 */:
-        default        /* other */: return "noncelltype"   ; break;
+        case POINT /* 1 */: return "point"; break;
+        case LINE /* 2 */: return "line"; break;
+        case QUADRILATERAL /* 3 */: return "quadrilateral"; break;
+        case TRIANGLE /* 4 */: return "triangle"; break;
+        case HEXAHEDRON /* 5 */: return "hexahedron"; break;
+        case TETRAHEDRON /* 6 */: return "tetrahedron"; break;
+        case PRISM /* 7 */: return "prism"; break;
+        case PYRAMID /* 8 */: return "pyramid"; break;
+        case NONCELLTYPE /* 0 */:
+        default /* other */: return "noncelltype"; break;
         }
     }
 
@@ -113,7 +122,7 @@ static_assert(sizeof(CellType) == 4);
 inline CellType CellType::by_id(uint8_t id)
 {
 
-    #define MM_DECL_SWITCH_CELL_TYPE(TYPE, NDIM, NNODE, NEDGE, NSURFACE) \
+#define MM_DECL_SWITCH_CELL_TYPE(TYPE, NDIM, NNODE, NEDGE, NSURFACE) \
     case TYPE: return CellType(TYPE, NDIM, NNODE, NEDGE, NSURFACE); break;
 
     switch (id)
@@ -133,8 +142,7 @@ inline CellType CellType::by_id(uint8_t id)
         // clang-format on
     }
 
-    #undef MM_DECL_SWITCH_CELL_TYPE
-
+#undef MM_DECL_SWITCH_CELL_TYPE
 }
 
 struct StaticMeshConstant
@@ -150,8 +158,8 @@ struct StaticMeshConstant
 
 // FIXME: StaticMeshBC may use polymorphism.
 class StaticMeshBC
-  : public NumberBase<int32_t, double>
-  , public StaticMeshConstant
+    : public NumberBase<int32_t, double>
+    , public StaticMeshConstant
 {
 
 public:
@@ -182,8 +190,9 @@ public:
     StaticMeshBC() = default;
 
     explicit StaticMeshBC(size_t nbound)
-      : m_facn(SimpleArray<int_type>(std::vector<size_t>{nbound, BFREL}))
-    {}
+        : m_facn(SimpleArray<int_type>(std::vector<size_t>{nbound, BFREL}))
+    {
+    }
 
     StaticMeshBC(StaticMeshBC const & other)
     {
@@ -224,20 +233,22 @@ public:
     size_t nbound() const { return m_facn.nbody(); }
 
     SimpleArray<int_type> const & facn() const { return m_facn; }
-    SimpleArray<int_type>       & facn()       { return m_facn; }
+    SimpleArray<int_type> & facn() { return m_facn; }
 
 }; /* end class StaticMeshBC */
 
-template < typename D /* derived type */, uint8_t ND >
+template <typename D /* derived type */, uint8_t ND>
 class StaticMeshBase
-  : public SpaceBase<ND, int32_t, double>
-  , public StaticMeshConstant
-  , public std::enable_shared_from_this<D>
+    : public SpaceBase<ND, int32_t, double>
+    , public StaticMeshConstant
+    , public std::enable_shared_from_this<D>
 {
 
 private:
 
-    class ctor_passkey {};
+    class ctor_passkey
+    {
+    };
 
 public:
 
@@ -249,36 +260,42 @@ public:
 
     static constexpr const auto NDIM = space_base::NDIM;
 
-    template < typename ... Args >
-    static std::shared_ptr<D> construct(Args && ... args)
+    template <typename... Args>
+    static std::shared_ptr<D> construct(Args &&... args)
     {
-        return std::make_shared<D>(std::forward<Args>(args) ..., ctor_passkey());
+        return std::make_shared<D>(std::forward<Args>(args)..., ctor_passkey());
     }
 
     /* NOLINTNEXTLINE(bugprone-easily-swappable-parameters) */
     StaticMeshBase(uint_type nnode, uint_type nface, uint_type ncell, ctor_passkey const &)
-      : m_nnode(nnode), m_nface(nface), m_ncell(ncell)
-      , m_nbound(0), m_ngstnode(0), m_ngstface(0), m_ngstcell(0)
-      , m_ndcrd(std::vector<size_t>{nnode, NDIM}, 0)
-      , m_fccnd(std::vector<size_t>{nface, NDIM}, 0)
-      , m_fcnml(std::vector<size_t>{nface, NDIM}, 0)
-      , m_fcara(std::vector<size_t>{nface}, 0)
-      , m_clcnd(std::vector<size_t>{ncell, NDIM}, 0)
-      , m_clvol(std::vector<size_t>{ncell}, 0)
-      , m_fctpn(std::vector<size_t>{nface})
-      , m_cltpn(std::vector<size_t>{ncell})
-      , m_clgrp(std::vector<size_t>{ncell})
-      , m_fcnds(std::vector<size_t>{nface, FCMND+1})
-      , m_fccls(std::vector<size_t>{nface, FCREL})
-      , m_clnds(std::vector<size_t>{ncell, CLMND+1})
-      , m_clfcs(std::vector<size_t>{ncell, CLMFC+1})
-      , m_bndfcs(std::vector<size_t>{0, StaticMeshBC::BFREL})
-    {}
+        : m_nnode(nnode)
+        , m_nface(nface)
+        , m_ncell(ncell)
+        , m_nbound(0)
+        , m_ngstnode(0)
+        , m_ngstface(0)
+        , m_ngstcell(0)
+        , m_ndcrd(std::vector<size_t>{nnode, NDIM}, 0)
+        , m_fccnd(std::vector<size_t>{nface, NDIM}, 0)
+        , m_fcnml(std::vector<size_t>{nface, NDIM}, 0)
+        , m_fcara(std::vector<size_t>{nface}, 0)
+        , m_clcnd(std::vector<size_t>{ncell, NDIM}, 0)
+        , m_clvol(std::vector<size_t>{ncell}, 0)
+        , m_fctpn(std::vector<size_t>{nface})
+        , m_cltpn(std::vector<size_t>{ncell})
+        , m_clgrp(std::vector<size_t>{ncell})
+        , m_fcnds(std::vector<size_t>{nface, FCMND + 1})
+        , m_fccls(std::vector<size_t>{nface, FCREL})
+        , m_clnds(std::vector<size_t>{ncell, CLMND + 1})
+        , m_clfcs(std::vector<size_t>{ncell, CLMFC + 1})
+        , m_bndfcs(std::vector<size_t>{0, StaticMeshBC::BFREL})
+    {
+    }
     StaticMeshBase() = delete;
-    StaticMeshBase(StaticMeshBase const & ) = delete;
-    StaticMeshBase(StaticMeshBase       &&) = delete;
-    StaticMeshBase & operator=(StaticMeshBase const & ) = delete;
-    StaticMeshBase & operator=(StaticMeshBase       &&) = delete;
+    StaticMeshBase(StaticMeshBase const &) = delete;
+    StaticMeshBase(StaticMeshBase &&) = delete;
+    StaticMeshBase & operator=(StaticMeshBase const &) = delete;
+    StaticMeshBase & operator=(StaticMeshBase &&) = delete;
     ~StaticMeshBase() = default;
 
 public:
@@ -312,7 +329,7 @@ public:
      */
     int_type fcjcl(int_type ifc) const { return m_fccls(ifc, 1); }
 
-// Helpers for interior data.
+    // Helpers for interior data.
 public:
 
     void build_interior(bool do_metric)
@@ -329,7 +346,7 @@ private:
     void build_faces_from_cells();
     void calc_metric();
 
-// Helpers for boundary data (as well as ghost).
+    // Helpers for boundary data (as well as ghost).
 public:
 
     void build_boundary();
@@ -340,7 +357,7 @@ private:
     std::tuple<size_t, size_t, size_t> count_ghost() const;
     void fill_ghost();
 
-// Shape data.
+    // Shape data.
 private:
 
     uint_type m_nnode = 0; ///< Number of nodes (interior).
@@ -354,12 +371,13 @@ private:
     bool m_use_incenter = false; ///< While true, m_clcnd uses in-center for simplices.
 
 // Data arrays.
-#define MM_DECL_StaticMesh_ARRAY(TYPE, NAME) \
-public: \
-    SimpleArray<TYPE> const & NAME() const { return m_ ## NAME; } \
-    SimpleArray<TYPE>       & NAME()       { return m_ ## NAME; } \
-private: \
-    SimpleArray<TYPE> m_ ## NAME
+#define MM_DECL_StaticMesh_ARRAY(TYPE, NAME)                    \
+public:                                                         \
+    SimpleArray<TYPE> const & NAME() const { return m_##NAME; } \
+    SimpleArray<TYPE> & NAME() { return m_##NAME; }             \
+                                                                \
+private:                                                        \
+    SimpleArray<TYPE> m_##NAME
 
     // geometry arrays.
     MM_DECL_StaticMesh_ARRAY(real_type, ndcrd);
@@ -386,13 +404,13 @@ private: \
 }; /* end class StaticMeshBase */
 
 class StaticMesh2d
-  : public StaticMeshBase<StaticMesh2d, 2>
+    : public StaticMeshBase<StaticMesh2d, 2>
 {
     using StaticMeshBase::StaticMeshBase;
 }; /* end class StaticMesh2d */
 
 class StaticMesh3d
-  : public StaticMeshBase<StaticMesh3d, 3>
+    : public StaticMeshBase<StaticMesh3d, 3>
 {
     using StaticMeshBase::StaticMeshBase;
 }; /* end class StaticMesh3d */

--- a/include/modmesh/mesh/StaticMesh_decl.hpp
+++ b/include/modmesh/mesh/StaticMesh_decl.hpp
@@ -42,8 +42,7 @@ namespace modmesh
 /**
  * Cell type for unstructured mesh.
  */
-struct CellType
-  : NumberBase<int32_t, double>
+struct CellType : NumberBase<int32_t, double>
 {
 
     /* symbols for type id codes */
@@ -119,17 +118,19 @@ inline CellType CellType::by_id(uint8_t id)
 
     switch (id)
     {
-    //                        id, ndim, nnode, nedge, nsurface
-    MM_DECL_SWITCH_CELL_TYPE(  0,    0,     0,     0,        0 ) // non-type
-    MM_DECL_SWITCH_CELL_TYPE(  1,    0,     1,     0,        0 ) // point/node/vertex
-    MM_DECL_SWITCH_CELL_TYPE(  2,    1,     2,     0,        0 ) // line/edge
-    MM_DECL_SWITCH_CELL_TYPE(  3,    2,     4,     4,        0 ) // quadrilateral
-    MM_DECL_SWITCH_CELL_TYPE(  4,    2,     3,     3,        0 ) // triangle
-    MM_DECL_SWITCH_CELL_TYPE(  5,    3,     8,    12,        6 ) // hexahedron/brick
-    MM_DECL_SWITCH_CELL_TYPE(  6,    3,     4,     6,        4 ) // tetrahedron
-    MM_DECL_SWITCH_CELL_TYPE(  7,    3,     6,     9,        5 ) // prism
-    MM_DECL_SWITCH_CELL_TYPE(  8,    3,     5,     8,        5 ) // pyramid
-    default: return CellType{}; break;
+        // clang-format off
+        //                        id, ndim, nnode, nedge, nsurface
+        MM_DECL_SWITCH_CELL_TYPE(  0,    0,     0,     0,        0 ) // non-type
+        MM_DECL_SWITCH_CELL_TYPE(  1,    0,     1,     0,        0 ) // point/node/vertex
+        MM_DECL_SWITCH_CELL_TYPE(  2,    1,     2,     0,        0 ) // line/edge
+        MM_DECL_SWITCH_CELL_TYPE(  3,    2,     4,     4,        0 ) // quadrilateral
+        MM_DECL_SWITCH_CELL_TYPE(  4,    2,     3,     3,        0 ) // triangle
+        MM_DECL_SWITCH_CELL_TYPE(  5,    3,     8,    12,        6 ) // hexahedron/brick
+        MM_DECL_SWITCH_CELL_TYPE(  6,    3,     4,     6,        4 ) // tetrahedron
+        MM_DECL_SWITCH_CELL_TYPE(  7,    3,     6,     9,        5 ) // prism
+        MM_DECL_SWITCH_CELL_TYPE(  8,    3,     5,     8,        5 ) // pyramid
+        default: return CellType{}; break;
+        // clang-format on
     }
 
     #undef MM_DECL_SWITCH_CELL_TYPE

--- a/include/modmesh/mesh/boundary.hpp
+++ b/include/modmesh/mesh/boundary.hpp
@@ -505,11 +505,13 @@ void StaticMeshBase<D, ND>::fill_ghost()
                 real_type const du0 = crd[0] - m_fccnd(ifc, 0);
                 real_type const du1 = crd[1] - m_fccnd(ifc, 1);
                 real_type const du2 = crd[2] - m_fccnd(ifc, 2);
+                // clang-format off
                 real_type const vob = std::fabs
                 (
                     (du0*m_fcnml(ifc, 0) + du1*m_fcnml(ifc, 1) + du2*m_fcnml(ifc, 2))
                   * m_fcara(ifc)
                 );
+                // clang-format on
                 voc += vob;
                 real_type const dv0 = m_fccnd(ifc, 0) + du0/4;
                 real_type const dv1 = m_fccnd(ifc, 1) + du1/4;

--- a/include/modmesh/mesh/boundary.hpp
+++ b/include/modmesh/mesh/boundary.hpp
@@ -43,12 +43,12 @@ namespace modmesh
  *
  * And fcnds could be reordered.
  */
-template < typename D /* derived type */, uint8_t ND >
+template <typename D /* derived type */, uint8_t ND>
 /* NOLINTNEXTLINE(readability-function-cognitive-complexity) */
 void StaticMeshBase<D, ND>::build_boundary()
 {
     assert(0 == m_nbound); // nothing should touch m_nbound beforehand.
-    for (size_t it = 0 ; it < fccls().shape(0) ; ++it)
+    for (size_t it = 0; it < fccls().shape(0); ++it)
     {
         if (fccls()(it, 1) < 0)
         {
@@ -59,7 +59,7 @@ void StaticMeshBase<D, ND>::build_boundary()
 
     std::vector<int_type> allfacn(m_nbound);
     size_t ait = 0;
-    for (size_t ifc = 0 ; ifc < nface() ; ++ifc)
+    for (size_t ifc = 0; ifc < nface(); ++ifc)
     {
         if (fcjcl(ifc) < 0)
         {
@@ -72,11 +72,11 @@ void StaticMeshBase<D, ND>::build_boundary()
     std::vector<bool> specified(m_nbound, false);
     size_t ibfc = 0;
     ssize_t nleft = m_nbound;
-    for (size_t ibnd = 0 ; ibnd < m_bcs.size() ; ++ibnd)
+    for (size_t ibnd = 0; ibnd < m_bcs.size(); ++ibnd)
     {
         StaticMeshBC & bnd = m_bcs[ibnd];
         auto & bfacn = bnd.facn();
-        for (size_t bfit = 0 ; bfit < bfacn.nbody() ; ++bfit)
+        for (size_t bfit = 0; bfit < bfacn.nbody(); ++bfit)
         {
             /**
              * First column is the face index in block.  The second column is the face
@@ -103,7 +103,7 @@ void StaticMeshBase<D, ND>::build_boundary()
         auto & bfacn = bnd.facn();
         size_t bfit = 0;
         size_t ibnd = m_bcs.size();
-        for (size_t sit = 0 ; sit < m_nbound ; ++sit)   // Specified ITerator.
+        for (size_t sit = 0; sit < m_nbound; ++sit) // Specified ITerator.
         {
             if (!specified[sit])
             {
@@ -116,42 +116,42 @@ void StaticMeshBase<D, ND>::build_boundary()
             }
         }
         m_bcs.push_back(std::move(bnd));
-        assert(m_bcs.size() == ibnd+1);
+        assert(m_bcs.size() == ibnd + 1);
     }
     assert(ibfc == m_nbound);
 }
 
-template < typename D /* derived type */, uint8_t ND >
+template <typename D /* derived type */, uint8_t ND>
 /* NOLINTNEXTLINE(readability-function-cognitive-complexity) */
 void StaticMeshBase<D, ND>::build_ghost()
 {
 
     std::tie(m_ngstnode, m_ngstface, m_ngstcell) = count_ghost();
 
-    #define MM_DECL_GHOST_SWAP1(N, T, D1, I) \
-    { \
+#define MM_DECL_GHOST_SWAP1(N, T, D1, I)                                  \
+    {                                                                     \
         SimpleArray<T> arr(std::vector<size_t>{m_ngst##D1 + m_n##D1}, I); \
-        arr.set_nghost(m_ngst##D1); \
-        for (int_type it = 0 ; it < static_cast<int_type>(m_n##D1) ; ++ it) \
-        { \
-            arr(it) = m_##N(it); \
-        } \
-        arr.swap(m_##N); \
+        arr.set_nghost(m_ngst##D1);                                       \
+        for (int_type it = 0; it < static_cast<int_type>(m_n##D1); ++it)  \
+        {                                                                 \
+            arr(it) = m_##N(it);                                          \
+        }                                                                 \
+        arr.swap(m_##N);                                                  \
     }
 
-    #define MM_DECL_GHOST_SWAP2(N, T, D1, D2, I) \
-    { \
+#define MM_DECL_GHOST_SWAP2(N, T, D1, D2, I)                                  \
+    {                                                                         \
         SimpleArray<T> arr(std::vector<size_t>{m_ngst##D1 + m_n##D1, D2}, I); \
-        arr.set_nghost(m_ngst##D1); \
-        for (int_type it = 0 ; it < static_cast<int_type>(m_n##D1) ; ++ it) \
-        { \
-            for (int_type jt = 0 ; jt < static_cast<int_type>(D2) ; ++jt) \
-            { \
-                arr(it, jt) = m_##N(it, jt); \
-            } \
-            arr(it) = m_##N(it); \
-        } \
-        arr.swap(m_##N); \
+        arr.set_nghost(m_ngst##D1);                                           \
+        for (int_type it = 0; it < static_cast<int_type>(m_n##D1); ++it)      \
+        {                                                                     \
+            for (int_type jt = 0; jt < static_cast<int_type>(D2); ++jt)       \
+            {                                                                 \
+                arr(it, jt) = m_##N(it, jt);                                  \
+            }                                                                 \
+            arr(it) = m_##N(it);                                              \
+        }                                                                     \
+        arr.swap(m_##N);                                                      \
     }
 
     // geometry arrays.
@@ -166,16 +166,15 @@ void StaticMeshBase<D, ND>::build_ghost()
     MM_DECL_GHOST_SWAP1(cltpn, int_type, cell, 0)
     MM_DECL_GHOST_SWAP1(clgrp, int_type, cell, -1)
     // connectivity arrays.
-    MM_DECL_GHOST_SWAP2(fcnds, int_type, face, FCMND+1, -1)
+    MM_DECL_GHOST_SWAP2(fcnds, int_type, face, FCMND + 1, -1)
     MM_DECL_GHOST_SWAP2(fccls, int_type, face, FCREL, -1)
-    MM_DECL_GHOST_SWAP2(clnds, int_type, cell, CLMND+1, -1)
-    MM_DECL_GHOST_SWAP2(clfcs, int_type, cell, CLMFC+1, -1)
+    MM_DECL_GHOST_SWAP2(clnds, int_type, cell, CLMND + 1, -1)
+    MM_DECL_GHOST_SWAP2(clfcs, int_type, cell, CLMFC + 1, -1)
 
-    #undef MM_DECL_GHOST_SWAP1
-    #undef MM_DECL_GHOST_SWAP2
+#undef MM_DECL_GHOST_SWAP1
+#undef MM_DECL_GHOST_SWAP2
 
     fill_ghost();
-
 }
 
 /**
@@ -184,13 +183,13 @@ void StaticMeshBase<D, ND>::build_ghost()
  * @return std::tuple<size_t, size_t, size_t>
  *  ngstnode, ngstface, ngstcell
  */
-template < typename D /* derived type */, uint8_t ND >
+template <typename D /* derived type */, uint8_t ND>
 /* NOLINTNEXTLINE(readability-function-cognitive-complexity) */
 std::tuple<size_t, size_t, size_t> StaticMeshBase<D, ND>::count_ghost() const
 {
     size_t ngstface = 0;
     size_t ngstnode = 0;
-    for (size_t ibfc = 0 ; ibfc < m_nbound ; ++ibfc)
+    for (size_t ibfc = 0; ibfc < m_nbound; ++ibfc)
     {
         const int_type ifc = m_bndfcs(ibfc, 0);
         const int_type icl = m_fccls(ifc, 0);
@@ -217,12 +216,12 @@ std::tuple<size_t, size_t, size_t> StaticMeshBase<D, ND>::count_ghost() const
  * indices for ghost information should be carefully treated.  All the
  * ghost indices are negative in shared arrays.
  */
-template < typename D /* derived type */, uint8_t ND >
+template <typename D /* derived type */, uint8_t ND>
 /* NOLINTNEXTLINE(readability-function-cognitive-complexity) */
 void StaticMeshBase<D, ND>::fill_ghost()
 {
     // arrays.
-    std::array<std::array<real_type, NDIM>, FCMND+2> cfd; // NOLINT(cppcoreguidelines-pro-type-member-init)
+    std::array<std::array<real_type, NDIM>, FCMND + 2> cfd; // NOLINT(cppcoreguidelines-pro-type-member-init)
     std::array<real_type, NDIM> crd; // NOLINT(cppcoreguidelines-pro-type-member-init)
     std::array<std::array<real_type, NDIM>, FCMND> radvec; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
@@ -232,24 +231,24 @@ void StaticMeshBase<D, ND>::fill_ghost()
     // coordinate.
     int_type ignd = -1;
     int_type igfc = -1;
-    for (int_type igcl = -1 ; igcl >= -static_cast<int_type>(ngstcell()) ; --igcl)
+    for (int_type igcl = -1; igcl >= -static_cast<int_type>(ngstcell()); --igcl)
     {
-        int_type const ibfc = m_bndfcs(-igcl-1, 0);
+        int_type const ibfc = m_bndfcs(-igcl - 1, 0);
         int_type const icl = m_fccls(ibfc, 0);
         // copy cell type and group.
         m_cltpn(igcl) = m_cltpn(icl);
         m_clgrp(igcl) = m_clgrp(icl);
         // process node list in ghost cell.
-        for (size_t inl = 0 ; inl <= CLMND ; ++inl) // copy nodes from current in-cell.
+        for (size_t inl = 0; inl <= CLMND; ++inl) // copy nodes from current in-cell.
         {
             m_clnds(igcl, inl) = m_clnds(icl, inl);
         }
-        for (size_t inl = 1 ; inl <= static_cast<size_t>(m_clnds(icl, 0)) ; ++inl)
+        for (size_t inl = 1; inl <= static_cast<size_t>(m_clnds(icl, 0)); ++inl)
         {
             int_type const ind = m_clnds(icl, inl);
             // try to find the node in the boundary face.
             bool mk_found = false;
-            for (size_t inf = 1 ; inf <= static_cast<size_t>(m_fcnds(ibfc, 0)) ; ++inf)
+            for (size_t inf = 1; inf <= static_cast<size_t>(m_fcnds(ibfc, 0)); ++inf)
             {
                 if (ind == m_fcnds(ibfc, inf))
                 {
@@ -265,13 +264,13 @@ void StaticMeshBase<D, ND>::fill_ghost()
                 // mirror coordinate of ghost cell.
                 // NOTE: fcnml always points outward.
                 real_type dist = 0.0;
-                for (size_t idm = 0 ; idm < NDIM ; ++idm)
+                for (size_t idm = 0; idm < NDIM; ++idm)
                 {
                     dist += (m_fccnd(ibfc, idm) - m_ndcrd(ind, idm)) * m_fcnml(ibfc, idm);
                 }
-                for (size_t idm = 0 ; idm < NDIM ; ++idm)
+                for (size_t idm = 0; idm < NDIM; ++idm)
                 {
-                    m_ndcrd(igcl, idm) = m_ndcrd(icl, idm) + 2*dist*m_fcnml(ibfc, idm);
+                    m_ndcrd(igcl, idm) = m_ndcrd(icl, idm) + 2 * dist * m_fcnml(ibfc, idm);
                 }
                 // decrement ghost node counter.
                 ignd -= 1;
@@ -280,35 +279,38 @@ void StaticMeshBase<D, ND>::fill_ghost()
         // set the relating cell as ghost cell.
         m_fccls(ibfc, 1) = igcl;
         // process face list in ghost cell.
-        for (size_t ifl = 0 ; ifl <= CLMFC ; ++ifl)
+        for (size_t ifl = 0; ifl <= CLMFC; ++ifl)
         {
             m_clfcs(igcl, ifl) = m_clfcs(icl, ifl); // copy in-face to ghost.
         }
-        for (size_t ifl = 1 ; ifl <= static_cast<size_t>(m_clfcs(icl, 0)) ; ++ifl)
+        for (size_t ifl = 1; ifl <= static_cast<size_t>(m_clfcs(icl, 0)); ++ifl)
         {
-            int_type const ifc = m_clfcs(icl, ifl);  // the face to be processed.
-            if (ifc == ibfc) { continue; }  // if boundary face then skip.
-            m_fctpn(igfc) = m_fctpn(ifc);  // copy face type.
-            m_fccls(igfc, 0) = igcl;  // save to ghost fccls.
-            m_clfcs(igcl, ifl) = igfc;  // save to ghost clfcs.
+            int_type const ifc = m_clfcs(icl, ifl); // the face to be processed.
+            if (ifc == ibfc)
+            {
+                continue;
+            } // if boundary face then skip.
+            m_fctpn(igfc) = m_fctpn(ifc); // copy face type.
+            m_fccls(igfc, 0) = igcl; // save to ghost fccls.
+            m_clfcs(igcl, ifl) = igfc; // save to ghost clfcs.
             // face-to-node connectivity.
-            for (size_t inf = 0 ; inf <= FCMND ; ++inf)
+            for (size_t inf = 0; inf <= FCMND; ++inf)
             {
                 m_fcnds(igfc, inf) = m_fcnds(ifc, inf);
             }
-            for (size_t inf = 1 ; inf <= static_cast<size_t>(m_fcnds(igfc, 0)) ; ++inf)
+            for (size_t inf = 1; inf <= static_cast<size_t>(m_fcnds(igfc, 0)); ++inf)
             {
                 int_type const ind = m_fcnds(igfc, inf);
                 if (gstndmap[ind] != static_cast<int_type>(nnode()))
                 {
-                    m_fcnds(igfc, inf) = gstndmap[ind];  // save gstnode to fcnds.
+                    m_fcnds(igfc, inf) = gstndmap[ind]; // save gstnode to fcnds.
                 }
             }
             // decrement ghost face counter.
             igfc -= 1;
         }
         // erase node map record.
-        for (size_t inl = 1 ; inl <= static_cast<size_t>(m_clnds(icl, 0)); ++inl)
+        for (size_t inl = 1; inl <= static_cast<size_t>(m_clnds(icl, 0)); ++inl)
         {
             gstndmap[m_clnds(icl, inl)] = nnode();
         }
@@ -318,7 +320,7 @@ void StaticMeshBase<D, ND>::fill_ghost()
     if (NDIM == 2)
     {
         // 2D faces must be edge.
-        for (int_type ifc = -1 ; ifc >= -static_cast<int_type>(ngstface()) ; --ifc)
+        for (int_type ifc = -1; ifc >= -static_cast<int_type>(ngstface()); --ifc)
         {
             // point 1.
             int_type ind = m_fcnds(ifc, 1);
@@ -335,45 +337,45 @@ void StaticMeshBase<D, ND>::fill_ghost()
     }
     else if (NDIM == 3)
     {
-        for (int_type ifc = -1 ; ifc >= -static_cast<int_type>(ngstface()) ; --ifc)
+        for (int_type ifc = -1; ifc >= -static_cast<int_type>(ngstface()); --ifc)
         {
             // find averaged point.
             cfd[0][0] = cfd[0][1] = cfd[0][2] = 0.0;
             size_t const nnd = m_fcnds(ifc, 0);
-            for (size_t inf = 1 ; inf <= nnd ; ++inf)
+            for (size_t inf = 1; inf <= nnd; ++inf)
             {
                 int_type const ind = m_fcnds(ifc, inf);
-                cfd[inf][0]  = m_ndcrd(ind, 0);
-                cfd[0  ][0] += m_ndcrd(ind, 0);
-                cfd[inf][1]  = m_ndcrd(ind, 1);
-                cfd[0  ][1] += m_ndcrd(ind, 1);
-                cfd[inf][2]  = m_ndcrd(ind, 2);
-                cfd[0  ][2] += m_ndcrd(ind, 2);
+                cfd[inf][0] = m_ndcrd(ind, 0);
+                cfd[0][0] += m_ndcrd(ind, 0);
+                cfd[inf][1] = m_ndcrd(ind, 1);
+                cfd[0][1] += m_ndcrd(ind, 1);
+                cfd[inf][2] = m_ndcrd(ind, 2);
+                cfd[0][2] += m_ndcrd(ind, 2);
             }
-            cfd[nnd+1][0] = cfd[1][0];
-            cfd[nnd+1][1] = cfd[1][1];
-            cfd[nnd+1][2] = cfd[1][2];
+            cfd[nnd + 1][0] = cfd[1][0];
+            cfd[nnd + 1][1] = cfd[1][1];
+            cfd[nnd + 1][2] = cfd[1][2];
             cfd[0][0] /= nnd;
             cfd[0][1] /= nnd;
             cfd[0][2] /= nnd;
             // calculate area.
             m_fccnd(ifc, 0) = m_fccnd(ifc, 1) = m_fccnd(ifc, 2) = 0.0;
             real_type voc = 0.0;
-            for (size_t inf = 1 ; inf <= nnd ; ++inf)
+            for (size_t inf = 1; inf <= nnd; ++inf)
             {
-                crd[0] = (cfd[0][0] + cfd[inf][0] + cfd[inf+1][0])/3;
-                crd[1] = (cfd[0][1] + cfd[inf][1] + cfd[inf+1][1])/3;
-                crd[2] = (cfd[0][2] + cfd[inf][2] + cfd[inf+1][2])/3;
+                crd[0] = (cfd[0][0] + cfd[inf][0] + cfd[inf + 1][0]) / 3;
+                crd[1] = (cfd[0][1] + cfd[inf][1] + cfd[inf + 1][1]) / 3;
+                crd[2] = (cfd[0][2] + cfd[inf][2] + cfd[inf + 1][2]) / 3;
                 real_type const du0 = cfd[inf][0] - cfd[0][0];
                 real_type const du1 = cfd[inf][1] - cfd[0][1];
                 real_type const du2 = cfd[inf][2] - cfd[0][2];
-                real_type const dv0 = cfd[inf+1][0] - cfd[0][0];
-                real_type const dv1 = cfd[inf+1][1] - cfd[0][1];
-                real_type const dv2 = cfd[inf+1][2] - cfd[0][2];
-                real_type const dw0 = du1*dv2 - du2*dv1;
-                real_type const dw1 = du2*dv0 - du0*dv2;
-                real_type const dw2 = du0*dv1 - du1*dv0;
-                real_type const vob = std::sqrt(dw0*dw0 + dw1*dw1 + dw2*dw2);
+                real_type const dv0 = cfd[inf + 1][0] - cfd[0][0];
+                real_type const dv1 = cfd[inf + 1][1] - cfd[0][1];
+                real_type const dv2 = cfd[inf + 1][2] - cfd[0][2];
+                real_type const dw0 = du1 * dv2 - du2 * dv1;
+                real_type const dw1 = du2 * dv0 - du0 * dv2;
+                real_type const dw2 = du0 * dv1 - du1 * dv0;
+                real_type const vob = std::sqrt(dw0 * dw0 + dw1 * dw1 + dw2 * dw2);
                 m_fccnd(ifc, 0) += crd[0] * vob;
                 m_fccnd(ifc, 1) += crd[1] * vob;
                 m_fccnd(ifc, 2) += crd[2] * vob;
@@ -388,7 +390,7 @@ void StaticMeshBase<D, ND>::fill_ghost()
     // compute ghost face normal vector and area.
     if (NDIM == 2)
     {
-        for (int_type ifc = -1 ; ifc >= -static_cast<int_type>(ngstface()) ; --ifc)
+        for (int_type ifc = -1; ifc >= -static_cast<int_type>(ngstface()); --ifc)
         {
             // 2D faces are always lines.
             int_type const ind = m_fcnds(ifc, 1);
@@ -397,7 +399,7 @@ void StaticMeshBase<D, ND>::fill_ghost()
             m_fcnml(ifc, 0) = m_ndcrd(jnd, 1) - m_ndcrd(ind, 1);
             m_fcnml(ifc, 1) = m_ndcrd(ind, 0) - m_ndcrd(jnd, 0);
             // face ara.
-            m_fcara(ifc) = std::sqrt(m_fcnml(ifc, 0)*m_fcnml(ifc, 0) + m_fcnml(ifc, 1)*m_fcnml(ifc, 1));
+            m_fcara(ifc) = std::sqrt(m_fcnml(ifc, 0) * m_fcnml(ifc, 0) + m_fcnml(ifc, 1) * m_fcnml(ifc, 1));
             // normalize face normal.
             m_fcnml(ifc, 0) /= m_fcara(ifc);
             m_fcnml(ifc, 1) /= m_fcara(ifc);
@@ -405,34 +407,30 @@ void StaticMeshBase<D, ND>::fill_ghost()
     }
     else if (NDIM == 3)
     {
-        for (int_type ifc = -1 ; ifc >= -static_cast<int_type>(ngstface()) ; --ifc)
+        for (int_type ifc = -1; ifc >= -static_cast<int_type>(ngstface()); --ifc)
         {
             // compute radial vector.
             size_t const nnd = m_fcnds(ifc);
-            for (size_t inf = 0 ; inf < nnd ; ++inf)
+            for (size_t inf = 0; inf < nnd; ++inf)
             {
-                int_type const ind = m_fcnds(ifc, inf+1);
+                int_type const ind = m_fcnds(ifc, inf + 1);
                 radvec[inf][0] = m_ndcrd(ind, 0) - m_fccnd(ifc, 0);
                 radvec[inf][1] = m_ndcrd(ind, 1) - m_fccnd(ifc, 1);
                 radvec[inf][2] = m_ndcrd(ind, 2) - m_fccnd(ifc, 2);
             }
             // compute cross product.
-            m_fcnml(ifc, 0) = radvec[nnd-1][1]*radvec[0][2] - radvec[nnd-1][2]*radvec[0][1];
-            m_fcnml(ifc, 1) = radvec[nnd-1][2]*radvec[0][0] - radvec[nnd-1][0]*radvec[0][2];
-            m_fcnml(ifc, 2) = radvec[nnd-1][0]*radvec[0][1] - radvec[nnd-1][1]*radvec[0][0];
-            for (size_t ind = 1 ; ind < nnd ; ++ind)
+            m_fcnml(ifc, 0) = radvec[nnd - 1][1] * radvec[0][2] - radvec[nnd - 1][2] * radvec[0][1];
+            m_fcnml(ifc, 1) = radvec[nnd - 1][2] * radvec[0][0] - radvec[nnd - 1][0] * radvec[0][2];
+            m_fcnml(ifc, 2) = radvec[nnd - 1][0] * radvec[0][1] - radvec[nnd - 1][1] * radvec[0][0];
+            for (size_t ind = 1; ind < nnd; ++ind)
             {
-                m_fcnml(ifc, 0) += radvec[ind-1][1]*radvec[ind][2] - radvec[ind-1][2]*radvec[ind][1];
-                m_fcnml(ifc, 1) += radvec[ind-1][2]*radvec[ind][0] - radvec[ind-1][0]*radvec[ind][2];
-                m_fcnml(ifc, 2) += radvec[ind-1][0]*radvec[ind][1] - radvec[ind-1][1]*radvec[ind][0];
+                m_fcnml(ifc, 0) += radvec[ind - 1][1] * radvec[ind][2] - radvec[ind - 1][2] * radvec[ind][1];
+                m_fcnml(ifc, 1) += radvec[ind - 1][2] * radvec[ind][0] - radvec[ind - 1][0] * radvec[ind][2];
+                m_fcnml(ifc, 2) += radvec[ind - 1][0] * radvec[ind][1] - radvec[ind - 1][1] * radvec[ind][0];
             }
             // compute face area.
-            m_fcara(ifc, 0) = std::sqrt
-            (
-                m_fcnml(ifc, 0)*m_fcnml(ifc, 0)
-              + m_fcnml(ifc, 1)*m_fcnml(ifc, 1)
-              + m_fcnml(ifc, 2)*m_fcnml(ifc, 2)
-            );
+            m_fcara(ifc, 0) = std::sqrt(
+                m_fcnml(ifc, 0) * m_fcnml(ifc, 0) + m_fcnml(ifc, 1) * m_fcnml(ifc, 1) + m_fcnml(ifc, 2) * m_fcnml(ifc, 2));
             // normalize normal vector.
             m_fcnml(ifc, 0) /= m_fcnml(ifc);
             m_fcnml(ifc, 1) /= m_fcnml(ifc);
@@ -445,12 +443,12 @@ void StaticMeshBase<D, ND>::fill_ghost()
     // compute cell centroids.
     if (NDIM == 2)
     {
-        for (int_type icl = -1 ; icl >= -static_cast<int_type>(ngstcell()) ; --icl)
+        for (int_type icl = -1; icl >= -static_cast<int_type>(ngstcell()); --icl)
         {
             // averaged point.
             crd[0] = crd[1] = 0.0;
             size_t const nnd = m_clnds(icl, 0);
-            for (size_t inl = 1 ; inl <= nnd ; ++inl)
+            for (size_t inl = 1; inl <= nnd; ++inl)
             {
                 int_type const ind = m_clnds(icl, inl);
                 crd[0] += m_ndcrd(ind, 0);
@@ -462,15 +460,15 @@ void StaticMeshBase<D, ND>::fill_ghost()
             m_clcnd(icl, 0) = m_clcnd(icl, 1) = 0.0;
             real_type voc = 0.0;
             size_t nfc = m_clfcs(icl, 0);
-            for (size_t ifl = 1 ; ifl <= nfc ; ++ifl)
+            for (size_t ifl = 1; ifl <= nfc; ++ifl)
             {
                 int_type const ifc = m_clfcs(icl, ifl);
                 real_type const du0 = crd[0] - m_fccnd(ifc, 0);
                 real_type const du1 = crd[1] - m_fccnd(ifc, 1);
-                real_type const vob = std::abs(du0*m_fcnml(ifc, 0) + du1*m_fcnml(ifc, 1)) * m_fcara(ifc);
+                real_type const vob = std::abs(du0 * m_fcnml(ifc, 0) + du1 * m_fcnml(ifc, 1)) * m_fcara(ifc);
                 voc += vob;
-                real_type const dv0 = m_fccnd(ifc, 0) + du0/3;
-                real_type const dv1 = m_fccnd(ifc, 1) + du1/3;
+                real_type const dv0 = m_fccnd(ifc, 0) + du0 / 3;
+                real_type const dv1 = m_fccnd(ifc, 1) + du1 / 3;
                 m_clcnd(icl, 0) += dv0 * vob;
                 m_clcnd(icl, 1) += dv1 * vob;
             }
@@ -480,12 +478,12 @@ void StaticMeshBase<D, ND>::fill_ghost()
     }
     else if (NDIM == 3)
     {
-        for (int_type icl = -1 ; icl >= -static_cast<int_type>(ngstcell()) ; --icl)
+        for (int_type icl = -1; icl >= -static_cast<int_type>(ngstcell()); --icl)
         {
             // averaged point.
             crd[0] = crd[1] = crd[2] = 0.0;
             size_t const nnd = m_clnds(icl, 0);
-            for (size_t inl = 1 ; inl <= nnd ; ++inl)
+            for (size_t inl = 1; inl <= nnd; ++inl)
             {
                 int_type const ind = m_clnds(icl, inl);
                 crd[0] += m_ndcrd(ind, 0);
@@ -499,7 +497,7 @@ void StaticMeshBase<D, ND>::fill_ghost()
             m_clcnd(icl, 0) = m_clcnd(icl, 1) = m_clcnd(icl, 2) = 0.0;
             real_type voc = 0.0;
             size_t const nfc = m_clfcs(icl, 0);
-            for (size_t ifl = 1 ; ifl <= nfc ; ++ifl)
+            for (size_t ifl = 1; ifl <= nfc; ++ifl)
             {
                 int_type const ifc = m_clfcs(icl, ifl);
                 real_type const du0 = crd[0] - m_fccnd(ifc, 0);
@@ -513,9 +511,9 @@ void StaticMeshBase<D, ND>::fill_ghost()
                 );
                 // clang-format on
                 voc += vob;
-                real_type const dv0 = m_fccnd(ifc, 0) + du0/4;
-                real_type const dv1 = m_fccnd(ifc, 1) + du1/4;
-                real_type const dv2 = m_fccnd(ifc, 2) + du2/4;
+                real_type const dv0 = m_fccnd(ifc, 0) + du0 / 4;
+                real_type const dv1 = m_fccnd(ifc, 1) + du1 / 4;
+                real_type const dv2 = m_fccnd(ifc, 2) + du2 / 4;
                 m_clcnd(icl, 0) += dv0 * vob;
                 m_clcnd(icl, 1) += dv1 * vob;
                 m_clcnd(icl, 2) += dv2 * vob;
@@ -527,15 +525,15 @@ void StaticMeshBase<D, ND>::fill_ghost()
     }
 
     // compute volume for each ghost cell.
-    for (int_type icl = -1 ; icl >= -static_cast<int_type>(ngstcell()) ; --icl)
+    for (int_type icl = -1; icl >= -static_cast<int_type>(ngstcell()); --icl)
     {
         m_clvol(icl) = 0.0;
-        for (size_t it = 1 ; it <= static_cast<size_t>(m_clfcs(icl, 0)) ; ++it)
+        for (size_t it = 1; it <= static_cast<size_t>(m_clfcs(icl, 0)); ++it)
         {
             int_type const ifc = m_clfcs(icl, it);
             // calculate volume associated with each face.
             real_type vol = 0.0;
-            for (size_t idm = 0 ; idm < NDIM ; ++idm)
+            for (size_t idm = 0; idm < NDIM; ++idm)
             {
                 vol += (m_fccnd(ifc, idm) - m_clcnd(icl, idm)) * m_fcnml(ifc, idm);
             }
@@ -546,7 +544,7 @@ void StaticMeshBase<D, ND>::fill_ghost()
             {
                 if (m_fccls(ifc, 0) == icl)
                 {
-                    for (size_t idm = 0 ; idm < NDIM ; ++idm)
+                    for (size_t idm = 0; idm < NDIM; ++idm)
                     {
                         m_fcnml(ifc, idm) = -m_fcnml(ifc, idm);
                     }
@@ -560,7 +558,6 @@ void StaticMeshBase<D, ND>::fill_ghost()
         m_clvol(icl) /= NDIM;
     }
 }
-
 
 } /* end namespace modmesh */
 

--- a/include/modmesh/mesh/interior.hpp
+++ b/include/modmesh/mesh/interior.hpp
@@ -344,11 +344,13 @@ struct FaceBuilder
 
     static size_t count_mface(SimpleArray<int_type> const & tcltpn)
     {
+        // clang-format off
         return std::accumulate
         (
             tcltpn.body(), tcltpn.body()+tcltpn.nbody(), 0
           , [](size_t a, int8_t b){ return a + CellType::by_id(b).nface(); }
         );
+        // clang-format on
     }
 
     void populate()
@@ -435,12 +437,14 @@ struct FaceBuilder
             // scan all nodes in ifc and jfc to see if all the same.
             for (int_type jnf = 1 ; jnf <= fcnds(jfc, 0) ; ++jnf)
             {
+                // clang-format off
                 auto result = std::find
                 (
                     fcnds.vptr(ifc, 1)
                   , fcnds.vptr(ifc, fcnds(ifc, 0)+1)
                   , fcnds(jfc, jnf)
                 );
+                // clang-format off
                 if (result != fcnds.vptr(ifc, fcnds(ifc, 0)+1))
                 {
                     ++cond;

--- a/include/modmesh/mesh/interior.hpp
+++ b/include/modmesh/mesh/interior.hpp
@@ -36,9 +36,9 @@ namespace modmesh
 namespace detail
 {
 
-template < typename N >
+template <typename N>
 struct FaceBuilder
-  : public StaticMeshConstant
+    : public StaticMeshConstant
 {
 
     using number_base = N;
@@ -51,10 +51,10 @@ struct FaceBuilder
         constexpr const size_t NFACE = 2;
         // extract 2 points from a line.
         clfcs(icl, 0) = NFACE;
-        for (size_t i = 0 ; i < NFACE ; ++i)
+        for (size_t i = 0; i < NFACE; ++i)
         {
-            fctpn(ifc+i) = CellType::POINT;
-            fcnds(ifc+i, 0) = 1; // number of nodes per face.
+            fctpn(ifc + i) = CellType::POINT;
+            fcnds(ifc + i, 0) = 1; // number of nodes per face.
         }
         // face 1.
         clfcs(icl, 1) = ifc;
@@ -71,10 +71,10 @@ struct FaceBuilder
         constexpr const size_t NFACE = 4;
         // extract 4 lines from a quadrilateral.
         clfcs(icl, 0) = NFACE;
-        for (size_t i = 0 ; i < NFACE ; ++i)
+        for (size_t i = 0; i < NFACE; ++i)
         {
-            fctpn(ifc+i) = CellType::LINE;
-            fcnds(ifc+i, 0) = 2; // number of nodes per face.
+            fctpn(ifc + i) = CellType::LINE;
+            fcnds(ifc + i, 0) = 2; // number of nodes per face.
         }
         // face 1.
         clfcs(icl, 1) = ifc;
@@ -101,10 +101,10 @@ struct FaceBuilder
         constexpr const size_t NFACE = 3;
         // extract 3 lines from a triangle.
         clfcs(icl, 0) = NFACE;
-        for (size_t i = 0 ; i < NFACE ; ++i)
+        for (size_t i = 0; i < NFACE; ++i)
         {
-            fctpn(ifc+i) = CellType::LINE;
-            fcnds(ifc+i, 0) = 2; // number of nodes per face.
+            fctpn(ifc + i) = CellType::LINE;
+            fcnds(ifc + i, 0) = 2; // number of nodes per face.
         }
         // face 1.
         clfcs(icl, 1) = ifc;
@@ -128,10 +128,10 @@ struct FaceBuilder
         constexpr const size_t NFACE = 6;
         // extract 6 quadrilaterals from a hexahedron.
         clfcs(icl, 0) = NFACE;
-        for (size_t i = 0 ; i < NFACE ; ++i)
+        for (size_t i = 0; i < NFACE; ++i)
         {
-            fctpn(ifc+i) = CellType::QUADRILATERAL;
-            fcnds(ifc+i, 0) = 4; // number of nodes per face.
+            fctpn(ifc + i) = CellType::QUADRILATERAL;
+            fcnds(ifc + i, 0) = 4; // number of nodes per face.
         }
         // face 1.
         clfcs(icl, 1) = ifc;
@@ -182,10 +182,10 @@ struct FaceBuilder
         constexpr const size_t NFACE = 4;
         // extract 4 triangles from a tetrahedron.
         clfcs(icl, 0) = NFACE;
-        for (size_t i = 0 ; i < NFACE ; ++i)
+        for (size_t i = 0; i < NFACE; ++i)
         {
-            fctpn(ifc+i) = CellType::TRIANGLE;
-            fcnds(ifc+i, 0) = 3; // number of nodes per face.
+            fctpn(ifc + i) = CellType::TRIANGLE;
+            fcnds(ifc + i, 0) = 3; // number of nodes per face.
         }
         // face 1.
         clfcs(icl, 1) = ifc;
@@ -218,15 +218,15 @@ struct FaceBuilder
         constexpr const size_t NFACE = 5;
         // extract 2 triangles and 3 quadrilaterals from a prism.
         clfcs(icl, 0) = NFACE;
-        for (size_t i = 0 ; i < 2 ; ++i)
+        for (size_t i = 0; i < 2; ++i)
         {
-            fctpn(ifc+i) = CellType::TRIANGLE;
-            fcnds(ifc+i, 0) = 3; // number of nodes per face.
+            fctpn(ifc + i) = CellType::TRIANGLE;
+            fcnds(ifc + i, 0) = 3; // number of nodes per face.
         }
-        for (size_t i = 2 ; i < NFACE ; ++i)
+        for (size_t i = 2; i < NFACE; ++i)
         {
-            fctpn(ifc+i) = CellType::QUADRILATERAL;
-            fcnds(ifc+i, 0) = 4; // number of nodes per face.
+            fctpn(ifc + i) = CellType::QUADRILATERAL;
+            fcnds(ifc + i, 0) = 4; // number of nodes per face.
         }
         // face 1.
         clfcs(icl, 1) = ifc;
@@ -269,15 +269,15 @@ struct FaceBuilder
         constexpr const size_t NFACE = 5;
         // extract 4 triangles and 1 quadrilaterals from a pyramid.
         clfcs(icl, 0) = NFACE;
-        for (size_t i = 0 ; i < 4 ; ++i)
+        for (size_t i = 0; i < 4; ++i)
         {
-            fctpn(ifc+i) = CellType::TRIANGLE;
-            fcnds(ifc+i, 0) = 3; // number of nodes per face.
+            fctpn(ifc + i) = CellType::TRIANGLE;
+            fcnds(ifc + i, 0) = 3; // number of nodes per face.
         }
-        for (size_t i = 4 ; i < NFACE ; ++i)
+        for (size_t i = 4; i < NFACE; ++i)
         {
-            fctpn(ifc+i) = CellType::QUADRILATERAL;
-            fcnds(ifc+i, 0) = 4; // number of nodes per face.
+            fctpn(ifc + i) = CellType::QUADRILATERAL;
+            fcnds(ifc + i, 0) = 4; // number of nodes per face.
         }
         // face 1.
         clfcs(icl, 1) = ifc;
@@ -327,15 +327,16 @@ struct FaceBuilder
 
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     FaceBuilder(size_t nnode_in, SimpleArray<int_type> const & cltpn_in, SimpleArray<int_type> const & clnds_in)
-      : nnode(nnode_in)
-      , nface(count_mface(cltpn_in))
-      , mface(nface)
-      , cltpn(cltpn_in), clnds(clnds_in)
-      , clfcs(small_vector<size_t>{cltpn.nbody(), CLMFC+1}, -1)
-      , fctpn(small_vector<size_t>{mface}, -1)
-      , fcnds(small_vector<size_t>{mface, FCMND+1}, -1)
-      , fccls(small_vector<size_t>{mface, FCREL}, -1)
-      , dedupmap(mface)
+        : nnode(nnode_in)
+        , nface(count_mface(cltpn_in))
+        , mface(nface)
+        , cltpn(cltpn_in)
+        , clnds(clnds_in)
+        , clfcs(small_vector<size_t>{cltpn.nbody(), CLMFC + 1}, -1)
+        , fctpn(small_vector<size_t>{mface}, -1)
+        , fcnds(small_vector<size_t>{mface, FCMND + 1}, -1)
+        , fccls(small_vector<size_t>{mface, FCREL}, -1)
+        , dedupmap(mface)
     {
         populate();
         make_dedupmap();
@@ -356,7 +357,7 @@ struct FaceBuilder
     void populate()
     {
         size_t ifc = 0;
-        for (size_t icl = 0 ; icl < cltpn.nbody() ; ++icl)
+        for (size_t icl = 0; icl < cltpn.nbody(); ++icl)
         {
             switch (cltpn(icl))
             {
@@ -391,10 +392,10 @@ struct FaceBuilder
     {
         // first pass: get the maximum number of faces.
         std::vector<size_t> ndnfc(nnode, 0);
-        for (size_t ifc = 0 ; ifc < mface ; ++ifc)
+        for (size_t ifc = 0; ifc < mface; ++ifc)
         {
             int_type const fcnnd = fcnds(ifc, 0);
-            for (int_type const * p = fcnds.vptr(ifc, 1) ; p != fcnds.vptr(ifc, fcnnd+1) ; ++p)
+            for (int_type const * p = fcnds.vptr(ifc, 1); p != fcnds.vptr(ifc, fcnnd + 1); ++p)
             {
                 ndnfc[*p] += 1;
             }
@@ -402,19 +403,19 @@ struct FaceBuilder
 
         // second pass: scan again to build hash table.
         size_t const ndmfc = *std::max_element(ndnfc.begin(), ndnfc.end());
-        SimpleArray<int_type> ndfcs(small_vector<size_t>{nnode, static_cast<size_t>(ndmfc)+1});
-        for (size_t ind = 0 ; ind < nnode ; ++ind)
+        SimpleArray<int_type> ndfcs(small_vector<size_t>{nnode, static_cast<size_t>(ndmfc) + 1});
+        for (size_t ind = 0; ind < nnode; ++ind)
         {
             ndfcs(ind, 0) = 0;
-            for (size_t it = 1 ; it <= ndmfc ; ++it)
+            for (size_t it = 1; it <= ndmfc; ++it)
             {
                 ndfcs(ind, it) = -1;
             }
         }
-        for (size_t ifc = 0 ; ifc < mface ; ++ifc)
+        for (size_t ifc = 0; ifc < mface; ++ifc)
         {
             int_type const fcnnd = fcnds(ifc, 0);
-            for (int_type const * p = fcnds.vptr(ifc, 1) ; p != fcnds.vptr(ifc, fcnnd+1) ; ++p)
+            for (int_type const * p = fcnds.vptr(ifc, 1); p != fcnds.vptr(ifc, fcnnd + 1); ++p)
             {
                 ndfcs(*p, 0) += 1;
                 ndfcs(*p, ndfcs(*p, 0)) = ifc;
@@ -435,7 +436,7 @@ struct FaceBuilder
         {
             int_type cond = 0;
             // scan all nodes in ifc and jfc to see if all the same.
-            for (int_type jnf = 1 ; jnf <= fcnds(jfc, 0) ; ++jnf)
+            for (int_type jnf = 1; jnf <= fcnds(jfc, 0); ++jnf)
             {
                 // clang-format off
                 auto result = std::find

--- a/include/modmesh/profile.hpp
+++ b/include/modmesh/profile.hpp
@@ -56,12 +56,16 @@ public:
         return instance;
     }
 
-    StopWatch() : m_start(clock_type::now()), m_stop(m_start) {}
+    StopWatch()
+        : m_start(clock_type::now())
+        , m_stop(m_start)
+    {
+    }
 
-    StopWatch(StopWatch const & ) = default;
-    StopWatch(StopWatch       &&) = default;
-    StopWatch & operator=(StopWatch const & ) = default;
-    StopWatch & operator=(StopWatch       &&) = default;
+    StopWatch(StopWatch const &) = default;
+    StopWatch(StopWatch &&) = default;
+    StopWatch & operator=(StopWatch const &) = default;
+    StopWatch & operator=(StopWatch &&) = default;
     ~StopWatch() = default;
 
     /**
@@ -140,7 +144,7 @@ public:
     std::string report() const
     {
         std::ostringstream ostm;
-        for (auto it = m_entry.begin() ; it != m_entry.end() ; ++it)
+        for (auto it = m_entry.begin(); it != m_entry.end(); ++it)
         {
             ostm
                 << it->first << " : "
@@ -183,15 +187,15 @@ public:
 
     void clear() { m_entry.clear(); }
 
-    TimeRegistry(TimeRegistry const & ) = delete;
-    TimeRegistry(TimeRegistry       &&) = delete;
-    TimeRegistry & operator=(TimeRegistry const & ) = delete;
-    TimeRegistry & operator=(TimeRegistry       &&) = delete;
+    TimeRegistry(TimeRegistry const &) = delete;
+    TimeRegistry(TimeRegistry &&) = delete;
+    TimeRegistry & operator=(TimeRegistry const &) = delete;
+    TimeRegistry & operator=(TimeRegistry &&) = delete;
 
     ~TimeRegistry() // NOLINT(modernize-use-equals-default)
     {
         // Uncomment for debugging.
-        //std::cout << report();
+        // std::cout << report();
     }
 
 private:
@@ -208,12 +212,15 @@ class ScopedTimer
 public:
 
     ScopedTimer() = delete;
-    ScopedTimer(ScopedTimer const & ) = delete;
-    ScopedTimer(ScopedTimer       &&) = delete;
-    ScopedTimer & operator=(ScopedTimer const & ) = delete;
-    ScopedTimer & operator=(ScopedTimer       &&) = delete;
+    ScopedTimer(ScopedTimer const &) = delete;
+    ScopedTimer(ScopedTimer &&) = delete;
+    ScopedTimer & operator=(ScopedTimer const &) = delete;
+    ScopedTimer & operator=(ScopedTimer &&) = delete;
 
-    explicit ScopedTimer(const char * name) : m_name(name) {}
+    explicit ScopedTimer(const char * name)
+        : m_name(name)
+    {
+    }
 
     ~ScopedTimer()
     {
@@ -235,7 +242,7 @@ private:
 #ifdef MODMESH_PROFILE
 
 #define MODMESH_TIME(NAME) \
-    ScopedTimer _local_scoped_timer_ ## __LINE__(NAME);
+    ScopedTimer _local_scoped_timer_##__LINE__(NAME);
 
 /*
  * No MODMESH_PROFILE defined: Disable profiling API.

--- a/include/modmesh/python/common.hpp
+++ b/include/modmesh/python/common.hpp
@@ -39,9 +39,9 @@
 #include <modmesh/modmesh.hpp>
 
 #ifdef __GNUG__
-#  define MODMESH_PYTHON_WRAPPER_VISIBILITY __attribute__((visibility("hidden")))
+#define MODMESH_PYTHON_WRAPPER_VISIBILITY __attribute__((visibility("hidden")))
 #else
-#  define MODMESH_PYTHON_WRAPPER_VISIBILITY
+#define MODMESH_PYTHON_WRAPPER_VISIBILITY
 #endif
 
 namespace modmesh
@@ -49,7 +49,7 @@ namespace modmesh
 namespace python
 {
 
-template < typename T >
+template <typename T>
 bool dtype_is_type(pybind11::array const & arr)
 {
     return pybind11::detail::npy_format_descriptor<T>::dtype().is(arr.dtype());
@@ -66,27 +66,38 @@ public:
         return instance;
     }
 
-    WrapperProfilerStatus(WrapperProfilerStatus const & ) = delete;
-    WrapperProfilerStatus(WrapperProfilerStatus       &&) = delete;
-    WrapperProfilerStatus & operator=(WrapperProfilerStatus const & ) = delete;
-    WrapperProfilerStatus & operator=(WrapperProfilerStatus       &&) = delete;
+    WrapperProfilerStatus(WrapperProfilerStatus const &) = delete;
+    WrapperProfilerStatus(WrapperProfilerStatus &&) = delete;
+    WrapperProfilerStatus & operator=(WrapperProfilerStatus const &) = delete;
+    WrapperProfilerStatus & operator=(WrapperProfilerStatus &&) = delete;
     ~WrapperProfilerStatus() = default;
 
     bool enabled() const { return m_enabled; }
-    WrapperProfilerStatus & enable()  { m_enabled = true ; return *this; }
-    WrapperProfilerStatus & disable() { m_enabled = false; return *this; }
+    WrapperProfilerStatus & enable()
+    {
+        m_enabled = true;
+        return *this;
+    }
+    WrapperProfilerStatus & disable()
+    {
+        m_enabled = false;
+        return *this;
+    }
 
 private:
 
     WrapperProfilerStatus()
-      : m_enabled(true)
-    {}
+        : m_enabled(true)
+    {
+    }
 
     std::atomic<bool> m_enabled;
 
 }; /* end class WrapperProfilerStatus */
 
-struct mmtag {};
+struct mmtag
+{
+};
 
 } /* end namespace python */
 } /* end namespace modmesh */
@@ -96,8 +107,9 @@ namespace pybind11
 namespace detail
 {
 
-template<> struct process_attribute<modmesh::python::mmtag>
-  : process_attribute_default<modmesh::python::mmtag>
+template <>
+struct process_attribute<modmesh::python::mmtag>
+    : process_attribute_default<modmesh::python::mmtag>
 {
 
     static void precall(function_call & call)
@@ -123,7 +135,6 @@ private:
         function_record const & r = call.func;
         return std::string(str(r.scope.attr("__name__"))) + std::string(".") + r.name;
     }
-
 };
 
 } /* end namespace detail */
@@ -150,8 +161,9 @@ ConcreteBufferNdarrayRemover : ConcreteBuffer::remover_type
     ConcreteBufferNdarrayRemover() = delete;
 
     explicit ConcreteBufferNdarrayRemover(pybind11::array arr_in)
-      : ndarray(std::move(arr_in))
-    {}
+        : ndarray(std::move(arr_in))
+    {
+    }
 
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays,readability-non-const-parameter)
     void operator()(int8_t *) const override {}
@@ -166,31 +178,30 @@ pybind11::array to_ndarray(SimpleArray<T> & sarr)
     namespace py = pybind11;
     std::vector<size_t> shape(sarr.shape().begin(), sarr.shape().end());
     std::vector<size_t> stride(sarr.stride().begin(), sarr.stride().end());
-    for (size_t & v: stride) { v *= sarr.itemsize(); }
-    return py::array
-    (
+    for (size_t & v : stride) { v *= sarr.itemsize(); }
+    return py::array(
         py::detail::npy_format_descriptor<T>::dtype() /* Numpy dtype */
-      , shape /* Buffer dimensions */
-      , stride /* Strides (in bytes) for each index */
-      , sarr.data() /* Pointer to buffer */
-      , py::cast(sarr.buffer().shared_from_this()) /* Owning Python object */
+        ,
+        shape /* Buffer dimensions */
+        ,
+        stride /* Strides (in bytes) for each index */
+        ,
+        sarr.data() /* Pointer to buffer */
+        ,
+        py::cast(sarr.buffer().shared_from_this()) /* Owning Python object */
     );
 }
 
-template < typename T >
+template <typename T>
 static SimpleArray<T> makeSimpleArray(pybind11::array_t<T> & ndarr)
 {
     typename SimpleArray<T>::shape_type shape;
-    for (ssize_t i = 0 ; i < ndarr.ndim() ; ++i)
+    for (ssize_t i = 0; i < ndarr.ndim(); ++i)
     {
         shape.push_back(ndarr.shape(i));
     }
-    std::shared_ptr<ConcreteBuffer> buffer = ConcreteBuffer::construct
-    (
-        ndarr.nbytes()
-      , ndarr.mutable_data()
-      , std::make_unique<ConcreteBufferNdarrayRemover>(ndarr)
-    );
+    std::shared_ptr<ConcreteBuffer> buffer = ConcreteBuffer::construct(
+        ndarr.nbytes(), ndarr.mutable_data(), std::make_unique<ConcreteBufferNdarrayRemover>(ndarr));
     return SimpleArray<T>(shape, buffer);
 }
 
@@ -220,7 +231,7 @@ public:
     using wrapped_type = Wrapped;
     using wrapped_base_type = WrappedBase;
     using holder_type = Holder;
-// clang-format off
+    // clang-format off
     using root_base_type = WrapBase
     <
         wrapper_type
@@ -234,7 +245,7 @@ public:
       , pybind11::class_< wrapped_type, holder_type >
       , pybind11::class_< wrapped_type, wrapped_base_type, holder_type >
     >;
-// clang-format on
+    // clang-format on
 
     static wrapper_type & commit(pybind11::module & mod)
     {
@@ -249,31 +260,29 @@ public:
     }
 
     WrapBase() = delete;
-    WrapBase(WrapBase const & ) = default;
-    WrapBase(WrapBase       &&) = delete;
-    WrapBase & operator=(WrapBase const & ) = default;
-    WrapBase & operator=(WrapBase       &&) = delete;
+    WrapBase(WrapBase const &) = default;
+    WrapBase(WrapBase &&) = delete;
+    WrapBase & operator=(WrapBase const &) = default;
+    WrapBase & operator=(WrapBase &&) = delete;
     ~WrapBase() = default;
 
-#define DECL_MM_PYBIND_CLASS_METHOD_UNTIMED(METHOD) \
-    template< class... Args > \
-    /* NOLINTNEXTLINE(bugprone-macro-parentheses) */ \
-    wrapper_type & METHOD(Args&&... args) \
-    { \
-        m_cls.METHOD(std::forward<Args>(args)...); \
-        return *static_cast<wrapper_type*>(this); \
+#define DECL_MM_PYBIND_CLASS_METHOD_UNTIMED(METHOD)                           \
+    template <class... Args> /* NOLINTNEXTLINE(bugprone-macro-parentheses) */ \
+    wrapper_type & METHOD(Args &&... args)                                    \
+    {                                                                         \
+        m_cls.METHOD(std::forward<Args>(args)...);                            \
+        return *static_cast<wrapper_type *>(this);                            \
     }
 
-#define DECL_MM_PYBIND_CLASS_METHOD_TIMED(METHOD) \
-    template< class... Args > \
-    /* NOLINTNEXTLINE(bugprone-macro-parentheses) */ \
-    wrapper_type & METHOD ## _timed(Args&&... args) \
-    { \
-        m_cls.METHOD(std::forward<Args>(args)..., mmtag()); \
-        return *static_cast<wrapper_type*>(this); \
+#define DECL_MM_PYBIND_CLASS_METHOD_TIMED(METHOD)                             \
+    template <class... Args> /* NOLINTNEXTLINE(bugprone-macro-parentheses) */ \
+    wrapper_type & METHOD##_timed(Args &&... args)                            \
+    {                                                                         \
+        m_cls.METHOD(std::forward<Args>(args)..., mmtag());                   \
+        return *static_cast<wrapper_type *>(this);                            \
     }
 
-#define DECL_MM_PYBIND_CLASS_METHOD(METHOD) \
+#define DECL_MM_PYBIND_CLASS_METHOD(METHOD)     \
     DECL_MM_PYBIND_CLASS_METHOD_UNTIMED(METHOD) \
     DECL_MM_PYBIND_CLASS_METHOD_TIMED(METHOD)
 
@@ -296,7 +305,7 @@ public:
 #undef DECL_MM_PYBIND_CLASS_METHOD_TIMED
 #undef DECL_MM_PYBIND_CLASS_METHOD
 
-    template < typename Func >
+    template <typename Func>
     wrapper_type & expose_SimpleArray(char const * name, Func && f)
     {
         namespace py = pybind11;
@@ -329,7 +338,7 @@ public:
         return *static_cast<wrapper_type *>(this);
     }
 
-    template < typename Func >
+    template <typename Func>
     wrapper_type & expose_SimpleArrayAsNdarray(char const * name, Func && f)
     {
         namespace py = pybind11;
@@ -367,9 +376,10 @@ public:
 protected:
 
     template <typename... Extra>
-    WrapBase(pybind11::module & mod, char const * pyname, char const * pydoc, const Extra & ... extra)
-      : m_cls(mod, pyname, pydoc, extra ...)
-    {}
+    WrapBase(pybind11::module & mod, char const * pyname, char const * pydoc, const Extra &... extra)
+        : m_cls(mod, pyname, pydoc, extra...)
+    {
+    }
 
 private:
 

--- a/include/modmesh/python/common.hpp
+++ b/include/modmesh/python/common.hpp
@@ -135,9 +135,11 @@ namespace modmesh
 namespace python
 {
 
+// clang-format off
 struct
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 ConcreteBufferNdarrayRemover : ConcreteBuffer::remover_type
+// clang-format on
 {
 
     static bool is_same_type(ConcreteBuffer::remover_type const & other)
@@ -195,6 +197,7 @@ static SimpleArray<T> makeSimpleArray(pybind11::array_t<T> & ndarr)
 /**
  * Helper template for pybind11 class wrappers.
  */
+// clang-format off
 template
 <
     class Wrapper
@@ -208,6 +211,7 @@ template
 class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapBase
+// clang-format on
 {
 
 public:
@@ -216,6 +220,7 @@ public:
     using wrapped_type = Wrapped;
     using wrapped_base_type = WrappedBase;
     using holder_type = Holder;
+// clang-format off
     using root_base_type = WrapBase
     <
         wrapper_type
@@ -229,6 +234,7 @@ public:
       , pybind11::class_< wrapped_type, holder_type >
       , pybind11::class_< wrapped_type, wrapped_base_type, holder_type >
     >;
+// clang-format on
 
     static wrapper_type & commit(pybind11::module & mod)
     {
@@ -300,27 +306,27 @@ public:
         static_assert(!std::is_const<array_reference>::value, "this_array_reference cannot be const");
         using array_type = typename std::remove_reference<array_reference>::type;
 
-        (*this).def_property
-        (
-            name
-          , [&f](wrapped_type & self) -> array_reference { return f(self); }
-          , [&f](wrapped_type & self, py::array_t<typename array_type::value_type> & ndarr)
-            {
-                array_reference this_array = f(self);
-                if (this_array.nbytes() != static_cast<size_t>(ndarr.nbytes()))
+        (*this)
+            .def_property(
+                name,
+                [&f](wrapped_type & self) -> array_reference
+                { return f(self); },
+                [&f](wrapped_type & self, py::array_t<typename array_type::value_type> & ndarr)
                 {
-                    std::ostringstream msg;
-                    msg
-                        << ndarr.nbytes() << " bytes of input array differ from "
-                        << this_array.nbytes() << " bytes of internal array"
-                    ;
-                    throw std::length_error(msg.str());
-                }
-                makeSimpleArray(ndarr).swap(this_array);
-            }
-        );
+                    array_reference this_array = f(self);
+                    if (this_array.nbytes() != static_cast<size_t>(ndarr.nbytes()))
+                    {
+                        std::ostringstream msg;
+                        msg << ndarr.nbytes() << " bytes of input array differ from "
+                            << this_array.nbytes() << " bytes of internal array";
+                        throw std::length_error(msg.str());
+                    }
+                    makeSimpleArray(ndarr).swap(this_array);
+                })
+            //
+            ;
 
-        return *static_cast<wrapper_type*>(this);
+        return *static_cast<wrapper_type *>(this);
     }
 
     template < typename Func >
@@ -333,27 +339,27 @@ public:
         static_assert(!std::is_const<array_reference>::value, "this_array_reference cannot be const");
         using array_type = typename std::remove_reference<array_reference>::type;
 
-        (*this).def_property
-        (
-            name
-          , [&f](wrapped_type & self) { return to_ndarray(f(self)); }
-          , [&f](wrapped_type & self, py::array_t<typename array_type::value_type> & ndarr)
-            {
-                array_reference this_array = f(self);
-                if (this_array.nbytes() != static_cast<size_t>(ndarr.nbytes()))
+        (*this)
+            .def_property(
+                name,
+                [&f](wrapped_type & self)
+                { return to_ndarray(f(self)); },
+                [&f](wrapped_type & self, py::array_t<typename array_type::value_type> & ndarr)
                 {
-                    std::ostringstream msg;
-                    msg
-                        << ndarr.nbytes() << " bytes of input array differ from "
-                        << this_array.nbytes() << " bytes of internal array"
-                    ;
-                    throw std::length_error(msg.str());
-                }
-                this_array.swap(makeSimpleArray(ndarr));
-            }
-        );
+                    array_reference this_array = f(self);
+                    if (this_array.nbytes() != static_cast<size_t>(ndarr.nbytes()))
+                    {
+                        std::ostringstream msg;
+                        msg << ndarr.nbytes() << " bytes of input array differ from "
+                            << this_array.nbytes() << " bytes of internal array";
+                        throw std::length_error(msg.str());
+                    }
+                    this_array.swap(makeSimpleArray(ndarr));
+                })
+            //
+            ;
 
-        return *static_cast<wrapper_type*>(this);
+        return *static_cast<wrapper_type *>(this);
     }
 
     class_ & cls() { return m_cls; }

--- a/include/modmesh/python/python.hpp
+++ b/include/modmesh/python/python.hpp
@@ -49,10 +49,12 @@ namespace modmesh
 namespace python
 {
 
+// clang-format off
 class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapWrapperProfilerStatus
-  : public WrapBase< WrapWrapperProfilerStatus, WrapperProfilerStatus >
+    // clang-format on
+    : public WrapBase< WrapWrapperProfilerStatus, WrapperProfilerStatus >
 {
 
 public:
@@ -68,11 +70,13 @@ protected:
         namespace py = pybind11;
 
         (*this)
+            // clang-format off
             .def_property_readonly_static("me", [](py::object const &) -> wrapped_type& { return wrapped_type::me(); })
             .def_property_readonly("enabled", &wrapped_type::enabled)
             .def("enable", &wrapped_type::enable)
             .def("disable", &wrapped_type::disable)
-        ;
+            // clang-format on
+            ;
 
         mod.attr("wrapper_profiler_status") = mod.attr("WrapperProfilerStatus").attr("me");
 
@@ -80,10 +84,12 @@ protected:
 
 }; /* end class WrapWrapperTimerStatus */
 
+// clang-format off
 class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapStopWatch
-  : public WrapBase< WrapStopWatch, StopWatch >
+    // clang-format on
+    : public WrapBase< WrapStopWatch, StopWatch >
 {
 
 public:
@@ -99,14 +105,18 @@ protected:
         namespace py = pybind11;
 
         (*this)
-            .def_property_readonly_static
-            (
-                "me", [](py::object const &) -> wrapped_type & { return wrapped_type::me(); }
-            )
+            .def_property_readonly_static(
+                "me",
+                [](py::object const &) -> wrapped_type &
+                { return wrapped_type::me(); })
             .def("lap", &wrapped_type::lap)
             .def_property_readonly("duration", &wrapped_type::duration)
-            .def_property_readonly_static("resolution", [](py::object const &) { return wrapped_type::resolution(); })
-        ;
+            .def_property_readonly_static(
+                "resolution",
+                [](py::object const &)
+                { return wrapped_type::resolution(); })
+            //
+            ;
 
         mod.attr("stop_watch") = mod.attr("StopWatch").attr("me");
 
@@ -114,10 +124,12 @@ protected:
 
 }; /* end class WrapStopWatch */
 
+// clang-format off
 class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapTimedEntry
-  : public WrapBase< WrapTimedEntry, TimedEntry >
+    // clang-format on
+    : public WrapBase< WrapTimedEntry, TimedEntry >
 {
 
 public:
@@ -138,16 +150,19 @@ protected:
             .def("start", &wrapped_type::start)
             .def("stop", &wrapped_type::stop)
             .def("add_time", &wrapped_type::add_time, py::arg("time"))
-        ;
+            //
+            ;
 
     }
 
 }; /* end class WrapTimedEntry */
 
+// clang-format off
 class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapTimeRegistry
-  : public WrapBase< WrapTimeRegistry, TimeRegistry >
+    // clang-format on
+    : public WrapBase< WrapTimeRegistry, TimeRegistry >
 {
 
 public:
@@ -163,22 +178,21 @@ protected:
         namespace py = pybind11;
 
         (*this)
-            .def_property_readonly_static
-            (
-                "me"
-              , [](py::object const &) -> wrapped_type& { return wrapped_type::me(); }
-            )
+            .def_property_readonly_static(
+                "me",
+                [](py::object const &) -> wrapped_type &
+                { return wrapped_type::me(); })
             .def("clear", &wrapped_type::clear)
             .def("entry", &wrapped_type::entry, py::arg("name"))
-            .def
-            (
-                "add_time"
-              , static_cast<void (wrapped_type::*)(std::string const &, double)>(&wrapped_type::add)
-              , py::arg("name"), py::arg("time")
-            )
+            .def(
+                "add_time",
+                static_cast<void (wrapped_type::*)(std::string const &, double)>(&wrapped_type::add),
+                py::arg("name"),
+                py::arg("time"))
             .def_property_readonly("names", &wrapped_type::names)
             .def("report", &wrapped_type::report)
-        ;
+            //
+            ;
 
         mod.attr("time_registry") = mod.attr("TimeRegistry").attr("me");
 
@@ -186,10 +200,12 @@ protected:
 
 }; /* end class WrapTimeRegistry */
 
+// clang-format off
 class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapConcreteBuffer
-  : public WrapBase< WrapConcreteBuffer, ConcreteBuffer, std::shared_ptr<ConcreteBuffer> >
+    // clang-format on
+    : public WrapBase< WrapConcreteBuffer, ConcreteBuffer, std::shared_ptr<ConcreteBuffer> >
 {
 
     friend root_base_type;
@@ -201,79 +217,73 @@ WrapConcreteBuffer
         namespace py = pybind11;
 
         (*this)
-            .def_timed(py::init([](size_t nbytes){ return wrapped_type::construct(nbytes); }), py::arg("nbytes"))
-            .def
-            (
-                py::init
-                (
+            .def_timed(
+                py::init(
+                    [](size_t nbytes)
+                    { return wrapped_type::construct(nbytes); }),
+                py::arg("nbytes"))
+            .def(
+                py::init(
                     [](py::array & arr_in)
                     {
-                        return wrapped_type::construct
-                        (
-                            arr_in.nbytes()
-                          , arr_in.mutable_data()
-                          , std::make_unique<ConcreteBufferNdarrayRemover>(arr_in)
-                        );
-                    }
-                )
-              , py::arg("array")
-            )
+                        return wrapped_type::construct(
+                            arr_in.nbytes(), arr_in.mutable_data(), std::make_unique<ConcreteBufferNdarrayRemover>(arr_in));
+                    }),
+                py::arg("array"))
             .def_timed("clone", &wrapped_type::clone)
             .def_property_readonly("nbytes", &wrapped_type::nbytes)
             .def("__len__", &wrapped_type::size)
-            .def("__getitem__", [](wrapped_type const & self, size_t it) { return self.at(it); })
-            .def("__setitem__", [](wrapped_type & self, size_t it, int8_t val) { self.at(it) = val; })
-            .def_buffer
-            (
+            .def(
+                "__getitem__",
+                [](wrapped_type const & self, size_t it)
+                { return self.at(it); })
+            .def(
+                "__setitem__",
+                [](wrapped_type & self, size_t it, int8_t val)
+                { self.at(it) = val; })
+            .def_buffer(
                 [](wrapped_type & self)
                 {
-                    return py::buffer_info
-                    (
-                        self.data() /* Pointer to buffer */
-                      , sizeof(int8_t) /* Size of one scalar */
-                      , py::format_descriptor<char>::format() /* Python struct-style format descriptor */
-                      , 1 /* Number of dimensions */
-                      , { self.size() } /* Buffer dimensions */
-                      , { 1 } /* Strides (in bytes) for each index */
+                    return py::buffer_info(
+                        self.data(), /* Pointer to buffer */
+                        sizeof(int8_t), /* Size of one scalar */
+                        py::format_descriptor<char>::format(), /* Python struct-style format descriptor */
+                        1, /* Number of dimensions */
+                        {self.size()}, /* Buffer dimensions */
+                        {1} /* Strides (in bytes) for each index */
                     );
-                }
-            )
-            .def_property_readonly
-            (
-                "ndarray"
-              , [](wrapped_type & self)
+                })
+            .def_property_readonly(
+                "ndarray",
+                [](wrapped_type & self)
                 {
                     namespace py = pybind11;
-                    return py::array
-                    (
-                        py::detail::npy_format_descriptor<int8_t>::dtype() /* Numpy dtype */
-                      , { self.size() } /* Buffer dimensions */
-                      , { 1 } /* Strides (in bytes) for each index */
-                      , self.data() /* Pointer to buffer */
-                      , py::cast(self.shared_from_this()) /* Owning Python object */
+                    return py::array(
+                        py::detail::npy_format_descriptor<int8_t>::dtype(), /* Numpy dtype */
+                        {self.size()}, /* Buffer dimensions */
+                        {1}, /* Strides (in bytes) for each index */
+                        self.data(), /* Pointer to buffer */
+                        py::cast(self.shared_from_this()) /* Owning Python object */
                     );
-                }
-            )
-            .def_property_readonly
-            (
-                "is_from_python"
-              , [](wrapped_type const & self)
+                })
+            .def_property_readonly(
+                "is_from_python",
+                [](wrapped_type const & self)
                 {
-                    return
-                        self.has_remover()
-                     && ConcreteBufferNdarrayRemover::is_same_type(self.get_remover())
-                    ;
-                }
-            )
-        ;
+                    return self.has_remover() && ConcreteBufferNdarrayRemover::is_same_type(self.get_remover());
+                })
+            //
+            ;
     }
 
 }; /* end class WrapConcreteBuffer */
 
+// clang-format off
 template <typename T>
 class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapSimpleArray
+    // clang-format on
   : public WrapBase< WrapSimpleArray<T>, SimpleArray<T> >
 {
 
@@ -290,15 +300,13 @@ WrapSimpleArray
         namespace py = pybind11;
 
         (*this)
-            .def_timed
-            (
-                py::init([](py::object const & shape) { return wrapped_type(make_shape(shape)); })
-              , py::arg("shape")
-            )
-            .def
-            (
-                py::init
-                (
+            .def_timed(
+                py::init(
+                    [](py::object const & shape)
+                    { return wrapped_type(make_shape(shape)); }),
+                py::arg("shape"))
+            .def(
+                py::init(
                     [](py::array & arr_in)
                     {
                         if (!dtype_is_type<T>(arr_in))
@@ -306,96 +314,95 @@ WrapSimpleArray
                             throw std::runtime_error("dtype mismatch");
                         }
                         shape_type shape;
-                        for (ssize_t i = 0 ; i < arr_in.ndim() ; ++i)
+                        for (ssize_t i = 0; i < arr_in.ndim(); ++i)
                         {
                             shape.push_back(arr_in.shape(i));
                         }
-                        std::shared_ptr<ConcreteBuffer> buffer = ConcreteBuffer::construct
-                        (
-                            arr_in.nbytes()
-                          , arr_in.mutable_data()
-                          , std::make_unique<ConcreteBufferNdarrayRemover>(arr_in)
-                        );
+                        std::shared_ptr<ConcreteBuffer> buffer = ConcreteBuffer::construct(
+                            arr_in.nbytes(),
+                            arr_in.mutable_data(),
+                            std::make_unique<ConcreteBufferNdarrayRemover>(arr_in));
                         return wrapped_type(shape, buffer);
-                    }
-                )
-              , py::arg("array")
-            )
-            .def_buffer
-            (
+                    }),
+                py::arg("array"))
+            .def_buffer(
                 [](wrapped_type & self)
                 {
                     std::vector<size_t> stride;
                     for (size_t i : self.stride())
                     {
-                        stride.push_back(i*sizeof(T));
+                        stride.push_back(i * sizeof(T));
                     }
-                    return py::buffer_info
-                    (
-                        self.data() /* Pointer to buffer */
-                      , sizeof(T) /* Size of one scalar */
-                      , py::format_descriptor<T>::format() /* Python struct-style format descriptor */
-                      , self.ndim() /* Number of dimensions */
-                      , std::vector<size_t>(self.shape().begin(), self.shape().end()) /* Buffer dimensions */
-                      , stride /* Strides (in bytes) for each index */
+                    return py::buffer_info(
+                        self.data(), /* Pointer to buffer */
+                        sizeof(T), /* Size of one scalar */
+                        py::format_descriptor<T>::format(), /* Python struct-style format descriptor */
+                        self.ndim(), /* Number of dimensions */
+                        std::vector<size_t>(self.shape().begin(), self.shape().end()), /* Buffer dimensions */
+                        stride /* Strides (in bytes) for each index */
                     );
-                }
-            )
-            .def_property_readonly("ndarray", [](wrapped_type & self) { return to_ndarray(self); })
-            .def_property_readonly
-            (
-                "is_from_python"
-              , [](wrapped_type const & self)
+                })
+            .def_property_readonly(
+                "ndarray",
+                [](wrapped_type & self)
+                { return to_ndarray(self); })
+            .def_property_readonly(
+                "is_from_python",
+                [](wrapped_type const & self)
                 {
-                    return
-                        self.buffer().has_remover()
-                     && ConcreteBufferNdarrayRemover::is_same_type(self.buffer().get_remover())
-                    ;
-                }
-            )
+                    return self.buffer().has_remover() && ConcreteBufferNdarrayRemover::is_same_type(self.buffer().get_remover());
+                })
             .def_property_readonly("nbytes", &wrapped_type::nbytes)
             .def_property_readonly("size", &wrapped_type::size)
             .def_property_readonly("itemsize", &wrapped_type::itemsize)
-            .def_property_readonly
-            (
-                "shape"
-              , [](wrapped_type const & self)
+            .def_property_readonly(
+                "shape",
+                [](wrapped_type const & self)
                 {
                     py::tuple ret(self.shape().size());
-                    for (size_t i=0; i<self.shape().size(); ++i)
+                    for (size_t i = 0; i < self.shape().size(); ++i)
                     {
                         ret[i] = self.shape()[i];
                     }
                     return ret;
-                }
-            )
-            .def_property_readonly
-            (
-                "stride"
-              , [](wrapped_type const & self)
+                })
+            .def_property_readonly(
+                "stride",
+                [](wrapped_type const & self)
                 {
                     py::tuple ret(self.stride().size());
-                    for (size_t i=0; i<self.stride().size(); ++i)
+                    for (size_t i = 0; i < self.stride().size(); ++i)
                     {
                         ret[i] = self.stride()[i];
                     }
                     return ret;
-                }
-            )
+                })
             .def("__len__", &wrapped_type::size)
-            .def("__getitem__", [](wrapped_type const & self, ssize_t key) { return self.at(key); })
-            .def("__getitem__", [](wrapped_type const & self, std::vector<ssize_t> const & key) { return self.at(key); })
-            .def("__setitem__", [](wrapped_type & self, ssize_t key, T val) { self.at(key) = val; })
-            .def("__setitem__", [](wrapped_type & self, std::vector<ssize_t> const & key, T val) { self.at(key) = val; })
-            .def
-            (
-                "reshape"
-              , [](wrapped_type const & self, py::object const & shape) { return self.reshape(make_shape(shape)); }
-            )
+            .def(
+                "__getitem__",
+                [](wrapped_type const & self, ssize_t key)
+                { return self.at(key); })
+            .def(
+                "__getitem__",
+                [](wrapped_type const & self, std::vector<ssize_t> const & key)
+                { return self.at(key); })
+            .def(
+                "__setitem__",
+                [](wrapped_type & self, ssize_t key, T val)
+                { self.at(key) = val; })
+            .def(
+                "__setitem__",
+                [](wrapped_type & self, std::vector<ssize_t> const & key, T val)
+                { self.at(key) = val; })
+            .def(
+                "reshape",
+                [](wrapped_type const & self, py::object const & shape)
+                { return self.reshape(make_shape(shape)); })
             .def_property_readonly("has_ghost", &wrapped_type::has_ghost)
             .def_property("nghost", &wrapped_type::nghost, &wrapped_type::set_nghost)
             .def_property_readonly("nbody", &wrapped_type::nbody)
-        ;
+            //
+            ;
 
     }
 
@@ -416,10 +423,12 @@ WrapSimpleArray
 
 }; /* end class WrapSimpleArray */
 
+// clang-format off
 template< typename Wrapper, typename GT >
 class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapStaticGridBase
+    // clang-format on
   : public WrapBase< Wrapper, GT >
 {
 
@@ -442,16 +451,22 @@ protected:
         namespace py = pybind11;
 
         (*this)
-            .def_property_readonly_static("NDIM", [](py::object const &) { return wrapped_type::NDIM; })
-        ;
+            .def_property_readonly_static(
+                "NDIM",
+                [](py::object const &)
+                { return wrapped_type::NDIM; })
+            //
+            ;
 
     }
 
 }; /* end class WrapStaticGridBase */
 
+// clang-format off
 class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapStaticGrid1d
+    // clang-format on
   : public WrapStaticGridBase< WrapStaticGrid1d, StaticGrid1d >
 {
 
@@ -470,23 +485,40 @@ protected:
         namespace py = pybind11;
 
         (*this)
-            .def_timed
-            (
-                py::init([](serial_type nx) { return std::make_unique<StaticGrid1d>(nx); })
-              , py::arg("nx")
-            )
-            .def("__len__", [](wrapped_type const & self) { return self.size(); })
-            .def("__getitem__", [](wrapped_type const & self, size_t it) { return self.at(it); })
-            .def("__setitem__", [](wrapped_type & self, size_t it, wrapped_type::real_type val) { self.at(it) = val; })
-            .def_property_readonly("nx", [](wrapped_type const & self) { return self.nx(); })
-            .expose_SimpleArray("coord", [](wrapped_type & self) -> decltype(auto) { return self.coord(); })
+            .def_timed(
+                py::init(
+                    [](serial_type nx)
+                    { return std::make_unique<StaticGrid1d>(nx); }),
+                py::arg("nx"))
+            .def(
+                "__len__",
+                [](wrapped_type const & self)
+                { return self.size(); })
+            .def(
+                "__getitem__",
+                [](wrapped_type const & self, size_t it)
+                { return self.at(it); })
+            .def(
+                "__setitem__",
+                [](wrapped_type & self, size_t it, wrapped_type::real_type val)
+                { self.at(it) = val; })
+            .def_property_readonly(
+                "nx",
+                [](wrapped_type const & self)
+                { return self.nx(); })
+            .expose_SimpleArray(
+                "coord",
+                [](wrapped_type & self) -> decltype(auto)
+                { return self.coord(); })
             .def_timed("fill", &wrapped_type::fill, py::arg("value"))
-        ;
+            //
+            ;
 
     }
 
 }; /* end class WrapStaticGrid1d */
 
+// clang-format off
 #define MM_DECL_StaticGridMD(NDIM) \
 class \
 MODMESH_PYTHON_WRAPPER_VISIBILITY \
@@ -496,7 +528,7 @@ WrapStaticGrid ## NDIM ## d \
 \
 public: \
 \
-    friend root_base_type; \
+      friend root_base_type; \
 \
     using base_type = WrapStaticGridBase< WrapStaticGrid ## NDIM ## d, StaticGrid ## NDIM ## d >; \
 \
@@ -507,16 +539,19 @@ protected: \
     {} \
 \
 }
+// clang-format on
 
 MM_DECL_StaticGridMD(2);
 MM_DECL_StaticGridMD(3);
 
 #undef MM_DECL_StaticGridMD
 
+// clang-format off
 template< typename Wrapper, typename GT >
 class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapStaticMeshBase
+    // clang-format on
   : public WrapBase< Wrapper, GT, std::shared_ptr<GT> >
 {
 
@@ -541,19 +576,20 @@ protected:
         namespace py = pybind11;
 
         (*this)
-            .def_timed
-            (
-                py::init([](uint_type nnode, uint_type nface, uint_type ncell)
-                { return wrapped_type::construct(nnode, nface, ncell); })
-              , py::arg("nnode")
-              , py::arg("nface")=0
-              , py::arg("ncell")=0
-            )
-        ;
+            .def_timed(
+                py::init(
+                    [](uint_type nnode, uint_type nface, uint_type ncell)
+                    { return wrapped_type::construct(nnode, nface, ncell); }),
+                py::arg("nnode"),
+                py::arg("nface") = 0,
+                py::arg("ncell") = 0)
+            //
+            ;
 
 #define MM_DECL_STATIC(NAME) \
 .def_property_readonly_static(#NAME, [](py::object const &) { return wrapped_type::NAME; })
 
+// clang-format off
         (*this)
             MM_DECL_STATIC(NDIM)
             MM_DECL_STATIC(FCMND)
@@ -562,6 +598,7 @@ protected:
             MM_DECL_STATIC(FCREL)
             MM_DECL_STATIC(BFREL)
         ;
+// clang-format on
 
 #undef MM_DECL_STATIC
 
@@ -577,12 +614,7 @@ protected:
         ;
 
         (*this)
-            .def_timed
-            (
-                "build_interior"
-              , &wrapped_type::build_interior
-              , py::arg("_do_metric")=true
-            )
+            .def_timed("build_interior", &wrapped_type::build_interior, py::arg("_do_metric") = true)
             .def_timed("build_boundary", &wrapped_type::build_boundary)
             .def_timed("build_ghost", &wrapped_type::build_ghost)
         ;
@@ -590,6 +622,7 @@ protected:
 #define MM_DECL_ARRAY(NAME) \
 .expose_SimpleArray(#NAME, [](wrapped_type & self) -> decltype(auto) { return self.NAME(); })
 
+// clang-format off
         (*this)
             MM_DECL_ARRAY(ndcrd)
             MM_DECL_ARRAY(fccnd)
@@ -606,6 +639,7 @@ protected:
             MM_DECL_ARRAY(clfcs)
             MM_DECL_ARRAY(bndfcs)
         ;
+// clang-format on
 
 #undef MM_DECL_ARRAY
 
@@ -613,6 +647,7 @@ protected:
 
 }; /* end class WrapStaticMeshBase */
 
+// clang-format off
 #define MM_DECL_StaticMeshMD(NDIM) \
 class \
 MODMESH_PYTHON_WRAPPER_VISIBILITY \
@@ -633,6 +668,7 @@ protected: \
     {} \
 \
 }
+// clang-format on
 
 MM_DECL_StaticMeshMD(2);
 MM_DECL_StaticMeshMD(3);

--- a/include/modmesh/python/python.hpp
+++ b/include/modmesh/python/python.hpp
@@ -38,9 +38,9 @@
 #include <modmesh/python/common.hpp>
 
 #ifdef __GNUG__
-#  define MODMESH_PYTHON_WRAPPER_VISIBILITY __attribute__((visibility("hidden")))
+#define MODMESH_PYTHON_WRAPPER_VISIBILITY __attribute__((visibility("hidden")))
 #else
-#  define MODMESH_PYTHON_WRAPPER_VISIBILITY
+#define MODMESH_PYTHON_WRAPPER_VISIBILITY
 #endif
 
 namespace modmesh
@@ -54,7 +54,7 @@ class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapWrapperProfilerStatus
     // clang-format on
-    : public WrapBase< WrapWrapperProfilerStatus, WrapperProfilerStatus >
+    : public WrapBase<WrapWrapperProfilerStatus, WrapperProfilerStatus>
 {
 
 public:
@@ -64,7 +64,7 @@ public:
 protected:
 
     WrapWrapperProfilerStatus(pybind11::module & mod, char const * pyname, char const * pydoc)
-      : root_base_type(mod, pyname, pydoc)
+        : root_base_type(mod, pyname, pydoc)
     {
 
         namespace py = pybind11;
@@ -79,7 +79,6 @@ protected:
             ;
 
         mod.attr("wrapper_profiler_status") = mod.attr("WrapperProfilerStatus").attr("me");
-
     }
 
 }; /* end class WrapWrapperTimerStatus */
@@ -89,7 +88,7 @@ class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapStopWatch
     // clang-format on
-    : public WrapBase< WrapStopWatch, StopWatch >
+    : public WrapBase<WrapStopWatch, StopWatch>
 {
 
 public:
@@ -99,7 +98,7 @@ public:
 protected:
 
     WrapStopWatch(pybind11::module & mod, char const * pyname, char const * pydoc)
-      : root_base_type(mod, pyname, pydoc)
+        : root_base_type(mod, pyname, pydoc)
     {
 
         namespace py = pybind11;
@@ -119,7 +118,6 @@ protected:
             ;
 
         mod.attr("stop_watch") = mod.attr("StopWatch").attr("me");
-
     }
 
 }; /* end class WrapStopWatch */
@@ -129,7 +127,7 @@ class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapTimedEntry
     // clang-format on
-    : public WrapBase< WrapTimedEntry, TimedEntry >
+    : public WrapBase<WrapTimedEntry, TimedEntry>
 {
 
 public:
@@ -139,7 +137,7 @@ public:
 protected:
 
     WrapTimedEntry(pybind11::module & mod, char const * pyname, char const * pydoc)
-      : root_base_type(mod, pyname, pydoc)
+        : root_base_type(mod, pyname, pydoc)
     {
 
         namespace py = pybind11;
@@ -152,7 +150,6 @@ protected:
             .def("add_time", &wrapped_type::add_time, py::arg("time"))
             //
             ;
-
     }
 
 }; /* end class WrapTimedEntry */
@@ -162,7 +159,7 @@ class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapTimeRegistry
     // clang-format on
-    : public WrapBase< WrapTimeRegistry, TimeRegistry >
+    : public WrapBase<WrapTimeRegistry, TimeRegistry>
 {
 
 public:
@@ -172,7 +169,7 @@ public:
 protected:
 
     WrapTimeRegistry(pybind11::module & mod, char const * pyname, char const * pydoc)
-      : root_base_type(mod, pyname, pydoc)
+        : root_base_type(mod, pyname, pydoc)
     {
 
         namespace py = pybind11;
@@ -195,7 +192,6 @@ protected:
             ;
 
         mod.attr("time_registry") = mod.attr("TimeRegistry").attr("me");
-
     }
 
 }; /* end class WrapTimeRegistry */
@@ -205,13 +201,13 @@ class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapConcreteBuffer
     // clang-format on
-    : public WrapBase< WrapConcreteBuffer, ConcreteBuffer, std::shared_ptr<ConcreteBuffer> >
+    : public WrapBase<WrapConcreteBuffer, ConcreteBuffer, std::shared_ptr<ConcreteBuffer>>
 {
 
     friend root_base_type;
 
     WrapConcreteBuffer(pybind11::module & mod, char const * pyname, char const * pydoc)
-      : root_base_type(mod, pyname, pydoc, pybind11::buffer_protocol())
+        : root_base_type(mod, pyname, pydoc, pybind11::buffer_protocol())
     {
 
         namespace py = pybind11;
@@ -284,17 +280,17 @@ class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapSimpleArray
     // clang-format on
-  : public WrapBase< WrapSimpleArray<T>, SimpleArray<T> >
+    : public WrapBase<WrapSimpleArray<T>, SimpleArray<T>>
 {
 
-    using root_base_type = WrapBase< WrapSimpleArray<T>, SimpleArray<T> >;
+    using root_base_type = WrapBase<WrapSimpleArray<T>, SimpleArray<T>>;
     using wrapped_type = typename root_base_type::wrapped_type;
     using shape_type = typename wrapped_type::shape_type;
 
     friend root_base_type;
 
     WrapSimpleArray(pybind11::module & mod, char const * pyname, char const * pydoc)
-      : root_base_type(mod, pyname, pydoc, pybind11::buffer_protocol())
+        : root_base_type(mod, pyname, pydoc, pybind11::buffer_protocol())
     {
 
         namespace py = pybind11;
@@ -403,7 +399,6 @@ WrapSimpleArray
             .def_property_readonly("nbody", &wrapped_type::nbody)
             //
             ;
-
     }
 
     static shape_type make_shape(pybind11::object const & shape_in)
@@ -429,12 +424,12 @@ class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapStaticGridBase
     // clang-format on
-  : public WrapBase< Wrapper, GT >
+    : public WrapBase<Wrapper, GT>
 {
 
 public:
 
-    using base_type = WrapBase< Wrapper, GT >;
+    using base_type = WrapBase<Wrapper, GT>;
     using wrapped_type = typename base_type::wrapped_type;
 
     using serial_type = typename wrapped_type::serial_type;
@@ -445,7 +440,7 @@ public:
 protected:
 
     WrapStaticGridBase(pybind11::module & mod, char const * pyname, char const * pydoc)
-      : base_type(mod, pyname, pydoc)
+        : base_type(mod, pyname, pydoc)
     {
 
         namespace py = pybind11;
@@ -457,7 +452,6 @@ protected:
                 { return wrapped_type::NDIM; })
             //
             ;
-
     }
 
 }; /* end class WrapStaticGridBase */
@@ -467,19 +461,19 @@ class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapStaticGrid1d
     // clang-format on
-  : public WrapStaticGridBase< WrapStaticGrid1d, StaticGrid1d >
+    : public WrapStaticGridBase<WrapStaticGrid1d, StaticGrid1d>
 {
 
 public:
 
     friend root_base_type;
 
-    using base_type = WrapStaticGridBase< WrapStaticGrid1d, StaticGrid1d >;
+    using base_type = WrapStaticGridBase<WrapStaticGrid1d, StaticGrid1d>;
 
 protected:
 
     WrapStaticGrid1d(pybind11::module & mod, char const * pyname, char const * pydoc)
-      : base_type(mod, pyname, pydoc)
+        : base_type(mod, pyname, pydoc)
     {
 
         namespace py = pybind11;
@@ -513,7 +507,6 @@ protected:
             .def_timed("fill", &wrapped_type::fill, py::arg("value"))
             //
             ;
-
     }
 
 }; /* end class WrapStaticGrid1d */
@@ -552,12 +545,12 @@ class
 MODMESH_PYTHON_WRAPPER_VISIBILITY
 WrapStaticMeshBase
     // clang-format on
-  : public WrapBase< Wrapper, GT, std::shared_ptr<GT> >
+    : public WrapBase<Wrapper, GT, std::shared_ptr<GT>>
 {
 
 public:
 
-    using base_type = WrapBase< Wrapper, GT, std::shared_ptr<GT> >;
+    using base_type = WrapBase<Wrapper, GT, std::shared_ptr<GT>>;
     using wrapped_type = typename base_type::wrapped_type;
 
     using int_type = typename wrapped_type::int_type;
@@ -570,7 +563,7 @@ public:
 protected:
 
     WrapStaticMeshBase(pybind11::module & mod, char const * pyname, char const * pydoc)
-      : base_type(mod, pyname, pydoc)
+        : base_type(mod, pyname, pydoc)
     {
 
         namespace py = pybind11;
@@ -587,9 +580,9 @@ protected:
             ;
 
 #define MM_DECL_STATIC(NAME) \
-.def_property_readonly_static(#NAME, [](py::object const &) { return wrapped_type::NAME; })
+    .def_property_readonly_static(#NAME, [](py::object const &) { return wrapped_type::NAME; })
 
-// clang-format off
+        // clang-format off
         (*this)
             MM_DECL_STATIC(NDIM)
             MM_DECL_STATIC(FCMND)
@@ -598,7 +591,7 @@ protected:
             MM_DECL_STATIC(FCREL)
             MM_DECL_STATIC(BFREL)
         ;
-// clang-format on
+        // clang-format on
 
 #undef MM_DECL_STATIC
 
@@ -610,19 +603,17 @@ protected:
             .def_property_readonly("ngstnode", &wrapped_type::ngstnode)
             .def_property_readonly("ngstface", &wrapped_type::ngstface)
             .def_property_readonly("ngstcell", &wrapped_type::ngstcell)
-            .def_property_readonly("nbcs", &wrapped_type::nbcs)
-        ;
+            .def_property_readonly("nbcs", &wrapped_type::nbcs);
 
         (*this)
             .def_timed("build_interior", &wrapped_type::build_interior, py::arg("_do_metric") = true)
             .def_timed("build_boundary", &wrapped_type::build_boundary)
-            .def_timed("build_ghost", &wrapped_type::build_ghost)
-        ;
+            .def_timed("build_ghost", &wrapped_type::build_ghost);
 
 #define MM_DECL_ARRAY(NAME) \
-.expose_SimpleArray(#NAME, [](wrapped_type & self) -> decltype(auto) { return self.NAME(); })
+    .expose_SimpleArray(#NAME, [](wrapped_type & self) -> decltype(auto) { return self.NAME(); })
 
-// clang-format off
+        // clang-format off
         (*this)
             MM_DECL_ARRAY(ndcrd)
             MM_DECL_ARRAY(fccnd)
@@ -639,10 +630,9 @@ protected:
             MM_DECL_ARRAY(clfcs)
             MM_DECL_ARRAY(bndfcs)
         ;
-// clang-format on
+        // clang-format on
 
 #undef MM_DECL_ARRAY
-
     }
 
 }; /* end class WrapStaticMeshBase */
@@ -688,10 +678,10 @@ class OneTimeInitializer
 
 public:
 
-    OneTimeInitializer(OneTimeInitializer const & ) = delete;
-    OneTimeInitializer(OneTimeInitializer       &&) = delete;
-    OneTimeInitializer & operator=(OneTimeInitializer const & ) = delete;
-    OneTimeInitializer & operator=(OneTimeInitializer       &&) = delete;
+    OneTimeInitializer(OneTimeInitializer const &) = delete;
+    OneTimeInitializer(OneTimeInitializer &&) = delete;
+    OneTimeInitializer & operator=(OneTimeInitializer const &) = delete;
+    OneTimeInitializer & operator=(OneTimeInitializer &&) = delete;
     ~OneTimeInitializer() = default;
 
     static OneTimeInitializer<T> & me()
@@ -700,11 +690,8 @@ public:
         return instance;
     }
 
-    OneTimeInitializer<T> & operator()
-    (
-        pybind11::module & mod
-      , bool import_numpy
-      , std::function<void(pybind11::module &)> const & initializer)
+    OneTimeInitializer<T> & operator()(
+        pybind11::module & mod, bool import_numpy, std::function<void(pybind11::module &)> const & initializer)
     {
         if (!initialized())
         {
@@ -722,7 +709,7 @@ public:
     }
 
     pybind11::module const & mod() const { return *m_mod; }
-    pybind11::module       & mod()       { return *m_mod; }
+    pybind11::module & mod() { return *m_mod; }
 
     bool initialized() const { return m_initialized && nullptr != m_mod; }
 
@@ -735,7 +722,10 @@ private:
             import_array2("cannot import numpy", false); // or numpy c api segfault.
             return true;
         };
-        if (!import_numpy()) { throw pybind11::error_already_set(); }
+        if (!import_numpy())
+        {
+            throw pybind11::error_already_set();
+        }
     }
 
     OneTimeInitializer() = default;
@@ -779,7 +769,6 @@ inline void initialize_impl(pybind11::module & mod)
 
     WrapStaticMesh2d::commit(mod, "StaticMesh2d", "StaticMesh2d");
     WrapStaticMesh3d::commit(mod, "StaticMesh3d", "StaticMesh3d");
-
 }
 
 } /* end namespace detail */

--- a/include/modmesh/small_vector.hpp
+++ b/include/modmesh/small_vector.hpp
@@ -34,7 +34,7 @@
 namespace modmesh
 {
 
-template < typename T, size_t N=3 >
+template <typename T, size_t N = 3>
 class small_vector
 {
 
@@ -45,7 +45,7 @@ public:
     using const_iterator = T const *;
 
     explicit small_vector(size_t size)
-      : m_size(size)
+        : m_size(size)
     {
         if (m_size > N)
         {
@@ -61,25 +61,26 @@ public:
     }
 
     explicit small_vector(size_t size, T const & v)
-      : small_vector(size)
+        : small_vector(size)
     {
         std::fill(begin(), end(), v);
     }
 
     explicit small_vector(std::vector<T> const & vector)
-      : small_vector(vector.size())
+        : small_vector(vector.size())
     {
         std::copy_n(vector.begin(), m_size, begin());
     }
 
-    template< class InputIt > small_vector(InputIt first, InputIt last)
-      : small_vector(last-first)
+    template <class InputIt>
+    small_vector(InputIt first, InputIt last)
+        : small_vector(last - first)
     {
         std::copy(first, last, begin());
     }
 
     small_vector(std::initializer_list<T> init)
-      : small_vector(init.size())
+        : small_vector(init.size())
     {
         std::copy_n(init.begin(), m_size, begin());
     }
@@ -87,7 +88,7 @@ public:
     small_vector() { m_head = m_data.data(); }
 
     small_vector(small_vector const & other)
-      : m_size(other.m_size)
+        : m_size(other.m_size)
     {
         if (other.m_head == other.m_data.data())
         {
@@ -104,7 +105,7 @@ public:
     }
 
     small_vector(small_vector && other) noexcept
-      : m_size(other.m_size)
+        : m_size(other.m_size)
     {
         if (other.m_head == other.m_data.data())
         {
@@ -179,7 +180,7 @@ public:
                 other.m_size = 0;
                 other.m_capacity = N;
                 other.m_head = other.m_data.data();
-           }
+            }
         }
         return *this;
     }
@@ -188,8 +189,8 @@ public:
     {
         if (size() < other.size())
         {
-            std::copy(other.begin(), other.begin()+size(), begin());
-            for (size_t it = size() ; it < other.size() ; ++it)
+            std::copy(other.begin(), other.begin() + size(), begin());
+            for (size_t it = size(); it < other.size(); ++it)
             {
                 push_back(other[it]);
             }
@@ -223,13 +224,21 @@ public:
     const_iterator cend() const noexcept { return end(); }
 
     T const & operator[](size_t it) const { return m_head[it]; }
-    T       & operator[](size_t it)       { return m_head[it]; }
+    T & operator[](size_t it) { return m_head[it]; }
 
-    T const & at(size_t it) const { validate_range(it); return (*this)[it]; }
-    T       & at(size_t it)       { validate_range(it); return (*this)[it]; }
+    T const & at(size_t it) const
+    {
+        validate_range(it);
+        return (*this)[it];
+    }
+    T & at(size_t it)
+    {
+        validate_range(it);
+        return (*this)[it];
+    }
 
     T const * data() const { return m_head; }
-    T       * data()       { return m_head; }
+    T * data() { return m_head; }
 
     void clear() noexcept
     {
@@ -272,11 +281,11 @@ private:
     T * m_head = nullptr;
     unsigned int m_size = 0;
     unsigned int m_capacity = N;
-    std::array<T,N> m_data;
+    std::array<T, N> m_data;
 
 }; /* end class small_vector */
 
-template < typename T >
+template <typename T>
 bool operator==(small_vector<T> const & lhs, small_vector<T> const & rhs)
 {
     return std::equal(lhs.begin(), lhs.end(), rhs.begin());


### PR DESCRIPTION
In the makefile, add a target `cformat` to check the coding style using `clang-format`.

Also add a variable `FORCE_CLANG_FORMAT` to control how clang-format is used:

* When it is not set, use `clang-format --dry-run` on each file to check the format and print check results.  For example:

  ```console
  $ make cformat 2>&1 | head -n 20
  clang-format --dry-run include/modmesh/ConcreteBuffer.hpp:
  include/modmesh/ConcreteBuffer.hpp:56:56: warning: code should be clang-formatted [-Wclang-format-violations]
      ConcreteBufferRemover(ConcreteBufferRemover const & ) = default;
                                                         ^
  include/modmesh/ConcreteBuffer.hpp:57:48: warning: code should be clang-formatted [-Wclang-format-violations]
      ConcreteBufferRemover(ConcreteBufferRemover       &&) = default;
                                                 ^
  include/modmesh/ConcreteBuffer.hpp:58:68: warning: code should be clang-formatted [-Wclang-format-violations]
      ConcreteBufferRemover & operator=(ConcreteBufferRemover const & ) = default;
                                                                     ^
  include/modmesh/ConcreteBuffer.hpp:59:60: warning: code should be clang-formatted [-Wclang-format-violations]
      ConcreteBufferRemover & operator=(ConcreteBufferRemover       &&) = default;
                                                             ^
  include/modmesh/ConcreteBuffer.hpp:76:64: warning: code should be clang-formatted [-Wclang-format-violations]
      ConcreteBufferDataDeleter(ConcreteBufferDataDeleter const & ) = delete;
                                                                 ^
  include/modmesh/ConcreteBuffer.hpp:77:76: warning: code should be clang-formatted [-Wclang-format-violations]
      ConcreteBufferDataDeleter & operator=(ConcreteBufferDataDeleter const & ) = delete;
                                                                             ^
  include/modmesh/ConcreteBuffer.hpp:83:84: warning: code should be clang-formatted [-Wclang-format-violations]
  ```

* When setting `FORCE_CLANG_FORMAT` to anything other than `inplace`, turn warning to error:

  ```console
  $ make cformat FORCE_CLANG_FORMAT=1 2>&1 | head -n 20
  clang-format --dry-run -Werror include/modmesh/ConcreteBuffer.hpp:
  include/modmesh/ConcreteBuffer.hpp:56:56: error: code should be clang-formatted [-Wclang-format-violations]
      ConcreteBufferRemover(ConcreteBufferRemover const & ) = default;
                                                         ^
  include/modmesh/ConcreteBuffer.hpp:57:48: error: code should be clang-formatted [-Wclang-format-violations]
      ConcreteBufferRemover(ConcreteBufferRemover       &&) = default;
                                                 ^
  include/modmesh/ConcreteBuffer.hpp:58:68: error: code should be clang-formatted [-Wclang-format-violations]
      ConcreteBufferRemover & operator=(ConcreteBufferRemover const & ) = default;
                                                                     ^
  include/modmesh/ConcreteBuffer.hpp:59:60: error: code should be clang-formatted [-Wclang-format-violations]
      ConcreteBufferRemover & operator=(ConcreteBufferRemover       &&) = default;
                                                             ^
  include/modmesh/ConcreteBuffer.hpp:76:64: error: code should be clang-formatted [-Wclang-format-violations]
      ConcreteBufferDataDeleter(ConcreteBufferDataDeleter const & ) = delete;
                                                                 ^
  include/modmesh/ConcreteBuffer.hpp:77:76: error: code should be clang-formatted [-Wclang-format-violations]
      ConcreteBufferDataDeleter & operator=(ConcreteBufferDataDeleter const & ) = delete;
                                                                             ^
  include/modmesh/ConcreteBuffer.hpp:83:84: error: code should be clang-formatted [-Wclang-format-violations]
  ```

* When setting `FORCE_CLANG_FORMAT` to `inplace`, format the files inplace:

  ```console
  $ make cformat FORCE_CLANG_FORMAT=inplace
  clang-format -i include/modmesh/ConcreteBuffer.hpp:
  clang-format -i include/modmesh/SimpleArray.hpp:
  clang-format -i include/modmesh/base.hpp:
  clang-format -i include/modmesh/grid.hpp:
  clang-format -i include/modmesh/mesh.hpp:
  clang-format -i include/modmesh/mesh/StaticMesh_decl.hpp:
  clang-format -i include/modmesh/mesh/boundary.hpp:
  clang-format -i include/modmesh/mesh/interior.hpp:
  clang-format -i include/modmesh/modmesh.hpp:
  clang-format -i include/modmesh/profile.hpp:
  clang-format -i include/modmesh/python/common.hpp:
  clang-format -i include/modmesh/python/python.hpp:
  clang-format -i include/modmesh/small_vector.hpp:
  clang-format -i src/modmesh.cpp:
  ```

# Note

In the pybind11 wrapping code, a lot of lambdas are used.  There is a trick to keep the last semi-colon placed after the closing parenthsis.  Copying, pasting, and swapping the wrapping code is easy when the ending semi-colon use a standalone line:

```cpp
(*this)
    // Swapping A and B is easy.
    .def_property_readonly("A", &wrapped_type::A)
    .def_property_readonly("B", &wrapped_type::B)
    // The semi-colon is in a standalone line.
    ;
```

When the semi-colon is at the end of each of the wrapping line, swapping is hard:

```cpp
(*this)
    .def_property_readonly("A", &wrapped_type::A)
    .def_property_readonly("B", &wrapped_type::B); // The semi-colon makes it hard to swap with A.
```