### PR TITLE
Add a simple axis marker in the view widget

### DIFF
--- a/cpp/binary/viewer/viewer.cpp
+++ b/cpp/binary/viewer/viewer.cpp
@@ -31,16 +31,6 @@
 
 #include <modmesh/view/view.hpp>
 
-int main(int argc, char ** argv)
-{
-    using namespace modmesh;
-
-    RApplication app(argc, argv);
-    app.main()->resize(1000, 600);
-
-    return app.exec();
-}
-
 namespace modmesh
 {
 
@@ -49,6 +39,19 @@ namespace python
 
 namespace detail
 {
+
+static void show_mark()
+{
+    RScene * scene = RApplication::instance()->main()->viewer()->scene();
+    for (Qt3DCore::QNode * child : scene->childNodes())
+    {
+        if (typeid(*child) == typeid(RAxisMark))
+        {
+            child->deleteLater();
+        }
+    }
+    new RAxisMark(scene);
+}
 
 static void update_appmesh(std::shared_ptr<StaticMesh> const & mesh)
 {
@@ -77,12 +80,25 @@ PYBIND11_EMBEDDED_MODULE(_modmesh_view, mod)
 
     mod
         .def("show", &modmesh::python::detail::update_appmesh, py::arg("mesh"))
+        .def("showMark", &modmesh::python::detail::show_mark)
         //
         ;
 
     wrap_view(mod);
 
     mod.attr("app") = py::cast(RApplication::instance());
+}
+
+int main(int argc, char ** argv)
+{
+    using namespace modmesh;
+
+    RApplication app(argc, argv);
+    app.main()->resize(1000, 600);
+
+    python::detail::show_mark();
+
+    return app.exec();
 }
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/view/CMakeLists.txt
+++ b/cpp/modmesh/view/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required(VERSION 3.16)
 set(MODMESH_VIEW_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/R3DWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RApplication.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RAxisMark.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMainWindow.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonText.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RStaticMesh.hpp
@@ -16,6 +17,7 @@ set(MODMESH_VIEW_HEADERS
 set(MODMESH_VIEW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/R3DWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RApplication.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RAxisMark.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMainWindow.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonText.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RStaticMesh.cpp

--- a/cpp/modmesh/view/RAxisMark.cpp
+++ b/cpp/modmesh/view/RAxisMark.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022, Yung-Yu Chen <yyc@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <modmesh/view/common_detail.hpp> // Must be the first include.
+#include <modmesh/view/RAxisMark.hpp>
+
+#include <modmesh/modmesh.hpp>
+
+#include <Qt>
+#include <QWidget>
+#include <Qt3DWindow>
+
+#include <QByteArray>
+#include <QGeometryRenderer>
+
+#include <Qt3DCore/QBuffer>
+#include <Qt3DCore/QEntity>
+#include <Qt3DCore/QGeometry>
+#include <Qt3DCore/QAttribute>
+#include <Qt3DCore/QTransform>
+
+#include <Qt3DExtras/QDiffuseSpecularMaterial>
+
+namespace modmesh
+{
+
+RLine::RLine(QVector3D const & v0, QVector3D const & v1, QColor const & color, Qt3DCore::QNode * parent)
+    : Qt3DCore::QEntity(parent)
+    , m_geometry(new Qt3DCore::QGeometry(this))
+    , m_renderer(new Qt3DRender::QGeometryRenderer())
+    , m_material(new Qt3DExtras::QDiffuseSpecularMaterial())
+{
+    {
+        auto * buf = new Qt3DCore::QBuffer(m_geometry);
+        {
+            QByteArray barray;
+            barray.resize(3 * 2 * sizeof(float));
+            float * ptr = reinterpret_cast<float *>(barray.data());
+            ptr[0] = v0.x();
+            ptr[1] = v0.y();
+            ptr[2] = v0.z();
+            ptr[3] = v1.x();
+            ptr[4] = v1.y();
+            ptr[5] = v1.z();
+            buf->setData(barray);
+        }
+
+        {
+            auto * vertices = new Qt3DCore::QAttribute(m_geometry);
+            vertices->setName(Qt3DCore::QAttribute::defaultPositionAttributeName());
+            vertices->setAttributeType(Qt3DCore::QAttribute::VertexAttribute);
+            vertices->setVertexBaseType(Qt3DCore::QAttribute::Float);
+            vertices->setVertexSize(3);
+            vertices->setBuffer(buf);
+            vertices->setByteStride(3 * sizeof(float));
+            vertices->setCount(2);
+            m_geometry->addAttribute(vertices);
+        }
+    }
+
+    {
+        auto * buf = new Qt3DCore::QBuffer(m_geometry);
+        {
+            QByteArray barray;
+            barray.resize(2 * sizeof(uint32_t));
+            auto * indices = reinterpret_cast<uint32_t *>(barray.data());
+            indices[0] = 0;
+            indices[1] = 1;
+            buf->setData(barray);
+        }
+
+        {
+            auto * indices = new Qt3DCore::QAttribute(m_geometry);
+            indices->setVertexBaseType(Qt3DCore::QAttribute::UnsignedInt);
+            indices->setAttributeType(Qt3DCore::QAttribute::IndexAttribute);
+            indices->setBuffer(buf);
+            indices->setCount(2);
+            m_geometry->addAttribute(indices);
+        }
+    }
+
+    m_renderer->setGeometry(m_geometry);
+    m_renderer->setPrimitiveType(Qt3DRender::QGeometryRenderer::Lines);
+    addComponent(m_renderer);
+    addComponent(m_material);
+    m_material->setAmbient(color);
+}
+
+RAxisMark::RAxisMark(Qt3DCore::QNode * parent)
+    : Qt3DCore::QEntity(parent)
+    , m_xmark(new RLine(QVector3D(0, 0, 0), QVector3D(1, 0, 0), QColor(255, 0, 0, 255), this))
+    , m_ymark(new RLine(QVector3D(0, 0, 0), QVector3D(0, 1, 0), QColor(0, 255, 0, 255), this))
+    , m_zmark(new RLine(QVector3D(0, 0, 0), QVector3D(0, 0, 1), QColor(0, 0, 255, 255), this))
+{
+}
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/view/RAxisMark.hpp
+++ b/cpp/modmesh/view/RAxisMark.hpp
@@ -30,15 +30,57 @@
 
 #include <modmesh/view/common_detail.hpp> // Must be the first include.
 
-#include <modmesh/view/R3DWidget.hpp>
-#include <modmesh/view/RApplication.hpp>
-#include <modmesh/view/RMainWindow.hpp>
-#include <modmesh/view/RPythonText.hpp>
-#include <modmesh/view/RStaticMesh.hpp>
-#include <modmesh/view/RAxisMark.hpp>
+#include <modmesh/modmesh.hpp>
+
+#include <Qt>
+#include <QWidget>
+#include <Qt3DWindow>
+
+#include <QByteArray>
+#include <QGeometryRenderer>
+
+#include <Qt3DCore/QBuffer>
+#include <Qt3DCore/QEntity>
+#include <Qt3DCore/QGeometry>
+#include <Qt3DCore/QAttribute>
+#include <Qt3DCore/QTransform>
+
+#include <Qt3DExtras/QDiffuseSpecularMaterial>
 
 namespace modmesh
 {
+
+class RLine
+    : public Qt3DCore::QEntity
+{
+
+public:
+
+    RLine(QVector3D const & v0, QVector3D const & v1, QColor const & color, Qt3DCore::QNode * parent = nullptr);
+
+private:
+
+    Qt3DCore::QGeometry * m_geometry = nullptr;
+    Qt3DRender::QGeometryRenderer * m_renderer = nullptr;
+    Qt3DExtras::QDiffuseSpecularMaterial * m_material = nullptr;
+
+}; /* end class RLine */
+
+class RAxisMark
+    : public Qt3DCore::QEntity
+{
+
+public:
+
+    RAxisMark(Qt3DCore::QNode * parent = nullptr);
+
+private:
+
+    RLine * m_xmark = nullptr;
+    RLine * m_ymark = nullptr;
+    RLine * m_zmark = nullptr;
+
+}; /* end class RAxisMark */
 
 } /* end namespace modmesh */
 

--- a/cpp/modmesh/view/RPythonText.cpp
+++ b/cpp/modmesh/view/RPythonText.cpp
@@ -87,7 +87,7 @@ def make_3d():
 
 mh = make_2d()
 mm.view.show(mh)
-mm.view.show(mh)
+
 print("position:", mm.view.app.viewer.position)
 print("up_vector:", mm.view.app.viewer.up_vector)
 print("view_center:", mm.view.app.viewer.view_center)


### PR DESCRIPTION
This is to address #69 .  This is a really simple axis marker consisting of 3 line segments of unit length (1).  The mark is an entity in the view widget and uses fixed coordinate.