### PR TITLE
Ignore the setting directory of JetBrains CLion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 __pycache__/
 build/
 dist/


### PR DESCRIPTION
`.idea` is the directory holding the settings of JetBrains CLion IDE.  Add it in the `.gitignore`.