### PR TITLE
Integrate PySide to modmesh aid (viewer)

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -202,7 +202,7 @@ jobs:
             VERBOSE=1 USE_CLANG_TIDY=OFF \
             BUILD_QT=OFF \
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DMODMESH_USE_PYSIDE:BOOL=OFF"
           make buildext VERBOSE=1
 
       - name: make pytest BUILD_QT=OFF
@@ -220,14 +220,14 @@ jobs:
             VERBOSE=1 USE_CLANG_TIDY=OFF \
             BUILD_QT=ON \
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DMODMESH_USE_PYSIDE:BOOL=ON"
           make buildext VERBOSE=1
 
       - name: make pytest BUILD_QT=ON
         run: |
           JOB_MAKE_ARGS="VERBOSE=1"
           if [ "${{ matrix.os }}" == "macos-12" ] ; then \
-            JOB_MAKE_ARGS="${JOB_MAKE_ARGS} BUILD_METAL=ON" ; \
+            JOB_MAKE_ARGS="${JOB_MAKE_ARGS} BUILD_METAL=ON MODMESH_USE_PYSIDE=ON" ; \
           fi
           make pytest ${JOB_MAKE_ARGS}
 
@@ -238,7 +238,7 @@ jobs:
             VERBOSE=1 USE_CLANG_TIDY=OFF \
             BUILD_QT=ON \
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DMODMESH_USE_PYSIDE:BOOL=ON"
 
       - name: make run_viewer_pytest
         run: |

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -57,6 +57,7 @@ jobs:
       run: |
         sudo pip3 install setuptools
         sudo pip3 install numpy pytest flake8
+        sudo pip3 install pyside6 shiboken6
 
     - name: dependency by manual script
       run: sudo ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
@@ -167,6 +168,7 @@ jobs:
           python3 -m pip -v install --upgrade setuptools
           python3 -m pip -v install --upgrade pip
           python3 -m pip -v install --upgrade numpy pytest flake8
+          python3 -m pip -v install --upgrade pyside6 shiboken6
 
       - name: dependency by manual script
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,44 @@ set(MODMESH_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/cpp" CACHE INTERNAL "")
 
 include_directories(${MODMESH_INCLUDE_DIR})
 
+set(MODMESH_USE_PYSIDE False CACHE BOOL "Choose to build with pyside or not")
+message(STATUS "MODMESH_USE_PYSIDE: ${MODMESH_USE_PYSIDE}")
+
+if (MODMESH_USE_PYSIDE)
+    add_compile_definitions(MODMESH_USE_PYSIDE)
+endif () # MODMESH_USE_PYSIDE
+
+execute_process(
+    COMMAND python3 -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))"
+    OUTPUT_VARIABLE PYSIDE6_PYTHON_PACKAGE_PATH
+)
+message(STATUS "PYSIDE6_PYTHON_PACKAGE_PATH: ${PYSIDE6_PYTHON_PACKAGE_PATH}")
+
+execute_process(
+    COMMAND python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))"
+    OUTPUT_VARIABLE SHIBOKEN6_PYTHON_PACKAGE_PATH
+)
+message(STATUS "SHIBOKEN6_PYTHON_PACKAGE_PATH: ${SHIBOKEN6_PYTHON_PACKAGE_PATH}")
+execute_process(
+    COMMAND python3 -c "import sys, os, shiboken6_generator; sys.stdout.write(os.path.dirname(shiboken6_generator.__file__))"
+    OUTPUT_VARIABLE SHIBOKEN6_GENERATOR_PYTHON_PACKAGE_PATH
+)
+message(STATUS "SHIBOKEN6_GENERATOR_PYTHON_PACKAGE_PATH: ${SHIBOKEN6_GENERATOR_PYTHON_PACKAGE_PATH}")
+
+if(NOT "${PYSIDE6_PYTHON_PACKAGE_PATH}" STREQUAL "")
+    include_directories("${PYSIDE6_PYTHON_PACKAGE_PATH}/include")
+    link_directories("${PYSIDE6_PYTHON_PACKAGE_PATH}")
+endif()
+if(NOT "${SHIBOKEN6_GENERATOR_PYTHON_PACKAGE_PATH}" STREQUAL "")
+    include_directories("${SHIBOKEN6_GENERATOR_PYTHON_PACKAGE_PATH}/include")
+endif()
+if(NOT "${SHIBOKEN6_PYTHON_PACKAGE_PATH}" STREQUAL "")
+    link_directories("${SHIBOKEN6_PYTHON_PACKAGE_PATH}")
+endif()
+
+file(GLOB PYSIDE6_LIBFILE LIST_DIRECTORIES false "${PYSIDE6_PYTHON_PACKAGE_PATH}/libpyside6.*")
+file(GLOB SHIBOKEN6_LIBFILE LIST_DIRECTORIES false "${SHIBOKEN6_PYTHON_PACKAGE_PATH}/libshiboken6.*")
+
 add_subdirectory(cpp/modmesh)
 
 include(GNUInstallDirs)

--- a/cpp/modmesh/CMakeLists.txt
+++ b/cpp/modmesh/CMakeLists.txt
@@ -104,6 +104,14 @@ if (BUILD_QT)
         Qt::Core
         Qt::Gui
     )
+
+    if (MODMESH_USE_PYSIDE)
+        target_link_libraries(
+            modmesh_primary PUBLIC
+            ${PYSIDE6_LIBFILE}
+            ${SHIBOKEN6_LIBFILE}
+        )
+    endif () # MODMESH_USE_PYSIDE
 else () # BUILD_QT
     add_library(
         modmesh_primary

--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -54,19 +54,45 @@ protected:
 
     WrapToggle(pybind11::module & mod, char const * pyname, char const * pydoc);
 
+    static std::string report(wrapped_type const & self);
+
 }; /* end class WrapToggle */
 
 WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const * pydoc)
     : base_type(mod, pyname, pydoc)
 {
     namespace py = pybind11;
+
+    (*this)
+        .def("report", &report)
+        //
+        ;
+
+    // Static properties.
     (*this)
         .def_property_readonly_static(
             "instance",
-            [](py::object const &) -> auto & {
-                return wrapped_type::instance();
-            })
-        .def_property("show_axis", &wrapped_type::get_show_axis, &wrapped_type::set_show_axis);
+            [](py::object const &) -> auto & { return wrapped_type::instance(); })
+        .def_property_readonly_static(
+            "USE_PYSIDE",
+            [](py::handle const &)
+            { return bool(wrapped_type::USE_PYSIDE); })
+        //
+        ;
+
+    // Instance properties.
+    (*this)
+        .def_property("show_axis", &wrapped_type::get_show_axis, &wrapped_type::set_show_axis)
+        //
+        ;
+}
+
+std::string WrapToggle::report(WrapToggle::wrapped_type const &)
+{
+    Formatter ret;
+    ret << "Toggle: "
+        << "USE_PYSIDE=" << bool(wrapped_type::USE_PYSIDE);
+    return ret >> Formatter::to_str;
 }
 
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapCommandLineInfo

--- a/cpp/modmesh/toggle/toggle.hpp
+++ b/cpp/modmesh/toggle/toggle.hpp
@@ -43,6 +43,14 @@ class Toggle
 
 public:
 
+    static constexpr bool USE_PYSIDE =
+#ifdef MODMESH_USE_PYSIDE
+        true
+#else // MODMESH_USE_PYSIDE
+        false
+#endif // MODMESH_USE_PYSIDE
+        ;
+
     static Toggle & instance();
 
     Toggle(Toggle const &) = delete;
@@ -58,7 +66,7 @@ private:
 
     Toggle() = default;
 
-    bool m_show_axis;
+    bool m_show_axis = false;
 
 }; /* end class Toggle */
 

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -33,6 +33,14 @@ import modmesh
 
 class ToggleTC(unittest.TestCase):
 
+    def test_report(self):
+        self.assertTrue(
+            "Toggle: USE_PYSIDE=" in modmesh.Toggle.instance.report())
+
+    def test_static_constexpr(self):
+        self.assertTrue(hasattr(modmesh.Toggle, "USE_PYSIDE"))
+        self.assertTrue(hasattr(modmesh.Toggle, "USE_PYSIDE"))
+
     def test_instance(self):
         self.assertTrue(hasattr(modmesh.Toggle.instance, "show_axis"))
 

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -39,7 +39,7 @@ class ToggleTC(unittest.TestCase):
 
     def test_static_constexpr(self):
         self.assertTrue(hasattr(modmesh.Toggle, "USE_PYSIDE"))
-        self.assertTrue(hasattr(modmesh.Toggle, "USE_PYSIDE"))
+        self.assertTrue(hasattr(modmesh.Toggle.instance, "USE_PYSIDE"))
 
     def test_instance(self):
         self.assertTrue(hasattr(modmesh.Toggle.instance, "show_axis"))


### PR DESCRIPTION
Use preprocessor macro `MODMESH_USE_PYSIDE` to control building PySide6 interoperation.  It is not stable yet and only the macos build in GitHub Actions uses it.

* Make a pybind11 caster for `QObject *` with PySide6
* Attempt to install pyside6 and shiboken6 on devbuild with ubuntu and macos, but they do not yet work for the build
* Provide a compile-time `USE_PYSIDE` toggle
* Parameterize the cmake files

The integration looks like below.  Native C++ qt is in the left.  PySide is in the right.

![image](https://user-images.githubusercontent.com/399122/205471159-133cd4ba-2a50-45a7-bdf3-9dc0f0e789eb.png)