### PR TITLE
Fix viewer crash with linear_wave app loaded

### DIFF
--- a/cpp/binary/viewer/viewer.cpp
+++ b/cpp/binary/viewer/viewer.cpp
@@ -48,6 +48,9 @@ PYBIND11_EMBEDDED_MODULE(_modmesh_view, mod) // NOLINT
 
 int main(int argc, char ** argv)
 {
+    // Set up Python interpreter.
+    modmesh::python::Interpreter::instance().initialize();
+
     modmesh::RApplication app(argc, argv);
     app.main()->resize(1000, 600);
     return app.exec();

--- a/cpp/modmesh/python/common.cpp
+++ b/cpp/modmesh/python/common.cpp
@@ -57,19 +57,25 @@ Interpreter & Interpreter::instance()
     return o;
 }
 
-Interpreter::Interpreter()
-    : m_interpreter(new pybind11::scoped_interpreter)
+Interpreter & Interpreter::initialize()
 {
-    setup_path();
+    if (nullptr == m_interpreter)
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        m_interpreter = new pybind11::scoped_interpreter(true, 0, nullptr, true);
+        setup_path();
+    }
+    return *this;
 }
 
-Interpreter::~Interpreter()
+Interpreter & Interpreter::finalize()
 {
-    // NOLINTNEXTLINE(readability-delete-null-pointer)
     if (nullptr != m_interpreter)
     {
         delete m_interpreter;
+        m_interpreter = nullptr;
     }
+    return *this;
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static): implicitly requires m_interpreter

--- a/cpp/modmesh/python/common.hpp
+++ b/cpp/modmesh/python/common.hpp
@@ -451,14 +451,18 @@ public:
     Interpreter(Interpreter &&) = delete;
     Interpreter & operator=(Interpreter const &) = delete;
     Interpreter & operator=(Interpreter &&) = delete;
-    ~Interpreter();
+    ~Interpreter() { finalize(); };
+
+    Interpreter & initialize();
+    Interpreter & finalize();
+    bool initialized() const { return nullptr != m_interpreter; }
 
     void preload_module(std::string const & name);
     void preload_modules(std::vector<std::string> const & names);
 
 private:
 
-    Interpreter();
+    Interpreter() = default;
     void setup_path();
 
     pybind11::scoped_interpreter * m_interpreter = nullptr;

--- a/cpp/modmesh/view/RApplication.cpp
+++ b/cpp/modmesh/view/RApplication.cpp
@@ -39,9 +39,6 @@ RApplication::RApplication(int & argc, char ** argv)
 {
     /* TODO: parse arguments */
 
-    // Set up Python interpreter.
-    python::Interpreter::instance();
-
     // Set up menu.
     auto * menuBar = new RMenuBar();
     auto * fileMenu = new RMenu(QString("File"));
@@ -79,7 +76,8 @@ RApplication::RApplication(int & argc, char ** argv)
         []()
         {
             namespace py = pybind11;
-            py::object appmod = py::module_::import("modmesh.app.sample_mesh");
+            py::module_ appmod = py::module_::import("modmesh.app.sample_mesh");
+            appmod.reload();
             appmod.attr("load_app")();
         });
     appMenu->addAction(app_sample_mesh);
@@ -106,6 +104,12 @@ RApplication::RApplication(int & argc, char ** argv)
 
     // Show main window.
     m_main->show();
+}
+
+RApplication::~RApplication()
+{
+    // Shuts down the interpreter when the application stops.
+    python::Interpreter::instance().finalize();
 }
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/view/RApplication.hpp
+++ b/cpp/modmesh/view/RApplication.hpp
@@ -46,6 +46,7 @@ class RApplication
 public:
 
     RApplication(int & argc, char ** argv);
+    ~RApplication();
 
     RMainWindow * main() { return m_main; }
 

--- a/modmesh/app/__init__.py
+++ b/modmesh/app/__init__.py
@@ -33,9 +33,4 @@ Sub-package for applications
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
 
 
-# Preloaded modules
-from . import linear_wave  # noqa: F401
-from . import sample_mesh  # noqa: F401
-
-
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/app/linear_wave.py
+++ b/modmesh/app/linear_wave.py
@@ -41,7 +41,8 @@ def load_app():
 from modmesh import spacetime as libst
 from modmesh.app import linear_wave as app
 
-svr = app.run_linear()
+# Need to hold the win object to keep PySide alive.
+win, svr = app.run_linear()
 """
 
 
@@ -60,9 +61,6 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         layout.addWidget(NavigationToolbar(static_canvas, self))
 
         self.ax = static_canvas.figure.subplots()
-
-
-_ui_holder = []
 
 
 def run_linear():
@@ -87,9 +85,6 @@ def run_linear():
     win = ApplicationWindow()
     win.show()
     win.activateWindow()
-    # FIXME: This is a hack for PySide object lifecycle management.
-    global _ui_holder
-    _ui_holder.append(win)
 
     win.ax.plot(svr.xctr() / np.pi, svr.get_so0(0).ndarray, '-')
 
@@ -98,6 +93,6 @@ def run_linear():
 
     win.ax.plot(svr.xctr() / np.pi, svr.get_so0(0).ndarray, '-')
 
-    return svr
+    return win, svr
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
The linear_wave app uses PySide6 for matplotlib to create a new window, and it seems to conflict with the shutdown sequence of python interpreter.

Change the interpreter shotdown order to fix it.

In addition, improve the interpreter wrapping API.  Do not initialize the interpreter in the constructor of the class Interpreter.

ref #100 