### PR TITLE
Use a runtime switch to turn off Python console redirect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,6 @@ if(NOT SKIP_PYTHON_EXECUTABLE)
     message(STATUS "use PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}")
 endif()
 
-option(DISABLE_REDIRECT "Disable redirecting stdout and stderr to python console" OFF)
-message(STATUS "DISABLE_REDIRECT: ${DISABLE_REDIRECT}")
-if(DISABLE_REDIRECT)
-    add_definitions(-DDISABLE_REDIRECT)
-endif()
-
 option(BUILD_QT "build with QT" ON)
 message(STATUS "BUILD_QT: ${BUILD_QT}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,12 @@ if(NOT SKIP_PYTHON_EXECUTABLE)
     message(STATUS "use PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}")
 endif()
 
+option(DISABLE_REDIRECT "Disable redirecting stdout and stderr to python console" OFF)
+message(STATUS "DISABLE_REDIRECT: ${DISABLE_REDIRECT}")
+if(DISABLE_REDIRECT)
+    add_definitions(-DDISABLE_REDIRECT)
+endif()
+
 option(BUILD_QT "build with QT" ON)
 message(STATUS "BUILD_QT: ${BUILD_QT}")
 

--- a/cpp/modmesh/python/common.cpp
+++ b/cpp/modmesh/python/common.cpp
@@ -200,8 +200,8 @@ PythonStreamRedirect & PythonStreamRedirect::activate()
 
         // Create string-IO objects. Other file-like object can be used here as
         // well, such as objects created by pybind11.
-        auto string_io = pybind11::module::import("io").attr("StringIO");
         {
+            auto string_io = pybind11::module::import("io").attr("StringIO");
             m_stdout_buffer = string_io();
             sys_module.attr("stdout") = m_stdout_buffer;
             m_stderr_buffer = string_io();
@@ -228,13 +228,13 @@ PythonStreamRedirect & PythonStreamRedirect::deactivate()
     return *this;
 }
 
-std::string PythonStreamRedirect::stdout_string()
+std::string PythonStreamRedirect::stdout_string() const
 {
     m_stdout_buffer.attr("seek")(0);
     return pybind11::str(m_stdout_buffer.attr("read")());
 }
 
-std::string PythonStreamRedirect::stderr_string()
+std::string PythonStreamRedirect::stderr_string() const
 {
     m_stderr_buffer.attr("seek")(0);
     return pybind11::str(m_stderr_buffer.attr("read")());

--- a/cpp/modmesh/python/common.hpp
+++ b/cpp/modmesh/python/common.hpp
@@ -505,24 +505,45 @@ private:
 // Suppress the warning "greater visibility than the type of its field"
 #pragma GCC diagnostic ignored "-Wattributes"
 #endif
-class PyStdErrOutStreamRedirect
+class PythonStreamRedirect
 {
 
 public:
-    PyStdErrOutStreamRedirect(bool disable);
-    ~PyStdErrOutStreamRedirect() noexcept(false);
+
+    PythonStreamRedirect(bool enabled)
+        : m_enabled(enabled)
+    {
+    }
+
+    ~PythonStreamRedirect() = default;
 
     std::string stdout_string();
     std::string stderr_string();
-    bool check_disable() { return m_disable; }
+
+    PythonStreamRedirect & set_enabled(bool enabled)
+    {
+        m_enabled = enabled;
+        return *this;
+    }
+
+    bool is_enabled() const { return m_enabled; }
+    bool is_disabled() const { return !m_enabled; }
+
+    PythonStreamRedirect & activate();
+    PythonStreamRedirect & deactivate();
+
+    bool is_activated() const { return bool(m_stdout_backup) || bool(m_stderr_backup); }
+    bool is_deactivated() const { return !is_activated(); }
 
 private:
-    bool m_disable;
-    pybind11::object m_stdout;
-    pybind11::object m_stderr;
+
+    bool m_enabled;
+    pybind11::object m_stdout_backup;
+    pybind11::object m_stderr_backup;
     pybind11::object m_stdout_buffer;
     pybind11::object m_stderr_buffer;
-}; /* end class PyStdErrOutStreamRedirect */
+
+}; /* end class PythonStreamRedirect */
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif

--- a/cpp/modmesh/python/common.hpp
+++ b/cpp/modmesh/python/common.hpp
@@ -509,12 +509,15 @@ class PyStdErrOutStreamRedirect
 {
 
 public:
-    PyStdErrOutStreamRedirect();
-    std::string stdout_string();
-    std::string stderr_string();
+    PyStdErrOutStreamRedirect(bool disable);
     ~PyStdErrOutStreamRedirect() noexcept(false);
 
+    std::string stdout_string();
+    std::string stderr_string();
+    bool check_disable() { return m_disable; }
+
 private:
+    bool m_disable;
     pybind11::object m_stdout;
     pybind11::object m_stderr;
     pybind11::object m_stdout_buffer;

--- a/cpp/modmesh/python/common.hpp
+++ b/cpp/modmesh/python/common.hpp
@@ -515,10 +515,8 @@ public:
     {
     }
 
-    ~PythonStreamRedirect() = default;
-
-    std::string stdout_string();
-    std::string stderr_string();
+    std::string stdout_string() const;
+    std::string stderr_string() const;
 
     PythonStreamRedirect & set_enabled(bool enabled)
     {

--- a/cpp/modmesh/view/RPythonConsoleDockWidget.cpp
+++ b/cpp/modmesh/view/RPythonConsoleDockWidget.cpp
@@ -130,18 +130,14 @@ void RPythonConsoleDockWidget::executeCommand()
     m_current_command_index = static_cast<int>(m_past_command_strings.size());
     auto & interp = modmesh::python::Interpreter::instance();
 
-#ifdef DISABLE_REDIRECT
-    bool disable_redirect = true;
-#else
-    bool disable_redirect = false;
-#endif
-    modmesh::python::PyStdErrOutStreamRedirect pyOutputRedirect(disable_redirect);
+    m_python_redirect.activate();
     interp.exec_code(code);
-    if (!pyOutputRedirect.check_disable())
+    if (m_python_redirect.is_activated())
     {
-        printCommandStdout(pyOutputRedirect.stdout_string());
-        printCommandStderr(pyOutputRedirect.stderr_string());
+        printCommandStdout(m_python_redirect.stdout_string());
+        printCommandStderr(m_python_redirect.stderr_string());
     }
+    m_python_redirect.deactivate();
 }
 
 void RPythonConsoleDockWidget::printCommandHistory()

--- a/cpp/modmesh/view/RPythonConsoleDockWidget.cpp
+++ b/cpp/modmesh/view/RPythonConsoleDockWidget.cpp
@@ -129,10 +129,19 @@ void RPythonConsoleDockWidget::executeCommand()
     m_command_string = "";
     m_current_command_index = static_cast<int>(m_past_command_strings.size());
     auto & interp = modmesh::python::Interpreter::instance();
-    modmesh::python::PyStdErrOutStreamRedirect pyOutputRedirect{};
+
+#ifdef DISABLE_REDIRECT
+    bool disable_redirect = true;
+#else
+    bool disable_redirect = false;
+#endif
+    modmesh::python::PyStdErrOutStreamRedirect pyOutputRedirect(disable_redirect);
     interp.exec_code(code);
-    printCommandStdout(pyOutputRedirect.stdout_string());
-    printCommandStderr(pyOutputRedirect.stderr_string());
+    if (!pyOutputRedirect.check_disable())
+    {
+        printCommandStdout(pyOutputRedirect.stdout_string());
+        printCommandStderr(pyOutputRedirect.stderr_string());
+    }
 }
 
 void RPythonConsoleDockWidget::printCommandHistory()

--- a/cpp/modmesh/view/RPythonConsoleDockWidget.hpp
+++ b/cpp/modmesh/view/RPythonConsoleDockWidget.hpp
@@ -85,6 +85,14 @@ public:
 
     QString command() const;
 
+    bool hasPythonRedirect() const { return m_python_redirect.is_enabled(); }
+
+    RPythonConsoleDockWidget & setPythonRedirect(bool enabled)
+    {
+        m_python_redirect.set_enabled(enabled);
+        return *this;
+    }
+
 public slots:
 
     void setCommand(QString const & value);
@@ -105,6 +113,8 @@ private:
     std::deque<std::string> m_past_command_strings;
     int m_current_command_index = 0;
     size_t m_past_limit = 1024;
+
+    python::PythonStreamRedirect m_python_redirect{/* enabled */ true};
 
     QString m_commandHtml = "<p style=\"color:Black;white-space:pre\"><b>&#62;&#62;&#62;</b> ";
     QString m_stderrHtml = "<p style=\"color:Red;white-space:pre\">";

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -132,6 +132,16 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRPythonConsoleDockWidget
                 {
                     return self.setCommand(QString::fromStdString(command));
                 })
+            .def_property(
+                "python_redirect",
+                [](wrapped_type const & self)
+                {
+                    return self.hasPythonRedirect();
+                },
+                [](wrapped_type & self, bool enabled)
+                {
+                    self.setPythonRedirect(enabled);
+                })
             //
             ;
     }

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Yung-Yu Chen <yyc@solvcon.net>
+# Copyright (c) 2022, Yung-Yu Chen <yyc@solvcon.net>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -25,37 +25,26 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
-import os
 import unittest
 
 import modmesh
+try:
+    from modmesh import view
+except ImportError:
+    view = None
 
 
-class ToggleTC(unittest.TestCase):
+@unittest.skipUnless(modmesh.HAS_VIEW, "Qt view is not built")
+class ViewTC(unittest.TestCase):
 
-    def test_instance(self):
-        self.assertTrue(hasattr(modmesh.Toggle.instance, "show_axis"))
+    def test_import(self):
+        self.assertTrue(hasattr(modmesh.view, "app"))
 
+    @unittest.skip("headless testing is not ready")
+    def test_pycon(self):
+        self.assertTrue(view.app.pycon.python_redirect)
+        view.app.pycon.python_redirect = False
+        self.assertFalse(view.app.pycon.python_redirect)
 
-class CommandLineInfoTC(unittest.TestCase):
-
-    def setUp(self):
-        self.cmdline = modmesh.ProcessInfo.instance.command_line
-
-    def test_populated(self):
-        if "viewer" in modmesh.clinfo.executable_basename:
-            self.assertTrue(self.cmdline.populated)
-            self.assertNotEqual(len(self.cmdline.populated_argv), 0)
-        else:
-            self.assertFalse(self.cmdline.populated)
-
-
-class MetalTC(unittest.TestCase):
-
-    # Github Actions macos-12 does not support GPU yet.
-    @unittest.skipUnless(modmesh.METAL_BUILT and "TEST_METAL" in os.environ,
-                         "Metal is not built")
-    def test_metal_status(self):
-        self.assertEqual(True, modmesh.metal_running())
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
The console widget redirect is turned on by default, and it can be turned off in runtime from Python:

```
# Default is true.
assert modmesh.view.app.pycon.python_redirect == True
# Turn it off by using the setter.
modmesh.view.app.pycon.python_redirect = False
```

Before we have a configuration file, which requires some careful thinking, we should use the interpreter for configuration in this way.

This PR is recreated from #155.  @tigercosmos , I think `a` is not a very distinguishable branch name.