### PR TITLE
Add a helper to convert QByteArray to SimpleArray

### DIFF
--- a/.github/workflows/modmesh_viewer.yml
+++ b/.github/workflows/modmesh_viewer.yml
@@ -2,6 +2,9 @@ name: modmesh_viewer
 
 on:
   push:
+  pull_request:
+  schedule:
+    - cron: '34 17 * * *'
 
 jobs:
   build:

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -68,6 +68,14 @@ struct ConcreteBufferRemover
 
 }; /* end struct ConcreteBufferRemover */
 
+struct ConcreteBufferNoRemove : public ConcreteBufferRemover
+{
+
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays,readability-non-const-parameter)
+    void operator()(int8_t *) const override {}
+
+}; /* end struct ConcreteBufferNoRemove */
+
 struct ConcreteBufferDataDeleter
 {
 

--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -167,8 +167,7 @@ public:
         }
     }
 
-    explicit SimpleArray(
-        small_vector<size_t> const & shape, std::shared_ptr<buffer_type> const & buffer)
+    explicit SimpleArray(small_vector<size_t> const & shape, std::shared_ptr<buffer_type> const & buffer)
         : SimpleArray(buffer)
     {
         if (buffer)
@@ -209,6 +208,8 @@ public:
         : m_buffer(std::move(other.m_buffer))
         , m_shape(std::move(other.m_shape))
         , m_stride(std::move(other.m_stride))
+        , m_nghost(other.m_nghost)
+        , m_body(other.m_body)
     {
     }
 

--- a/cpp/modmesh/view/RAxisMark.cpp
+++ b/cpp/modmesh/view/RAxisMark.cpp
@@ -59,7 +59,7 @@ RLine::RLine(QVector3D const & v0, QVector3D const & v1, QColor const & color, Q
         auto * buf = new Qt3DCore::QBuffer(m_geometry);
         {
             QByteArray barray;
-            barray.resize(3 * 2 * sizeof(float));
+            barray.resize(2 * 3 * sizeof(float));
             float * ptr = reinterpret_cast<float *>(barray.data());
             ptr[0] = v0.x();
             ptr[1] = v0.y();

--- a/cpp/modmesh/view/RStaticMesh.cpp
+++ b/cpp/modmesh/view/RStaticMesh.cpp
@@ -28,6 +28,8 @@
 
 #include <modmesh/view/RStaticMesh.hpp> // Must be the first include.
 
+#include <modmesh/view/common_detail.hpp>
+
 namespace modmesh
 {
 
@@ -49,13 +51,13 @@ void RStaticMesh::update_geometry_impl(StaticMesh const & mh, Qt3DCore::QGeometr
     auto * buf = new Qt3DCore::QBuffer(geom);
     {
         QByteArray barray;
-        barray.resize(3 * mh.nnode() * sizeof(float));
-        float * ptr = reinterpret_cast<float *>(barray.data());
+        barray.resize(mh.nnode() * 3 * sizeof(float));
+        SimpleArray<float> sarr = makeSimpleArray<float>(barray, small_vector<size_t>{mh.nnode(), 3}, /*copy*/ false);
         for (uint32_t ind = 0; ind < mh.nnode(); ++ind)
         {
-            *ptr++ = mh.ndcrd(ind, 0);
-            *ptr++ = mh.ndcrd(ind, 1);
-            *ptr++ = (3 == mh.ndim()) ? mh.ndcrd(ind, 2) : 0;
+            sarr(ind, 0) = mh.ndcrd(ind, 0);
+            sarr(ind, 1) = mh.ndcrd(ind, 1);
+            sarr(ind, 2) = (3 == mh.ndim()) ? mh.ndcrd(ind, 2) : 0;
         }
         buf->setData(barray);
     }


### PR DESCRIPTION
Use the SimpleArray converter to improve bound-checking of the mesh coordinate data setup in RStaticMesh.

Also fix a bug of missing m_nghost and m_body in the move constructor of SimpleArray.