### PR TITLE
WIP: implement configuration

### DIFF
--- a/cpp/binary/viewer/CMakeLists.txt
+++ b/cpp/binary/viewer/CMakeLists.txt
@@ -97,6 +97,8 @@ endif()
 
 add_custom_target(run_viewer_pytest $<TARGET_FILE:viewer> --mode=pytest)
 
+file(COPY ${PROJECT_ROOT_DIR}/config.json DESTINATION ${viewer_BINARY_DIR})
+
 install(TARGETS viewer
     RUNTIME DESTINATION "${INSTALL_VIEWERDIR}"
     BUNDLE DESTINATION "${INSTALL_VIEWERDIR}"

--- a/cpp/modmesh/python/CMakeLists.txt
+++ b/cpp/modmesh/python/CMakeLists.txt
@@ -6,11 +6,13 @@ cmake_minimum_required(VERSION 3.16)
 set(MODMESH_PYTYON_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/python.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/common.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/wrap_config.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/module.hpp
     CACHE FILEPATH "" FORCE)
 
 set(MODMESH_PYTHON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/common.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/wrap_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/module.cpp
     CACHE FILEPATH "" FORCE)
 

--- a/cpp/modmesh/python/common.cpp
+++ b/cpp/modmesh/python/common.cpp
@@ -263,6 +263,44 @@ std::string PythonStreamRedirect::stderr_string() const
     return pybind11::str(m_stderr_buffer.attr("read")());
 }
 
+Config & Config::instance()
+{
+    static Config o;
+    return o;
+}
+
+void Config::initialize_from_file(const char * file_path)
+{
+    try
+    {
+        // NOLINTNEXTLINE(misc-const-correctness)
+        pybind11::object mod_sys = pybind11::module_::import("modmesh.system");
+        m_data = new pybind11::dict();
+        *m_data = pybind11::cast<pybind11::dict>(mod_sys.attr("load_json_from_file")(file_path));
+    }
+    catch (const pybind11::error_already_set & e)
+    {
+        std::cerr << e.what() << std::endl;
+    }
+}
+
+pybind11::object Config::get(const char * key) { return (*m_data)[key]; };
+pybind11::object Config::get(const std::vector<const char *> keys)
+{
+    pybind11::object data = *m_data;
+    for (auto i = 0; i < keys.size(); i++)
+    {
+        data = data[keys[i]];
+    }
+    return data;
+};
+
+void Config::set(const char * key, const int value) { (*m_data)[key] = value; }
+
+void Config::set(const char * key, const float value) { (*m_data)[key] = value; }
+
+void Config::set(const char * key, const char * value) { (*m_data)[key] = value; }
+
 } /* end namespace python */
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/python/common.hpp
+++ b/cpp/modmesh/python/common.hpp
@@ -545,6 +545,49 @@ private:
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+// Suppress the warning "greater visibility than the type of its field"
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+class Config
+{
+public:
+
+    static Config & instance();
+
+    Config(Config const &) = delete;
+    Config(Config &&) = delete;
+    Config & operator=(Config const &) = delete;
+    Config & operator=(Config &&) = delete;
+    ~Config() { delete m_data; };
+
+    void initialize() { m_data = new pybind11::dict(); }
+    void initialize_from_file(const char * file_path);
+
+    pybind11::object get(const char * key);
+    pybind11::object get(const std::vector<const char *> keys);
+
+    void set(const char * key, const int value);
+    // void set(const std::vector<const char *> keys, const int value); // TODO
+
+    // In Python, "number" is analogous to the float type.
+    void set(const char * key, const float value);
+    // void set(const std::vector<const char *> keys, const float value); // TODO
+
+    void set(const char * key, const char * value);
+    // void set(const std::vector<const char *> keys, const char * value); // TODO
+
+private:
+    Config() = default;
+    // need to be initialized after `Interpreter` is initialized
+    pybind11::dict * m_data;
+}; /* end class Config */
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
 } /* end namespace python */
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/python/module.cpp
+++ b/cpp/modmesh/python/module.cpp
@@ -29,6 +29,7 @@
 #ifdef QT_CORE_LIB
 #include <modmesh/view/wrap_view.hpp>
 #endif // QT_CORE_LIB
+#include <modmesh/python/wrap_config.hpp>
 
 namespace modmesh
 {
@@ -52,6 +53,7 @@ void initialize(pybind11::module_ mod)
 #else // QT_CORE_LIB
     mod.attr("HAS_VIEW") = false;
 #endif // QT_CORE_LIB
+    wrap_Config(mod);
 }
 
 int program_entrance(int argc, char ** argv)
@@ -64,6 +66,10 @@ int program_entrance(int argc, char ** argv)
         .initialize()
         .setup_modmesh_path()
         .setup_process();
+
+    // must behind the interpreter construction
+    auto & config = Config::instance();
+    config.initialize_from_file("config.json"); // TODO: tiger: get a default path from the argument parser
 
     int ret = 0;
 

--- a/cpp/modmesh/python/wrap_config.cpp
+++ b/cpp/modmesh/python/wrap_config.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <modmesh/python/python.hpp> // Must be the first include.
+#include <modmesh/python/wrap_config.hpp>
+
+namespace modmesh
+{
+
+namespace python
+{
+
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapConfig
+    : public WrapBase<WrapConfig, Config>
+{
+
+public:
+
+    using base_type = WrapBase<WrapConfig, Config>;
+    using wrapped_type = typename base_type::wrapped_type;
+
+    friend root_base_type;
+
+protected:
+
+    WrapConfig(pybind11::module & mod, char const * pyname, char const * pydoc);
+
+}; /* end class WrapConfig */
+
+WrapConfig::WrapConfig(pybind11::module & mod, char const * pyname, char const * pydoc)
+    : base_type(mod, pyname, pydoc)
+{
+    namespace py = pybind11;
+    (*this)
+        .def_property_readonly_static(
+            "instance",
+            [](py::object const &) -> auto & {
+                return wrapped_type::instance();
+            })
+        .def(
+            "__getitem__",
+            [](wrapped_type & self, const char * key)
+            { return self.get(key); })
+        .def(
+            "__setitem__",
+            [](wrapped_type & self, const char * key, const int val)
+            { self.set(key, val); })
+        .def(
+            "__setitem__",
+            [](wrapped_type & self, const char * key, const float val)
+            { self.set(key, val); })
+        .def(
+            "__setitem__",
+            [](wrapped_type & self, const char * key, const char * val)
+            { self.set(key, val); });
+}
+
+void wrap_Config(pybind11::module & mod)
+{
+    WrapConfig::commit(mod, "config", "config");
+}
+
+} /* end namespace python */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/python/wrap_config.hpp
+++ b/cpp/modmesh/python/wrap_config.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+/*
+ * Copyright (c) 2022, Yung-Yu Chen <yyc@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <modmesh/python/python.hpp> // Must be the first include.
+
+namespace modmesh
+{
+
+namespace python
+{
+
+void wrap_Config(pybind11::module & mod);
+
+} /* end namespace python */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/system.py
+++ b/modmesh/system.py
@@ -45,6 +45,7 @@ __all__ = [
     'setup_process',
     'enter_main',
     'exec_code',
+    'load_json_from_file,'
 ]
 
 
@@ -68,6 +69,9 @@ def _parse_command_line(argv):
                         default='viewer',
                         choices=['viewer', 'python', 'pytest'],
                         help='mode selection (default = %(default)s)')
+    parser.add_argument('--config-path', action='store',
+                        default='config.json',
+                        help='the path of configuration file')
     args = parser.parse_args(argv[1:])
     if parser.exited:
         args.exit = (parser.exited_status, parser.exited_message)
@@ -89,6 +93,19 @@ def _run_pytest():
     mmpath = os.path.abspath(mmpath)
     return pytest.main(['-v', '-x', mmpath])
 
+
+def load_json_from_file(file_path):
+    import json
+
+    if not os.path.exists(file_path):
+        raise ValueError(f"json file `{os.path.abspath(file_path)}` does not exists.")
+
+    with open(file_path) as f:
+        try:
+            loaded_json = json.load(f) 
+        except Exception as e:
+            raise e
+    return loaded_json
 
 def setup_process(argv):
     """Set up the runtime environment for the process."""


### PR DESCRIPTION
The configuration is accessible for both C++ (`Config`) and Python (`modmesh.config`) . (#165)
The data of configuration is decided to use `py::dict` to leverage Python `json` module and to avoid third-party libraries in C++
Now we don't use `modmesh.view.app.pycon.python_redirect = False`, instead, we will just set `modmesh.config["python_redirect"] = True`

---

The config file will look like:
```json
{
    "A": 1,
    "B": "B",
    "C": {
        "D": 1.2
    }
}
```

C++ access:
```c++
    std::cout << "A: " << pybind11::cast<int>(config.get("A")) << std::endl; // A: 1
    config.set("A", 5);

    std::cout << "A: " << pybind11::cast<int>(config.get("A")) << std::endl; // A: 5
    std::cout << "B: " << pybind11::cast<std::string>(config.get("B")) << std::endl; // B: B
 
    // TODO: support a list of keys
    std::cout << "D: " << pybind11::cast<std::string>(config.get({"C", "D"}, "B")) << std::endl; // D: 1.2
```

Python access, for both interpreter mode or viewer mode:
```python
import modmesh.config as config
a = config["A"]
config["A"] = 5
```

