### PR TITLE
Remove macos v11 release build from CI to speed up the PR process

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -208,9 +208,8 @@ jobs:
 
     strategy:
       matrix:
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
-        os: [macos-11, macos-12]
+        os: [macos-12]
         cmake_build_type: [Release]
 
       fail-fast: false


### PR DESCRIPTION
Macos v11 is two versions away from the latest (v13).