### PR TITLE
Create Python middle layer for the 1D Euler solver

### DIFF
--- a/cpp/modmesh/onedim/CMakeLists.txt
+++ b/cpp/modmesh/onedim/CMakeLists.txt
@@ -4,14 +4,14 @@
 cmake_minimum_required(VERSION 3.16)
 
 set(MODMESH_ONEDIM_HEADERS
-    ${CMAKE_CURRENT_SOURCE_DIR}/Euler1DSolver.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Euler1DCore.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/onedim.hpp
     CACHE FILEPATH "" FORCE
     )
 
 set(MODMESH_ONEDIM_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/Euler1DSolver.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Euler1DCore.cpp
     CACHE FILEPATH "" FORCE
 )
 

--- a/cpp/modmesh/onedim/Euler1DCore.cpp
+++ b/cpp/modmesh/onedim/Euler1DCore.cpp
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <modmesh/onedim/Euler1DSolver.hpp>
+#include <modmesh/onedim/Euler1DCore.hpp>
 #include <cmath>
 
 namespace modmesh
@@ -35,13 +35,13 @@ namespace modmesh
 namespace onedim
 {
 
-std::ostream & operator<<(std::ostream & os, const Euler1DSolver & sol)
+std::ostream & operator<<(std::ostream & os, const Euler1DCore & sol)
 {
-    os << "Euler1DSolver(ncoord=" << sol.ncoord() << ", time_increment=" << sol.time_increment() << ")";
+    os << "Euler1DCore(ncoord=" << sol.ncoord() << ", time_increment=" << sol.time_increment() << ")";
     return os;
 }
 
-void Euler1DSolver::initialize_data(size_t ncoord)
+void Euler1DCore::initialize_data(size_t ncoord)
 {
     if (0 == ncoord % 2)
     {
@@ -54,7 +54,7 @@ void Euler1DSolver::initialize_data(size_t ncoord)
     m_gamma = SimpleArray<double>(/*shape*/ small_vector<size_t>{ncoord}, /*value*/ 1.4);
 }
 
-SimpleArray<double> Euler1DSolver::density() const
+SimpleArray<double> Euler1DCore::density() const
 {
     SimpleArray<double> ret(ncoord());
     for (size_t it = 0; it < ncoord(); ++it)
@@ -64,7 +64,7 @@ SimpleArray<double> Euler1DSolver::density() const
     return ret;
 }
 
-SimpleArray<double> Euler1DSolver::velocity() const
+SimpleArray<double> Euler1DCore::velocity() const
 {
     SimpleArray<double> ret(ncoord());
     for (size_t it = 0; it < ncoord(); ++it)
@@ -74,7 +74,7 @@ SimpleArray<double> Euler1DSolver::velocity() const
     return ret;
 }
 
-SimpleArray<double> Euler1DSolver::pressure() const
+SimpleArray<double> Euler1DCore::pressure() const
 {
     SimpleArray<double> ret(ncoord());
     for (size_t it = 0; it < ncoord(); ++it)
@@ -84,7 +84,7 @@ SimpleArray<double> Euler1DSolver::pressure() const
     return ret;
 }
 
-void Euler1DSolver::update_cfl(bool odd_plane)
+void Euler1DCore::update_cfl(bool odd_plane)
 {
     const int_type start = BOUND_COUNT - (odd_plane ? 1 : 0);
     const int_type stop = ncoord() - BOUND_COUNT - (odd_plane ? 0 : 1);
@@ -109,7 +109,7 @@ void Euler1DSolver::update_cfl(bool odd_plane)
     }
 }
 
-void Euler1DSolver::march_half_so0(bool odd_plane)
+void Euler1DCore::march_half_so0(bool odd_plane)
 {
     const int_type start = BOUND_COUNT - (odd_plane ? 1 : 0);
     const int_type stop = ncoord() - BOUND_COUNT - (odd_plane ? 0 : 1);
@@ -144,7 +144,7 @@ void Euler1DSolver::march_half_so0(bool odd_plane)
     }
 }
 
-void Euler1DSolver::treat_boundary_so0()
+void Euler1DCore::treat_boundary_so0()
 {
     // Set outside value from inside value.
     {
@@ -163,7 +163,7 @@ void Euler1DSolver::treat_boundary_so0()
     }
 }
 
-void Euler1DSolver::treat_boundary_so1()
+void Euler1DCore::treat_boundary_so1()
 {
     // Set outside value from inside value.
     {

--- a/cpp/modmesh/onedim/Euler1DCore.hpp
+++ b/cpp/modmesh/onedim/Euler1DCore.hpp
@@ -40,8 +40,8 @@ namespace modmesh
 namespace onedim
 {
 
-class Euler1DSolver
-    : public std::enable_shared_from_this<Euler1DSolver>
+class Euler1DCore
+    : public std::enable_shared_from_this<Euler1DCore>
 {
 
 public:
@@ -58,33 +58,33 @@ private:
 
 public:
 
-    std::shared_ptr<Euler1DSolver> clone()
+    std::shared_ptr<Euler1DCore> clone()
     {
-        auto ret = std::make_shared<Euler1DSolver>(*this);
+        auto ret = std::make_shared<Euler1DCore>(*this);
         return ret;
     }
 
     template <class... Args>
-    static std::shared_ptr<Euler1DSolver> construct(Args &&... args)
+    static std::shared_ptr<Euler1DCore> construct(Args &&... args)
     {
-        return std::make_shared<Euler1DSolver>(std::forward<Args>(args)..., ctor_passkey());
+        return std::make_shared<Euler1DCore>(std::forward<Args>(args)..., ctor_passkey());
     }
 
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-    Euler1DSolver(size_t ncoord, double time_increment, ctor_passkey const &)
+    Euler1DCore(size_t ncoord, double time_increment, ctor_passkey const &)
         : m_time_increment(time_increment)
     {
         initialize_data(ncoord);
     }
 
-    explicit Euler1DSolver(ctor_passkey const &);
+    explicit Euler1DCore(ctor_passkey const &);
 
-    Euler1DSolver() = delete;
-    Euler1DSolver(Euler1DSolver const &) = default;
-    Euler1DSolver(Euler1DSolver &&) = default;
-    Euler1DSolver & operator=(Euler1DSolver const &) = default;
-    Euler1DSolver & operator=(Euler1DSolver &&) = default;
-    ~Euler1DSolver() = default;
+    Euler1DCore() = delete;
+    Euler1DCore(Euler1DCore const &) = default;
+    Euler1DCore(Euler1DCore &&) = default;
+    Euler1DCore & operator=(Euler1DCore const &) = default;
+    Euler1DCore & operator=(Euler1DCore &&) = default;
+    ~Euler1DCore() = default;
 
     void initialize_data(size_t ncoord);
 
@@ -136,11 +136,11 @@ private:
     SimpleArray<double> m_so0;
     SimpleArray<double> m_so1;
     SimpleArray<double> m_gamma;
-}; /* end class Euler1DSolver */
+}; /* end class Euler1DCore */
 
-std::ostream & operator<<(std::ostream & os, const Euler1DSolver & sol);
+std::ostream & operator<<(std::ostream & os, const Euler1DCore & sol);
 
-inline double Euler1DSolver::pressure(size_t it) const
+inline double Euler1DCore::pressure(size_t it) const
 {
     double ret = m_so0(it, 1);
     ret *= ret;
@@ -253,7 +253,7 @@ struct Euler1DKernel
 }; /* end struct Euler1DKernel */
 
 template <size_t ALPHA>
-inline void Euler1DSolver::march_half_so1_alpha(bool odd_plane)
+inline void Euler1DCore::march_half_so1_alpha(bool odd_plane)
 {
     const int_type start = BOUND_COUNT - (odd_plane ? 1 : 0);
     const int_type stop = ncoord() - BOUND_COUNT - (odd_plane ? 0 : 1);
@@ -289,7 +289,7 @@ inline void Euler1DSolver::march_half_so1_alpha(bool odd_plane)
 }
 
 template <size_t ALPHA>
-inline void Euler1DSolver::march_half1_alpha()
+inline void Euler1DCore::march_half1_alpha()
 {
     march_half_so0(/*odd_plane*/ false);
     update_cfl(/*odd_plane*/ false);
@@ -297,7 +297,7 @@ inline void Euler1DSolver::march_half1_alpha()
 }
 
 template <size_t ALPHA>
-inline void Euler1DSolver::march_half2_alpha()
+inline void Euler1DCore::march_half2_alpha()
 {
     // In the second half step, no treating boundary conditions.
     march_half_so0(/*odd_plane*/ true);
@@ -306,7 +306,7 @@ inline void Euler1DSolver::march_half2_alpha()
 }
 
 template <size_t ALPHA>
-inline void Euler1DSolver::march_alpha(size_t steps)
+inline void Euler1DCore::march_alpha(size_t steps)
 {
     for (size_t it = 0; it < steps; ++it)
     {

--- a/cpp/modmesh/onedim/onedim.hpp
+++ b/cpp/modmesh/onedim/onedim.hpp
@@ -9,6 +9,6 @@
  * One-dimensional space-time CESE solver.
  */
 
-#include <modmesh/onedim/Euler1DSolver.hpp>
+#include <modmesh/onedim/Euler1DCore.hpp>
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/python/wrapper/onedim/wrap_onedim.cpp
+++ b/cpp/modmesh/python/wrapper/onedim/wrap_onedim.cpp
@@ -38,13 +38,13 @@ namespace python
 
 using namespace modmesh::onedim; // NOLINT(google-build-using-namespace)
 
-class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapEuler1DSolver
-    : public WrapBase<WrapEuler1DSolver, Euler1DSolver, std::shared_ptr<Euler1DSolver>>
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapEuler1DCore
+    : public WrapBase<WrapEuler1DCore, Euler1DCore, std::shared_ptr<Euler1DCore>>
 {
 
 public:
 
-    using base_type = WrapBase<WrapEuler1DSolver, Euler1DSolver, std::shared_ptr<Euler1DSolver>>;
+    using base_type = WrapBase<WrapEuler1DCore, Euler1DCore, std::shared_ptr<Euler1DCore>>;
     using wrapper_type = typename base_type::wrapper_type;
     using wrapped_type = typename base_type::wrapped_type;
 
@@ -52,7 +52,7 @@ public:
 
 protected:
 
-    WrapEuler1DSolver(pybind11::module & mod, const char * pyname, const char * clsdoc)
+    WrapEuler1DCore(pybind11::module & mod, const char * pyname, const char * clsdoc)
         : base_type(mod, pyname, clsdoc)
     {
 
@@ -162,13 +162,13 @@ protected:
         return *this;
     }
 
-}; /* end class WrapEuler1DSolver */
+}; /* end class WrapEuler1DCore */
 
 void wrap_onedim(pybind11::module & mod)
 {
     mod.doc() = "One-dimensional space-time CESE method code";
 
-    WrapEuler1DSolver::commit(mod, "Euler1DSolver", "Solve the Euler equation");
+    WrapEuler1DCore::commit(mod, "Euler1DCore", "Solve the Euler equation");
 }
 
 } /* end namespace python */

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -39,7 +39,7 @@ from .. import onedim
 def load_app():
     view.app.pytext.code = """
 # Need to hold the win object to keep PySide alive.
-win, svr = mm.app.euler1d.run(animate=True, interval=10, max_steps=50)
+win = mm.app.euler1d.run(animate=True, interval=10, max_steps=50)
 print(mm.apputil.environ)
 #win.march_alpha2()
 win.start()
@@ -50,7 +50,7 @@ win.start()
 
 
 class ApplicationWindow(QtWidgets.QMainWindow):
-    def __init__(self):
+    def __init__(self, svr, max_steps):
         super().__init__()
         self._main = QtWidgets.QWidget()
         self.setCentralWidget(self._main)
@@ -63,13 +63,15 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         layout.addWidget(self.canvas)
         layout.addWidget(NavigationToolbar(self.canvas, self))
 
+        self.max_steps = max_steps
         self.step = 0
-        self.max_steps = 0
 
-        self.svr = None
+        self.svr = svr
         self.ax = self.canvas.figure.subplots()
         self.timer = None
-        self.line = None
+        self.line_density = None
+        self.line_velocity = None
+        self.line_pressure = None
 
     def start(self):
         self.timer.start()
@@ -86,69 +88,47 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         if self.max_steps and self.step > self.max_steps:
             self.stop()
 
-    def set_solver(self, svr, interval):
+    def setup_solver(self, interval):
         """
-        :param svr: Solver
         :param interval: milliseconds
         :return: nothing
         """
-        self.svr = svr
+        svr = self.svr
         x = svr.coord[::2]
-        self.line0, = self.ax.plot(x, svr.density[::2], 'r+')
-        self.line1, = self.ax.plot(x, svr.velocity[::2], 'g+')
-        self.line2, = self.ax.plot(x, svr.pressure[::2], 'b+')
+        self.line_density, = self.ax.plot(x, svr.density[::2], 'r+')
+        self.line_velocity, = self.ax.plot(x, svr.velocity[::2], 'g+')
+        self.line_pressure, = self.ax.plot(x, svr.pressure[::2], 'b+')
         self.timer = self.canvas.new_timer(interval)
         self.timer.add_callback(self.march_alpha2)
 
     def _update_canvas(self):
         x = self.svr.coord[::2]
-        self.line0.set_data(x, self.svr.density[::2])
-        self.line1.set_data(x, self.svr.velocity[::2])
-        self.line2.set_data(x, self.svr.pressure[::2])
-        self.line0.figure.canvas.draw()
-        self.line1.figure.canvas.draw()
-        self.line2.figure.canvas.draw()
+        self.line_density.set_data(x, self.svr.density[::2])
+        self.line_velocity.set_data(x, self.svr.velocity[::2])
+        self.line_pressure.set_data(x, self.svr.pressure[::2])
+        self.line_density.figure.canvas.draw()
+        self.line_velocity.figure.canvas.draw()
+        self.line_pressure.figure.canvas.draw()
 
 
 def run(animate, interval=10, max_steps=50):
-    dt = 0.05
-    dx = 0.1
-    ncoord = 201
-    svr = onedim.Euler1DSolver(ncoord=ncoord, time_increment=dt)
+    svr = onedim.Euler1DSolver(
+        xmin=-10, xmax=10, ncoord=201, time_increment=0.05)
+    svr.init_sods_problem(
+        density0=1.0, pressure0=1.0, density1=0.125, pressure1=0.1,
+        xdiaphragm=0.0, gamma=1.4)
 
-    garr = np.linspace(-dx * (ncoord // 2), dx * (ncoord // 2), num=ncoord)
-    svr.coord[...] = garr
-
-    # Initialize.
-    svr.cfl.fill(0)
-    svr.gamma.fill(1.4)
-    d = ncoord // 2
-    # u0
-    svr.so0[0:d, 0] = 1.0
-    svr.so0[d:, 0] = 0.125
-    # u1
-    svr.so0[0:d, 1] = 0.0
-    svr.so0[d:, 1] = 0.0
-    # u2
-    svr.so0[0:d, 2] = 2.5
-    svr.so0[d:, 2] = 0.25
-    # Derivative.
-    svr.so1.fill(0)
-
-    win = ApplicationWindow()
-    win.max_steps = max_steps
+    win = ApplicationWindow(svr=svr, max_steps=max_steps)
     win.show()
     win.activateWindow()
 
-    svr.setup_march()
-
     if animate:
-        win.set_solver(svr, interval)
+        win.setup_solver(interval)
     else:
         win.ax.plot(svr.xctr() / np.pi, svr.get_so0(0), '-')
         svr.march_alpha2(50)
         win.ax.plot(svr.xctr() / np.pi, svr.get_so0(0), '+')
 
-    return win, svr
+    return win
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/onedim.py
+++ b/modmesh/onedim.py
@@ -6,6 +6,7 @@
 One-dimensional space-time CESE method implementation.
 """
 
+import numpy as np
 
 try:
     from _modmesh import onedim as _impl  # noqa: F401
@@ -13,7 +14,6 @@ except ImportError:
     from ._modmesh import onedim as _impl  # noqa: F401
 
 _toload = [
-    'Euler1DSolver',
 ]
 
 
@@ -23,11 +23,71 @@ def _load():
 
 
 __all__ = _toload + [
+    'Euler1DSolver',
 ]
-
 
 _load()
 del _load
 del _toload
+
+
+class Euler1DSolver:
+    def __init__(self, xmin, xmax, ncoord, time_increment=0.05):
+        self._svr = self.init_solver(xmin, xmax, ncoord, time_increment)
+
+    def __getattr__(self, name):
+        """
+        If something is not available in this Python object, fall back to the
+        C++ implementation.
+        """
+        return getattr(self._svr, name)
+
+    @staticmethod
+    def init_solver(xmin, xmax, ncoord, time_increment):
+        # Create the solver object.
+        svr = _impl.Euler1DSolver(ncoord=ncoord, time_increment=time_increment)
+
+        # Initialize spatial grid.
+        svr.coord[...] = np.linspace(xmin, xmax, num=ncoord)
+        dx = svr.coord[2] - svr.coord[0]
+
+        # Initialize field.
+        svr.cfl.fill(0)
+        svr.gamma.fill(1.4)  # Air.
+        svr.so0[...] = 0.0
+        svr.so1[...] = 0.0
+
+        return svr
+
+    @staticmethod
+    def calc_u2(gamma, density, velocity, pressure):
+        ie = 1. / (gamma - 1) * pressure / density
+        ke = velocity * velocity / 2
+        return density * (ie + ke)
+
+    def init_sods_problem(self, density0, pressure0, density1, pressure1,
+                          xdiaphragm=0.0, gamma=1.4):
+        # Fill gamma.
+        self._svr.gamma.fill(gamma)
+        # Determine u0 and u2 value at left and right.
+        u0_left = density0
+        u0_right = density1
+        u2_left = self.calc_u2(gamma, density0, 0.0, pressure0)
+        u2_right = self.calc_u2(gamma, density1, 0.0, pressure1)
+        # Create Boolean selection arrays for left and right.
+        slct_left = self._svr.coord < xdiaphragm
+        slct_right = np.logical_not(slct_left)
+        # u0
+        self._svr.so0[slct_left, 0] = u0_left
+        self._svr.so0[slct_right, 0] = u0_right
+        # u1
+        self._svr.so0[:, 1] = 0.0
+        # u2
+        self._svr.so0[slct_left, 2] = u2_left
+        self._svr.so0[slct_right, 2] = u2_right
+        # Initialize derivative to zero.
+        self._svr.so1.fill(0)
+        # Setup the rest in the solver for time-marching.
+        self._svr.setup_march()
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/onedim.py
+++ b/modmesh/onedim.py
@@ -45,11 +45,10 @@ class Euler1DSolver:
     @staticmethod
     def init_solver(xmin, xmax, ncoord, time_increment):
         # Create the solver object.
-        svr = _impl.Euler1DSolver(ncoord=ncoord, time_increment=time_increment)
+        svr = _impl.Euler1DCore(ncoord=ncoord, time_increment=time_increment)
 
         # Initialize spatial grid.
         svr.coord[...] = np.linspace(xmin, xmax, num=ncoord)
-        dx = svr.coord[2] - svr.coord[0]
 
         # Initialize field.
         svr.cfl.fill(0)

--- a/modmesh/onedim/__init__.py
+++ b/modmesh/onedim/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2022, Yung-Yu Chen <yyc@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+One-dimensional space-time CESE method implementation.
+"""
+
+
+from ._euler1d import Euler1DSolver
+
+
+__all__ = [
+    'Euler1DSolver',
+]
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/onedim/_euler1d.py
+++ b/modmesh/onedim/_euler1d.py
@@ -3,7 +3,7 @@
 
 
 """
-One-dimensional space-time CESE method implementation.
+One-dimensional Solver for the Euler Equations
 """
 
 import numpy as np
@@ -11,24 +11,12 @@ import numpy as np
 try:
     from _modmesh import onedim as _impl  # noqa: F401
 except ImportError:
-    from ._modmesh import onedim as _impl  # noqa: F401
-
-_toload = [
-]
+    from .._modmesh import onedim as _impl  # noqa: F401
 
 
-def _load():
-    for name in _toload:  # noqa: F821
-        globals()[name] = getattr(_impl, name)
-
-
-__all__ = _toload + [
+__all__ = [
     'Euler1DSolver',
 ]
-
-_load()
-del _load
-del _toload
 
 
 class Euler1DSolver:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ class CMakeExtension(Extension):
 
 
 class cmake_build_ext(build_ext):
-
     user_options = build_ext.user_options + [
         ('cmake-args=', None, 'arguments to cmake'),
         ('make-args=', None, 'arguments to make'),
@@ -62,12 +61,12 @@ class cmake_build_ext(build_ext):
 
 
 def main():
-
     setup(
         name="modmesh",
         version="0.0",
         packages=[
             'modmesh',
+            'modmesh.onedim',
         ],
         ext_modules=[CMakeExtension("modmesh._modmesh")],
         cmdclass={'build_ext': cmake_build_ext},

--- a/tests/test_onedim_euler.py
+++ b/tests/test_onedim_euler.py
@@ -12,31 +12,26 @@ class Euler1DSolverTC(unittest.TestCase):
 
     @staticmethod
     def _build_solver(resolution):
-        # Build grid.
-        xcrd = np.arange(resolution + 1, dtype='float64') / resolution
-        xcrd *= 2 * np.pi
-        dx = xcrd[2] - xcrd[0]
-
-        # Build solver.
         time_stop = 2 * np.pi
         cfl_max = 1.0
+        xmin = 0.0
+        xmax = 2 * np.pi
+        dx = xmax / resolution * 2
         dt_max = dx * cfl_max
         nstep = int(np.ceil(time_stop / dt_max))
         dt = time_stop / nstep
-        svr = onedim.Euler1DSolver(ncoord=resolution + 1, time_increment=dt)
-        svr.coord[...] = xcrd
 
-        # Initialize.
-        svr.cfl.fill(0)
-        svr.so0.fill(0)
-        svr.so1.fill(0)
+        svr = onedim.Euler1DSolver(
+            xmin=xmin, xmax=xmax, ncoord=resolution + 1,
+            time_increment=dt)
         svr.setup_march()
 
-        return nstep, xcrd, svr
+        return nstep, svr
 
     def setUp(self):
         self.resolution = 8
-        self.nstep, self.xcrd, self.svr = self._build_solver(self.resolution)
+        self.nstep, self.svr = self._build_solver(self.resolution)
+        self.xcrd = self.svr.coord.copy()
         self.cycle = 10
 
     def test_coord(self):


### PR DESCRIPTION
Rename the C++ class implementing the 1D CESE method for the Euler equations to `Euler1DCore`, denoting the calculation core.  Make a new Python class named like the old C++ class: `Euler1DSolver`, working as the middle layer in Python.

The Python middle layer allows us to implementing logic that does not need the speed of C++ (not in a tight loop, or Python/numpy is sufficiently fast) in Python.  Being able to write Python significantly help coding productivity.