### PR TITLE
Update nouse_install.yml to disable automatic rootdir determination

### DIFF
--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -82,7 +82,7 @@ jobs:
         cd tmp/
         python3 -c 'import os; print(os.getcwd())'
         python3 -c "import modmesh; print(modmesh._modmesh.__file__)"
-        pytest -v
+        pytest --rootdir=/tmp -v
         cd ..
 
   nouse_install_macos:
@@ -158,5 +158,5 @@ jobs:
           cd tmp/
           python3 -c 'import os; print(os.getcwd())'
           python3 -c "import modmesh; print(modmesh._modmesh.__file__)"
-          pytest -v
+          pytest --rootdir=/tmp -v
           cd ..


### PR DESCRIPTION
nouse_install.yml should use pytest --rootdir=/tmp

Explicitly set the rootdir for pytest so that it does not find the Python code in the source directory.  See https://docs.pytest.org/en/6.2.x/customize.html#initialization-determining-rootdir-and-configfile .