### PR TITLE
build(Makefile): make python3-config protable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,11 @@ CMAKE_ARGS ?=
 VERBOSE ?=
 FORCE_CLANG_FORMAT ?=
 
-pyextsuffix := $(shell python3-config --extension-suffix)
+WHICH_PYTHON := $(shell which python)
+REALPATH_PYTHON := $(shell realpath $(WHICH_PYTHON))
+DIRNAME_PYTHON := $(shell dirname $(REALPATH_PYTHON))
+
+pyextsuffix := $(shell $(DIRNAME_PYTHON)/python3-config --extension-suffix)
 pyvminor := $(shell python3 -c 'import sys; print("%d%d" % sys.version_info[0:2])')
 
 ifeq ($(CMAKE_BUILD_TYPE), Debug)

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ VERBOSE ?=
 FORCE_CLANG_FORMAT ?=
 
 WHICH_PYTHON := $(shell which python3)
-REALPATH_PYTHON := $(shell realpath $(WHICH_PYTHON))
-DIRNAME_PYTHON := $(shell dirname $(REALPATH_PYTHON))
+REALPATH_PYTHON := $(realpath $(WHICH_PYTHON))
+DIRNAME_PYTHON := $(dir dirname $(REALPATH_PYTHON))
 
 pyextsuffix := $(shell $(DIRNAME_PYTHON)/python3-config --extension-suffix)
 pyvminor := $(shell python3 -c 'import sys; print("%d%d" % sys.version_info[0:2])')

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ CMAKE_ARGS ?=
 VERBOSE ?=
 FORCE_CLANG_FORMAT ?=
 
-WHICH_PYTHON := $(shell which python)
+WHICH_PYTHON := $(shell which python3)
 REALPATH_PYTHON := $(shell realpath $(WHICH_PYTHON))
 DIRNAME_PYTHON := $(shell dirname $(REALPATH_PYTHON))
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,14 @@ CMAKE_ARGS ?=
 VERBOSE ?=
 FORCE_CLANG_FORMAT ?=
 
+# !!! NOTE: USING ANY VENV IS STRONGLY DISCOURAGED IN DEVELOPING MODMESH !!!
+# This treatment is a "smarter" way to find python3-config executable.
+# In case Python is not system Python. For example. Python virtual environment
+# is used.
+# However, please note a Python virtual environment is strongly discouraged in
+# developing modmesh. We do not actively resolve bugs related to any virtual
+# env including venv or conda.
+# See https://github.com/solvcon/modmesh/pull/177 for more details.
 WHICH_PYTHON := $(shell which python3)
 REALPATH_PYTHON := $(realpath $(WHICH_PYTHON))
 DIRNAME_PYTHON := $(dir dirname $(REALPATH_PYTHON))

--- a/cpp/binary/pymod_modmesh/CMakeLists.txt
+++ b/cpp/binary/pymod_modmesh/CMakeLists.txt
@@ -33,8 +33,14 @@ if (CLANG_TIDY_EXE AND USE_CLANG_TIDY)
     )
 endif ()
 
+include(CMakePrintHelpers)
+get_filename_component(REALPATH_PYTHON "${PYTHON_EXECUTABLE}" REALPATH)
+get_filename_component(PYTHON_VENV_BIN "${REALPATH_PYTHON}" DIRECTORY)
+cmake_print_variables(REALPATH_PYTHON)
+cmake_print_variables(PYTHON_VENV_BIN)
+
 execute_process(
-    COMMAND $(dirname $(realpath $(which python)))/python3-config --extension-suffix
+    COMMAND ${PYTHON_VENV_BIN}/python3-config --extension-suffix
     OUTPUT_VARIABLE PYEXTSUFFIX
 )
 

--- a/cpp/binary/pymod_modmesh/CMakeLists.txt
+++ b/cpp/binary/pymod_modmesh/CMakeLists.txt
@@ -34,7 +34,7 @@ if (CLANG_TIDY_EXE AND USE_CLANG_TIDY)
 endif ()
 
 execute_process(
-    COMMAND python3-config --extension-suffix
+    COMMAND $(dirname $(realpath $(which python)))/python3-config --extension-suffix
     OUTPUT_VARIABLE PYEXTSUFFIX
 )
 


### PR DESCRIPTION
When using python virtual environment, python-config or python3-config are maybe not included in PATH, and thus the command may return incorrect information of python configuration.