### PR TITLE
Add arrow heads to the lines of the axis markers

### DIFF
--- a/cpp/modmesh/python/wrapper/view/wrap_view.cpp
+++ b/cpp/modmesh/python/wrapper/view/wrap_view.cpp
@@ -77,6 +77,34 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapR3DWidget
 
 }; /* end class WrapR3DWidget */
 
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRLine
+    : public WrapBase<WrapRLine, RLine>
+{
+
+    friend root_base_type;
+
+    WrapRLine(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : root_base_type(mod, pyname, pydoc)
+    {
+        namespace py = pybind11;
+
+        (*this)
+            .def(
+                py::init(
+                    [](float x0, float y0, float z0, float x1, float y1, float z1, uint8_t color_r, uint8_t color_g, uint8_t color_b)
+                    {
+                        auto * scene = RApplication::instance()->main()->viewer()->scene();
+                        QVector3D v0(x0, y0, z0);
+                        QVector3D v1(x1, y1, z1);
+                        QColor color(color_r, color_g, color_b, 255);
+                        auto * ret = new RLine(v0, v1, color, scene);
+                        ret->addArrowHead(0.2, 0.4);
+                        return ret;
+                    }));
+    }
+
+}; /* end class WrapRLine */
+
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRApplication
     : public WrapBase<WrapRApplication, RApplication>
 {
@@ -111,6 +139,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRApplication
 void wrap_view(pybind11::module & mod)
 {
     WrapR3DWidget::commit(mod, "R3DWidget", "R3DWidget");
+    WrapRLine::commit(mod, "RLine", "RLine");
     WrapRApplication::commit(mod, "RApplication", "RApplication");
 }
 

--- a/cpp/modmesh/view/RAxisMark.cpp
+++ b/cpp/modmesh/view/RAxisMark.cpp
@@ -97,8 +97,8 @@ void RLine::addArrowHead(float erate, float wrate)
     if (!m_arrow_head)
     {
         QVector3D v2 = (m_v1 - m_v0) * erate;
-        v2 += m_v1;
-        m_arrow_head = new RArrowHead(m_v1, v2, color(), this);
+        v2 = m_v1 - v2;
+        m_arrow_head = new RArrowHead(v2, m_v1, color(), this);
         m_arrow_head->setBottomRadiusRatio(wrate);
     }
 }

--- a/cpp/modmesh/view/RAxisMark.hpp
+++ b/cpp/modmesh/view/RAxisMark.hpp
@@ -47,8 +47,37 @@
 
 #include <Qt3DExtras/QDiffuseSpecularMaterial>
 
+namespace Qt3DExtras
+{
+
+class QConeMesh;
+
+}
+
 namespace modmesh
 {
+
+class RArrowHead
+    : public Qt3DCore::QEntity
+{
+
+public:
+
+    RArrowHead(QVector3D const & v0, QVector3D const & v1, QColor const & color, Qt3DCore::QNode * parent = nullptr);
+
+    void setColor(QColor const & color);
+    float length() const;
+    void setLength(float v);
+    float bottomRadius() const;
+    void setBottomRadius(float v);
+    void setBottomRadiusRatio(float v);
+
+private:
+
+    Qt3DExtras::QConeMesh * m_renderer = nullptr;
+    Qt3DExtras::QDiffuseSpecularMaterial * m_material = nullptr;
+
+}; /* end class RArrowHead */
 
 class RLine
     : public Qt3DCore::QEntity
@@ -58,11 +87,19 @@ public:
 
     RLine(QVector3D const & v0, QVector3D const & v1, QColor const & color, Qt3DCore::QNode * parent = nullptr);
 
+    void addArrowHead(float erate, float wrate);
+
+    QColor color() const;
+    void setColor(QColor const & color);
+
 private:
 
     Qt3DCore::QGeometry * m_geometry = nullptr;
     Qt3DRender::QGeometryRenderer * m_renderer = nullptr;
     Qt3DExtras::QDiffuseSpecularMaterial * m_material = nullptr;
+    RArrowHead * m_arrow_head = nullptr;
+    QVector3D m_v0;
+    QVector3D m_v1;
 
 }; /* end class RLine */
 

--- a/cpp/modmesh/view/RPythonText.cpp
+++ b/cpp/modmesh/view/RPythonText.cpp
@@ -91,6 +91,9 @@ mm.view.show(mh)
 print("position:", mm.view.app.viewer.position)
 print("up_vector:", mm.view.app.viewer.up_vector)
 print("view_center:", mm.view.app.viewer.view_center)
+
+# line = mm.view.RLine(-1, -1, -1, -2, -2, -2, 0, 128, 128)
+# print(line)
 )""""));
 }
 


### PR DESCRIPTION
The arrow heads help the axis markers to better show the direction.

All lines can have the arrow head added too.

Work is still in progress.  The arrow head should ends at the line, not extend it.