### PR TITLE
Add a single tetrahedron mesh for testing 3D mesh code

### DIFF
--- a/include/modmesh/mesh/interior.hpp
+++ b/include/modmesh/mesh/interior.hpp
@@ -793,7 +793,7 @@ void StaticMeshBase<D, ND>::calc_metric()
     {
         for (size_t icl = 0 ; icl < ncell() ; ++icl)
         {
-            if ((use_incenter()) && (m_cltpn(icl) == 5))
+            if ((use_incenter()) && (CellType::TETRAHEDRON == m_cltpn(icl)))
             {
                 real_type voc = 0.0;
                 {

--- a/include/modmesh/python/python.hpp
+++ b/include/modmesh/python/python.hpp
@@ -627,6 +627,16 @@ protected:
         // clang-format on
 
 #undef MM_DECL_ARRAY
+
+        this->cls().attr("NONCELLTYPE") = uint8_t(CellType::NONCELLTYPE);
+        this->cls().attr("POINT") = uint8_t(CellType::POINT);
+        this->cls().attr("LINE") = uint8_t(CellType::LINE);
+        this->cls().attr("QUADRILATERAL") = uint8_t(CellType::QUADRILATERAL);
+        this->cls().attr("TRIANGLE") = uint8_t(CellType::TRIANGLE);
+        this->cls().attr("HEXAHEDRON") = uint8_t(CellType::HEXAHEDRON);
+        this->cls().attr("TETRAHEDRON") = uint8_t(CellType::TETRAHEDRON);
+        this->cls().attr("PRISM") = uint8_t(CellType::PRISM);
+        this->cls().attr("PYRAMID") = uint8_t(CellType::PYRAMID);
     }
 
 }; /* end class WrapStaticMeshBase */

--- a/src/viewer/modmesh/viewer/PythonInterpreter.cpp
+++ b/src/viewer/modmesh/viewer/PythonInterpreter.cpp
@@ -202,6 +202,25 @@ class
 
 }; /* end class WrapRApplication */
 
+namespace detail
+{
+
+template <uint8_t ND>
+static void update_appmesh(std::shared_ptr<StaticMesh<ND>> const & mesh)
+{
+    RScene * scene = RApplication::instance()->main()->viewer()->scene();
+    for (Qt3DCore::QNode * child : scene->childNodes())
+    {
+        if (typeid(*child) == typeid(RStaticMesh))
+        {
+            child->deleteLater();
+        }
+    }
+    new RStaticMesh(mesh, scene);
+}
+
+} /* end namespace detail */
+
 } /* end namespace python */
 
 } /* end namespace modmesh */
@@ -212,38 +231,9 @@ PYBIND11_EMBEDDED_MODULE(_modmesh_view, mod)
     using namespace modmesh::python;
     namespace py = pybind11;
 
-    // FIXME: Do not distinguish 2/3D.
     mod
-        .def(
-            "show",
-            [](std::shared_ptr<StaticMesh2d> const & mesh)
-            {
-                RApplication * app = RApplication::instance();
-                RScene * scene = app->main()->viewer()->scene();
-                for (Qt3DCore::QNode * child : scene->childNodes())
-                {
-                    if (typeid(*child) == typeid(RStaticMesh<2>))
-                    {
-                        child->deleteLater();
-                    }
-                }
-                new RStaticMesh<2>(mesh, scene);
-            })
-        .def(
-            "show",
-            [](std::shared_ptr<StaticMesh3d> const & mesh)
-            {
-                RApplication * app = RApplication::instance();
-                RScene * scene = app->main()->viewer()->scene();
-                for (Qt3DCore::QNode * child : scene->childNodes())
-                {
-                    if (typeid(*child) == typeid(RStaticMesh<3>))
-                    {
-                        child->deleteLater();
-                    }
-                }
-                new RStaticMesh<3>(mesh, scene);
-            })
+        .def("show", &modmesh::python::detail::update_appmesh<2>, py::arg("mesh"))
+        .def("show", &modmesh::python::detail::update_appmesh<3>, py::arg("mesh"))
         //
         ;
 

--- a/src/viewer/modmesh/viewer/PythonInterpreter.cpp
+++ b/src/viewer/modmesh/viewer/PythonInterpreter.cpp
@@ -32,6 +32,7 @@
 
 #include <modmesh/viewer/RMainWindow.hpp>
 #include <modmesh/viewer/RStaticMesh.hpp>
+#include <modmesh/viewer/R3DWidget.hpp>
 
 namespace modmesh
 {
@@ -120,13 +121,98 @@ _set_modmesh_path())"""";
     py::exec("modmesh.view = _modmesh_view");
 }
 
+namespace python
+{
+
+// clang-format off
+class
+MODMESH_PYTHON_WRAPPER_VISIBILITY
+WrapR3DWidget
+    // clang-format on
+    : public WrapBase<WrapR3DWidget, R3DWidget>
+{
+
+    friend root_base_type;
+
+    WrapR3DWidget(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : root_base_type(mod, pyname, pydoc)
+    {
+
+        namespace py = pybind11;
+
+#define DECL_QVECTOR3D_PROPERTY(NAME, GETTER, SETTER)          \
+    .def_property(                                             \
+        #NAME,                                                 \
+        [](wrapped_type & self)                                \
+        {                                                      \
+            QVector3D const v = self.camera()->GETTER();       \
+            return py::make_tuple(v.x(), v.y(), v.z());        \
+        },                                                     \
+        [](wrapped_type & self, std::vector<double> const & v) \
+        {                                                      \
+            double const x = v.at(0);                          \
+            double const y = v.at(1);                          \
+            double const z = v.at(2);                          \
+            self.camera()->SETTER(QVector3D(x, y, z));         \
+        })
+
+        (*this)
+            DECL_QVECTOR3D_PROPERTY(position, position, setPosition)
+                DECL_QVECTOR3D_PROPERTY(up_vector, upVector, setUpVector)
+                    DECL_QVECTOR3D_PROPERTY(view_center, viewCenter, setViewCenter)
+            //
+            ;
+
+#undef DECL_QVECTOR3D_PROPERTY
+    }
+
+}; /* end class WrapR3DWidget */
+
+class
+    MODMESH_PYTHON_WRAPPER_VISIBILITY
+        WrapRApplication
+    // clang-format on
+    : public WrapBase<WrapRApplication, RApplication>
+{
+
+    friend root_base_type;
+
+    WrapRApplication(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : root_base_type(mod, pyname, pydoc)
+    {
+
+        namespace py = pybind11;
+
+        (*this)
+            .def_property_readonly_static(
+                "instance",
+                [](py::object const &)
+                {
+                    return RApplication::instance();
+                })
+            .def_property_readonly(
+                "viewer",
+                [](wrapped_type & self)
+                {
+                    return self.main()->viewer();
+                })
+            //
+            ;
+    }
+
+}; /* end class WrapRApplication */
+
+} /* end namespace python */
+
 } /* end namespace modmesh */
 
 PYBIND11_EMBEDDED_MODULE(_modmesh_view, mod)
 {
     using namespace modmesh;
+    using namespace modmesh::python;
     namespace py = pybind11;
 
+    // FIXME: Do not distinguish 2/3D.
     mod
         .def(
             "show",
@@ -142,7 +228,29 @@ PYBIND11_EMBEDDED_MODULE(_modmesh_view, mod)
                     }
                 }
                 new RStaticMesh<2>(mesh, scene);
-            });
+            })
+        .def(
+            "show",
+            [](std::shared_ptr<StaticMesh3d> const & mesh)
+            {
+                RApplication * app = RApplication::instance();
+                RScene * scene = app->main()->viewer()->scene();
+                for (Qt3DCore::QNode * child : scene->childNodes())
+                {
+                    if (typeid(*child) == typeid(RStaticMesh<3>))
+                    {
+                        child->deleteLater();
+                    }
+                }
+                new RStaticMesh<3>(mesh, scene);
+            })
+        //
+        ;
+
+    WrapR3DWidget::commit(mod, "R3DWidget", "R3DWidget");
+    WrapRApplication::commit(mod, "RApplication", "RApplication");
+
+    mod.attr("app") = py::cast(RApplication::instance());
 }
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/src/viewer/modmesh/viewer/R3DWidget.cpp
+++ b/src/viewer/modmesh/viewer/R3DWidget.cpp
@@ -29,8 +29,6 @@
 #include <modmesh/viewer/base.hpp> // Must be the first include.
 #include <modmesh/viewer/R3DWidget.hpp>
 
-#include <Qt3DRender/QCamera>
-
 namespace modmesh
 {
 
@@ -45,7 +43,7 @@ R3DWidget::R3DWidget(Qt3DExtras::Qt3DWindow * window, RScene * scene, QWidget * 
     // Set up the camera.
     Qt3DRender::QCamera * camera = m_view->camera();
     camera->lens()->setPerspectiveProjection(45.0f, 16.0f / 9.0f, 0.1f, 1000.0f);
-    camera->setPosition(QVector3D(0, 0, 40.0f));
+    camera->setPosition(QVector3D(0, 0, 10.0f));
     camera->setViewCenter(QVector3D(0, 0, 0));
 
     // Set up the camera control.

--- a/src/viewer/modmesh/viewer/R3DWidget.hpp
+++ b/src/viewer/modmesh/viewer/R3DWidget.hpp
@@ -35,6 +35,7 @@
 #include <Qt3DWindow>
 
 #include <Qt3DCore/QEntity>
+#include <Qt3DRender/QCamera>
 
 #include <QOrbitCameraController>
 
@@ -42,6 +43,12 @@
 
 namespace modmesh
 {
+
+class RCameraController
+    : public Qt3DExtras::QOrbitCameraController
+{
+    using Qt3DExtras::QOrbitCameraController::QOrbitCameraController;
+}; /* end class RCameraController */
 
 class RScene
     : public Qt3DCore::QEntity
@@ -51,16 +58,16 @@ public:
 
     RScene(Qt3DCore::QNode * parent = nullptr)
         : Qt3DCore::QEntity(parent)
-        , m_controller(new Qt3DExtras::QOrbitCameraController(this))
+        , m_controller(new RCameraController(this))
     {
     }
 
-    Qt3DExtras::QOrbitCameraController const * controller() const { return m_controller; }
-    Qt3DExtras::QOrbitCameraController * controller() { return m_controller; }
+    RCameraController const * controller() const { return m_controller; }
+    RCameraController * controller() { return m_controller; }
 
 private:
 
-    Qt3DExtras::QOrbitCameraController * m_controller = nullptr;
+    RCameraController * m_controller = nullptr;
 
 }; /* end class RScene */
 
@@ -83,6 +90,7 @@ public:
 
     Qt3DExtras::Qt3DWindow * view() { return m_view; }
     RScene * scene() { return m_scene; }
+    Qt3DRender::QCamera * camera() { return m_view->camera(); }
 
 private:
 

--- a/src/viewer/modmesh/viewer/RPythonText.cpp
+++ b/src/viewer/modmesh/viewer/RPythonText.cpp
@@ -61,14 +61,31 @@ void RPythonText::setUp()
 
     m_text->setPlainText(QString(R""""(# Sample input
 import modmesh as mm
-mh = mm.StaticMesh2d(nnode=4, nface=0, ncell=3)
-mh.ndcrd.ndarray[:, :] = (0, 0), (-1, -1), (1, -1), (0, 1)
-mh.cltpn.ndarray[:] = 4
-mh.clnds.ndarray[:, :4] = (3, 0, 1, 2), (3, 0, 2, 3), (3, 0, 3, 1)
-mh.build_interior()
-mh.build_boundary()
-mh.build_ghost()
-mm.view.show(mh))""""));
+ndim = 2
+if 2 == ndim:
+    mh = mm.StaticMesh2d(nnode=4, nface=0, ncell=3)
+    mh.ndcrd.ndarray[:, :] = (0, 0), (-1, -1), (1, -1), (0, 1)
+    mh.cltpn.ndarray[:] = modmesh.StaticMesh2d.TRIANGLE
+    mh.clnds.ndarray[:, :4] = (3, 0, 1, 2), (3, 0, 2, 3), (3, 0, 3, 1)
+    mh.build_interior()
+    mh.build_boundary()
+    mh.build_ghost()
+else:
+    mh = modmesh.StaticMesh3d(nnode=4, nface=4, ncell=1)
+    mh.ndcrd.ndarray[:, :] = (0, 0, 0), (0, 1, 0), (-1, 1, 0), (0, 1, 1)
+    mh.cltpn.ndarray[:] = modmesh.StaticMesh3d.TETRAHEDRON
+    mh.clnds.ndarray[:, :5] = [(4, 0, 1, 2, 3)]
+    mh.build_interior()
+    mh.build_boundary()
+    mh.build_ghost()
+#mm.view.app.viewer.up_vector = (0, 1, 0)
+#mm.view.app.viewer.position = (-10, -10, -20)
+#mm.view.app.viewer.view_center = (0, 0, 0)
+mm.view.show(mh)
+print("position:", mm.view.app.viewer.position)
+print("up_vector:", mm.view.app.viewer.up_vector)
+print("view_center:", mm.view.app.viewer.view_center)
+)""""));
 }
 
 void RPythonText::runPythonCode()


### PR DESCRIPTION
Add a single tetrahedron to show that the 3D mesh code basically works, although may have some issues that are not known.

This is to address issue #60.