### PR TITLE
Improve the test case test_toggle:CommandLineInfoTC.test_populated

### DIFF
--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -37,16 +37,17 @@ class ToggleTC(unittest.TestCase):
         self.assertTrue(hasattr(modmesh.Toggle.instance, "show_axis"))
 
 
-@unittest.skipUnless("viewer" in modmesh.clinfo.executable_basename,
-                     "not in viewer binary")
 class CommandLineInfoTC(unittest.TestCase):
 
     def setUp(self):
         self.cmdline = modmesh.ProcessInfo.instance.command_line
 
     def test_populated(self):
-        self.assertTrue(self.cmdline.populated)
-        self.assertNotEqual(len(self.cmdline.populated_argv), 0)
+        if "viewer" in modmesh.clinfo.executable_basename:
+            self.assertTrue(self.cmdline.populated)
+            self.assertNotEqual(len(self.cmdline.populated_argv), 0)
+        else:
+            self.assertFalse(self.cmdline.populated)
 
 
 class ViewTC(unittest.TestCase):


### PR DESCRIPTION
Determine the results inside the test function.  Do not skip from outside.