### PR TITLE
Move (macos) metal device initialization code

### DIFF
--- a/cpp/binary/viewer/viewer.cpp
+++ b/cpp/binary/viewer/viewer.cpp
@@ -33,9 +33,6 @@
 #include <modmesh/modmesh.hpp>
 #include <modmesh/view/view.hpp>
 #include <modmesh/view/wrap_view.hpp>
-#ifdef MODMESH_METAL
-#include <modmesh/device/metal/metal.hpp>
-#endif // MODMESH_METAL
 
 PYBIND11_EMBEDDED_MODULE(_modmesh, mod) // NOLINT
 {
@@ -55,10 +52,6 @@ int main(int argc, char ** argv)
 {
     modmesh::ProcessInfo::instance().populate_command_line(argc, argv);
     auto & clinfo = modmesh::ProcessInfo::instance().command_line();
-
-#ifdef MODMESH_METAL
-    modmesh::device::MetalManager::instance();
-#endif // MODMESH_METAL
 
     // Initialize the Python interpreter.
     modmesh::python::Interpreter::instance()

--- a/cpp/modmesh/toggle/toggle.cpp
+++ b/cpp/modmesh/toggle/toggle.cpp
@@ -27,6 +27,9 @@
  */
 
 #include <modmesh/toggle/toggle.hpp>
+#ifdef MODMESH_METAL
+#include <modmesh/device/metal/metal.hpp>
+#endif // MODMESH_METAL
 
 namespace modmesh
 {
@@ -35,6 +38,13 @@ Toggle & Toggle::instance()
 {
     static Toggle o;
     return o;
+}
+
+ProcessInfo::ProcessInfo()
+{
+#ifdef MODMESH_METAL
+    modmesh::device::MetalManager::instance();
+#endif // MODMESH_METAL
 }
 
 ProcessInfo & ProcessInfo::instance()

--- a/cpp/modmesh/toggle/toggle.cpp
+++ b/cpp/modmesh/toggle/toggle.cpp
@@ -40,6 +40,7 @@ Toggle & Toggle::instance()
     return o;
 }
 
+// NOLINTNEXTLINE(modernize-use-equals-default) lack of MODMESH_METAL
 ProcessInfo::ProcessInfo()
 {
 #ifdef MODMESH_METAL

--- a/cpp/modmesh/toggle/toggle.hpp
+++ b/cpp/modmesh/toggle/toggle.hpp
@@ -144,7 +144,7 @@ public:
 
 private:
 
-    ProcessInfo() = default;
+    ProcessInfo();
 
     CommandLineInfo m_command_line;
 


### PR DESCRIPTION
Move the metal device initialization code from viewer main() to ProcessInfo constructor.

This makes the main() function cleaner.