### PR TITLE
Add macos build test to modmesh_viewer.yml

### DIFF
--- a/.github/workflows/modmesh_viewer.yml
+++ b/.github/workflows/modmesh_viewer.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
         matrix:
-          os: [ubuntu-22.04]
+          os: [ubuntu-22.04, macos-latest]
           cmake_build_type: [Release, Debug]
 
         fail-fast: false
@@ -40,6 +40,16 @@ jobs:
             libgl1-mesa-dev
 
         sudo pip3 install numpy pytest flake8
+        
+    - name: dependency (macos)
+      if: ${{ startsWith(matrix.os, 'macos-latest') }}
+      run: |
+        brew install python3 llvm qt6
+        ln -s "$(brew --prefix llvm)/bin/clang-format" "/usr/local/bin/clang-format"
+        ln -s "$(brew --prefix llvm)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
+        echo "which pip3: $(which pip3)"
+        pip3 install -U setuptools
+        pip3 install -U numpy pytest flake8
 
     - name: dependency (manual)
       run: sudo ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11

--- a/.github/workflows/modmesh_viewer.yml
+++ b/.github/workflows/modmesh_viewer.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
         matrix:
-          os: [ubuntu-22.04, macos-latest]
+          os: [ubuntu-22.04, macos-12]
           cmake_build_type: [Release, Debug]
 
         fail-fast: false
@@ -42,7 +42,7 @@ jobs:
         sudo pip3 install numpy pytest flake8
         
     - name: dependency (macos)
-      if: ${{ startsWith(matrix.os, 'macos-latest') }}
+      if: ${{ startsWith(matrix.os, 'macos-12') }}
       run: |
         brew install python3 llvm qt6
         ln -s "$(brew --prefix llvm)/bin/clang-format" "/usr/local/bin/clang-format"


### PR DESCRIPTION
1. Specify the version of mac os: 12
2. Align the commands with the ones in https://github.com/solvcon/modmesh/blob/9eef4aaf004cbf86478368714e13493d34e0d59a/.github/workflows/modmesh_pytest.yml#L48