### PR TITLE
Add a whitespace after the ">>>" prompt in the console history

### DIFF
--- a/cpp/modmesh/view/RPythonConsoleDockWidget.hpp
+++ b/cpp/modmesh/view/RPythonConsoleDockWidget.hpp
@@ -106,7 +106,7 @@ private:
     int m_current_command_index = 0;
     size_t m_past_limit = 1024;
 
-    QString m_commandHtml = "<p style=\"color:Black;white-space:pre\"><b>&#62;&#62;&#62;</b>";
+    QString m_commandHtml = "<p style=\"color:Black;white-space:pre\"><b>&#62;&#62;&#62;</b> ";
     QString m_stderrHtml = "<p style=\"color:Red;white-space:pre\">";
     QString m_stdoutHtml = "<p style=\"color:Blue;white-space:pre\">";
     QString m_endHtml = "</p><br>";


### PR DESCRIPTION
The prompt of console history was:

```
>>>command
```

There should be a whitespace between `>>>` and `command`:

```
>>> command
```