### PR TITLE
build(Makefile): rm _modmesh${PYEXTSUFFIX} copied by cmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,9 +171,11 @@ lint: cformat cinclude flake8
 .PHONY: clean
 clean:
 	rm -f $(MODMESH_ROOT)/modmesh/_modmesh$(pyextsuffix)
+	rm -f $(MODMESH_ROOT)/_modmesh$(pyextsuffix)
 	make -C $(BUILD_PATH) clean
 
 .PHONY: cmakeclean
 cmakeclean:
 	rm -f $(MODMESH_ROOT)/modmesh/_modmesh$(pyextsuffix)
+	rm -f $(MODMESH_ROOT)/_modmesh$(pyextsuffix)
 	rm -rf $(BUILD_PATH)


### PR DESCRIPTION
For me, this line https://github.com/solvcon/modmesh/blob/master/cpp/binary/pymod_modmesh/CMakeLists.txt#L48 would copy the linked `_modmesh${PYEXTSUFFIX}` binary to my modmesh source root directory. This pull request tries to clean that binary.

I am not entirely sure if this line is on purpose or not. I thought `_modmesh${PYEXTSUFFIX}` is meant to be placed in `CMAKE_INSTALL_PREFIX`.