### PR TITLE
Remove duplicated edges when drawing the wireframe of a mesh

### DIFF
--- a/cpp/modmesh/mesh/StaticMesh.hpp
+++ b/cpp/modmesh/mesh/StaticMesh.hpp
@@ -285,6 +285,7 @@ public:
         , m_fccls(std::vector<size_t>{nface, FCREL})
         , m_clnds(std::vector<size_t>{ncell, CLMND + 1})
         , m_clfcs(std::vector<size_t>{ncell, CLMFC + 1})
+        , m_ednds(std::vector<size_t>{0, 2})
         , m_bndfcs(std::vector<size_t>{0, StaticMeshBC::BFREL})
     {
     }
@@ -307,6 +308,7 @@ public:
     uint_type ngstcell() const { return m_ngstcell; }
     bool use_incenter() const { return m_use_incenter; }
 
+    uint_type nedge() const { return m_ednds.shape(0); }
     size_t nbcs() const { return m_bcs.size(); }
 
     /**
@@ -330,14 +332,20 @@ public:
     // Helpers for interior data.
 public:
 
-    void build_interior(bool do_metric)
+    void build_interior(bool do_metric, bool do_edge = true)
     {
         build_faces_from_cells();
         if (do_metric)
         {
             calc_metric();
         }
+        if (do_edge)
+        {
+            build_edge();
+        }
     }
+
+    void build_edge();
 
 private:
 
@@ -398,6 +406,7 @@ private:                                                                \
     MM_DECL_StaticMesh_ARRAY(int_type, fccls);
     MM_DECL_StaticMesh_ARRAY(int_type, clnds);
     MM_DECL_StaticMesh_ARRAY(int_type, clfcs);
+    MM_DECL_StaticMesh_ARRAY(int_type, ednds);
     // boundary information.
     MM_DECL_StaticMesh_ARRAY(int_type, bndfcs);
     std::vector<StaticMeshBC> m_bcs;

--- a/cpp/modmesh/python/wrapper/modmesh/wrap_StaticMesh.cpp
+++ b/cpp/modmesh/python/wrapper/modmesh/wrap_StaticMesh.cpp
@@ -95,12 +95,14 @@ WrapStaticMesh::WrapStaticMesh(pybind11::module & mod, char const * pyname, char
         .def_property_readonly("ngstnode", &wrapped_type::ngstnode)
         .def_property_readonly("ngstface", &wrapped_type::ngstface)
         .def_property_readonly("ngstcell", &wrapped_type::ngstcell)
+        .def_property_readonly("nedge", &wrapped_type::nedge)
         .def_property_readonly("nbcs", &wrapped_type::nbcs);
 
     (*this)
-        .def_timed("build_interior", &wrapped_type::build_interior, py::arg("_do_metric") = true)
+        .def_timed("build_interior", &wrapped_type::build_interior, py::arg("_do_metric") = true, py::arg("_build_edge") = true)
         .def_timed("build_boundary", &wrapped_type::build_boundary)
-        .def_timed("build_ghost", &wrapped_type::build_ghost);
+        .def_timed("build_ghost", &wrapped_type::build_ghost)
+        .def_timed("build_edge", &wrapped_type::build_edge);
 
 #define MM_DECL_ARRAY(NAME) \
     .expose_SimpleArray(#NAME, [](wrapped_type & self) -> decltype(auto) { return self.NAME(); })
@@ -120,6 +122,7 @@ WrapStaticMesh::WrapStaticMesh(pybind11::module & mod, char const * pyname, char
             MM_DECL_ARRAY(fccls)
             MM_DECL_ARRAY(clnds)
             MM_DECL_ARRAY(clfcs)
+            MM_DECL_ARRAY(ednds)
             MM_DECL_ARRAY(bndfcs)
         ;
     // clang-format on

--- a/cpp/modmesh/view/RPythonText.cpp
+++ b/cpp/modmesh/view/RPythonText.cpp
@@ -38,26 +38,26 @@ RPythonText::RPythonText(
     QWidget * parent,
     Qt::WindowFlags flags)
     : QDockWidget(title, parent, flags)
+    , m_text(new QTextEdit)
+    , m_run(new QPushButton)
+    , m_layout(new QVBoxLayout)
+    , m_widget(new QWidget)
 {
-    setUp();
-}
-
-void RPythonText::setUp()
-{
-    m_text = new QTextEdit();
     m_text->setFont(QFont("Courier New"));
-    m_run = new QPushButton(QString("run"));
-
-    m_layout = new QVBoxLayout();
+    m_run->setText(QString("run"));
     m_layout->addWidget(m_text);
     m_layout->addWidget(m_run);
-    m_widget = new QWidget();
     m_widget->setLayout(m_layout);
 
     setWidget(m_widget);
 
     connect(m_run, &QPushButton::clicked, this, &RPythonText::runPythonCode);
 
+    setUp();
+}
+
+void RPythonText::setUp()
+{
     m_text->setPlainText(QString(R""""(# Sample input
 import modmesh as mm
 
@@ -90,6 +90,7 @@ def make_3d():
 mh = make_2d()
 mm.view.show(mh)
 
+print("nedge:", mh.nedge)
 print("position:", mm.view.app.viewer.position)
 print("up_vector:", mm.view.app.viewer.up_vector)
 print("view_center:", mm.view.app.viewer.view_center)

--- a/cpp/modmesh/view/common_detail.hpp
+++ b/cpp/modmesh/view/common_detail.hpp
@@ -78,6 +78,15 @@ SimpleArray<T> makeSimpleArray(QByteArray & qbarr, small_vector<size_t> shape, b
     return SimpleArray<T>(small_vector<size_t>(shape), cbuf);
 }
 
+template <typename T>
+QByteArray makeQByteArray(SimpleArray<T> const & sarr)
+{
+    QByteArray barray;
+    barray.resize(sarr.nbytes());
+    std::copy_n(sarr.data(), sarr.size(), reinterpret_cast<T *>(barray.data()));
+    return barray;
+}
+
 } /* end namespace modmesh */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
This is to address issue #68.

A new array `ednds` is added to StaticMesh.  Each row contains the two nodes forming the edge, from the tail to head.

A new (private) argument _build_edge is added to StaticMesh.build_interior() and its default value is False.  A standalone function build_edge() is added to StaticMesh too.

RStaticMesh::update_geometry_impl() is updated to use the new ednds array.

A new free helper function makeQByteArray() is added to copy the data from a SimpleArray to Qt QByteArray.