### PR TITLE
Correct the wrong deletion of the controller of scene

### DIFF
--- a/src/viewer/modmesh/viewer/PythonInterpreter.cpp
+++ b/src/viewer/modmesh/viewer/PythonInterpreter.cpp
@@ -134,9 +134,12 @@ PYBIND11_EMBEDDED_MODULE(_modmesh_view, mod)
             {
                 RApplication * app = RApplication::instance();
                 RScene * scene = app->main()->viewer()->scene();
-                for (RStaticMesh<2> * child : scene->findChildren<RStaticMesh<2> *>())
+                for (Qt3DCore::QNode * child : scene->childNodes())
                 {
-                    delete child;
+                    if (typeid(*child) == typeid(RStaticMesh<2>))
+                    {
+                        child->deleteLater();
+                    }
                 }
                 new RStaticMesh<2>(mesh, scene);
             });


### PR DESCRIPTION
The camera controller of scene is also a child of it.  For some reason, `QObject::findChildren<RStaticMesh<ND> *>()` does not only return `RStaticMesh<ND> *`, but also the controller.  Consequently the controller gets deleted when "show" is called to replace the `RStaticMesh`.

The fix uses a loop through `QNode::childNodes()` and RTTI in the loop to correctly delete only `RStaticMesh<ND>`.

This is to fix the issue introduced in #63 , and eventually addresses #57 .