### PR TITLE
Serialize toggle data to json (through Python dict as intermediate)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,8 @@ Checks: >
     -modernize-loop-convert,
     -modernize-use-nodiscard,
     -modernize-use-trailing-return-type,
+    -cppcoreguidelines-avoid-const-or-ref-data-members,
+    -cppcoreguidelines-avoid-do-while,
     -cppcoreguidelines-avoid-magic-numbers,
     -cppcoreguidelines-non-private-member-variables-in-classes,
     -cppcoreguidelines-macro-usage,

--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -59,6 +59,22 @@ protected:
 WrapSolidToggle::WrapSolidToggle(pybind11::module & mod, const char * pyname, const char * pydoc)
     : base_type(mod, pyname, pydoc)
 {
+    namespace py = pybind11;
+
+    (*this)
+        .def(
+            "get_names",
+            [](wrapped_type const &)
+            {
+                // Hardcoding the property names in a lambda does not scale,
+                // but I have only 1 property at the moment.
+                py::list r;
+                r.append("use_pyside");
+                return r;
+            })
+        //
+        ;
+
     // Instance properties.
     (*this)
         .def_property_readonly("use_pyside", &wrapped_type::use_pyside)
@@ -86,6 +102,22 @@ protected:
 WrapFixedToggle::WrapFixedToggle(pybind11::module & mod, const char * pyname, const char * pydoc)
     : base_type(mod, pyname, pydoc)
 {
+    namespace py = pybind11;
+
+    (*this)
+        .def(
+            "get_names",
+            [](wrapped_type const &)
+            {
+                // Hardcoding the property names in a lambda does not scale,
+                // but I have only 1 property at the moment.
+                py::list r;
+                r.append("show_axis");
+                return r;
+            })
+        //
+        ;
+
     // Instance properties.
     (*this)
         .def_property("show_axis", &wrapped_type::get_show_axis, &wrapped_type::set_show_axis)

--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -223,33 +223,34 @@ protected:
 namespace detail
 {
 
-struct Toggle2Dict
+struct Toggle2Python
 {
 
-    explicit Toggle2Dict(Toggle & toggle)
+    explicit Toggle2Python(Toggle & toggle)
         : m_toggle(toggle)
     {
     }
 
-    static pybind11::list from_toggle(Toggle & toggle)
+    static pybind11::object from_toggle(Toggle & toggle, std::string const & type)
     {
-        Toggle2Dict o(toggle);
-        pybind11::list l = o.load();
-        return l;
-    }
-
-    static pybind11::dict fixed_from_toggle(Toggle & toggle)
-    {
-        Toggle2Dict const o(toggle);
-        pybind11::dict d = o.load_fixed();
-        return d;
-    }
-
-    static pybind11::dict dynamic_from_toggle(Toggle & toggle)
-    {
-        Toggle2Dict o(toggle);
-        pybind11::dict d = o.load_dynamic();
-        return d;
+        pybind11::object r;
+        if (type == "fixed")
+        {
+            Toggle2Python const o(toggle);
+            r = o.load_fixed();
+        }
+        else if (type == "dynamic")
+        {
+            Toggle2Python o(toggle);
+            pybind11::dict d = o.load_dynamic();
+            return d;
+        }
+        else
+        {
+            Toggle2Python o(toggle);
+            r = o.load();
+        }
+        return r;
     }
 
     pybind11::list load()
@@ -341,7 +342,7 @@ private:
         return result;
     }
 
-}; /* end struct Toggle2Dict */
+}; /* end struct Toggle2Python */
 
 } /* end namespace detail */
 
@@ -358,9 +359,7 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
 
     // Conversion.
     (*this)
-        .def("as_dict", detail::Toggle2Dict::from_toggle)
-        .def("fixed_as_dict", detail::Toggle2Dict::fixed_from_toggle)
-        .def("dynamic_as_dict", detail::Toggle2Dict::dynamic_from_toggle)
+        .def("to_python", detail::Toggle2Python::from_toggle, py::arg("type")="")
         //
         ;
 

--- a/cpp/modmesh/toggle/toggle.cpp
+++ b/cpp/modmesh/toggle/toggle.cpp
@@ -63,15 +63,15 @@ Toggle & Toggle::instance()
     return o;
 }
 
-FixedToggle::FixedToggle()
-{
-    set_use_pyside(
+SolidToggle::SolidToggle()
+    : m_use_pyside(
 #ifdef MODMESH_USE_PYSIDE
-        true
+          true
 #else
-        false
+          false
 #endif
-    );
+      )
+{
 }
 
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects,readability-redundant-string-init,cert-err58-cpp)
@@ -162,6 +162,7 @@ void DynamicToggleTable::add_subkey(std::string const & key)
         m_key2index.insert({key, index});
     }
 }
+
 std::vector<std::string> DynamicToggleTable::keys() const
 {
     std::vector<std::string> ret;

--- a/cpp/modmesh/toggle/toggle.hpp
+++ b/cpp/modmesh/toggle/toggle.hpp
@@ -180,7 +180,25 @@ inline DynamicToggleIndex HierarchicalToggleAccess::get_index(std::string const 
     return m_table->get_index(rekey(key));
 }
 
-#define MM_TOGGLE_STATIC_BOOL(NAME, DEFAULT)     \
+#define MM_TOGGLE_SOLID_BOOL(NAME)         \
+public:                                    \
+    bool NAME() const { return m_##NAME; } \
+                                           \
+private:                                   \
+    bool m_##NAME;
+
+class SolidToggle
+{
+
+public:
+
+    SolidToggle();
+
+    MM_TOGGLE_SOLID_BOOL(use_pyside)
+
+}; /* end class SolidToggle */
+
+#define MM_TOGGLE_FIXED_BOOL(NAME, DEFAULT)      \
 public:                                          \
     bool get_##NAME() const { return m_##NAME; } \
     void set_##NAME(bool v) { m_##NAME = v; }    \
@@ -193,10 +211,7 @@ class FixedToggle
 
 public:
 
-    FixedToggle();
-
-    MM_TOGGLE_STATIC_BOOL(use_pyside, true)
-    MM_TOGGLE_STATIC_BOOL(show_axis, false)
+    MM_TOGGLE_FIXED_BOOL(show_axis, false)
 
 }; /* end class FixedToggle */
 
@@ -210,6 +225,8 @@ public:
     Toggle * clone() const { return new Toggle(*this); }
 
     ~Toggle() = default;
+
+    SolidToggle const & solid() const { return m_solid; }
 
     FixedToggle const & fixed() const { return m_fixed; }
     FixedToggle & fixed() { return m_fixed; }
@@ -246,6 +263,7 @@ private:
     Toggle & operator=(Toggle const &) = default;
     Toggle & operator=(Toggle &&) = default;
 
+    SolidToggle m_solid;
     FixedToggle m_fixed;
     DynamicToggleTable m_dynamic_table;
 

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -502,7 +502,7 @@ void initialize_view(pybind11::module & mod)
         wrap_view(mod);
     };
 
-    if (Toggle::instance().fixed().get_use_pyside())
+    if (Toggle::instance().solid().use_pyside())
     {
         try
         {

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -147,7 +147,7 @@ class Controller:
 
         self.use_sub = use_sub
         if self.use_sub is None:
-            self.use_sub = mm.Toggle.fixed.use_pyside
+            self.use_sub = mm.Toggle.solid.use_pyside
         self._main = QtWidgets.QWidget()
         if self.use_sub:
             # FIXME: sub window causes missing QWindow with the following

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -147,7 +147,7 @@ class Controller:
 
         self.use_sub = use_sub
         if self.use_sub is None:
-            self.use_sub = mm.Toggle.solid.use_pyside
+            self.use_sub = mm.Toggle.instance.solid.use_pyside
         self._main = QtWidgets.QWidget()
         if self.use_sub:
             # FIXME: sub window causes missing QWindow with the following

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -259,7 +259,8 @@ class ToggleSerializationTC(unittest.TestCase):
         golden = [{'fixed': {'use_pyside': self.USE_PYSIDE,
                              'show_axis': False}},
                   {'dynamic': {'k1': {'kreal': -2.12}, 'kbool': True}}]
-        data = tg.as_dict()
+        data = tg.to_python()
+        self.assertIsInstance(data, list)  # return a list of dict
         self.assertEqual(data, golden)
         # JSON string differs by platform, use back-n-force conversion to test
         self.assertEqual(json.loads(json.dumps(data)), golden)
@@ -270,7 +271,8 @@ class ToggleSerializationTC(unittest.TestCase):
         self.assertEqual(tg.dynamic_keys(), [])
 
         golden = {'show_axis': False, 'use_pyside': self.USE_PYSIDE}
-        data = tg.fixed_as_dict()
+        data = tg.to_python(type="fixed")
+        self.assertIsInstance(data, dict)
         self.assertEqual(data, golden)
         # JSON string differs by platform, use back-n-force conversion to test
         self.assertEqual(json.loads(json.dumps(data)), golden)
@@ -285,7 +287,8 @@ class ToggleSerializationTC(unittest.TestCase):
         tg.set_real("k1.kreal", -2.12)
 
         golden = {'k1': {'kreal': -2.12}, 'kbool': True}
-        data = tg.dynamic_as_dict()
+        data = tg.to_python(type="dynamic")
+        self.assertIsInstance(data, dict)
         self.assertEqual(data, golden)
         # JSON string differs by platform, use back-n-force conversion to test
         self.assertEqual(json.loads(json.dumps(data)), golden)

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -28,6 +28,7 @@
 import os
 import unittest
 import math
+import json
 
 import modmesh
 
@@ -240,6 +241,24 @@ class ToggleHierarchicalTC(unittest.TestCase):
                           'level1p', 'level1p.level2p',
                           'level1p.level2p.test_int32',
                           'level1p.test_bool', 'test_int8'])
+
+
+class ToggleSerializationTC(unittest.TestCase):
+
+    def test_to_json(self):
+        tg = modmesh.Toggle.instance.clone()
+        tg.dynamic_clear()
+        self.assertEqual(tg.dynamic_keys(), [])
+
+        tg.set_bool("kbool", True)
+        tg.add_subkey("k1")
+        tg.set_real("k1.kreal", -2.12)
+
+        golden = {'k1': {'kreal': -2.12}, 'kbool': True}
+        data = tg.dynamic_as_dict()
+        self.assertEqual(data, golden)
+        # JSON string differs by platform, use back-n-force conversion to test
+        self.assertEqual(json.loads(json.dumps(data)), golden)
 
 
 class CommandLineInfoTC(unittest.TestCase):

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -40,7 +40,7 @@ class ToggleTC(unittest.TestCase):
             "Toggle: USE_PYSIDE=" in modmesh.Toggle.instance.report())
 
     def test_solid_names(self):
-        solid = modmesh.Toggle.solid
+        solid = modmesh.Toggle.instance.solid
 
         # Test names
         golden = ["use_pyside"]
@@ -51,7 +51,7 @@ class ToggleTC(unittest.TestCase):
             self.assertTrue(hasattr(solid, n))
 
     def test_fixed_defaults(self):
-        fixed = modmesh.Toggle.fixed
+        fixed = modmesh.Toggle.instance.fixed
 
         # Hardcoding the property names and default values does not scale, but
         # I have only one property at the momemnt.  A better way for testing
@@ -187,11 +187,17 @@ class ToggleDynamicTC(unittest.TestCase):
         tg.dynamic_clear()
         self.assertEqual(tg.dynamic_keys(), [])
 
-        # Raise exception when the requested key is not available (no need to
-        # test for all types).
+        # Raise exception when the requested key is not available with the
+        # dynamic getter (no need to test for all types).
         with self.assertRaisesRegex(
                 AttributeError,
-                r'Cannt get non-existing key "dunder_nonexist"'
+                r'Cannot get non-existing key "dunder_nonexist"'
+        ):
+            tg.dynamic.dunder_nonexist
+        # Overall getter has a different message
+        with self.assertRaisesRegex(
+                AttributeError,
+                r'Cannot get by key "dunder_nonexist'
         ):
             tg.dunder_nonexist
 
@@ -216,12 +222,18 @@ class ToggleDynamicTC(unittest.TestCase):
         self.assertTrue(hasattr(tg, "dunder_int32"))
         self.assertFalse(hasattr(tg, "dunder_nonexist"))
 
-        # Raise exception when the key to be set is not available (no need to
-        # test for all types).
+        # Raise exception when the key to be set is not available with the
+        # dynamic setter (no need to test for all types).
         with self.assertRaisesRegex(
                 AttributeError,
                 r'Cannot set non-existing key "dunder_nonexist_real"; '
                 r'use set_TYPE\(\) instead'
+        ):
+            tg.dynamic.dunder_nonexist_real = 12.4
+        # Overall setter has a different message
+        with self.assertRaisesRegex(
+                AttributeError,
+                r'Cannot set by key "dunder_nonexist_real"'
         ):
             tg.dunder_nonexist_real = 12.4
 

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -245,7 +245,37 @@ class ToggleHierarchicalTC(unittest.TestCase):
 
 class ToggleSerializationTC(unittest.TestCase):
 
+    USE_PYSIDE = modmesh.Toggle.instance.fixed.use_pyside
+
     def test_to_json(self):
+        tg = modmesh.Toggle.instance.clone()
+        tg.dynamic_clear()
+        self.assertEqual(tg.dynamic_keys(), [])
+
+        tg.set_bool("kbool", True)
+        tg.add_subkey("k1")
+        tg.set_real("k1.kreal", -2.12)
+
+        golden = [{'fixed': {'use_pyside': self.USE_PYSIDE,
+                             'show_axis': False}},
+                  {'dynamic': {'k1': {'kreal': -2.12}, 'kbool': True}}]
+        data = tg.as_dict()
+        self.assertEqual(data, golden)
+        # JSON string differs by platform, use back-n-force conversion to test
+        self.assertEqual(json.loads(json.dumps(data)), golden)
+
+    def test_fixed_to_json(self):
+        tg = modmesh.Toggle.instance.clone()
+        tg.dynamic_clear()
+        self.assertEqual(tg.dynamic_keys(), [])
+
+        golden = {'show_axis': False, 'use_pyside': self.USE_PYSIDE}
+        data = tg.fixed_as_dict()
+        self.assertEqual(data, golden)
+        # JSON string differs by platform, use back-n-force conversion to test
+        self.assertEqual(json.loads(json.dumps(data)), golden)
+
+    def test_dynamic_to_json(self):
         tg = modmesh.Toggle.instance.clone()
         tg.dynamic_clear()
         self.assertEqual(tg.dynamic_keys(), [])

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -40,8 +40,8 @@ class ToggleTC(unittest.TestCase):
             "Toggle: USE_PYSIDE=" in modmesh.Toggle.instance.report())
 
     def test_instance(self):
-        self.assertTrue(hasattr(modmesh.Toggle.fixed, "use_pyside"))
-        self.assertTrue(hasattr(modmesh.Toggle.fixed, "show_axis"))
+        self.assertTrue(hasattr(modmesh.Toggle.solid, "use_pyside"))
+        self.assertEqual(modmesh.Toggle.fixed.show_axis, False)
 
     def test_clone(self):
         tg = modmesh.Toggle.instance.clone()
@@ -245,8 +245,6 @@ class ToggleHierarchicalTC(unittest.TestCase):
 
 class ToggleSerializationTC(unittest.TestCase):
 
-    USE_PYSIDE = modmesh.Toggle.instance.fixed.use_pyside
-
     def test_to_json(self):
         tg = modmesh.Toggle.instance.clone()
         tg.dynamic_clear()
@@ -256,11 +254,22 @@ class ToggleSerializationTC(unittest.TestCase):
         tg.add_subkey("k1")
         tg.set_real("k1.kreal", -2.12)
 
-        golden = [{'fixed': {'use_pyside': self.USE_PYSIDE,
-                             'show_axis': False}},
+        golden = [{'fixed': {'show_axis': False}},
                   {'dynamic': {'k1': {'kreal': -2.12}, 'kbool': True}}]
         data = tg.to_python()
         self.assertIsInstance(data, list)  # return a list of dict
+        self.assertEqual(data, golden)
+        # JSON string differs by platform, use back-n-force conversion to test
+        self.assertEqual(json.loads(json.dumps(data)), golden)
+
+    def test_solid_to_json(self):
+        tg = modmesh.Toggle.instance.clone()
+        tg.dynamic_clear()
+        self.assertEqual(tg.dynamic_keys(), [])
+
+        golden = {'use_pyside': tg.solid.use_pyside}
+        data = tg.to_python(type="solid")
+        self.assertIsInstance(data, dict)
         self.assertEqual(data, golden)
         # JSON string differs by platform, use back-n-force conversion to test
         self.assertEqual(json.loads(json.dumps(data)), golden)
@@ -270,7 +279,7 @@ class ToggleSerializationTC(unittest.TestCase):
         tg.dynamic_clear()
         self.assertEqual(tg.dynamic_keys(), [])
 
-        golden = {'show_axis': False, 'use_pyside': self.USE_PYSIDE}
+        golden = {'show_axis': False}
         data = tg.to_python(type="fixed")
         self.assertIsInstance(data, dict)
         self.assertEqual(data, golden)

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -39,9 +39,30 @@ class ToggleTC(unittest.TestCase):
         self.assertTrue(
             "Toggle: USE_PYSIDE=" in modmesh.Toggle.instance.report())
 
-    def test_instance(self):
-        self.assertTrue(hasattr(modmesh.Toggle.solid, "use_pyside"))
-        self.assertEqual(modmesh.Toggle.fixed.show_axis, False)
+    def test_solid_names(self):
+        solid = modmesh.Toggle.solid
+
+        # Test names
+        golden = ["use_pyside"]
+        self.assertEqual(sorted(solid.get_names()), golden)
+
+        # Test key existence
+        for n in sorted(solid.get_names()):
+            self.assertTrue(hasattr(solid, n))
+
+    def test_fixed_defaults(self):
+        fixed = modmesh.Toggle.fixed
+
+        # Hardcoding the property names and default values does not scale, but
+        # I have only one property at the momemnt.  A better way for testing
+        # should be implmented in the future.
+
+        # Test names
+        golden = ["show_axis"]
+        self.assertEqual(sorted(fixed.get_names()), golden)
+
+        # Test property defaults
+        self.assertEqual(fixed.show_axis, False)
 
     def test_clone(self):
         tg = modmesh.Toggle.instance.clone()


### PR DESCRIPTION
Add a Python wrapper `Toggle.to_python()` to convert the Toggle object to Python object.  The Python object (dict or list of dict) can be then serialized to json using Python batteries.

The Toggle object is also changed to be managed in 3 parts: solid, fixed, and dynamic.  Class `SolidToggle` holds the toggles determined during compile time.  Class `FixedToggle` holds the toggles whose value is determined during runtime but the name is hard-coded in C++.  Class `DynamicToggleTable` provides hierarchical toggles whose names and values can be arbitrarily changed during runtime.  The dynamic toggles cannot be determined during compile time.  They are flexible but much slower than the solid and fixed toggles.

Ref issue #84 