### PR TITLE
Add application code in Python

### DIFF
--- a/cpp/modmesh/python/wrapper/view/wrap_view.cpp
+++ b/cpp/modmesh/python/wrapper/view/wrap_view.cpp
@@ -107,6 +107,26 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRLine
 
 }; /* end class WrapRLine */
 
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRPythonText
+    : public WrapBase<WrapRPythonText, RPythonText>
+{
+
+    friend root_base_type;
+
+    WrapRPythonText(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : root_base_type(mod, pyname, pydoc)
+    {
+
+        namespace py = pybind11;
+
+        (*this)
+            .def_property("code", &wrapped_type::code, &wrapped_type::setCode)
+            //
+            ;
+    }
+
+}; /* end class WrapRPythonText */
+
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRApplication
     : public WrapBase<WrapRApplication, RApplication>
 {
@@ -131,6 +151,12 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRApplication
                 [](wrapped_type & self)
                 {
                     return self.main()->viewer();
+                })
+            .def_property_readonly(
+                "pytext",
+                [](wrapped_type & self)
+                {
+                    return self.main()->pytext();
                 })
             //
             ;
@@ -175,6 +201,7 @@ void wrap_view(pybind11::module & mod)
 
     WrapR3DWidget::commit(mod, "R3DWidget", "R3DWidget");
     WrapRLine::commit(mod, "RLine", "RLine");
+    WrapRPythonText::commit(mod, "RPythonText", "RPythonText");
     WrapRApplication::commit(mod, "RApplication", "RApplication");
 
     mod

--- a/cpp/modmesh/view/RApplication.cpp
+++ b/cpp/modmesh/view/RApplication.cpp
@@ -45,7 +45,7 @@ RApplication::RApplication(int & argc, char ** argv)
     // Set up menu.
     auto * menuBar = new RMenuBar();
     auto * fileMenu = new RMenu(QString("File"));
-    auto * newMenu = new RMenu(QString("New"));
+    auto * appMenu = new RMenu(QString("App"));
 
     auto * newFileAction = new RAction(
         QString("New file"),
@@ -56,6 +56,7 @@ RApplication::RApplication(int & argc, char ** argv)
             qDebug() << "Create new file!";
         });
 
+    auto * newMenu = new RMenu(QString("New"));
     newMenu->addAction(newFileAction);
     fileMenu->addMenu(newMenu);
 
@@ -71,6 +72,32 @@ RApplication::RApplication(int & argc, char ** argv)
 #endif
 
     menuBar->addMenu(fileMenu);
+
+    auto * app_sample_mesh = new RAction(
+        QString("Load sample_mesh"),
+        QString("Load sample_mesh"),
+        []()
+        {
+            namespace py = pybind11;
+            py::object appmod = py::module_::import("modmesh.app.sample_mesh");
+            appmod.attr("load_app")();
+        });
+    appMenu->addAction(app_sample_mesh);
+
+    auto * app_linear_wave = new RAction(
+        QString("Load linear_wave"),
+        QString("Load linear_wave"),
+        []()
+        {
+            namespace py = pybind11;
+            py::module_ appmod = py::module_::import("modmesh.app.linear_wave");
+            appmod.reload();
+            appmod.attr("load_app")();
+        });
+    appMenu->addAction(app_linear_wave);
+
+    menuBar->addMenu(appMenu);
+
     m_main->setMenuBar(menuBar);
 
     // Setup main window

--- a/cpp/modmesh/view/RPythonText.cpp
+++ b/cpp/modmesh/view/RPythonText.cpp
@@ -58,46 +58,7 @@ RPythonText::RPythonText(
 
 void RPythonText::setUp()
 {
-    m_text->setPlainText(QString(R""""(# Sample input
-import modmesh as mm
-
-mm.view.show_mark()
-
-def make_2d():
-    mh = mm.StaticMesh(ndim=2, nnode=4, nface=0, ncell=3)
-    mh.ndcrd.ndarray[:, :] = (0, 0), (-1, -1), (1, -1), (0, 1)
-    mh.cltpn.ndarray[:] = mm.StaticMesh.TRIANGLE
-    mh.clnds.ndarray[:, :4] = (3, 0, 1, 2), (3, 0, 2, 3), (3, 0, 3, 1)
-    mh.build_interior()
-    mh.build_boundary()
-    mh.build_ghost()
-    return mh
-
-def make_3d():
-    mh = mm.StaticMesh(ndim=3, nnode=4, nface=4, ncell=1)
-    mh.ndcrd.ndarray[:, :] = (0, 0, 0), (0, 1, 0), (-1, 1, 0), (0, 1, 1)
-    mh.cltpn.ndarray[:] = mm.StaticMesh.TETRAHEDRON
-    mh.clnds.ndarray[:, :5] = [(4, 0, 1, 2, 3)]
-    mh.build_interior()
-    mh.build_boundary()
-    mh.build_ghost()
-    return mh
-
-#mm.view.app.viewer.up_vector = (0, 1, 0)
-#mm.view.app.viewer.position = (-10, -10, -20)
-#mm.view.app.viewer.view_center = (0, 0, 0)
-
-mh = make_2d()
-mm.view.show(mh)
-
-print("nedge:", mh.nedge)
-print("position:", mm.view.app.viewer.position)
-print("up_vector:", mm.view.app.viewer.up_vector)
-print("view_center:", mm.view.app.viewer.view_center)
-
-# line = mm.view.RLine(-1, -1, -1, -2, -2, -2, 0, 128, 128)
-# print(line)
-)""""));
+    m_text->setPlainText(QString(""));
 }
 
 void RPythonText::runPythonCode()
@@ -113,6 +74,16 @@ void RPythonText::runPythonCode()
     {
         std::cerr << e.what() << std::endl;
     }
+}
+
+std::string RPythonText::code() const
+{
+    return m_text->toPlainText().toStdString();
+}
+
+void RPythonText::setCode(std::string const & value)
+{
+    m_text->setPlainText(QString(value.c_str()));
 }
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/view/RPythonText.hpp
+++ b/cpp/modmesh/view/RPythonText.hpp
@@ -50,6 +50,9 @@ public:
         QWidget * parent = nullptr,
         Qt::WindowFlags flags = Qt::WindowFlags());
 
+    std::string code() const;
+    void setCode(std::string const & value);
+
 private:
 
     void setUp();

--- a/modmesh/app/__init__.py
+++ b/modmesh/app/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
+# Copyright (c) 2018, Yung-Yu Chen <yyc@solvcon.net>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -26,15 +26,16 @@
 
 
 """
-modmesh
+Sub-package for applications
 """
 
 
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
 
 
-from .core import *  # noqa: F401, F403
-from . import view  # noqa: F401
+# Preloaded modules
+from . import linear_wave  # noqa: F401
+from . import sample_mesh  # noqa: F401
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/app/linear_wave.py
+++ b/modmesh/app/linear_wave.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2018, Yung-Yu Chen <yyc@solvcon.net>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+import numpy as np
+
+from matplotlib.backends.qt_compat import QtWidgets
+from matplotlib.backends.backend_qtagg import (
+    FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+from matplotlib.figure import Figure
+
+from .. import view
+from .. import spacetime as libst
+
+
+def load_app():
+    view.app.pytext.code = """import importlib
+from modmesh import spacetime as libst
+from modmesh.app import linear_wave as app
+
+svr = app.run_linear()
+"""
+
+
+class ApplicationWindow(QtWidgets.QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self._main = QtWidgets.QWidget()
+        self.setCentralWidget(self._main)
+        layout = QtWidgets.QVBoxLayout(self._main)
+
+        static_canvas = FigureCanvas(Figure(figsize=(15, 10)))
+        # Ideally one would use self.addToolBar here, but it is slightly
+        # incompatible between PyQt6 and other bindings, so we just add the
+        # toolbar as a plain widget instead.
+        layout.addWidget(static_canvas)
+        layout.addWidget(NavigationToolbar(static_canvas, self))
+
+        self.ax = static_canvas.figure.subplots()
+
+
+_ui_holder = []
+
+
+def run_linear():
+    grid = libst.Grid(0, 4 * 2 * np.pi, 4 * 64)
+
+    cfl = 1
+    dx = (grid.xmax - grid.xmin) / grid.ncelm
+    dt = dx * cfl
+    svr = libst.LinearScalarSolver(grid=grid, time_increment=dt)
+
+    # Initialize
+    for e in svr.selms(odd_plane=False):
+        if e.xctr < 2 * np.pi or e.xctr > 2 * 2 * np.pi:
+            v = 0
+            dv = 0
+        else:
+            v = np.sin(e.xctr)
+            dv = np.cos(e.xctr)
+        e.set_so0(0, v)
+        e.set_so1(0, dv)
+
+    win = ApplicationWindow()
+    win.show()
+    win.activateWindow()
+    # FIXME: This is a hack for PySide object lifecycle management.
+    global _ui_holder
+    _ui_holder.append(win)
+
+    win.ax.plot(svr.xctr() / np.pi, svr.get_so0(0).ndarray, '-')
+
+    svr.setup_march()
+    svr.march_alpha2(50)
+
+    win.ax.plot(svr.xctr() / np.pi, svr.get_so0(0).ndarray, '-')
+
+    return svr
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/app/sample_mesh.py
+++ b/modmesh/app/sample_mesh.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
+# Copyright (c) 2021, Yung-Yu Chen <yyc@solvcon.net>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -26,15 +26,56 @@
 
 
 """
-modmesh
+Show sample mesh
 """
 
 
-# Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
+from .. import core
+from .. import view
 
 
-from .core import *  # noqa: F401, F403
-from . import view  # noqa: F401
+def load_app():
+    view.app.pytext.code = """import modmesh as mm
+from modmesh import app
 
+#mm.view.app.viewer.up_vector = (0, 1, 0)
+#mm.view.app.viewer.position = (-10, -10, -20)
+#mm.view.app.viewer.view_center = (0, 0, 0)
+
+mh = app.sample_mesh.make_triangle()
+#mh = app.sample_mesh.make_tetrahedron()
+mm.view.show_mark()
+mm.view.show(mh)
+
+print("nedge:", mh.nedge)
+print("position:", mm.view.app.viewer.position)
+print("up_vector:", mm.view.app.viewer.up_vector)
+print("view_center:", mm.view.app.viewer.view_center)
+
+# line = mm.view.RLine(-1, -1, -1, -2, -2, -2, 0, 128, 128)
+# print(line)
+"""
+
+
+def make_triangle():
+    mh = core.StaticMesh(ndim=2, nnode=4, nface=0, ncell=3)
+    mh.ndcrd.ndarray[:, :] = (0, 0), (-1, -1), (1, -1), (0, 1)
+    mh.cltpn.ndarray[:] = core.StaticMesh.TRIANGLE
+    mh.clnds.ndarray[:, :4] = (3, 0, 1, 2), (3, 0, 2, 3), (3, 0, 3, 1)
+    mh.build_interior()
+    mh.build_boundary()
+    mh.build_ghost()
+    return mh
+
+
+def make_tetrahedron():
+    mh = core.StaticMesh(ndim=3, nnode=4, nface=4, ncell=1)
+    mh.ndcrd.ndarray[:, :] = (0, 0, 0), (0, 1, 0), (-1, 1, 0), (0, 1, 1)
+    mh.cltpn.ndarray[:] = core.StaticMesh.TETRAHEDRON
+    mh.clnds.ndarray[:, :5] = [(4, 0, 1, 2, 3)]
+    mh.build_interior()
+    mh.build_boundary()
+    mh.build_ghost()
+    return mh
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -26,15 +26,54 @@
 
 
 """
-modmesh
+General mesh data definition and manipulation in one, two, and
+three-dimensional space.
 """
 
 
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
 
 
-from .core import *  # noqa: F401, F403
-from . import view  # noqa: F401
+__all__ = [  # noqa: F822
+    'WrapperProfilerStatus',
+    'wrapper_profiler_status',
+    'StopWatch',
+    'stop_watch',
+    'TimeRegistry',
+    'time_registry',
+    'ConcreteBuffer',
+    'SimpleArrayBool',
+    'SimpleArrayInt8',
+    'SimpleArrayInt16',
+    'SimpleArrayInt32',
+    'SimpleArrayInt64',
+    'SimpleArrayUint8',
+    'SimpleArrayUint16',
+    'SimpleArrayUint32',
+    'SimpleArrayUint64',
+    'SimpleArrayFloat32',
+    'SimpleArrayFloat64',
+    'StaticGrid1d',
+    'StaticGrid2d',
+    'StaticGrid3d',
+    'StaticMesh',
+]
 
+
+# A hidden loophole to impolementation; it should only be used for testing
+# during development.
+try:
+    import _modmesh as _impl  # noqa: F401
+except ImportError:
+    from . import _modmesh as _impl  # noqa: F401
+
+
+def _load():
+    for name in __all__:
+        globals()[name] = getattr(_impl, name)
+
+
+_load()
+del _load
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/spacetime.py
+++ b/modmesh/spacetime.py
@@ -38,10 +38,9 @@ del _load
 del _toload
 
 
-class SolverProxy():
+class SolverProxy:
 
     def __init__(self, *args, **kw):
-
         self.svr = Solver(*args, **kw)  # noqa: F821
         self.svr.kernel.xp_calc = self._xp_calc
         self.svr.kernel.xn_calc = self._xn_calc

--- a/modmesh/view.py
+++ b/modmesh/view.py
@@ -26,15 +26,42 @@
 
 
 """
-modmesh
+Viewer
 """
 
 
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
 
 
-from .core import *  # noqa: F401, F403
-from . import view  # noqa: F401
+__all__ = [  # noqa: F822
+    'R3DWidget',
+    'RLine',
+    'RPythonText',
+    'RApplication',
+    'show',
+    'show_mark',
+    'clip_image',
+    'save_image',
+    'app',
+]
 
+
+# Try to import the viewer code but easily give up.
+enable = False
+try:
+    import _modmesh_view as _impl  # noqa: F401
+    enable = True
+except ImportError:
+    pass
+
+
+def _load():
+    if enable:
+        for name in __all__:
+            globals()[name] = getattr(_impl, name)
+
+
+_load()
+del _load
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
A new Python sub-package `modmesh.app` is created to house application code (written in Python).  At this point there are two of them: `linear_wave` (for the 1D CESE solver) and `sample_mesh` (for simple 2D/3D unstructured mesh).

The linear wave requires PySide6 because it uses matplotlib for visualization.

Two additional Python modules `core` and `view` are created.

ref #100 