### PR TITLE
Add dynamic feature toggle

### DIFF
--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -56,6 +56,79 @@ protected:
 
     static std::string report(wrapped_type const & self);
 
+    static pybind11::object getattr(wrapped_type const & self, std::string const & key)
+    {
+        namespace py = pybind11;
+
+        DynamicToggleIndex const index = self.get_dynamic_index(key);
+        switch (index.type)
+        {
+        case DynamicToggleIndex::TYPE_NONE:
+            throw py::attribute_error(Formatter() << "Cannt get non-existing key \"" << key << "\"");
+            break;
+        case DynamicToggleIndex::TYPE_BOOL:
+            return py::cast(self.get_bool(key));
+            break;
+        case DynamicToggleIndex::TYPE_INT8:
+            return py::cast(self.get_int8(key));
+            break;
+        case DynamicToggleIndex::TYPE_INT16:
+            return py::cast(self.get_int16(key));
+            break;
+        case DynamicToggleIndex::TYPE_INT32:
+            return py::cast(self.get_int32(key));
+            break;
+        case DynamicToggleIndex::TYPE_INT64:
+            return py::cast(self.get_int64(key));
+            break;
+        case DynamicToggleIndex::TYPE_REAL:
+            return py::cast(self.get_real(key));
+            break;
+        case DynamicToggleIndex::TYPE_STRING:
+            return py::cast(self.get_string(key));
+            break;
+        default:
+            return py::none();
+            break;
+        }
+    }
+
+    static void setattr(wrapped_type & self, std::string const & key, pybind11::object & value)
+    {
+        namespace py = pybind11;
+
+        DynamicToggleIndex const index = self.get_dynamic_index(key);
+        switch (index.type)
+        {
+        case DynamicToggleIndex::TYPE_NONE:
+            throw pybind11::attribute_error(Formatter() << "Cannot set non-existing key \"" << key << "\"; use set_TYPE() instead");
+            break;
+        case DynamicToggleIndex::TYPE_BOOL:
+            self.set_bool(key, py::cast<bool>(value));
+            break;
+        case DynamicToggleIndex::TYPE_INT8:
+            self.set_int8(key, py::cast<int8_t>(value));
+            break;
+        case DynamicToggleIndex::TYPE_INT16:
+            self.set_int16(key, py::cast<int16_t>(value));
+            break;
+        case DynamicToggleIndex::TYPE_INT32:
+            self.set_int32(key, py::cast<int32_t>(value));
+            break;
+        case DynamicToggleIndex::TYPE_INT64:
+            self.set_int64(key, py::cast<int64_t>(value));
+            break;
+        case DynamicToggleIndex::TYPE_REAL:
+            self.set_real(key, py::cast<double>(value));
+            break;
+        case DynamicToggleIndex::TYPE_STRING:
+            self.set_string(key, py::cast<std::string>(value));
+            break;
+        default:
+            break;
+        }
+    }
+
 }; /* end class WrapToggle */
 
 WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const * pydoc)
@@ -65,6 +138,30 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
 
     (*this)
         .def("report", &report)
+        //
+        ;
+
+    // Dynamic properties.  Number of the properties can be freely changed
+    // during runtime.
+    (*this)
+        .def("__getattr__", getattr)
+        .def("__setattr__", setattr)
+        .def("dynamic_keys", &wrapped_type::dynamic_keys)
+        .def("dynamic_clear", &wrapped_type::dynamic_clear)
+        .def("get_bool", &wrapped_type::get_bool, py::arg("key"))
+        .def("set_bool", &wrapped_type::set_bool, py::arg("key"), py::arg("value"))
+        .def("get_int8", &wrapped_type::get_int8, py::arg("key"))
+        .def("set_int8", &wrapped_type::set_int8, py::arg("key"), py::arg("value"))
+        .def("get_int16", &wrapped_type::get_int16, py::arg("key"))
+        .def("set_int16", &wrapped_type::set_int16, py::arg("key"), py::arg("value"))
+        .def("get_int32", &wrapped_type::get_int32, py::arg("key"))
+        .def("set_int32", &wrapped_type::set_int32, py::arg("key"), py::arg("value"))
+        .def("get_int64", &wrapped_type::get_int64, py::arg("key"))
+        .def("set_int64", &wrapped_type::set_int64, py::arg("key"), py::arg("value"))
+        .def("get_real", &wrapped_type::get_real, py::arg("key"))
+        .def("set_real", &wrapped_type::set_real, py::arg("key"), py::arg("value"))
+        .def("get_string", &wrapped_type::get_string, py::arg("key"))
+        .def("set_string", &wrapped_type::set_string, py::arg("key"), py::arg("value"))
         //
         ;
 

--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -101,6 +101,12 @@ protected:
         switch (index.type)
         {
         case DynamicToggleIndex::TYPE_NONE:
+            /* It is intentional to throw an exception when the key does not
+             * exist.  Key-value pairs in the toggle object are supposed to be
+             * added using the set_TYPE() functions, not the Pythonic
+             * __setattr__().
+             *
+             * Do not try to "fix" the exception using RTTI. */
             throw pybind11::attribute_error(Formatter() << "Cannot set non-existing key \"" << key << "\"; use set_TYPE() instead");
             break;
         case DynamicToggleIndex::TYPE_BOOL:

--- a/cpp/modmesh/toggle/toggle.cpp
+++ b/cpp/modmesh/toggle/toggle.cpp
@@ -81,7 +81,7 @@ std::string const DynamicToggleTable::sentinel_string = "";
         }                                                                \
         return SENTINEL;                                                 \
     }
-MM_DECL_DYNGET(bool, bool, 0)
+MM_DECL_DYNGET(bool, bool, false)
 MM_DECL_DYNGET(int8_t, int8, 0)
 MM_DECL_DYNGET(int16_t, int16, 0)
 MM_DECL_DYNGET(int32_t, int32, 0)

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -27,6 +27,7 @@
 
 import os
 import unittest
+import math
 
 import modmesh
 
@@ -43,6 +44,139 @@ class ToggleTC(unittest.TestCase):
 
     def test_instance(self):
         self.assertTrue(hasattr(modmesh.Toggle.instance, "show_axis"))
+
+
+class ToggleDynamicTC(unittest.TestCase):
+
+    def test_all_types(self):
+        tg = modmesh.Toggle.instance
+        tg.dynamic_clear()
+        self.assertEqual(tg.dynamic_keys(), [])
+
+        # Add a key of Boolean.
+        tg.set_bool("test_bool", True)
+        self.assertTrue(tg.get_bool("test_bool"))
+        # Make sure the key appears.
+        self.assertEqual(tg.dynamic_keys(), ["test_bool"])
+        # Test sentinel.
+        self.assertEqual(tg.get_bool("test_no_bool"), False)
+
+        # Add a key of int8.
+        tg.set_int8("test_int8", 23)
+        self.assertEqual(tg.get_int8("test_int8"), 23)
+        # Make sure the key appears
+        self.assertEqual(sorted(tg.dynamic_keys()),
+                         ["test_bool", "test_int8"])
+        # Test sentinel.
+        self.assertEqual(tg.get_int8("test_no_int8"), 0)
+
+        # Add a key of int16.
+        tg.set_int16("test_int16", -46)
+        self.assertEqual(tg.get_int16("test_int16"), -46)
+        # Make sure the key appears
+        self.assertEqual(sorted(tg.dynamic_keys()),
+                         ["test_bool", "test_int16", "test_int8"])
+        # Test sentinel.
+        self.assertEqual(tg.get_int16("test_no_int16"), 0)
+
+        # Add a key of int32.
+        tg.set_int32("test_int32", 842)
+        self.assertEqual(tg.get_int32("test_int32"), 842)
+        # Make sure the key appears
+        self.assertEqual(sorted(tg.dynamic_keys()),
+                         ["test_bool", "test_int16", "test_int32",
+                          "test_int8"])
+        # Test sentinel.
+        self.assertEqual(tg.get_int32("test_no_int32"), 0)
+
+        # Add a key of int64.
+        tg.set_int64("test_int64", -9912)
+        self.assertEqual(tg.get_int64("test_int64"), -9912)
+        # Make sure the key appears
+        self.assertEqual(sorted(tg.dynamic_keys()),
+                         ["test_bool", "test_int16", "test_int32",
+                          "test_int64", "test_int8"])
+        # Test sentinel.
+        self.assertEqual(tg.get_int64("test_no_int64"), 0)
+
+        # Clear dynamic keys (and the values).
+        tg.dynamic_clear()
+        self.assertEqual(tg.dynamic_keys(), [])
+
+        # Add a key of real.
+        tg.set_real("test_real", 2.87)
+        self.assertEqual(tg.get_real("test_real"), 2.87)
+        # Make sure the key appears
+        self.assertEqual(sorted(tg.dynamic_keys()), ["test_real"])
+        # Test sentinel.
+        self.assertTrue(math.isnan(tg.get_real("test_no_real")))
+
+        # Add a key of string.
+        tg.set_string("test_string", "a random line")
+        self.assertEqual(tg.get_string("test_string"), "a random line")
+        # Make sure the key appears
+        self.assertEqual(sorted(tg.dynamic_keys()),
+                         ["test_real", "test_string"])
+        # Test sentinel.
+        self.assertEqual(tg.get_string("test_no_string"), "")
+
+        # Clear dynamic keys (and the values) the second time.
+        tg.dynamic_clear()
+        self.assertEqual(tg.dynamic_keys(), [])
+
+    def test_fatigue(self):
+        tg = modmesh.Toggle.instance
+        tg.dynamic_clear()
+        self.assertEqual(tg.dynamic_keys(), [])
+
+        # Test sentinel.
+        self.assertEqual(tg.get_bool("test_bool"), False)
+
+        # Add a key of Boolean.
+        tg.set_bool("test_bool", True)
+        self.assertTrue(tg.get_bool("test_bool"))
+        # Make sure the key appears.
+        self.assertEqual(tg.dynamic_keys(), ["test_bool"])
+
+        # Fatigue test.
+        tg.set_bool("test_bool", False)
+        self.assertFalse(tg.get_bool("test_bool"))
+        tg.set_bool("test_bool", True)
+        self.assertTrue(tg.get_bool("test_bool"))
+        tg.set_bool("test_bool", False)
+        self.assertFalse(tg.get_bool("test_bool"))
+        tg.set_bool("test_bool", True)
+        self.assertTrue(tg.get_bool("test_bool"))
+
+        tg.dynamic_clear()
+
+    def test_dunder_has_get_set(self):
+        tg = modmesh.Toggle.instance
+        tg.dynamic_clear()
+        self.assertEqual(tg.dynamic_keys(), [])
+
+        # Raise IndexError when the key to be got is not available.
+        with self.assertRaisesRegex(
+                AttributeError,
+                r'Cannt get non-existing key "dunder_nonexist"'
+        ):
+            tg.dunder_nonexist
+
+        # Need to use set_TYPE() to create the dynamic key-value pair.
+        tg.set_int32("dunder_int32", 632)
+        self.assertEqual(tg.dunder_int32, 632)
+
+        # Check for key existence.
+        self.assertTrue(hasattr(tg, "dunder_int32"))
+        self.assertFalse(hasattr(tg, "dunder_nonexist"))
+
+        # Raise IndexError when the key to be set is not available.
+        with self.assertRaisesRegex(
+                AttributeError,
+                r'Cannot set non-existing key "dunder_nonexist_real"; '
+                r'use set_TYPE\(\) instead'
+        ):
+            tg.dunder_nonexist_real = 12.4
 
 
 class CommandLineInfoTC(unittest.TestCase):

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -155,7 +155,8 @@ class ToggleDynamicTC(unittest.TestCase):
         tg.dynamic_clear()
         self.assertEqual(tg.dynamic_keys(), [])
 
-        # Raise IndexError when the key to be got is not available.
+        # Raise exception when the requested key is not available (no need to
+        # test for all types).
         with self.assertRaisesRegex(
                 AttributeError,
                 r'Cannt get non-existing key "dunder_nonexist"'
@@ -163,14 +164,28 @@ class ToggleDynamicTC(unittest.TestCase):
             tg.dunder_nonexist
 
         # Need to use set_TYPE() to create the dynamic key-value pair.
+        # (Make sure all supported types are tested.)
+        tg.set_bool("dunder_bool", True)
+        self.assertEqual(tg.dunder_bool, True)
+        tg.set_int8("dunder_int8", 12)
+        self.assertEqual(tg.dunder_int8, 12)
+        tg.set_int16("dunder_int16", -23634)
+        self.assertEqual(tg.dunder_int16, -23634)
         tg.set_int32("dunder_int32", 632)
         self.assertEqual(tg.dunder_int32, 632)
+        tg.set_int64("dunder_int64", 764)
+        self.assertEqual(tg.dunder_int64, 764)
+        tg.set_real("dunder_real", -232.1228)
+        self.assertEqual(tg.dunder_real, -232.1228)
+        tg.set_string("dunder_string", "a line")
+        self.assertEqual(tg.dunder_string, "a line")
 
-        # Check for key existence.
+        # Check for key existence (no need to test for all types).
         self.assertTrue(hasattr(tg, "dunder_int32"))
         self.assertFalse(hasattr(tg, "dunder_nonexist"))
 
-        # Raise IndexError when the key to be set is not available.
+        # Raise exception when the key to be set is not available (no need to
+        # test for all types).
         with self.assertRaisesRegex(
                 AttributeError,
                 r'Cannot set non-existing key "dunder_nonexist_real"; '


### PR DESCRIPTION
Ref issue #84 

Add a class `modmesh::DynamicToggleTable` to store key-value pairs whose number can change during runtime. It accepts limited types: Boolean, (signed) int8,
16, 32, 64, (double) real, and string.

The Pythonic interface `__getattr__` and `__setattr__` are provided.  In Python, addition of a key-value pair should be done using the `set_TYPE()` function.  The
Pythonic `__getattr__` should get any type.