### PR TITLE
Avoid Qt API qputenv which is hard for refactoring to non-Qt code

### DIFF
--- a/cpp/modmesh/python/module.cpp
+++ b/cpp/modmesh/python/module.cpp
@@ -57,6 +57,7 @@ void initialize(pybind11::module_ mod)
 int program_entrance(int argc, char ** argv)
 {
     ProcessInfo::instance().populate_command_line(argc, argv);
+    ProcessInfo::instance().set_environment_variables();
     auto & clinfo = ProcessInfo::instance().command_line();
 
     // Initialize the Python interpreter.

--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -151,6 +151,12 @@ WrapProcessInfo::WrapProcessInfo(pybind11::module & mod, char const * pyname, ch
             [](py::object const &) -> auto & {
                 return wrapped_type::instance();
             })
+        .def(
+            "set_environment_variables",
+            [](wrapped_type & self) -> auto & {
+                return self.set_environment_variables();
+            },
+            py::return_value_policy::reference_internal)
         .def_property_readonly(
             "command_line",
             [](wrapped_type & self) -> auto & {

--- a/cpp/modmesh/toggle/toggle.hpp
+++ b/cpp/modmesh/toggle/toggle.hpp
@@ -34,9 +34,12 @@
 
 #include <string>
 #include <vector>
+#include <cstdlib>
 
 namespace modmesh
 {
+
+int setenv(const char * name, const char * value, int overwrite);
 
 class Toggle
 {
@@ -147,6 +150,8 @@ public:
         m_command_line.populate(argc, argv, CommandLineInfo::PopulatePasskey{});
         return *this;
     }
+
+    ProcessInfo & set_environment_variables();
 
     CommandLineInfo const & command_line() const { return m_command_line; }
     CommandLineInfo & command_line() { return m_command_line; }

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -497,14 +497,6 @@ OneTimeInitializer<view_pymod_tag> & OneTimeInitializer<view_pymod_tag>::me()
 
 void initialize_view(pybind11::module & mod)
 {
-// TODO: There is some bug in QT RHI, this is a workaround to force QT use opengl directly
-// see: https://doc.qt.io/qtforpython/overviews/qt3drender-porting-to-rhi.html
-// for more detail
-#if defined(QT3D_USE_RHI)
-    qputenv("QT3D_RENDERER", "rhi");
-#else
-    qputenv("QT3D_RENDERER", "opengl");
-#endif // QT3D_USE_RHI
     auto initialize_impl = [](pybind11::module & mod)
     {
         wrap_view(mod);


### PR DESCRIPTION
Use POSIX setenv instead.  The POSIX setenv is not thread-safe.  Add a TODO for thread safety in the future.