### PR TITLE
bump pybind11 from 2.6.1 to 2.9.2

### DIFF
--- a/contrib/dependency/install.sh
+++ b/contrib/dependency/install.sh
@@ -44,8 +44,8 @@ pybind11() {
   cmakeargs+=("-DCMAKE_BUILD_TYPE=Release")
   cmakeargs+=("-DPYTHON_EXECUTABLE:FILEPATH=`which python3`")
   cmakeargs+=("-DPYBIND11_TEST=OFF")
-  install ${PYBIND_ORG:-pybind} pybind11 ${PYBIND_BRANCH:-v2.6.1} \
-    ${PYBIND_LOCAL:-pybind11-2.6.1} "${cmakeargs[@]}"
+  install ${PYBIND_ORG:-pybind} pybind11 ${PYBIND_BRANCH:-v2.9.2} \
+    ${PYBIND_LOCAL:-pybind11-2.9.2} "${cmakeargs[@]}"
 
 }
 


### PR DESCRIPTION
To support the latest APIs.