### PR TITLE
Revert fa21d6e18904df4c6c05f3d93c7f911e90f7b6f4

### DIFF
--- a/cpp/modmesh/view/RAxisMark.cpp
+++ b/cpp/modmesh/view/RAxisMark.cpp
@@ -132,7 +132,7 @@ RLine::RLine(QVector3D const & v0, QVector3D const & v1, QColor const & color, Q
             vertices->setName(Qt3DCore::QAttribute::defaultPositionAttributeName());
             vertices->setAttributeType(Qt3DCore::QAttribute::VertexAttribute);
             vertices->setVertexBaseType(Qt3DCore::QAttribute::Float);
-            vertices->setVertexSize(5);
+            vertices->setVertexSize(3);
             vertices->setBuffer(buf);
             vertices->setByteStride(3 * sizeof(float));
             vertices->setCount(2);

--- a/cpp/modmesh/view/RStaticMesh.cpp
+++ b/cpp/modmesh/view/RStaticMesh.cpp
@@ -55,7 +55,7 @@ void RStaticMesh::update_geometry_impl(StaticMesh const & mh, Qt3DCore::QGeometr
         vertices->setName(Qt3DCore::QAttribute::defaultPositionAttributeName());
         vertices->setAttributeType(Qt3DCore::QAttribute::VertexAttribute);
         vertices->setVertexBaseType(Qt3DCore::QAttribute::Float);
-        vertices->setVertexSize(5);
+        vertices->setVertexSize(3);
         auto * buf = new Qt3DCore::QBuffer(geom);
         {
             // Copy mesh node coordinates into the Qt buffer.


### PR DESCRIPTION
I was wrong in the review https://github.com/solvcon/modmesh/pull/167#pullrequestreview-1211075520 to think it is ok to set vertex size to an illegal value.  It is not because it may result into memory error.  I think it is implied in the qt3d doc: https://doc.qt.io/qt-6/qt3dcore-qattribute.html#vertexSize-prop.

I will file an issue to track it.  The vertex size may be an important parameter for qt3d and I do not fully understand its meaning.

On my macos, using 5 causes wrong rendering of the lines.