### PR TITLE
Add a new --mode=python by using the standard Python interpreter entry point

### DIFF
--- a/cpp/modmesh/buffer/small_vector.hpp
+++ b/cpp/modmesh/buffer/small_vector.hpp
@@ -31,6 +31,7 @@
 #include <stdexcept>
 #include <array>
 #include <vector>
+#include <algorithm>
 
 namespace modmesh
 {

--- a/cpp/modmesh/python/common.cpp
+++ b/cpp/modmesh/python/common.cpp
@@ -29,6 +29,8 @@
 #include <modmesh/python/common.hpp> // Must be the first include.
 #include <pybind11/stl.h> // Required for automatic conversion.
 
+#include <modmesh/toggle/toggle.hpp>
+
 #include <pybind11/numpy.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
@@ -72,7 +74,11 @@ Interpreter & Interpreter::finalize()
 {
     if (nullptr != m_interpreter)
     {
-        delete m_interpreter;
+        // Py_Main and Py_BytesMain may finalize the interpreter before this is reached.
+        if (0 != Py_IsInitialized())
+        {
+            delete m_interpreter;
+        }
         m_interpreter = nullptr;
     }
     return *this;
@@ -102,18 +108,22 @@ _set_modmesh_path())"""";
     return *this;
 }
 
-Interpreter & Interpreter::setup_process(int argc, char ** argv_in)
+Interpreter & Interpreter::setup_process()
 {
-    std::vector<std::string> argv;
-    argv.reserve(argc);
-    for (int i = 0; i < argc; ++i)
-    {
-        argv.emplace_back(argv_in[i]);
-    }
     // NOLINTNEXTLINE(misc-const-correctness)
     pybind11::object mod_sys = pybind11::module_::import("modmesh.system");
-    mod_sys.attr("setup_process")(argv);
+    CommandLineInfo const & cmdinfo = ProcessInfo::instance().command_line();
+    mod_sys.attr("setup_process")(cmdinfo.python_argv());
     return *this;
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+int Interpreter::enter_main()
+{
+    // NOLINTNEXTLINE(misc-const-correctness)
+    pybind11::object mod_sys = pybind11::module_::import("modmesh.system");
+    CommandLineInfo const & cmdinfo = ProcessInfo::instance().command_line();
+    return pybind11::cast<int>(mod_sys.attr("enter_main")(cmdinfo.python_argv()));
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static): implicitly requires m_interpreter

--- a/cpp/modmesh/python/common.hpp
+++ b/cpp/modmesh/python/common.hpp
@@ -472,7 +472,9 @@ public:
     void preload_modules(std::vector<std::string> const & names);
 
     Interpreter & setup_modmesh_path();
-    Interpreter & setup_process(int argc, char ** argv);
+    Interpreter & setup_process();
+
+    int enter_main();
 
 private:
 

--- a/cpp/modmesh/python/wrapper/modmesh/wrap_Toggle.cpp
+++ b/cpp/modmesh/python/wrapper/modmesh/wrap_Toggle.cpp
@@ -69,9 +69,75 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
         .def_property("show_axis", &wrapped_type::get_show_axis, &wrapped_type::set_show_axis);
 }
 
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapCommandLineInfo
+    : public WrapBase<WrapCommandLineInfo, CommandLineInfo>
+{
+
+public:
+
+    using base_type = WrapBase<WrapCommandLineInfo, CommandLineInfo>;
+    using wrapped_type = typename base_type::wrapped_type;
+
+    friend root_base_type;
+
+protected:
+
+    WrapCommandLineInfo(pybind11::module & mod, char const * pyname, char const * pydoc);
+
+}; /* end class WrapCommandLineInfo */
+
+WrapCommandLineInfo::WrapCommandLineInfo(pybind11::module & mod, char const * pyname, char const * pydoc)
+    : base_type(mod, pyname, pydoc)
+{
+    (*this)
+        .def("freeze", &wrapped_type::freeze)
+        .def_property_readonly("frozen", &wrapped_type::frozen)
+        .def_property_readonly("populated", &wrapped_type::populated)
+        .def_property_readonly("populated_argv", &wrapped_type::populated_argv)
+        .def_property_readonly("executable_basename", &wrapped_type::executable_basename)
+        .def_property("python_argv", &wrapped_type::python_argv, &wrapped_type::set_python_argv);
+}
+
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapProcessInfo
+    : public WrapBase<WrapProcessInfo, ProcessInfo>
+{
+
+public:
+
+    using base_type = WrapBase<WrapProcessInfo, ProcessInfo>;
+    using wrapped_type = typename base_type::wrapped_type;
+
+    friend root_base_type;
+
+protected:
+
+    WrapProcessInfo(pybind11::module & mod, char const * pyname, char const * pydoc);
+
+}; /* end class WrapProcessInfo */
+
+WrapProcessInfo::WrapProcessInfo(pybind11::module & mod, char const * pyname, char const * pydoc)
+    : base_type(mod, pyname, pydoc)
+{
+    namespace py = pybind11;
+    (*this)
+        .def_property_readonly_static(
+            "instance",
+            [](py::object const &) -> auto & {
+                return wrapped_type::instance();
+            })
+        .def_property_readonly(
+            "command_line",
+            [](wrapped_type & self) -> auto & {
+                return self.command_line();
+            },
+            py::return_value_policy::reference_internal);
+}
+
 void wrap_Toggle(pybind11::module & mod)
 {
     WrapToggle::commit(mod, "Toggle", "Toggle");
+    WrapCommandLineInfo::commit(mod, "CommandLineInfo", "CommandLineInfo");
+    WrapProcessInfo::commit(mod, "ProcessInfo", "ProcessInfo");
 
 #ifdef MODMESH_METAL
     mod.attr("METAL_BUILT") = true;

--- a/modmesh/__init__.py
+++ b/modmesh/__init__.py
@@ -33,12 +33,16 @@ modmesh: the description of the package is intentionally left blank
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
 
 
+from . import core
 from .core import *  # noqa: F401, F403
 from . import apputil  # noqa: F401
 from . import view  # noqa: F401
 from . import spacetime  # noqa: F401
 from . import onedim  # noqa: F401
 from . import system  # noqa: F401
+
+
+clinfo = core.ProcessInfo.instance.command_line  # noqa: F401
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -58,6 +58,8 @@ __all__ = [  # noqa: F822
     'StaticGrid3d',
     'StaticMesh',
     'Toggle',
+    'CommandLineInfo',
+    'ProcessInfo',
     'METAL_BUILT',
     'metal_running',
 ]

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -25,6 +25,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
+import os
 import unittest
 import time
 
@@ -42,6 +43,8 @@ class StopWatchTC(unittest.TestCase):
         sw = modmesh.stop_watch
         self.assertGreater(1.e-6, sw.resolution)
 
+    @unittest.skipUnless("nt" != os.name,
+                         "timing code on windows does not work yet")
     def test_lap_with_sleep(self):
 
         sw = modmesh.stop_watch

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -37,6 +37,18 @@ class ToggleTC(unittest.TestCase):
         self.assertTrue(hasattr(modmesh.Toggle.instance, "show_axis"))
 
 
+@unittest.skipUnless("viewer" in modmesh.clinfo.executable_basename,
+                     "not in viewer binary")
+class CommandLineInfoTC(unittest.TestCase):
+
+    def setUp(self):
+        self.cmdline = modmesh.ProcessInfo.instance.command_line
+
+    def test_populated(self):
+        self.assertTrue(self.cmdline.populated)
+        self.assertNotEqual(len(self.cmdline.populated_argv), 0)
+
+
 class MetalTC(unittest.TestCase):
 
     # Github Actions macos-12 does not support GPU yet.


### PR DESCRIPTION
Use `Py_BytesMain` for the "python" mode of viewer. `Py_BytesMain` is the stable API to enter the standard interpreter from an embedding executable: https://docs.python.org/3.10/c-api/veryhigh.html#c.Py_BytesMain

Create the new class ProcessInfo and the member datum CommandLineInfo.  CommandLineInfo provides the flags processed from the command line arguments to provide information for the execution mode.