### PR TITLE
Move the example mesh from C++ to Python

### DIFF
--- a/include/modmesh/python/common.hpp
+++ b/include/modmesh/python/common.hpp
@@ -41,7 +41,7 @@
 #ifdef __GNUG__
 #define MODMESH_PYTHON_WRAPPER_VISIBILITY __attribute__((visibility("hidden")))
 #else
-#define MODMESH_PYTHON_WRAPPER_VISIBILITY
+#define MODMESH_PYTHON_WRAPPER_VISIBILITY PYBIND11_EXPORT
 #endif
 
 namespace modmesh

--- a/include/modmesh/python/python.hpp
+++ b/include/modmesh/python/python.hpp
@@ -37,12 +37,6 @@
 #include <modmesh/modmesh.hpp>
 #include <modmesh/python/common.hpp>
 
-#ifdef __GNUG__
-#define MODMESH_PYTHON_WRAPPER_VISIBILITY __attribute__((visibility("hidden")))
-#else
-#define MODMESH_PYTHON_WRAPPER_VISIBILITY
-#endif
-
 namespace modmesh
 {
 

--- a/src/viewer/CMakeLists.txt
+++ b/src/viewer/CMakeLists.txt
@@ -27,6 +27,7 @@ qt_add_executable(
     modmesh/viewer/R3DWidget.cpp
     modmesh/viewer/RMainWindow.cpp
     modmesh/viewer/RPythonText.cpp
+    modmesh/viewer/PythonInterpreter.cpp
     main.cpp
 )
 

--- a/src/viewer/main.cpp
+++ b/src/viewer/main.cpp
@@ -26,17 +26,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <modmesh/python/python.hpp> // Must be the first include.
+#include <modmesh/viewer/base.hpp> // Must be the first include.
 #include <modmesh/modmesh.hpp>
+
 #include <modmesh/viewer/RStaticMesh.hpp>
-#include <modmesh/viewer/R3DWidget.hpp>
-#include <modmesh/viewer/RPythonText.hpp>
 #include <modmesh/viewer/RMainWindow.hpp>
-
-#include <pybind11/embed.h>
-
-#include <QApplication>
-#include <QMainWindow>
 
 std::shared_ptr<modmesh::StaticMesh2d> make_3triangles()
 {
@@ -75,57 +69,11 @@ std::shared_ptr<modmesh::StaticMesh2d> make_3triangles()
 
 int main(int argc, char ** argv)
 {
-    /*
-     * Sequence of application startup:
-     *   1. (Todo) Parsing arguments and parameters.
-     *   2. Initialize application globals.
-     *   3. Initialize GUI globals.
-     *   4. Set up GUI windowing.
-     */
-
     using namespace modmesh;
-    namespace py = pybind11;
 
-    // Start the interpreter.
-    py::scoped_interpreter interpreter_guard{};
+    RApplication app(argc, argv);
+    app.main()->resize(800, 400);
+    new RStaticMesh<2>(make_3triangles(), app.main()->viewer()->scene());
 
-    // Instantiate the application object.
-    QApplication app(argc, argv);
-
-    // Load the Python extension module.
-    std::cerr << "Loading modmesh._modmesh ... ";
-    bool load_failure = false;
-    try
-    {
-        py::module_::import("modmesh._modmesh");
-    }
-    catch (const py::error_already_set & e)
-    {
-        if (std::string::npos == std::string(e.what()).find("ModuleNotFoundError"))
-        {
-            throw;
-        }
-        else
-        {
-            std::cerr << "fails" << std::endl;
-            load_failure = true;
-        }
-    }
-    if (!load_failure)
-    {
-        std::cerr << "succeeds" << std::endl;
-    }
-
-    // Create the main window.
-    RMainWindow main_window;
-
-    // Set up window.
-    main_window.resize(800, 400);
-    main_window.show();
-
-    // Create and set up main 3D view.
-    new RStaticMesh<2>(make_3triangles(), main_window.viewer()->scene());
-
-    // Run the application.
     return app.exec();
 }

--- a/src/viewer/main.cpp
+++ b/src/viewer/main.cpp
@@ -32,48 +32,12 @@
 #include <modmesh/viewer/RStaticMesh.hpp>
 #include <modmesh/viewer/RMainWindow.hpp>
 
-std::shared_ptr<modmesh::StaticMesh2d> make_3triangles()
-{
-    auto mh = modmesh::StaticMesh2d::construct(/*nnode*/ 4, /*nface*/ 0, /*ncell*/ 3);
-
-    mh->ndcrd(0, 0) = 0;
-    mh->ndcrd(0, 1) = 0;
-    mh->ndcrd(1, 0) = -1;
-    mh->ndcrd(1, 1) = -1;
-    mh->ndcrd(2, 0) = 1;
-    mh->ndcrd(2, 1) = -1;
-    mh->ndcrd(3, 0) = 0;
-    mh->ndcrd(3, 1) = 1;
-
-    std::fill(mh->cltpn().begin(), mh->cltpn().end(), modmesh::CellType::TRIANGLE);
-
-    mh->clnds(0, 0) = 3;
-    mh->clnds(0, 1) = 0;
-    mh->clnds(0, 2) = 1;
-    mh->clnds(0, 3) = 2;
-    mh->clnds(1, 0) = 3;
-    mh->clnds(1, 1) = 0;
-    mh->clnds(1, 2) = 2;
-    mh->clnds(1, 3) = 3;
-    mh->clnds(2, 0) = 3;
-    mh->clnds(2, 1) = 0;
-    mh->clnds(2, 2) = 3;
-    mh->clnds(2, 3) = 1;
-
-    mh->build_interior(/*do_metric*/ true);
-    mh->build_boundary();
-    mh->build_ghost();
-
-    return mh;
-}
-
 int main(int argc, char ** argv)
 {
     using namespace modmesh;
 
     RApplication app(argc, argv);
-    app.main()->resize(800, 400);
-    new RStaticMesh<2>(make_3triangles(), app.main()->viewer()->scene());
+    app.main()->resize(1000, 600);
 
     return app.exec();
 }

--- a/src/viewer/modmesh/viewer/PythonInterpreter.hpp
+++ b/src/viewer/modmesh/viewer/PythonInterpreter.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * Copyright (c) 2022, Yung-Yu Chen <yyc@solvcon.net>
+ * Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -32,55 +32,31 @@
 
 #include <pybind11/embed.h>
 
-#include <modmesh/viewer/RPythonText.hpp>
-#include <modmesh/viewer/R3DWidget.hpp>
-
-#include <Qt>
-#include <QApplication>
-#include <QMainWindow>
-
 namespace modmesh
 {
 
-class RMainWindow
-    : public QMainWindow
+class PythonInterpreter
 {
 
 public:
 
-    RMainWindow()
-        : QMainWindow()
-    {
-        setUp();
-    }
+    static PythonInterpreter & instance();
 
-    RPythonText * pytext() { return m_pytext; }
-    R3DWidget * viewer() { return m_viewer; }
-
-private:
-
-    void setUp();
-
-    RPythonText * m_pytext = nullptr;
-    R3DWidget * m_viewer = nullptr;
-
-}; /* end class RPythonText */
-
-class RApplication
-    : public QApplication
-{
-
-public:
-
-    RApplication(int & argc, char ** argv);
-
-    RMainWindow * main() { return m_main; }
+    PythonInterpreter(PythonInterpreter const &) = delete;
+    PythonInterpreter(PythonInterpreter &&) = delete;
+    PythonInterpreter & operator=(PythonInterpreter const &) = delete;
+    PythonInterpreter & operator=(PythonInterpreter &&) = delete;
+    ~PythonInterpreter();
 
 private:
 
-    RMainWindow * m_main = nullptr;
+    PythonInterpreter();
 
-}; /* end class RApplication */
+    void load_modules();
+
+    pybind11::scoped_interpreter * m_interpreter = nullptr;
+
+}; /* end class PythonInterpreter */
 
 } /* end namespace modmesh */
 

--- a/src/viewer/modmesh/viewer/PythonInterpreter.hpp
+++ b/src/viewer/modmesh/viewer/PythonInterpreter.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
+ * Copyright (c) 2022, Yung-Yu Chen <yyc@solvcon.net>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/viewer/modmesh/viewer/R3DWidget.cpp
+++ b/src/viewer/modmesh/viewer/R3DWidget.cpp
@@ -26,8 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <modmesh/modmesh.hpp>
-
+#include <modmesh/viewer/base.hpp> // Must be the first include.
 #include <modmesh/viewer/R3DWidget.hpp>
 
 #include <Qt3DRender/QCamera>

--- a/src/viewer/modmesh/viewer/R3DWidget.hpp
+++ b/src/viewer/modmesh/viewer/R3DWidget.hpp
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <modmesh/modmesh.hpp>
+#include <modmesh/viewer/base.hpp> // Must be the first include.
 
 #include <Qt>
 #include <QWidget>

--- a/src/viewer/modmesh/viewer/RMainWindow.cpp
+++ b/src/viewer/modmesh/viewer/RMainWindow.cpp
@@ -26,10 +26,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <modmesh/python/python.hpp> // Must be the first include.
-#include <pybind11/embed.h>
-
+#include <modmesh/viewer/base.hpp> // Must be the first include.
 #include <modmesh/viewer/RMainWindow.hpp>
+
+#include <modmesh/viewer/PythonInterpreter.hpp>
 #include <modmesh/viewer/RPythonText.hpp>
 #include <modmesh/viewer/R3DWidget.hpp>
 
@@ -44,6 +44,15 @@ void RMainWindow::setUp()
 
     m_viewer = new R3DWidget();
     setCentralWidget(m_viewer);
+}
+
+RApplication::RApplication(int & argc, char ** argv)
+    : QApplication(argc, argv)
+    , m_main(new RMainWindow)
+{
+    /* TODO: parse arguments */
+    PythonInterpreter::instance();
+    m_main->show();
 }
 
 } /* end namespace modmesh */

--- a/src/viewer/modmesh/viewer/RMainWindow.hpp
+++ b/src/viewer/modmesh/viewer/RMainWindow.hpp
@@ -76,6 +76,8 @@ public:
 
     RMainWindow * main() { return m_main; }
 
+    static RApplication * instance() { return dynamic_cast<RApplication *>(QApplication::instance()); }
+
 private:
 
     RMainWindow * m_main = nullptr;

--- a/src/viewer/modmesh/viewer/RPythonText.cpp
+++ b/src/viewer/modmesh/viewer/RPythonText.cpp
@@ -26,7 +26,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "RPythonText.hpp"
+#include <modmesh/viewer/base.hpp> // Must be the first include.
+#include <modmesh/viewer/RPythonText.hpp>
+
+#include <pybind11/embed.h>
 
 namespace modmesh
 {

--- a/src/viewer/modmesh/viewer/RPythonText.cpp
+++ b/src/viewer/modmesh/viewer/RPythonText.cpp
@@ -58,6 +58,17 @@ void RPythonText::setUp()
     setWidget(m_widget);
 
     connect(m_run, &QPushButton::clicked, this, &RPythonText::runPythonCode);
+
+    m_text->setPlainText(QString(R""""(# Sample input
+import modmesh as mm
+mh = mm.StaticMesh2d(nnode=4, nface=0, ncell=3)
+mh.ndcrd.ndarray[:, :] = (0, 0), (-1, -1), (1, -1), (0, 1)
+mh.cltpn.ndarray[:] = 4
+mh.clnds.ndarray[:, :4] = (3, 0, 1, 2), (3, 0, 2, 3), (3, 0, 3, 1)
+mh.build_interior()
+mh.build_boundary()
+mh.build_ghost()
+mm.view.show(mh))""""));
 }
 
 void RPythonText::runPythonCode()

--- a/src/viewer/modmesh/viewer/RPythonText.hpp
+++ b/src/viewer/modmesh/viewer/RPythonText.hpp
@@ -28,12 +28,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <modmesh/python/python.hpp> // Must be the first include.
-#include <pybind11/embed.h>
+#include <modmesh/viewer/base.hpp> // Must be the first include.
 
 #include <Qt>
 #include <QDockWidget>
-
 #include <QTextEdit>
 #include <QPushButton>
 #include <QVBoxLayout>

--- a/src/viewer/modmesh/viewer/RStaticMesh.hpp
+++ b/src/viewer/modmesh/viewer/RStaticMesh.hpp
@@ -28,6 +28,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <modmesh/viewer/base.hpp> // Must be the first include.
+
 #include <modmesh/modmesh.hpp>
 
 #include <Qt>

--- a/src/viewer/modmesh/viewer/base.hpp
+++ b/src/viewer/modmesh/viewer/base.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * Copyright (c) 2022, Yung-Yu Chen <yyc@solvcon.net>
+ * Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -28,59 +28,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <modmesh/viewer/base.hpp> // Must be the first include.
-
-#include <pybind11/embed.h>
-
-#include <modmesh/viewer/RPythonText.hpp>
-#include <modmesh/viewer/R3DWidget.hpp>
-
-#include <Qt>
-#include <QApplication>
-#include <QMainWindow>
+// Shared by all code.
+#include <modmesh/python/python.hpp> // Must be the first include.
+#include <modmesh/modmesh.hpp>
 
 namespace modmesh
 {
-
-class RMainWindow
-    : public QMainWindow
-{
-
-public:
-
-    RMainWindow()
-        : QMainWindow()
-    {
-        setUp();
-    }
-
-    RPythonText * pytext() { return m_pytext; }
-    R3DWidget * viewer() { return m_viewer; }
-
-private:
-
-    void setUp();
-
-    RPythonText * m_pytext = nullptr;
-    R3DWidget * m_viewer = nullptr;
-
-}; /* end class RPythonText */
-
-class RApplication
-    : public QApplication
-{
-
-public:
-
-    RApplication(int & argc, char ** argv);
-
-    RMainWindow * main() { return m_main; }
-
-private:
-
-    RMainWindow * m_main = nullptr;
-
-}; /* end class RApplication */
 
 } /* end namespace modmesh */
 


### PR DESCRIPTION
* Add code to find where to load `modmesh` Python extension module.
* Move the C++ code that generates the 2D unstructured mesh example to the `RPythonText` default content.