### PR TITLE
feat(profiling): integrate scoped-based timer to onedim core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ setup.mk
 *.tlog
 *.obj
 *.pdb
+*.env

--- a/cpp/modmesh/onedim/Euler1DCore.cpp
+++ b/cpp/modmesh/onedim/Euler1DCore.cpp
@@ -27,7 +27,7 @@
  */
 
 #include <modmesh/onedim/Euler1DCore.hpp>
-#include <modmesh/toggle/toggle.hpp>
+#include <modmesh/toggle/profile.hpp>
 #include <cmath>
 
 namespace modmesh

--- a/cpp/modmesh/onedim/Euler1DCore.cpp
+++ b/cpp/modmesh/onedim/Euler1DCore.cpp
@@ -27,6 +27,7 @@
  */
 
 #include <modmesh/onedim/Euler1DCore.hpp>
+#include <modmesh/toggle/toggle.hpp>
 #include <cmath>
 
 namespace modmesh
@@ -43,6 +44,7 @@ std::ostream & operator<<(std::ostream & os, const Euler1DCore & sol)
 
 void Euler1DCore::initialize_data(size_t ncoord)
 {
+    MODMESH_TIME("Euler1DCore::initialize_data");
     if (0 == ncoord % 2)
     {
         throw std::invalid_argument("ncoord cannot be even");
@@ -56,6 +58,7 @@ void Euler1DCore::initialize_data(size_t ncoord)
 
 SimpleArray<double> Euler1DCore::density() const
 {
+    MODMESH_TIME("Euler1DCore::density");
     SimpleArray<double> ret(ncoord());
     for (size_t it = 0; it < ncoord(); ++it)
     {
@@ -66,6 +69,7 @@ SimpleArray<double> Euler1DCore::density() const
 
 SimpleArray<double> Euler1DCore::velocity() const
 {
+    MODMESH_TIME("Euler1DCore::velocity");
     SimpleArray<double> ret(ncoord());
     for (size_t it = 0; it < ncoord(); ++it)
     {
@@ -76,6 +80,7 @@ SimpleArray<double> Euler1DCore::velocity() const
 
 SimpleArray<double> Euler1DCore::pressure() const
 {
+    MODMESH_TIME("Euler1DCore::pressure");
     SimpleArray<double> ret(ncoord());
     for (size_t it = 0; it < ncoord(); ++it)
     {
@@ -86,6 +91,7 @@ SimpleArray<double> Euler1DCore::pressure() const
 
 void Euler1DCore::update_cfl(bool odd_plane)
 {
+    MODMESH_TIME("Euler1DCore::update_cfl");
     const int_type start = BOUND_COUNT - (odd_plane ? 1 : 0);
     const auto stop = static_cast<int_type>(ncoord() - BOUND_COUNT - (odd_plane ? 0 : 1));
     const double hdt = m_time_increment / 2;
@@ -111,6 +117,7 @@ void Euler1DCore::update_cfl(bool odd_plane)
 
 void Euler1DCore::march_half_so0(bool odd_plane)
 {
+    MODMESH_TIME("Euler1DCore::march_half_so0");
     const int_type start = BOUND_COUNT - (odd_plane ? 1 : 0);
     const auto stop = static_cast<int_type>(ncoord() - BOUND_COUNT - (odd_plane ? 0 : 1));
     // Kernal at xneg solution element.

--- a/cpp/modmesh/onedim/Euler1DCore.hpp
+++ b/cpp/modmesh/onedim/Euler1DCore.hpp
@@ -32,6 +32,7 @@
 #include <modmesh/base.hpp>
 #include <modmesh/math.hpp>
 #include <modmesh/buffer/buffer.hpp>
+#include <modmesh/toggle/profile.hpp>
 #include <memory>
 
 namespace modmesh
@@ -182,6 +183,8 @@ struct Euler1DKernel
 
     Euler1DKernel & derive()
     {
+        MODMESH_TIME("Euler1DKernel::derive");
+
         // TODO: reduce numerical calculation.
         jac[0][0] = 0.0;
         jac[0][1] = 1.0;

--- a/cpp/modmesh/onedim/Euler1DCore.hpp
+++ b/cpp/modmesh/onedim/Euler1DCore.hpp
@@ -258,6 +258,8 @@ struct Euler1DKernel
 template <size_t ALPHA>
 inline void Euler1DCore::march_half_so1_alpha(bool odd_plane)
 {
+    MODMESH_TIME("Euler1DKernel::march_half_so1_alpha");
+
     const int_type start = BOUND_COUNT - (odd_plane ? 1 : 0);
     const int_type stop = static_cast<int_type>(ncoord() - BOUND_COUNT - (odd_plane ? 0 : 1));
     // Kernal at xneg solution element.

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -214,19 +214,25 @@ def run(interval=10, max_steps=50, no_view_mgr=False, **kw):
 
 if __name__ == "__main__":
     import sys
-    from PySide6.QtCore import QTimer
-    from PySide6.QtWidgets import QApplication
-    app = QApplication()
+    try:
+        from PySide6.QtCore import QTimer
+        from PySide6.QtWidgets import QApplication
+        app = QApplication()
 
-    ctrl = run(interval=10, max_steps=50, no_view_mgr=True, profiling=True)
-    ctrl.start()
+        ctrl = run(interval=10, max_steps=50, no_view_mgr=True, profiling=True)
+        ctrl.start()
 
-    # The trick to close the event loop of app automatically
-    # The timer will emit a closeAllWindows event after 20 seconds
-    # after the app is executed.
-    QTimer.singleShot(20000, app.closeAllWindows)
+        # The trick to close the event loop of app automatically
+        # The timer will emit a closeAllWindows event after 20 seconds
+        # after the app is executed.
+        QTimer.singleShot(20000, app.closeAllWindows)
 
-    sys.exit(app.exec())
+        sys.exit(app.exec())
+
+    except ImportError:
+        print("Something wrong when importing PySide6.")
+        print("Do you install PySide6?")
+        sys.exit(1)
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -25,6 +25,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
+__package__ = "modmesh.app"
+
+
 import sys
 from dataclasses import dataclass
 
@@ -182,16 +185,48 @@ class Controller:
         view.mgr.pycon.writeToHistory('\n')
 
 
-def run(interval=10, max_steps=50, **kw):
+class ControllerNoViewMgr(Controller):
+    def __init__(self, shocktube, max_steps, use_sub=None, profiling=False):
+
+        super().__init__(shocktube, max_steps, use_sub=None, profiling=profiling)
+
+    @staticmethod
+    def log(msg):
+        sys.stdout.write(msg)
+        sys.stdout.write("\n")
+
+
+def run(interval=10, max_steps=50, no_view_mgr=False, **kw):
     st = euler1d.ShockTube()
     st.build_constant(gamma=1.4, pressure1=1.0, density1=1.0, pressure5=0.1,
                       density5=0.125)
     st.build_numerical(xmin=-10, xmax=10, ncoord=201, time_increment=0.05)
 
-    ctrl = Controller(shocktube=st, max_steps=max_steps, **kw)
+    if no_view_mgr:
+        ctrl = ControllerNoViewMgr(shocktube=st, max_steps=max_steps, **kw)
+    else:
+        ctrl = Controller(shocktube=st, max_steps=max_steps, **kw)
     ctrl.setup_solver(interval)
     ctrl.show()
 
     return ctrl
+
+
+if __name__ == "__main__":
+    import sys
+    from PySide6.QtCore import QTimer
+    from PySide6.QtWidgets import QApplication
+    app = QApplication()
+
+    ctrl = run(interval=10, max_steps=50, no_view_mgr=True, profiling=True)
+    ctrl.start()
+
+    # The trick to close the event loop of app automatically
+    # The timer will emit a closeAllWindows event after 20 seconds
+    # after the app is executed.
+    QTimer.singleShot(20000, app.closeAllWindows)
+
+    sys.exit(app.exec())
+
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -46,6 +46,9 @@ def load_app():
 # Use the functions for more examples:
 ctrl.start()  # Start the movie
 ctrl.step()  # Stepping the solution
+
+# Note: you can enable profiling info by "profiling" option
+ctrl = mm.app.euler1d.run(interval=10, max_steps=50, profiling=True) # enable profiling info
 """)
     cmd = "ctrl = mm.app.euler1d.run(interval=10, max_steps=50)"
     view.mgr.pycon.command = cmd
@@ -96,7 +99,7 @@ class Plot:
 
 
 class Controller:
-    def __init__(self, shocktube, max_steps, use_sub=None):
+    def __init__(self, shocktube, max_steps, use_sub=None, profiling=False):
         if None is shocktube.gamma:
             raise ValueError("shocktube does not have constant built")
         if None is shocktube.svr:
@@ -131,6 +134,8 @@ class Controller:
         layout.addWidget(self.plt.canvas)
         layout.addWidget(NavigationToolbar(self.plt.canvas, self._main))
 
+        self.profiling = profiling
+
     def show(self):
         self._main.show()
         if self.use_sub:
@@ -154,6 +159,8 @@ class Controller:
         self.shocktube.build_field(t=time_current)
         cfl = self.shocktube.svr.cfl
         self.log(f"CFL: min {cfl.min()} max {cfl.max()}")
+        if self.profiling:
+            self.log(mm.time_registry.report())
         self.plt.update_lines(self.shocktube)
 
     def setup_solver(self, interval):

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -51,7 +51,7 @@ ctrl.start()  # Start the movie
 ctrl.step()  # Stepping the solution
 
 # Note: you can enable profiling info by "profiling" option
-ctrl = mm.app.euler1d.run(interval=10, max_steps=50, profiling=True) # enable profiling info
+ctrl = mm.app.euler1d.run(interval=10, max_steps=50, profiling=True)
 """)
     cmd = "ctrl = mm.app.euler1d.run(interval=10, max_steps=50)"
     view.mgr.pycon.command = cmd
@@ -188,7 +188,10 @@ class Controller:
 class ControllerNoViewMgr(Controller):
     def __init__(self, shocktube, max_steps, use_sub=None, profiling=False):
 
-        super().__init__(shocktube, max_steps, use_sub=None, profiling=profiling)
+        super().__init__(shocktube,
+                         max_steps,
+                         use_sub=None,
+                         profiling=profiling)
 
     @staticmethod
     def log(msg):
@@ -213,7 +216,6 @@ def run(interval=10, max_steps=50, no_view_mgr=False, **kw):
 
 
 if __name__ == "__main__":
-    import sys
     try:
         from PySide6.QtCore import QTimer
         from PySide6.QtWidgets import QApplication

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -25,8 +25,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
+# This is a hack to make this file runs directly from command line.
 __package__ = "modmesh.app"
-
 
 import sys
 from dataclasses import dataclass
@@ -187,7 +187,6 @@ class Controller:
 
 class ControllerNoViewMgr(Controller):
     def __init__(self, shocktube, max_steps, use_sub=None, profiling=False):
-
         super().__init__(shocktube,
                          max_steps,
                          use_sub=None,
@@ -219,6 +218,7 @@ if __name__ == "__main__":
     try:
         from PySide6.QtCore import QTimer
         from PySide6.QtWidgets import QApplication
+
         app = QApplication()
 
         ctrl = run(interval=10, max_steps=50, no_view_mgr=True, profiling=True)
@@ -235,6 +235,5 @@ if __name__ == "__main__":
         print("Something wrong when importing PySide6.")
         print("Do you install PySide6?")
         sys.exit(1)
-
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
This pull request is the first step of #135 .

# How to test this pull request
Run this driving script from gist [euler1d_profiling-py](https://gist.github.com/tai271828/d5f50e4a06274b1203ed79f6739039dd#file-euler1d_profiling-py). The following output will be generated on your stdout after all pictures of shock tube are played and the image window is closed.

```
Euler1DCore.march_alpha2 : count = 51 , time = 0.0365707 (second)
Euler1DCore.setup_march : count = 1 , time = 2.2676e-05 (second)
Euler1DCore::density : count = 51 , time = 0.0020337 (second)
Euler1DCore::initialize_data : count = 1 , time = 1.6329e-05 (second)
Euler1DCore::march_half_so0 : count = 102 , time = 0.0179795 (second)
Euler1DCore::pressure : count = 51 , time = 0.00219614 (second)
Euler1DCore::update_cfl : count = 103 , time = 0.00225837 (second)
Euler1DCore::velocity : count = 51 , time = 0.00142665 (second)
Euler1DKernel::derive : count = 20298 , time = 0.0137601 (second)
Euler1DKernel::march_half_so1_alpha : count = 102 , time = 0.01569 (second)
```

