### PR TITLE
Output stack trace to std::cerr when Python exception is thrown from viewer

### DIFF
--- a/cpp/modmesh/python/common.cpp
+++ b/cpp/modmesh/python/common.cpp
@@ -163,7 +163,7 @@ void Interpreter::preload_module(std::string const & name)
     }
     catch (const py::error_already_set & e)
     {
-        if (std::string::npos == std::string(e.what()).find("ModuleNotFoundError"))
+        if (e.matches(PyExc_ModuleNotFoundError))
         {
             throw;
         }

--- a/cpp/modmesh/python/common.cpp
+++ b/cpp/modmesh/python/common.cpp
@@ -105,26 +105,49 @@ Interpreter & Interpreter::setup_modmesh_path()
     if path:
         sys.path.insert(0, path)
 _set_modmesh_path())"""";
-    pybind11::exec(cmd);
+    try
+    {
+        pybind11::exec(cmd);
+    }
+    catch (const pybind11::error_already_set & e)
+    {
+        std::cerr << e.what() << std::endl;
+    }
     return *this;
 }
 
 Interpreter & Interpreter::setup_process()
 {
-    // NOLINTNEXTLINE(misc-const-correctness)
-    pybind11::object mod_sys = pybind11::module_::import("modmesh.system");
     CommandLineInfo const & cmdinfo = ProcessInfo::instance().command_line();
-    mod_sys.attr("setup_process")(cmdinfo.python_argv());
+    try
+    {
+        // NOLINTNEXTLINE(misc-const-correctness)
+        pybind11::object mod_sys = pybind11::module_::import("modmesh.system");
+        mod_sys.attr("setup_process")(cmdinfo.python_argv());
+    }
+    catch (const pybind11::error_already_set & e)
+    {
+        std::cerr << e.what() << std::endl;
+    }
     return *this;
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 int Interpreter::enter_main()
 {
-    // NOLINTNEXTLINE(misc-const-correctness)
-    pybind11::object mod_sys = pybind11::module_::import("modmesh.system");
+    int ret = -1;
     CommandLineInfo const & cmdinfo = ProcessInfo::instance().command_line();
-    return pybind11::cast<int>(mod_sys.attr("enter_main")(cmdinfo.python_argv()));
+    try
+    {
+        // NOLINTNEXTLINE(misc-const-correctness)
+        pybind11::object mod_sys = pybind11::module_::import("modmesh.system");
+        ret = pybind11::cast<int>(mod_sys.attr("enter_main")(cmdinfo.python_argv()));
+    }
+    catch (const pybind11::error_already_set & e)
+    {
+        std::cerr << e.what() << std::endl;
+    }
+    return ret;
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static): implicitly requires m_interpreter
@@ -171,10 +194,10 @@ void Interpreter::preload_modules(std::vector<std::string> const & names)
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void Interpreter::exec_code(std::string const & code)
 {
-    // NOLINTNEXTLINE(misc-const-correctness)
-    pybind11::object mod_sys = pybind11::module_::import("modmesh.system");
     try
     {
+        // NOLINTNEXTLINE(misc-const-correctness)
+        pybind11::object mod_sys = pybind11::module_::import("modmesh.system");
         mod_sys.attr("exec_code")(code);
     }
     catch (const pybind11::error_already_set & e)

--- a/cpp/modmesh/view/RAction.cpp
+++ b/cpp/modmesh/view/RAction.cpp
@@ -54,9 +54,16 @@ RAppAction::RAppAction(const QString & text, const QString & tipText, const QStr
 void RAppAction::run()
 {
     namespace py = pybind11;
-    py::module_ appmod = py::module_::import(m_appName.toStdString().c_str());
-    appmod.reload();
-    appmod.attr("load_app")();
+    try
+    {
+        py::module_ appmod = py::module_::import(m_appName.toStdString().c_str());
+        appmod.reload();
+        appmod.attr("load_app")();
+    }
+    catch (const pybind11::error_already_set & e)
+    {
+        std::cerr << e.what() << std::endl;
+    }
 }
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -490,7 +490,14 @@ void initialize_view(pybind11::module & mod)
 
     if (Toggle::USE_PYSIDE)
     {
-        pybind11::module::import("PySide6");
+        try
+        {
+            pybind11::module::import("PySide6");
+        }
+        catch (const pybind11::error_already_set & e)
+        {
+            std::cerr << e.what() << std::endl;
+        }
     }
 
     OneTimeInitializer<view_pymod_tag>::me()(mod, initialize_impl);


### PR DESCRIPTION
#133 


For example:
![image](https://user-images.githubusercontent.com/33109379/206725472-c26d1da9-e7d8-4bfa-ada9-42e824226c0c.png)
