### PR TITLE
Add support for hierarchical feature toggle

### DIFF
--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -66,45 +66,36 @@ WrapFixedToggle::WrapFixedToggle(pybind11::module & mod, const char * pyname, co
         ;
 }
 
-class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapToggle
-    : public WrapBase<WrapToggle, Toggle>
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapHierarchicalToggleAccess
+    : public WrapBase<WrapHierarchicalToggleAccess, HierarchicalToggleAccess>
 {
 
 public:
 
-    using base_type = WrapBase<WrapToggle, Toggle>;
+    using base_type = WrapBase<WrapHierarchicalToggleAccess, HierarchicalToggleAccess>;
     using wrapped_type = typename base_type::wrapped_type;
 
     friend root_base_type;
 
-protected:
-
-    WrapToggle(pybind11::module & mod, char const * pyname, char const * pydoc);
-
-    static std::string report(wrapped_type const & self);
-    static pybind11::object getattr(wrapped_type const & self, std::string const & key);
+    static pybind11::object getattr(wrapped_type & self, std::string const & key);
     static void setattr(wrapped_type & self, std::string const & key, pybind11::object & value);
 
-}; /* end class WrapToggle */
+protected:
 
-WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const * pydoc)
+    WrapHierarchicalToggleAccess(pybind11::module & mod, char const * pyname, char const * pydoc);
+
+}; /* end class WrapHierarchicalToggleAccess */
+
+WrapHierarchicalToggleAccess::WrapHierarchicalToggleAccess(pybind11::module & mod, char const * pyname, char const * pydoc)
     : base_type(mod, pyname, pydoc)
 {
     namespace py = pybind11;
-
-    (*this)
-        .def("clone", &wrapped_type::clone, py::return_value_policy::take_ownership)
-        .def("report", &report)
-        //
-        ;
 
     // Dynamic properties.  Number of the properties can be freely changed
     // during runtime.
     (*this)
         .def("__getattr__", getattr)
         .def("__setattr__", setattr)
-        .def("dynamic_keys", &wrapped_type::dynamic_keys)
-        .def("dynamic_clear", &wrapped_type::dynamic_clear)
         .def("get_bool", &wrapped_type::get_bool, py::arg("key"))
         .def("set_bool", &wrapped_type::set_bool, py::arg("key"), py::arg("value"))
         .def("get_int8", &wrapped_type::get_int8, py::arg("key"))
@@ -119,43 +110,22 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
         .def("set_real", &wrapped_type::set_real, py::arg("key"), py::arg("value"))
         .def("get_string", &wrapped_type::get_string, py::arg("key"))
         .def("set_string", &wrapped_type::set_string, py::arg("key"), py::arg("value"))
-        //
-        ;
-
-    // Static properties.
-    (*this)
-        .def_property_readonly_static(
-            "instance",
-            [](py::object const &) -> auto &
-            { return wrapped_type::instance(); })
-        .def_property_readonly_static(
-            "fixed",
-            [](py::object const &) -> auto &
-            { return wrapped_type::instance().fixed(); })
-        //
-        ;
-
-    // Instance properties.
-    (*this)
+        .def("get_subkey", &wrapped_type::get_subkey, py::arg("key"))
+        .def("add_subkey", &wrapped_type::add_subkey, py::arg("key"))
         //
         ;
 }
 
-std::string WrapToggle::report(WrapToggle::wrapped_type const & self)
-{
-    return Formatter() << "Toggle: USE_PYSIDE=" << self.fixed().get_use_pyside();
-}
-
-pybind11::object WrapToggle::getattr(wrapped_type const & self, std::string const & key)
+pybind11::object WrapHierarchicalToggleAccess::getattr(wrapped_type & self, std::string const & key)
 {
     namespace py = pybind11;
 
-    DynamicToggleIndex const index = self.get_dynamic_index(key);
+    DynamicToggleIndex const index = self.get_index(key);
     switch (index.type)
     {
     case DynamicToggleIndex::TYPE_NONE:
         throw py::attribute_error(
-            Formatter() << "Cannt get non-existing key \"" << key << "\"");
+            Formatter() << "Cannt get non-existing key \"" << self.rekey(key) << "\"");
         break;
     case DynamicToggleIndex::TYPE_BOOL:
         return py::cast(self.get_bool(key));
@@ -178,17 +148,20 @@ pybind11::object WrapToggle::getattr(wrapped_type const & self, std::string cons
     case DynamicToggleIndex::TYPE_STRING:
         return py::cast(self.get_string(key));
         break;
+    case DynamicToggleIndex::TYPE_SUBKEY:
+        return py::cast(self.get_subkey(key));
+        break;
     default:
         return py::none();
         break;
     }
 }
 
-void WrapToggle::setattr(wrapped_type & self, std::string const & key, pybind11::object & value)
+void WrapHierarchicalToggleAccess::setattr(wrapped_type & self, std::string const & key, pybind11::object & value)
 {
     namespace py = pybind11;
 
-    DynamicToggleIndex const index = self.get_dynamic_index(key);
+    DynamicToggleIndex const index = self.get_index(key);
     switch (index.type)
     {
     case DynamicToggleIndex::TYPE_NONE:
@@ -199,7 +172,7 @@ void WrapToggle::setattr(wrapped_type & self, std::string const & key, pybind11:
          *
          * Do not try to "fix" the exception using RTTI. */
         throw pybind11::attribute_error(
-            Formatter() << "Cannot set non-existing key \"" << key << "\"; "
+            Formatter() << "Cannot set non-existing key \"" << self.rekey(key) << "\"; "
                         << "use set_TYPE() instead");
         break;
     case DynamicToggleIndex::TYPE_BOOL:
@@ -226,6 +199,98 @@ void WrapToggle::setattr(wrapped_type & self, std::string const & key, pybind11:
     default:
         break;
     }
+}
+
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapToggle
+    : public WrapBase<WrapToggle, Toggle>
+{
+
+public:
+
+    using base_type = WrapBase<WrapToggle, Toggle>;
+    using wrapped_type = typename base_type::wrapped_type;
+
+    friend root_base_type;
+
+protected:
+
+    WrapToggle(pybind11::module & mod, char const * pyname, char const * pydoc);
+
+    static std::string report(wrapped_type const & self);
+
+}; /* end class WrapToggle */
+
+WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const * pydoc)
+    : base_type(mod, pyname, pydoc)
+{
+    namespace py = pybind11;
+
+    (*this)
+        .def("clone", &wrapped_type::clone, py::return_value_policy::take_ownership)
+        .def("report", &report)
+        //
+        ;
+
+    // Dynamic properties.  Number of the properties can be freely changed
+    // during runtime.
+    (*this)
+        .def(
+            "__getattr__",
+            [](wrapped_type & self, std::string const & key)
+            {
+                HierarchicalToggleAccess access(self.dynamic());
+                return WrapHierarchicalToggleAccess::getattr(access, key);
+            })
+        .def(
+            "__setattr__",
+            [](wrapped_type & self, std::string const & key, pybind11::object & value)
+            {
+                HierarchicalToggleAccess access(self.dynamic());
+                WrapHierarchicalToggleAccess::setattr(access, key, value);
+            })
+        .def("dynamic_keys", &wrapped_type::dynamic_keys)
+        .def("dynamic_clear", &wrapped_type::dynamic_clear)
+        .def("get_bool", &wrapped_type::get_bool, py::arg("key"))
+        .def("set_bool", &wrapped_type::set_bool, py::arg("key"), py::arg("value"))
+        .def("get_int8", &wrapped_type::get_int8, py::arg("key"))
+        .def("set_int8", &wrapped_type::set_int8, py::arg("key"), py::arg("value"))
+        .def("get_int16", &wrapped_type::get_int16, py::arg("key"))
+        .def("set_int16", &wrapped_type::set_int16, py::arg("key"), py::arg("value"))
+        .def("get_int32", &wrapped_type::get_int32, py::arg("key"))
+        .def("set_int32", &wrapped_type::set_int32, py::arg("key"), py::arg("value"))
+        .def("get_int64", &wrapped_type::get_int64, py::arg("key"))
+        .def("set_int64", &wrapped_type::set_int64, py::arg("key"), py::arg("value"))
+        .def("get_real", &wrapped_type::get_real, py::arg("key"))
+        .def("set_real", &wrapped_type::set_real, py::arg("key"), py::arg("value"))
+        .def("get_string", &wrapped_type::get_string, py::arg("key"))
+        .def("set_string", &wrapped_type::set_string, py::arg("key"), py::arg("value"))
+        .def("get_subkey", &wrapped_type::get_subkey, py::arg("key"))
+        .def("add_subkey", &wrapped_type::add_subkey, py::arg("key"))
+        //
+        ;
+
+    // Static properties.
+    (*this)
+        .def_property_readonly_static(
+            "instance",
+            [](py::object const &) -> auto &
+            { return wrapped_type::instance(); })
+        .def_property_readonly_static(
+            "fixed",
+            [](py::object const &) -> auto &
+            { return wrapped_type::instance().fixed(); })
+        //
+        ;
+
+    // Instance properties.
+    (*this)
+        //
+        ;
+}
+
+std::string WrapToggle::report(WrapToggle::wrapped_type const & self)
+{
+    return Formatter() << "Toggle: USE_PYSIDE=" << self.fixed().get_use_pyside();
 }
 
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapCommandLineInfo
@@ -304,6 +369,7 @@ WrapProcessInfo::WrapProcessInfo(pybind11::module & mod, char const * pyname, ch
 void wrap_Toggle(pybind11::module & mod)
 {
     WrapFixedToggle::commit(mod, "FixedToggle", "FixedToggle");
+    WrapHierarchicalToggleAccess::commit(mod, "HierarchicalToggleAccess", "HierarchicalToggleAccess");
     WrapToggle::commit(mod, "Toggle", "Toggle");
     WrapCommandLineInfo::commit(mod, "CommandLineInfo", "CommandLineInfo");
     WrapProcessInfo::commit(mod, "ProcessInfo", "ProcessInfo");

--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -177,25 +177,30 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
             "instance",
             [](py::object const &) -> auto &
             { return wrapped_type::instance(); })
-        .def_property_readonly_static(
-            "USE_PYSIDE",
-            [](py::handle const &)
-            { return bool(wrapped_type::USE_PYSIDE); })
         //
         ;
 
     // Instance properties.
     (*this)
-        .def_property("show_axis", &wrapped_type::get_show_axis, &wrapped_type::set_show_axis)
+        .def_property_readonly(
+            "use_pyside",
+            [](wrapped_type const & self)
+            { return self.fixed().get_use_pyside(); })
+        .def_property(
+            "show_axis",
+            [](wrapped_type const & self)
+            { return self.fixed().get_show_axis(); },
+            [](wrapped_type & self, bool v)
+            { self.fixed().set_show_axis(v); })
         //
         ;
 }
 
-std::string WrapToggle::report(WrapToggle::wrapped_type const &)
+std::string WrapToggle::report(WrapToggle::wrapped_type const & self)
 {
     Formatter ret;
     ret << "Toggle: "
-        << "USE_PYSIDE=" << bool(wrapped_type::USE_PYSIDE);
+        << "USE_PYSIDE=" << self.fixed().get_use_pyside();
     return ret >> Formatter::to_str;
 }
 

--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -39,6 +39,41 @@ namespace modmesh
 namespace python
 {
 
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapFixedToggle
+    : public WrapBase<WrapFixedToggle, FixedToggle>
+{
+
+public:
+
+    using base_type = WrapBase<WrapFixedToggle, FixedToggle>;
+    using wrapped_type = typename base_type::wrapped_type;
+
+    friend root_base_type;
+
+protected:
+
+    WrapFixedToggle(pybind11::module & mod, char const * pyname, char const * pydoc);
+};
+
+WrapFixedToggle::WrapFixedToggle(pybind11::module & mod, const char * pyname, const char * pydoc)
+    : base_type(mod, pyname, pydoc)
+{
+    // Instance properties.
+    (*this)
+        .def_property_readonly(
+            "use_pyside",
+            [](wrapped_type const & self)
+            { return self.get_use_pyside(); })
+        .def_property(
+            "show_axis",
+            [](wrapped_type const & self)
+            { return self.get_show_axis(); },
+            [](wrapped_type & self, bool v)
+            { self.set_show_axis(v); })
+        //
+        ;
+}
+
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapToggle
     : public WrapBase<WrapToggle, Toggle>
 {
@@ -177,21 +212,15 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
             "instance",
             [](py::object const &) -> auto &
             { return wrapped_type::instance(); })
+        .def_property_readonly_static(
+            "fixed",
+            [](py::object const &) -> auto &
+            { return wrapped_type::instance().fixed(); })
         //
         ;
 
     // Instance properties.
     (*this)
-        .def_property_readonly(
-            "use_pyside",
-            [](wrapped_type const & self)
-            { return self.fixed().get_use_pyside(); })
-        .def_property(
-            "show_axis",
-            [](wrapped_type const & self)
-            { return self.fixed().get_show_axis(); },
-            [](wrapped_type & self, bool v)
-            { self.fixed().set_show_axis(v); })
         //
         ;
 }
@@ -279,6 +308,7 @@ WrapProcessInfo::WrapProcessInfo(pybind11::module & mod, char const * pyname, ch
 
 void wrap_Toggle(pybind11::module & mod)
 {
+    WrapFixedToggle::commit(mod, "FixedToggle", "FixedToggle");
     WrapToggle::commit(mod, "Toggle", "Toggle");
     WrapCommandLineInfo::commit(mod, "CommandLineInfo", "CommandLineInfo");
     WrapProcessInfo::commit(mod, "ProcessInfo", "ProcessInfo");

--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -93,6 +93,7 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
     namespace py = pybind11;
 
     (*this)
+        .def("clone", &wrapped_type::clone, py::return_value_policy::take_ownership)
         .def("report", &report)
         //
         ;

--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -82,9 +82,7 @@ protected:
     WrapToggle(pybind11::module & mod, char const * pyname, char const * pydoc);
 
     static std::string report(wrapped_type const & self);
-
     static pybind11::object getattr(wrapped_type const & self, std::string const & key);
-
     static void setattr(wrapped_type & self, std::string const & key, pybind11::object & value);
 
 }; /* end class WrapToggle */
@@ -144,10 +142,7 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
 
 std::string WrapToggle::report(WrapToggle::wrapped_type const & self)
 {
-    Formatter ret;
-    ret << "Toggle: "
-        << "USE_PYSIDE=" << self.fixed().get_use_pyside();
-    return ret >> Formatter::to_str;
+    return Formatter() << "Toggle: USE_PYSIDE=" << self.fixed().get_use_pyside();
 }
 
 pybind11::object WrapToggle::getattr(wrapped_type const & self, std::string const & key)

--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -60,16 +60,8 @@ WrapFixedToggle::WrapFixedToggle(pybind11::module & mod, const char * pyname, co
 {
     // Instance properties.
     (*this)
-        .def_property_readonly(
-            "use_pyside",
-            [](wrapped_type const & self)
-            { return self.get_use_pyside(); })
-        .def_property(
-            "show_axis",
-            [](wrapped_type const & self)
-            { return self.get_show_axis(); },
-            [](wrapped_type & self, bool v)
-            { self.set_show_axis(v); })
+        .def_property_readonly("use_pyside", &wrapped_type::get_use_pyside)
+        .def_property("show_axis", &wrapped_type::get_show_axis, &wrapped_type::set_show_axis)
         //
         ;
 }
@@ -91,84 +83,9 @@ protected:
 
     static std::string report(wrapped_type const & self);
 
-    static pybind11::object getattr(wrapped_type const & self, std::string const & key)
-    {
-        namespace py = pybind11;
+    static pybind11::object getattr(wrapped_type const & self, std::string const & key);
 
-        DynamicToggleIndex const index = self.get_dynamic_index(key);
-        switch (index.type)
-        {
-        case DynamicToggleIndex::TYPE_NONE:
-            throw py::attribute_error(Formatter() << "Cannt get non-existing key \"" << key << "\"");
-            break;
-        case DynamicToggleIndex::TYPE_BOOL:
-            return py::cast(self.get_bool(key));
-            break;
-        case DynamicToggleIndex::TYPE_INT8:
-            return py::cast(self.get_int8(key));
-            break;
-        case DynamicToggleIndex::TYPE_INT16:
-            return py::cast(self.get_int16(key));
-            break;
-        case DynamicToggleIndex::TYPE_INT32:
-            return py::cast(self.get_int32(key));
-            break;
-        case DynamicToggleIndex::TYPE_INT64:
-            return py::cast(self.get_int64(key));
-            break;
-        case DynamicToggleIndex::TYPE_REAL:
-            return py::cast(self.get_real(key));
-            break;
-        case DynamicToggleIndex::TYPE_STRING:
-            return py::cast(self.get_string(key));
-            break;
-        default:
-            return py::none();
-            break;
-        }
-    }
-
-    static void setattr(wrapped_type & self, std::string const & key, pybind11::object & value)
-    {
-        namespace py = pybind11;
-
-        DynamicToggleIndex const index = self.get_dynamic_index(key);
-        switch (index.type)
-        {
-        case DynamicToggleIndex::TYPE_NONE:
-            /* It is intentional to throw an exception when the key does not
-             * exist.  Key-value pairs in the toggle object are supposed to be
-             * added using the set_TYPE() functions, not the Pythonic
-             * __setattr__().
-             *
-             * Do not try to "fix" the exception using RTTI. */
-            throw pybind11::attribute_error(Formatter() << "Cannot set non-existing key \"" << key << "\"; use set_TYPE() instead");
-            break;
-        case DynamicToggleIndex::TYPE_BOOL:
-            self.set_bool(key, py::cast<bool>(value));
-            break;
-        case DynamicToggleIndex::TYPE_INT8:
-            self.set_int8(key, py::cast<int8_t>(value));
-            break;
-        case DynamicToggleIndex::TYPE_INT16:
-            self.set_int16(key, py::cast<int16_t>(value));
-            break;
-        case DynamicToggleIndex::TYPE_INT32:
-            self.set_int32(key, py::cast<int32_t>(value));
-            break;
-        case DynamicToggleIndex::TYPE_INT64:
-            self.set_int64(key, py::cast<int64_t>(value));
-            break;
-        case DynamicToggleIndex::TYPE_REAL:
-            self.set_real(key, py::cast<double>(value));
-            break;
-        case DynamicToggleIndex::TYPE_STRING:
-            self.set_string(key, py::cast<std::string>(value));
-            break;
-        default:
-            break;
-        }
-    }
+    static void setattr(wrapped_type & self, std::string const & key, pybind11::object & value);
 
 }; /* end class WrapToggle */
 
@@ -231,6 +148,88 @@ std::string WrapToggle::report(WrapToggle::wrapped_type const & self)
     ret << "Toggle: "
         << "USE_PYSIDE=" << self.fixed().get_use_pyside();
     return ret >> Formatter::to_str;
+}
+
+pybind11::object WrapToggle::getattr(wrapped_type const & self, std::string const & key)
+{
+    namespace py = pybind11;
+
+    DynamicToggleIndex const index = self.get_dynamic_index(key);
+    switch (index.type)
+    {
+    case DynamicToggleIndex::TYPE_NONE:
+        throw py::attribute_error(
+            Formatter() << "Cannt get non-existing key \"" << key << "\"");
+        break;
+    case DynamicToggleIndex::TYPE_BOOL:
+        return py::cast(self.get_bool(key));
+        break;
+    case DynamicToggleIndex::TYPE_INT8:
+        return py::cast(self.get_int8(key));
+        break;
+    case DynamicToggleIndex::TYPE_INT16:
+        return py::cast(self.get_int16(key));
+        break;
+    case DynamicToggleIndex::TYPE_INT32:
+        return py::cast(self.get_int32(key));
+        break;
+    case DynamicToggleIndex::TYPE_INT64:
+        return py::cast(self.get_int64(key));
+        break;
+    case DynamicToggleIndex::TYPE_REAL:
+        return py::cast(self.get_real(key));
+        break;
+    case DynamicToggleIndex::TYPE_STRING:
+        return py::cast(self.get_string(key));
+        break;
+    default:
+        return py::none();
+        break;
+    }
+}
+
+void WrapToggle::setattr(wrapped_type & self, std::string const & key, pybind11::object & value)
+{
+    namespace py = pybind11;
+
+    DynamicToggleIndex const index = self.get_dynamic_index(key);
+    switch (index.type)
+    {
+    case DynamicToggleIndex::TYPE_NONE:
+        /* It is intentional to throw an exception when the key does not
+         * exist.  Key-value pairs in the toggle object are supposed to be
+         * added using the set_TYPE() functions, not the Pythonic
+         * __setattr__().
+         *
+         * Do not try to "fix" the exception using RTTI. */
+        throw pybind11::attribute_error(
+            Formatter() << "Cannot set non-existing key \"" << key << "\"; "
+                        << "use set_TYPE() instead");
+        break;
+    case DynamicToggleIndex::TYPE_BOOL:
+        self.set_bool(key, py::cast<bool>(value));
+        break;
+    case DynamicToggleIndex::TYPE_INT8:
+        self.set_int8(key, py::cast<int8_t>(value));
+        break;
+    case DynamicToggleIndex::TYPE_INT16:
+        self.set_int16(key, py::cast<int16_t>(value));
+        break;
+    case DynamicToggleIndex::TYPE_INT32:
+        self.set_int32(key, py::cast<int32_t>(value));
+        break;
+    case DynamicToggleIndex::TYPE_INT64:
+        self.set_int64(key, py::cast<int64_t>(value));
+        break;
+    case DynamicToggleIndex::TYPE_REAL:
+        self.set_real(key, py::cast<double>(value));
+        break;
+    case DynamicToggleIndex::TYPE_STRING:
+        self.set_string(key, py::cast<std::string>(value));
+        break;
+    default:
+        break;
+    }
 }
 
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapCommandLineInfo

--- a/cpp/modmesh/toggle/toggle.cpp
+++ b/cpp/modmesh/toggle/toggle.cpp
@@ -63,6 +63,17 @@ Toggle & Toggle::instance()
     return o;
 }
 
+FixedToggle::FixedToggle()
+{
+    set_use_pyside(
+#ifdef MODMESH_USE_PYSIDE
+        true
+#else
+        false
+#endif
+    );
+}
+
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects,readability-redundant-string-init,cert-err58-cpp)
 std::string const DynamicToggleTable::sentinel_string = "";
 

--- a/cpp/modmesh/toggle/toggle.cpp
+++ b/cpp/modmesh/toggle/toggle.cpp
@@ -79,18 +79,22 @@ std::string const DynamicToggleTable::sentinel_string = "";
 
 /* The macro gives debuggers a hard time. Manually expand it if you need to
  * step in a debugger. */
-#define MM_DECL_DYNGET(CTYPE, MTYPE, SENTINEL)                           \
-    CTYPE DynamicToggleTable::get_##MTYPE(std::string const & key) const \
-    {                                                                    \
-        auto it = m_key2index.find(key);                                 \
-        if (it != m_key2index.end())                                     \
-        {                                                                \
-            if (it->second.is_##MTYPE())                                 \
-            {                                                            \
-                return m_vector_##MTYPE.at(it->second.index);            \
-            }                                                            \
-        }                                                                \
-        return SENTINEL;                                                 \
+#define MM_DECL_DYNGET(CTYPE, MTYPE, SENTINEL)                                 \
+    CTYPE DynamicToggleTable::get_##MTYPE(std::string const & key) const       \
+    {                                                                          \
+        auto it = m_key2index.find(key);                                       \
+        if (it != m_key2index.end())                                           \
+        {                                                                      \
+            if (it->second.is_##MTYPE())                                       \
+            {                                                                  \
+                return m_vector_##MTYPE.at(it->second.index);                  \
+            }                                                                  \
+        }                                                                      \
+        return SENTINEL;                                                       \
+    }                                                                          \
+    CTYPE HierarchicalToggleAccess::get_##MTYPE(std::string const & key) const \
+    {                                                                          \
+        return m_table->get_##MTYPE(rekey(key));                               \
     }
 MM_DECL_DYNGET(bool, bool, false)
 MM_DECL_DYNGET(int8_t, int8, 0)
@@ -125,6 +129,10 @@ MM_DECL_DYNGET(std::string const &, string, sentinel_string)
             m_key2index.insert({key, index});                                                                                  \
             m_vector_##MTYPE.push_back(value);                                                                                 \
         }                                                                                                                      \
+    }                                                                                                                          \
+    void HierarchicalToggleAccess::set_##MTYPE(std::string const & key, CTYPE value)                                           \
+    {                                                                                                                          \
+        m_table->set_##MTYPE(rekey(key), value);                                                                               \
     }
 MM_DECL_DYNSET(bool, bool, BOOL)
 MM_DECL_DYNSET(int8_t, int8, INT8)
@@ -135,6 +143,25 @@ MM_DECL_DYNSET(double, real, REAL)
 MM_DECL_DYNSET(std::string const &, string, STRING)
 #undef MM_DECL_DYNSET
 
+HierarchicalToggleAccess HierarchicalToggleAccess::get_subkey(const std::string & key)
+{
+    return m_table->get_subkey(rekey(key));
+}
+
+void HierarchicalToggleAccess::add_subkey(const std::string & key)
+{
+    return m_table->add_subkey(rekey(key));
+}
+
+void DynamicToggleTable::add_subkey(std::string const & key)
+{
+    auto it = m_key2index.find(key);
+    if (it == m_key2index.end())
+    {
+        DynamicToggleIndex const index{0, DynamicToggleIndex::TYPE_SUBKEY};
+        m_key2index.insert({key, index});
+    }
+}
 std::vector<std::string> DynamicToggleTable::keys() const
 {
     std::vector<std::string> ret;

--- a/cpp/modmesh/toggle/toggle.hpp
+++ b/cpp/modmesh/toggle/toggle.hpp
@@ -36,8 +36,13 @@
 #include <vector>
 #include <unordered_map>
 
-#define MM_TOGGLE_CONSTEXPR_BOOL(NAME, VALUE) \
-    static constexpr bool NAME = VALUE
+#define MM_TOGGLE_STATIC_BOOL(NAME, DEFAULT)     \
+public:                                          \
+    bool get_##NAME() const { return m_##NAME; } \
+    void set_##NAME(bool v) { m_##NAME = v; }    \
+                                                 \
+private:                                         \
+    bool m_##NAME = DEFAULT;
 
 namespace modmesh
 {
@@ -120,16 +125,20 @@ private:
 
 }; /* end class DynamicToggleTable */
 
+class FixedToggle
+{
+public:
+    FixedToggle();
+
+    MM_TOGGLE_STATIC_BOOL(use_pyside, true)
+    MM_TOGGLE_STATIC_BOOL(show_axis, false)
+}; /* end class FixedToggle */
+
 class Toggle
 {
 
 public:
 
-#ifdef MODMESH_USE_PYSIDE
-    MM_TOGGLE_CONSTEXPR_BOOL(USE_PYSIDE, true);
-#else
-    MM_TOGGLE_CONSTEXPR_BOOL(USE_PYSIDE, false);
-#endif
     static Toggle & instance();
 
     Toggle(Toggle const &) = delete;
@@ -138,8 +147,8 @@ public:
     Toggle & operator=(Toggle &&) = delete;
     ~Toggle() = default;
 
-    bool get_show_axis() const { return m_show_axis; }
-    void set_show_axis(bool v) { m_show_axis = v; }
+    FixedToggle const & fixed() const { return m_fixed; }
+    FixedToggle & fixed() { return m_fixed; }
 
     std::vector<std::string> dynamic_keys() const { return m_dynamic_table.keys(); }
     void dynamic_clear() { m_dynamic_table.clear(); }
@@ -164,7 +173,7 @@ private:
 
     Toggle() = default;
 
-    bool m_show_axis = false;
+    FixedToggle m_fixed;
     DynamicToggleTable m_dynamic_table;
 
 }; /* end class Toggle */

--- a/cpp/modmesh/toggle/toggle.hpp
+++ b/cpp/modmesh/toggle/toggle.hpp
@@ -141,10 +141,8 @@ public:
 
     static Toggle & instance();
 
-    Toggle(Toggle const &) = delete;
-    Toggle(Toggle &&) = delete;
-    Toggle & operator=(Toggle const &) = delete;
-    Toggle & operator=(Toggle &&) = delete;
+    Toggle * clone() const { return new Toggle(*this); }
+
     ~Toggle() = default;
 
     FixedToggle const & fixed() const { return m_fixed; }
@@ -172,6 +170,10 @@ public:
 private:
 
     Toggle() = default;
+    Toggle(Toggle const &) = default;
+    Toggle(Toggle &&) = default;
+    Toggle & operator=(Toggle const &) = default;
+    Toggle & operator=(Toggle &&) = default;
 
     FixedToggle m_fixed;
     DynamicToggleTable m_dynamic_table;

--- a/cpp/modmesh/view/R3DWidget.cpp
+++ b/cpp/modmesh/view/R3DWidget.cpp
@@ -53,7 +53,7 @@ R3DWidget::R3DWidget(Qt3DExtras::Qt3DWindow * window, RScene * scene, QWidget * 
     control->setLinearSpeed(50.0f);
     control->setLookSpeed(180.0f);
 
-    if (Toggle::instance().get_show_axis())
+    if (Toggle::instance().fixed().get_show_axis())
     {
         showMark();
     }

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -502,7 +502,7 @@ void initialize_view(pybind11::module & mod)
         wrap_view(mod);
     };
 
-    if (Toggle::USE_PYSIDE)
+    if (Toggle::instance().fixed().get_use_pyside())
     {
         try
         {

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -145,7 +145,9 @@ class Controller:
         self.current_step = 0
         self.timer = None
 
-        self.use_sub = mm.Toggle.USE_PYSIDE if use_sub is None else use_sub
+        self.use_sub = use_sub
+        if self.use_sub is None:
+            self.use_sub = mm.Toggle.fixed.use_pyside
         self._main = QtWidgets.QWidget()
         if self.use_sub:
             # FIXME: sub window causes missing QWindow with the following

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -57,6 +57,7 @@ __all__ = [  # noqa: F822
     'StaticGrid2d',
     'StaticGrid3d',
     'StaticMesh',
+    'HierarchicalToggleAccess',
     'Toggle',
     'CommandLineInfo',
     'ProcessInfo',

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -38,11 +38,8 @@ class ToggleTC(unittest.TestCase):
         self.assertTrue(
             "Toggle: USE_PYSIDE=" in modmesh.Toggle.instance.report())
 
-    def test_static_constexpr(self):
-        self.assertTrue(hasattr(modmesh.Toggle, "USE_PYSIDE"))
-        self.assertTrue(hasattr(modmesh.Toggle.instance, "USE_PYSIDE"))
-
     def test_instance(self):
+        self.assertTrue(hasattr(modmesh.Toggle.instance, "use_pyside"))
         self.assertTrue(hasattr(modmesh.Toggle.instance, "show_axis"))
 
 

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -204,6 +204,44 @@ class ToggleDynamicTC(unittest.TestCase):
             tg.dunder_nonexist_real = 12.4
 
 
+class ToggleHierarchicalTC(unittest.TestCase):
+
+    def test_multi_level(self):
+        tg = modmesh.Toggle.instance.clone()
+        tg.dynamic_clear()
+        self.assertEqual(tg.dynamic_keys(), [])
+
+        tg.set_int8("test_int8", 21)
+        self.assertEqual(tg.test_int8, 21)
+        self.assertEqual(sorted(tg.dynamic_keys()), ["test_int8"])
+        tg.add_subkey("level1")
+        self.assertIsInstance(tg.level1, modmesh.HierarchicalToggleAccess)
+        self.assertEqual(sorted(tg.dynamic_keys()), ["level1", "test_int8"])
+
+        tg.set_real("level1.test_real", 9.42)
+        self.assertEqual(tg.level1.test_real, 9.42)
+        self.assertEqual(sorted(tg.dynamic_keys()),
+                         ["level1", "level1.test_real", "test_int8"])
+
+        # Add second-level subkeys.
+        tg.add_subkey("level1.level2")
+        self.assertIsInstance(tg.level1.level2,
+                              modmesh.HierarchicalToggleAccess)
+        tg.add_subkey("level1p")
+        tg.level1p.add_subkey("level2p")
+        self.assertIsInstance(tg.level1p.level2p,
+                              modmesh.HierarchicalToggleAccess)
+        tg.level1p.set_bool("test_bool", True)
+        self.assertEqual(tg.get_bool('level1p.test_bool'), True)
+        tg.set_int32('level1p.level2p.test_int32', -2132)
+        self.assertEqual(tg.level1p.level2p.test_int32, -2132)
+        self.assertEqual(sorted(tg.dynamic_keys()),
+                         ['level1', 'level1.level2', 'level1.test_real',
+                          'level1p', 'level1p.level2p',
+                          'level1p.level2p.test_int32',
+                          'level1p.test_bool', 'test_int8'])
+
+
 class CommandLineInfoTC(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -42,11 +42,24 @@ class ToggleTC(unittest.TestCase):
         self.assertTrue(hasattr(modmesh.Toggle.fixed, "use_pyside"))
         self.assertTrue(hasattr(modmesh.Toggle.fixed, "show_axis"))
 
+    def test_clone(self):
+        tg = modmesh.Toggle.instance.clone()
+        tg.dynamic_clear()
+        self.assertEqual(tg.dynamic_keys(), [])
+
+        tg.set_bool("test_bool", True)
+        self.assertTrue(tg.get_bool("test_bool"))
+        self.assertEqual(tg.dynamic_keys(), ["test_bool"])
+
+        tg1 = tg.clone()
+        self.assertEqual(tg.dynamic_keys(), tg1.dynamic_keys())
+        self.assertEqual(tg.get_bool("test_bool"), tg1.get_bool("test_bool"))
+
 
 class ToggleDynamicTC(unittest.TestCase):
 
     def test_all_types(self):
-        tg = modmesh.Toggle.instance
+        tg = modmesh.Toggle.instance.clone()
         tg.dynamic_clear()
         self.assertEqual(tg.dynamic_keys(), [])
 
@@ -122,7 +135,7 @@ class ToggleDynamicTC(unittest.TestCase):
         self.assertEqual(tg.dynamic_keys(), [])
 
     def test_fatigue(self):
-        tg = modmesh.Toggle.instance
+        tg = modmesh.Toggle.instance.clone()
         tg.dynamic_clear()
         self.assertEqual(tg.dynamic_keys(), [])
 
@@ -148,7 +161,7 @@ class ToggleDynamicTC(unittest.TestCase):
         tg.dynamic_clear()
 
     def test_dunder_has_get_set(self):
-        tg = modmesh.Toggle.instance
+        tg = modmesh.Toggle.instance.clone()
         tg.dynamic_clear()
         self.assertEqual(tg.dynamic_keys(), [])
 

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -39,8 +39,8 @@ class ToggleTC(unittest.TestCase):
             "Toggle: USE_PYSIDE=" in modmesh.Toggle.instance.report())
 
     def test_instance(self):
-        self.assertTrue(hasattr(modmesh.Toggle.instance, "use_pyside"))
-        self.assertTrue(hasattr(modmesh.Toggle.instance, "show_axis"))
+        self.assertTrue(hasattr(modmesh.Toggle.fixed, "use_pyside"))
+        self.assertTrue(hasattr(modmesh.Toggle.fixed, "show_axis"))
 
 
 class ToggleDynamicTC(unittest.TestCase):


### PR DESCRIPTION
Ref issue #84 

Support dot-separated hierarchical key access, i.e., `modmesh.Toggle.instance`.`level1.level2.key`.  The feature is built on top of the dynamic toggle support added with #206 .

The PR also includes a new class `FixedToggle` which houses all compile-time-named, runtime-initialized toggles.  It is to provide `Toggle` a cleaner implementation.  The "fixed" toggles are in `FixedToggle` and need to be flat.  The "dynamic" toggles are in `DynamicToggleTable` and may be hierarchical.  The outer class `Toggle` manages both.

Class `Toggle` is enhanced to allow clone for testing.