### PR TITLE
Fix qt geometry render issue by modified vertex size

### DIFF
--- a/cpp/modmesh/view/RAxisMark.cpp
+++ b/cpp/modmesh/view/RAxisMark.cpp
@@ -132,7 +132,7 @@ RLine::RLine(QVector3D const & v0, QVector3D const & v1, QColor const & color, Q
             vertices->setName(Qt3DCore::QAttribute::defaultPositionAttributeName());
             vertices->setAttributeType(Qt3DCore::QAttribute::VertexAttribute);
             vertices->setVertexBaseType(Qt3DCore::QAttribute::Float);
-            vertices->setVertexSize(3);
+            vertices->setVertexSize(5);
             vertices->setBuffer(buf);
             vertices->setByteStride(3 * sizeof(float));
             vertices->setCount(2);

--- a/cpp/modmesh/view/RStaticMesh.cpp
+++ b/cpp/modmesh/view/RStaticMesh.cpp
@@ -55,7 +55,7 @@ void RStaticMesh::update_geometry_impl(StaticMesh const & mh, Qt3DCore::QGeometr
         vertices->setName(Qt3DCore::QAttribute::defaultPositionAttributeName());
         vertices->setAttributeType(Qt3DCore::QAttribute::VertexAttribute);
         vertices->setVertexBaseType(Qt3DCore::QAttribute::Float);
-        vertices->setVertexSize(3);
+        vertices->setVertexSize(5);
         auto * buf = new Qt3DCore::QBuffer(geom);
         {
             // Copy mesh node coordinates into the Qt buffer.


### PR DESCRIPTION
Fix render can not show `Line` by modified vertex size from **3** to **5**
but still no idea why vertex size have to `>= 5`

ref: [Qt official docs](https://doc.qt.io/qt-6/qt3dcore-qattribute.html#vertexSize-prop)