### PR TITLE
Fix a bug of wrong dtype of the numpy.ndarray created from ConcreteBuffer on aarch64

### DIFF
--- a/cpp/modmesh/buffer/pymod/wrap_ConcreteBuffer.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_ConcreteBuffer.cpp
@@ -81,7 +81,7 @@ WrapConcreteBuffer::WrapConcreteBuffer(pybind11::module & mod, char const * pyna
                 return py::buffer_info(
                     self.data(), /* Pointer to buffer */
                     sizeof(int8_t), /* Size of one scalar */
-                    py::format_descriptor<char>::format(), /* Python struct-style format descriptor */
+                    py::format_descriptor<int8_t>::format(), /* Python struct-style format descriptor */
                     1, /* Number of dimensions */
                     {self.size()}, /* Buffer dimensions */
                     {1} /* Strides (in bytes) for each index */


### PR DESCRIPTION
On aarch64 (arm64 on Linux), `char` is unsigned but it is signed on other platform.  To avoid the ambiguity the `format_descriptor` to construct the buffer protocol object is changed to use `int8_t` (signed) type.