### PR TITLE
fix: Clear scene before assign new mesh

### DIFF
--- a/src/viewer/modmesh/viewer/PythonInterpreter.cpp
+++ b/src/viewer/modmesh/viewer/PythonInterpreter.cpp
@@ -133,6 +133,11 @@ PYBIND11_EMBEDDED_MODULE(_modmesh_view, mod)
             [](std::shared_ptr<StaticMesh2d> const & mesh)
             {
                 RApplication * app = RApplication::instance();
+                RScene * scene = app->main()->viewer()->scene();
+                for (RStaticMesh<2> * child : scene->findChildren<RStaticMesh<2> *>())
+                {
+                    delete child;
+                }
                 new RStaticMesh<2>(mesh, app->main()->viewer()->scene());
             });
 }

--- a/src/viewer/modmesh/viewer/PythonInterpreter.cpp
+++ b/src/viewer/modmesh/viewer/PythonInterpreter.cpp
@@ -138,7 +138,7 @@ PYBIND11_EMBEDDED_MODULE(_modmesh_view, mod)
                 {
                     delete child;
                 }
-                new RStaticMesh<2>(mesh, app->main()->viewer()->scene());
+                new RStaticMesh<2>(mesh, scene);
             });
 }
 


### PR DESCRIPTION
This PR aims to solve https://github.com/solvcon/modmesh/issues/57 by clear the scene nodes of the viewer each time when the Run button is clicked.