### PR TITLE
Make the viewer binary a multi-purpose binary

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -99,6 +99,13 @@ jobs:
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
 
+    - name: make run_viewer_pytest
+      run: |
+        make run_viewer_pytest \
+          ${JOB_MAKE_ARGS} \
+          CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
+          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+
   build_macos:
 
     if: ${{ github.event_name != '' || (github.event_name == '' && github.repository_owner == 'solvcon') }}
@@ -187,6 +194,13 @@ jobs:
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
 
+      - name: make run_viewer_pytest
+        run: |
+          make run_viewer_pytest \
+            ${JOB_MAKE_ARGS} \
+            CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
+            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+
   build_windows:
 
     if: ${{ github.event_name != '' || (github.event_name == '' && github.repository_owner == 'solvcon') }}
@@ -249,4 +263,12 @@ jobs:
             -Dpybind11_DIR="$(pybind11-config --cmakedir)" `
             -S${{ github.workspace }} `
             -B${{ github.workspace }}/build
-          cmake --build ${{ github.workspace }}/build --config ${{ matrix.cmake_build_type }} --target ALL_BUILD
+          cmake --build ${{ github.workspace }}/build `
+            --config ${{ matrix.cmake_build_type }} `
+            --target ALL_BUILD
+
+      - name: cmake run_viewer_pytest
+        run: |
+          cmake --build ${{ github.workspace }}/build `
+            --config ${{ matrix.cmake_build_type }} `
+            --target run_viewer_pytest

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,10 @@ pytest: $(MODMESH_ROOT)/modmesh/_modmesh$(pyextsuffix)
 viewer: $(MODMESH_ROOT)/modmesh/_modmesh$(pyextsuffix)
 	make -C $(BUILD_PATH) VERBOSE=$(VERBOSE) viewer $(MAKE_PARALLEL)
 
+.PHONY: run_viewer_pytest
+run_viewer_pytest: viewer
+	cmake --build $(BUILD_PATH) --target run_viewer_pytest VERBOSE=1
+
 .PHONY: flake8
 flake8:
 	make -C $(BUILD_PATH) VERBOSE=$(VERBOSE) flake8

--- a/cpp/binary/viewer/CMakeLists.txt
+++ b/cpp/binary/viewer/CMakeLists.txt
@@ -46,6 +46,8 @@ qt_add_executable(
     ${MODMESH_PYMOD_SPACETIME_SOURCES}
 )
 
+add_custom_target(run_viewer_pytest $<TARGET_FILE:viewer> --mode=pytest)
+
 qt_add_resources(
     viewer "app_icon"
     PREFIX "/"

--- a/cpp/binary/viewer/viewer.cpp
+++ b/cpp/binary/viewer/viewer.cpp
@@ -53,16 +53,18 @@ PYBIND11_EMBEDDED_MODULE(_modmesh_view, mod) // NOLINT
 
 int main(int argc, char ** argv)
 {
-    // Set up Python interpreter.
-    modmesh::python::Interpreter::instance().initialize();
-
 #ifdef MODMESH_METAL
     modmesh::device::MetalManager::instance();
 #endif // MODMESH_METAL
 
-    modmesh::RApplication app(argc, argv);
-    app.main()->resize(1000, 600);
-    return app.exec();
+    // Initialize the Python interpreter.
+    modmesh::python::Interpreter::instance()
+        .initialize()
+        .setup_modmesh_path();
+
+    modmesh::python::Interpreter::instance().setup_process(argc, argv);
+    modmesh::python::Interpreter::instance().finalize();
+    return 0;
 }
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/python/common.hpp
+++ b/cpp/modmesh/python/common.hpp
@@ -471,10 +471,12 @@ public:
     void preload_module(std::string const & name);
     void preload_modules(std::vector<std::string> const & names);
 
+    Interpreter & setup_modmesh_path();
+    Interpreter & setup_process(int argc, char ** argv);
+
 private:
 
     Interpreter() = default;
-    void setup_path();
 
     pybind11::scoped_interpreter * m_interpreter = nullptr;
 

--- a/cpp/modmesh/view/RApplication.cpp
+++ b/cpp/modmesh/view/RApplication.cpp
@@ -37,9 +37,30 @@
 namespace modmesh
 {
 
-RApplication::RApplication(int & argc, char ** argv)
-    : QApplication(argc, argv)
-    , m_main(new RMainWindow)
+RApplication * RApplication::initialize(int argc, char ** argv)
+{
+    RApplication * ret = dynamic_cast<RApplication *>(QApplication::instance());
+    if (nullptr == ret)
+    {
+        ret = new RApplication(argc, argv);
+    }
+    return ret;
+}
+
+RApplication * RApplication::instance()
+{
+    RApplication * ret = dynamic_cast<RApplication *>(QApplication::instance());
+    static int argc = 1;
+    static char exename[] = "viewer";
+    static char * argv[] = {exename};
+    if (nullptr == ret)
+    {
+        ret = initialize(argc, argv);
+    }
+    return ret;
+}
+
+RApplication & RApplication::setup()
 {
     /* TODO: parse arguments */
 
@@ -165,7 +186,10 @@ RApplication::RApplication(int & argc, char ** argv)
     m_main->setWindowIcon(QIcon(m_iconFilePath));
 
     // Show main window.
+    m_main->resize(1000, 600);
     m_main->show();
+
+    return *this;
 }
 
 RApplication::~RApplication()

--- a/cpp/modmesh/view/RApplication.hpp
+++ b/cpp/modmesh/view/RApplication.hpp
@@ -45,14 +45,22 @@ class RApplication
 
 public:
 
-    RApplication(int & argc, char ** argv);
     ~RApplication();
+
+    RApplication & setup();
 
     RMainWindow * main() { return m_main; }
 
-    static RApplication * instance() { return dynamic_cast<RApplication *>(QApplication::instance()); }
+    static RApplication * initialize(int argc, char ** argv);
+    static RApplication * instance();
 
 private:
+
+    RApplication(int & argc, char ** argv)
+        : QApplication(argc, argv)
+        , m_main(new RMainWindow)
+    {
+    }
 
     RMainWindow * m_main = nullptr;
 

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -160,6 +160,13 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRApplication
                 {
                     return self.main()->pytext();
                 })
+            .def("setup", &RApplication::setup)
+            .def(
+                "exec",
+                [](wrapped_type & self)
+                {
+                    return self.exec();
+                })
             //
             ;
     }
@@ -225,10 +232,15 @@ void wrap_view(pybind11::module & mod)
                 viewer->grabPixmap().save(filename.c_str());
             },
             py::arg("filename"))
+        .def(
+            "app",
+            []()
+            {
+                return RApplication::instance();
+            },
+            py::return_value_policy::reference)
         //
         ;
-
-    mod.attr("app") = py::cast(RApplication::instance());
 
     if (Toggle::instance().get_show_axis())
     {

--- a/modmesh/__init__.py
+++ b/modmesh/__init__.py
@@ -38,6 +38,7 @@ from . import apputil  # noqa: F401
 from . import view  # noqa: F401
 from . import spacetime  # noqa: F401
 from . import onedim  # noqa: F401
+from . import system  # noqa: F401
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/app/bad_euler1d.py
+++ b/modmesh/app/bad_euler1d.py
@@ -37,7 +37,7 @@ from .. import spacetime as libst
 
 
 def load_app():
-    view.app.pytext.code = """
+    view.app().pytext.code = """
 # Need to hold the win object to keep PySide alive.
 win, svr = mm.app.bad_euler1d.run(animate=True, interval=10)
 """.lstrip()

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -37,7 +37,7 @@ from ..onedim import euler1d
 
 
 def load_app():
-    view.app.pytext.code = """
+    view.app().pytext.code = """
 # Need to hold the win object to keep PySide alive.
 win = mm.app.euler1d.run(animate=True, interval=10, max_steps=50)
 print(mm.apputil.environ)

--- a/modmesh/app/linear_wave.py
+++ b/modmesh/app/linear_wave.py
@@ -37,7 +37,7 @@ from .. import spacetime as libst
 
 
 def load_app():
-    view.app.pytext.code = """
+    view.app().pytext.code = """
 # Need to hold the win object to keep PySide alive.
 win, svr = mm.app.linear_wave.run_linear(animate=True, interval=10)
 """.lstrip()

--- a/modmesh/app/sample_mesh.py
+++ b/modmesh/app/sample_mesh.py
@@ -35,11 +35,11 @@ from .. import view
 
 
 def load_app():
-    view.app.pytext.code = """import modmesh as mm
+    view.app().pytext.code = """import modmesh as mm
 
-#mm.view.app.viewer.up_vector = (0, 1, 0)
-#mm.view.app.viewer.position = (-10, -10, -20)
-#mm.view.app.viewer.view_center = (0, 0, 0)
+#mm.view.app().viewer.up_vector = (0, 1, 0)
+#mm.view.app().viewer.position = (-10, -10, -20)
+#mm.view.app().viewer.view_center = (0, 0, 0)
 
 mh = mm.app.sample_mesh.make_triangle()
 #mh = mm.app.sample_mesh.make_tetrahedron()
@@ -47,9 +47,9 @@ mm.view.show_mark()
 mm.view.show(mh)
 
 print("nedge:", mh.nedge)
-print("position:", mm.view.app.viewer.position)
-print("up_vector:", mm.view.app.viewer.up_vector)
-print("view_center:", mm.view.app.viewer.view_center)
+print("position:", mm.view.app().viewer.position)
+print("up_vector:", mm.view.app().viewer.up_vector)
+print("view_center:", mm.view.app().viewer.view_center)
 
 # line = mm.view.RLine(-1, -1, -1, -2, -2, -2, 0, 128, 128)
 # print(line)

--- a/modmesh/system.py
+++ b/modmesh/system.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2022, Yung-Yu Chen <yyc@solvcon.net>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+Runtime system code
+"""
+
+
+import builtins
+import sys
+import os
+import argparse
+
+import modmesh
+from . import view
+
+
+__all__ = [
+    'setup_process',
+]
+
+
+class ModmeshArgumentParser(argparse.ArgumentParser):
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self.exited = False
+        self.exited_status = None
+        self.exited_message = None
+
+    def exit(self, status=0, message=None):
+        self.exited = True
+        self.exited_status = status
+        self.exited_message = message
+        return
+
+
+def _parse_command_line(argv):
+    parser = ModmeshArgumentParser(description="Viewer")
+    parser.add_argument('--mode', dest='mode', action='store',
+                        default='viewer',
+                        choices=['viewer', 'command', 'terminal', 'pytest'],
+                        help='mode selection (default = %(default)s)')
+    parser.add_argument('--command', dest='command', action='store',
+                        default='', help='command to run')
+    args = parser.parse_args(argv[1:])
+    if parser.exited:
+        args.exit = (parser.exited_status, parser.exited_message)
+    else:
+        args.exit = tuple()
+    return args
+
+
+def _setup_builtin():
+    """Install the namespace."""
+    builtins.modmesh = modmesh
+    builtins.mm = modmesh
+
+
+def _run_viewer(argv):
+    """Run the viewer application."""
+    view.app().setup()
+    return view.app().exec()
+
+
+def _run_ipython(argv):
+    # Import IPython locally to avoid making it a dependency to the whole
+    # modmesh.
+    import IPython
+    ret = IPython.start_ipython(argv=[])
+    return ret
+
+
+def _run_command(cmd):
+    exec(cmd)
+    return 0
+
+
+def _run_pytest():
+    # Import pytest locally to avoid making it a dependency to the whole
+    # modmesh.
+    import pytest
+    mmpath = os.path.join(os.path.dirname(modmesh.__file__), '..', 'tests')
+    mmpath = os.path.abspath(mmpath)
+    return pytest.main(['-v', '-x', mmpath])
+
+
+def setup_process(argv):
+    """Set up the runtime environment for the process."""
+    _setup_builtin()
+    args = _parse_command_line(argv)
+    ret = 0
+    if args.exit:
+        ret = args.exit[0]
+    elif 'command' == args.mode or args.command:
+        ret = _run_command(args.command)
+    elif 'viewer' == args.mode:
+        ret = _run_viewer(argv)
+    elif 'terminal' == args.mode:
+        ret = _run_ipython(argv)
+    elif 'pytest' == args.mode:
+        ret = _run_pytest()
+    else:
+        sys.stderr.write('mode {} is not supported'.format(args.mode))
+    return ret
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Address #103 

Change the start-up code so that the viewer binary can run in the following 4 modes:
1. viewer: open a windows
2. command: take a string as Python code
3. terminal: start text-based iPython prompt
4. pytest: run the Python test cases

In this way, the viewer binary can be used to run the Python test cases.  A new target run_viewer_pytest is added to the make file.  CI (Ubuntu, macos, and Windows) uses the new target to run unit tests.