### PR TITLE
Add google-test version 1.12.1 and make extension initializer cleaner

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -80,6 +80,12 @@ jobs:
         echo "flake8 path: $(which flake8)"
         echo "flake8 version: $(flake8 --version)"
 
+    - name: make gtest BUILD_QT=OFF
+      run: |
+        make gtest \
+          VERBOSE=1 USE_CLANG_TIDY=OFF \
+          BUILD_QT=OFF
+
     - name: make buildext BUILD_QT=OFF
       run: |
         rm -f build/*/Makefile
@@ -194,6 +200,12 @@ jobs:
           echo "clang-tidy version: $(clang-tidy -version)"
           echo "flake8 path: $(which flake8)"
           echo "flake8 version: $(flake8 --version)"
+
+      - name: make gtest BUILD_QT=OFF
+        run: |
+          make gtest \
+          VERBOSE=1 USE_CLANG_TIDY=OFF \
+          BUILD_QT=OFF
 
       - name: make buildext BUILD_QT=OFF
         run: |
@@ -312,6 +324,12 @@ jobs:
           cmake --build ${{ github.workspace }}/build `
             --config ${{ matrix.cmake_build_type }} `
             --target ALL_BUILD
+
+      - name: cmake run_gtest
+        run: |
+          cmake --build ${{ github.workspace }}/build `
+            --config ${{ matrix.cmake_build_type }} `
+            --target run_gtest
 
       - name: cmake run_viewer_pytest
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         path:
           - 'cpp'
+          - 'gtests'
 
     steps:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,4 +154,11 @@ endif()
 add_custom_target(flake8)
 flake8("flake8")
 
+set(USE_GOOGLETEST True CACHE BOOL "Build with googletest")
+message(STATUS "USE_GOOGLETEST: ${USE_GOOGLETEST}")
+
+if(USE_GOOGLETEST)
+add_subdirectory(gtests)
+endif() # USE_GOOGLETEST
+
 # vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/Makefile
+++ b/Makefile
@@ -107,11 +107,15 @@ pytest: buildext
 viewer: cmake
 	cmake --build $(BUILD_PATH) --target $@ VERBOSE=$(VERBOSE) $(MAKE_PARALLEL)
 
+.PHONY: gtest
+gtest: cmake
+	cmake --build $(BUILD_PATH) --target run_gtest VERBOSE=$(VERBOSE) $(MAKE_PARALLEL)
+
 .PHONY: run_viewer_pytest
 run_viewer_pytest: viewer
 	cmake --build $(BUILD_PATH) --target $@ VERBOSE=$(VERBOSE)
 
-CFFILES = $(shell find cpp -type f -name '*.[ch]pp' | sort)
+CFFILES = $(shell find cpp gtests -type f -name '*.[ch]pp' | sort)
 ifeq ($(CFCMD),)
 	ifeq ($(FORCE_CLANG_FORMAT),)
 		CFCMD = clang-format --dry-run

--- a/cmake/Flake8.cmake
+++ b/cmake/Flake8.cmake
@@ -9,6 +9,6 @@ macro(flake8 target_name)
     add_custom_command(TARGET ${target_name}
         PRE_BUILD
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND ${flake8_BIN} . --exclude thirdparty,tmp
+        COMMAND ${flake8_BIN} . --exclude thirdparty,tmp,_deps
         COMMENT "Running flake8 on ${CMAKE_CURRENT_SOURCE_DIR} ...")
 endmacro()

--- a/cpp/modmesh/buffer/CMakeLists.txt
+++ b/cpp/modmesh/buffer/CMakeLists.txt
@@ -19,6 +19,7 @@ set(MODMESH_BUFFER_PYMODHEADERS
     CACHE FILEPATH "" FORCE)
 
 set(MODMESH_BUFFER_PYMODSOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/buffer_pymod.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_ConcreteBuffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_SimpleArray.cpp
     CACHE FILEPATH "" FORCE)

--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -32,6 +32,11 @@
 
 #include <stdexcept>
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 namespace modmesh
 {
 

--- a/cpp/modmesh/buffer/pymod/buffer_pymod.cpp
+++ b/cpp/modmesh/buffer/pymod/buffer_pymod.cpp
@@ -1,7 +1,5 @@
-#pragma once
-
 /*
- * Copyright (c) 2022, Yung-Yu Chen <yyc@solvcon.net>
+ * Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -28,11 +26,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <pybind11/pybind11.h> // Must be the first include.
-#include <pybind11/stl.h>
-
-#include <modmesh/modmesh.hpp>
-#include <modmesh/python/common.hpp>
+#include <modmesh/toggle/pymod/toggle_pymod.hpp> // Must be the first include.
+#include <modmesh/buffer/pymod/buffer_pymod.hpp>
 
 namespace modmesh
 {
@@ -40,12 +35,30 @@ namespace modmesh
 namespace python
 {
 
-void initialize_buffer(pybind11::module & mod);
-void wrap_ConcreteBuffer(pybind11::module & mod);
-void wrap_SimpleArray(pybind11::module & mod);
+struct buffer_pymod_tag;
+
+template <>
+OneTimeInitializer<buffer_pymod_tag> & OneTimeInitializer<buffer_pymod_tag>::me()
+{
+    static OneTimeInitializer<buffer_pymod_tag> instance;
+    return instance;
+}
+
+void initialize_buffer(pybind11::module & mod)
+{
+    auto initialize_impl = [](pybind11::module & mod)
+    {
+        import_numpy();
+
+        wrap_ConcreteBuffer(mod);
+        wrap_SimpleArray(mod);
+    };
+
+    OneTimeInitializer<buffer_pymod_tag>::me()(mod, initialize_impl);
+}
 
 } /* end namespace python */
 
 } /* end namespace modmesh */
 
-// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:
+// vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/mesh/CMakeLists.txt
+++ b/cpp/modmesh/mesh/CMakeLists.txt
@@ -18,6 +18,7 @@ set(MODMESH_MESH_PYMODHEADERS
     CACHE FILEPATH "" FORCE)
 
 set(MODMESH_MESH_PYMODSOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/mesh_pymod.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_StaticGrid.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_StaticMesh.cpp
     CACHE FILEPATH "" FORCE)

--- a/cpp/modmesh/mesh/pymod/mesh_pymod.cpp
+++ b/cpp/modmesh/mesh/pymod/mesh_pymod.cpp
@@ -1,7 +1,5 @@
-#pragma once
-
 /*
- * Copyright (c) 2022, Yung-Yu Chen <yyc@solvcon.net>
+ * Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -28,11 +26,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <pybind11/pybind11.h> // Must be the first include.
-#include <pybind11/stl.h>
-
-#include <modmesh/modmesh.hpp>
-#include <modmesh/python/common.hpp>
+#include <modmesh/toggle/pymod/toggle_pymod.hpp> // Must be the first include.
+#include <modmesh/buffer/pymod/buffer_pymod.hpp>
 
 namespace modmesh
 {
@@ -40,12 +35,28 @@ namespace modmesh
 namespace python
 {
 
-void initialize_buffer(pybind11::module & mod);
-void wrap_ConcreteBuffer(pybind11::module & mod);
-void wrap_SimpleArray(pybind11::module & mod);
+struct mesh_pymod_tag;
+
+template <>
+OneTimeInitializer<mesh_pymod_tag> & OneTimeInitializer<mesh_pymod_tag>::me()
+{
+    static OneTimeInitializer<mesh_pymod_tag> instance;
+    return instance;
+}
+
+void initialize_mesh(pybind11::module & mod)
+{
+    auto initialize_impl = [](pybind11::module & mod)
+    {
+        wrap_StaticGrid(mod);
+        wrap_StaticMesh(mod);
+    };
+
+    OneTimeInitializer<mesh_pymod_tag>::me()(mod, initialize_impl);
+}
 
 } /* end namespace python */
 
 } /* end namespace modmesh */
 
-// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:
+// vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/mesh/pymod/mesh_pymod.hpp
+++ b/cpp/modmesh/mesh/pymod/mesh_pymod.hpp
@@ -40,6 +40,7 @@ namespace modmesh
 namespace python
 {
 
+void initialize_mesh(pybind11::module & mod);
 void wrap_StaticGrid(pybind11::module & mod);
 void wrap_StaticMesh(pybind11::module & mod);
 

--- a/cpp/modmesh/python/module.cpp
+++ b/cpp/modmesh/python/module.cpp
@@ -22,6 +22,8 @@
 #include <modmesh/python/python.hpp> // Must be the first include.
 #include <modmesh/python/module.hpp>
 #include <modmesh/toggle/pymod/toggle_pymod.hpp>
+#include <modmesh/buffer/pymod/buffer_pymod.hpp>
+#include <modmesh/mesh/pymod/mesh_pymod.hpp>
 #include <modmesh/onedim/pymod/onedim_pymod.hpp>
 #include <modmesh/spacetime/pymod/spacetime_pymod.hpp>
 #ifdef QT_CORE_LIB
@@ -36,7 +38,9 @@ namespace python
 
 void initialize(pybind11::module_ mod)
 {
-    initialize_modmesh(mod);
+    initialize_toggle(mod);
+    initialize_buffer(mod);
+    initialize_mesh(mod);
     pybind11::module_ spacetime_mod = mod.def_submodule("spacetime", "spacetime");
     initialize_spacetime(spacetime_mod);
     pybind11::module_ onedim_mod = mod.def_submodule("onedim", "onedim");

--- a/cpp/modmesh/toggle/pymod/toggle_pymod.cpp
+++ b/cpp/modmesh/toggle/pymod/toggle_pymod.cpp
@@ -35,30 +35,24 @@ namespace modmesh
 namespace python
 {
 
-struct modmesh_pymod_tag;
+struct toggle_pymod_tag;
 
 template <>
-OneTimeInitializer<modmesh_pymod_tag> & OneTimeInitializer<modmesh_pymod_tag>::me()
+OneTimeInitializer<toggle_pymod_tag> & OneTimeInitializer<toggle_pymod_tag>::me()
 {
-    static OneTimeInitializer<modmesh_pymod_tag> instance;
+    static OneTimeInitializer<toggle_pymod_tag> instance;
     return instance;
 }
 
-void initialize_modmesh(pybind11::module & mod)
+void initialize_toggle(pybind11::module & mod)
 {
     auto initialize_impl = [](pybind11::module & mod)
     {
-        import_numpy();
-
         wrap_profile(mod);
-        wrap_ConcreteBuffer(mod);
-        wrap_SimpleArray(mod);
-        wrap_StaticGrid(mod);
-        wrap_StaticMesh(mod);
         wrap_Toggle(mod);
     };
 
-    OneTimeInitializer<modmesh_pymod_tag>::me()(mod, initialize_impl);
+    OneTimeInitializer<toggle_pymod_tag>::me()(mod, initialize_impl);
 }
 
 } /* end namespace python */

--- a/cpp/modmesh/toggle/pymod/toggle_pymod.hpp
+++ b/cpp/modmesh/toggle/pymod/toggle_pymod.hpp
@@ -40,7 +40,7 @@ namespace modmesh
 namespace python
 {
 
-void initialize_modmesh(pybind11::module & mod);
+void initialize_toggle(pybind11::module & mod);
 void wrap_profile(pybind11::module & mod);
 void wrap_StaticGrid(pybind11::module & mod);
 void wrap_StaticMesh(pybind11::module & mod);

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Copyright (c) 2022, Yung-Yu Chen <yyc@solvcon.net>
+# BSD-style license; see COPYING
+
+cmake_minimum_required(VERSION 3.16)
+
+# See https://google.github.io/googletest/quickstart-cmake.html for the
+# recommended cmake configuration
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz
+    DOWNLOAD_EXTRACT_TIMESTAMP ON
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+
+add_executable(
+    test_nopython
+    test_nopython_buffer.cpp
+    test_nopython_modmesh.cpp
+)
+target_link_libraries(
+    test_nopython
+    GTest::gtest_main
+)
+
+include(GoogleTest)
+gtest_discover_tests(test_nopython)
+
+add_custom_target(run_gtest
+    COMMAND $<TARGET_FILE:test_nopython>
+    DEPENDS test_nopython)

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -1,0 +1,23 @@
+#include <modmesh/buffer/buffer.hpp>
+
+#include <gtest/gtest.h>
+
+#ifdef Py_PYTHON_H
+#error "Python.h should not be included."
+#endif
+
+TEST(nopython_buffer, dummy)
+{
+    EXPECT_TRUE(true);
+}
+
+TEST(SimpleArray, construction)
+{
+    namespace mm = modmesh;
+    mm::SimpleArray<double> arr_double(10);
+    EXPECT_EQ(arr_double.nbody(), 10);
+    mm::SimpleArray<int> arr_int(17);
+    EXPECT_EQ(arr_int.nbody(), 17);
+}
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/gtests/test_nopython_modmesh.cpp
+++ b/gtests/test_nopython_modmesh.cpp
@@ -1,0 +1,14 @@
+#include <modmesh/modmesh.hpp>
+
+#include <gtest/gtest.h>
+
+#ifdef Py_PYTHON_H
+#error "Python.h should not be included."
+#endif
+
+TEST(nopython_modmesh, dummy)
+{
+    EXPECT_TRUE(true);
+}
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/thirdparty/googletest.sh
+++ b/thirdparty/googletest.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Install Apple Metal. See: https://developer.apple.com/metal/cpp/
+
+script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+download_md5 () {
+  local loc=$1
+  local url=$2
+  local md5hash=$3
+  if [ $(uname) == Darwin ] ; then
+    local md5="md5 -q"
+  elif [ $(uname) == Linux ] ; then
+    local md5=md5sum
+  fi
+  if [ ! -e $loc ] || [ $md5hash != `$md5 $loc | cut -d ' ' -f 1` ] ; then
+    mkdir -p $(dirname $loc)
+    rm -f $loc
+    echo "Download from $url"
+    curl -sSL -o $loc $url
+  fi
+  local md5hash_calc=`$md5 $loc | cut -d ' ' -f 1`
+  if [ $md5hash != $md5hash_calc ] ; then
+    echo "$(basename $loc) md5 hash $md5hash but got $md5hash_calc"
+  else
+    echo "$(basename $loc) md5 hash $md5hash confirmed"
+  fi
+}
+
+version=1.12.1
+filename=googletest-${version}.tar.gz
+dstpath=googletest-release-${version}
+
+pushd ${script_root}/install
+
+download_md5 \
+  ${script_root}/archive/${filename} \
+  https://github.com/google/googletest/archive/refs/tags/release-${version}.tar.gz \
+  e82199374acdfda3f425331028eb4e2a
+
+rm -rf ${dstpath}
+tar xfz ${script_root}/archive/${filename} ${dstpath}/googletest
+rm -rf googletest
+mv ${dstpath}/googletest googletest
+rm -rf googletest/docs googletest/samples googletest/test
+rm -rf ${dstpath}
+
+popd


### PR DESCRIPTION
* Add google test version 1.12.1
  * Create two trivial test files for including `modmesh/modmesh.hpp` and `modmesh/buffer/buffer.hpp` without including `Python.h`
* Move python module initialization calls to their own directories
  * Make the initialization calls of `_modmesh` extension module cleaner