### PR TITLE
Add environment variable from the setup to solve issue 118

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ endif()
 add_subdirectory(cpp/binary/pymod_modmesh)
 if(BUILD_QT)
 add_subdirectory(cpp/binary/viewer)
+set(ENV{QT3D_RENDERER} ${QT3D_RENDERER})
+message(STATUS "QT3D_RENDERER: " $ENV{QT3D_RENDERER})
 endif()
 
 add_custom_target(flake8)

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ CMAKE_PREFIX_PATH ?=
 CMAKE_ARGS ?=
 VERBOSE ?=
 FORCE_CLANG_FORMAT ?=
+QT3D_RENDERER ?=
 
 pyextsuffix := $(shell python3-config --extension-suffix)
 pyvminor := $(shell python3 -c 'import sys; print("%d%d" % sys.version_info[0:2])')
@@ -136,6 +137,7 @@ CMAKE_CMD = cmake $(MODMESH_ROOT) \
 	-DUSE_CLANG_TIDY=$(USE_CLANG_TIDY) \
 	-DLINT_AS_ERRORS=ON \
 	-DMODMESH_PROFILE=$(MODMESH_PROFILE) \
+	-DQT3D_RENDERER=$(QT3D_RENDERER) \
 	$(CMAKE_ARGS)
 
 $(BUILD_PATH)/Makefile: CMakeLists.txt Makefile


### PR DESCRIPTION
@yungyuc

`QT3D_RENENDER := opengl` is first added in `setup.mk`. 
Then, by this line (https://github.com/minchuncho/modmesh/blob/54fc5160f1da289c25f41eca7d351ae77ac81136/Makefile#L140) `QT3D_RENENDER` is treated as one of the CMake argument and hopefully by this line (https://github.com/minchuncho/modmesh/blob/54fc5160f1da289c25f41eca7d351ae77ac81136/CMakeLists.txt#L100), `QT3D_RENENDER=opengl` can be set as an environment variable.

Unfortunately, it failed to do as expected.