### PR TITLE
Fix the Linux crash due to a bug using wrong type of argument to QApplication constructor

### DIFF
--- a/cpp/modmesh/view/RApplication.cpp
+++ b/cpp/modmesh/view/RApplication.cpp
@@ -37,11 +37,13 @@
 namespace modmesh
 {
 
-RApplication * RApplication::initialize(int argc, char ** argv)
+RApplication * RApplication::initialize(int & argc, char ** argv)
 {
     RApplication * ret = dynamic_cast<RApplication *>(QApplication::instance());
     if (nullptr == ret)
     {
+        // Be very careful that QApplication (where RApplication inherits from)
+        // needs int& argc!!
         ret = new RApplication(argc, argv);
     }
     return ret;

--- a/cpp/modmesh/view/RApplication.hpp
+++ b/cpp/modmesh/view/RApplication.hpp
@@ -51,7 +51,7 @@ public:
 
     RMainWindow * mainWindow() { return m_mainWindow; }
 
-    static RApplication * initialize(int argc, char ** argv);
+    static RApplication * initialize(int & argc, char ** argv);
     static RApplication * instance();
 
     R3DWidget * add3DWidget();


### PR DESCRIPTION
Fix #159 a bug that wrongly use a temporary for `int &` argument to `QApplication` constructor

See https://doc.qt.io/qt-6/qapplication.html#QApplication .  The first argument `argc` needs to be a type `int &` and the object (variable) referenced needs to be available during the whole lifetime time of `QApplication`.

While macos and windows do not seem to crash, the Ubuntu Linux is particularly sensitive with the bug, and gets the following stacktrace:

```
Thread 1 "viewer" received signal SIGSEGV, Segmentation fault. __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:65
65      ../sysdeps/x86_64/multiarch/strlen-avx2.S: No such file or directory.
(gdb) where
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:65
#1  0x00007ffff7adb3f8 in std::char_traits<char>::length(char const*) (__s=0x2 <error: Cannot access memory at address 0x2>) at /opt/rh/gcc-toolset-10/root/usr/include/c++/10/bits/char_traits.h:371
#2  QByteArrayView::lengthHelperPointer<char>(char const*) (data=0x2 <error: Cannot access memory at address 0x2>) at /home/qt/work/qt/qtbase/src/corelib/text/qbytearrayview.h:144
#3  QByteArrayView::QByteArrayView<char*, true>(char* const&) (data=@0x555555943460: 0x2 <error: Cannot access memory at address 0x2>, this=<optimized out>) at /home/qt/work/qt/qtbase/src/corelib/text/qbytearrayview.h:188
#4  QCoreApplication::arguments() () at /home/qt/work/qt/qtbase/src/corelib/kernel/qcoreapplication.cpp:2498
```

It is similar to https://bugreports.qt.io/browse/QTBUG-59510, in which the root cause was pointed out.