### PR TITLE
(Re-)fix clang-tidy errors that show up with v15

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,7 +31,8 @@ Checks: >
     -readability-named-parameter,
     -readability-magic-numbers,
     -readability-redundant-access-specifiers,
-    -misc-non-private-member-variables-in-classes
+    -misc-non-private-member-variables-in-classes,
+    -misc-confusable-identifiers
 WarningsAsErrors: ''
 HeaderFilterRegex: 'modmesh.*'
 AnalyzeTemporaryDtors: false

--- a/cpp/modmesh/onedim/Euler1DSolver.cpp
+++ b/cpp/modmesh/onedim/Euler1DSolver.cpp
@@ -103,7 +103,7 @@ void Euler1DSolver::update_cfl(bool odd_plane)
         // CFL.
         const double dxpos = m_coord(it + 1) - m_coord(it);
         const double dxneg = m_coord(it) - m_coord(it - 1);
-        double cfl = hdt * wspd / (dxpos < dxneg ? dxpos : dxneg);
+        const double cfl = hdt * wspd / (dxpos < dxneg ? dxpos : dxneg);
         // Set back.
         m_cfl(it) = cfl;
     }

--- a/cpp/modmesh/python/common.hpp
+++ b/cpp/modmesh/python/common.hpp
@@ -185,7 +185,7 @@ std::enable_if_t<is_simple_array_v<S>, pybind11::array> to_ndarray(S && sarr)
 {
     namespace py = pybind11;
     using T = typename std::remove_reference_t<S>::value_type;
-    std::vector<size_t> shape(sarr.shape().begin(), sarr.shape().end());
+    std::vector<size_t> const shape(sarr.shape().begin(), sarr.shape().end());
     std::vector<size_t> stride(sarr.stride().begin(), sarr.stride().end());
     for (size_t & v : stride) { v *= sarr.itemsize(); }
     return py::array(
@@ -209,7 +209,7 @@ static SimpleArray<T> makeSimpleArray(pybind11::array_t<T> & ndarr)
     {
         shape.push_back(ndarr.shape(i));
     }
-    std::shared_ptr<ConcreteBuffer> buffer = ConcreteBuffer::construct(
+    std::shared_ptr<ConcreteBuffer> const buffer = ConcreteBuffer::construct(
         ndarr.nbytes(), ndarr.mutable_data(), std::make_unique<ConcreteBufferNdarrayRemover>(ndarr));
     return SimpleArray<T>(shape, buffer);
 }
@@ -334,7 +334,7 @@ public:
                     array_reference this_array = f(self);
                     if (this_array.nbytes() != static_cast<size_t>(ndarr.nbytes()))
                     {
-                        std::ostringstream msg;
+                        std::ostringstream msg; // NOLINT(misc-const-correctness) tidy bug
                         msg << ndarr.nbytes() << " bytes of input array differ from "
                             << this_array.nbytes() << " bytes of internal array";
                         throw std::length_error(msg.str());
@@ -367,7 +367,7 @@ public:
                     array_reference this_array = f(self);
                     if (this_array.nbytes() != static_cast<size_t>(ndarr.nbytes()))
                     {
-                        std::ostringstream msg;
+                        std::ostringstream msg; // NOLINT(misc-const-correctness) tidy bug
                         msg << ndarr.nbytes() << " bytes of input array differ from "
                             << this_array.nbytes() << " bytes of internal array";
                         throw std::length_error(msg.str());

--- a/cpp/modmesh/spacetime/kernel/BadEuler1DSolver.cpp
+++ b/cpp/modmesh/spacetime/kernel/BadEuler1DSolver.cpp
@@ -54,7 +54,7 @@ void BadEuler1DSolver::update_cfl(bool odd_plane)
         // CFL.
         const double dxpos = se.xpos() - se.x();
         const double dxneg = se.x() - se.xneg();
-        double cfl = m_field.hdt() * wspd / (dxpos < dxneg ? dxpos : dxneg);
+        const double cfl = m_field.hdt() * wspd / (dxpos < dxneg ? dxpos : dxneg);
         // Set back.
         se.cfl() = cfl;
     }

--- a/cpp/modmesh/spacetime/kernel/BadEuler1DSolver.hpp
+++ b/cpp/modmesh/spacetime/kernel/BadEuler1DSolver.hpp
@@ -59,7 +59,7 @@ public:
         auto ret = std::make_shared<BadEuler1DSolver>(*this);
         if (grid)
         {
-            std::shared_ptr<Grid> new_grid = m_field.clone_grid();
+            std::shared_ptr<Grid> const new_grid = m_field.clone_grid();
             ret->m_field.set_grid(new_grid);
         }
         return ret;


### PR DESCRIPTION
I have fixed them once but an imperfect merge regressed.

Also turns off misc-confusable-identifiers check that was added with clang-tidy v15.  It slows down the clang-tidy by 5x.  Other new checks (https://releases.llvm.org/15.0.0/tools/clang/tools/extra/docs/ReleaseNotes.html#new-checks) also slows down a little bit, but tolerable.