### PR TITLE
fix ci nouse_install fail

### DIFF
--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -120,7 +120,11 @@ jobs:
           echo "which python3: $(which python3)"
           ls -al $(which python3)
           python3 -m pip -v install --upgrade setuptools
-          python3 -m pip -v install --upgrade pip
+          # TODO:
+          # This issue was linked to #213
+          # temporary remove pip upgrade, due to latest pip will let cmake
+          # fail to find Numpy
+          # python3 -m pip -v install --upgrade pip
           python3 -m pip -v install --upgrade numpy pytest flake8
 
       - name: dependency by manual script


### PR DESCRIPTION
Temporary cancel upgrade pip version to avoid ci fail, because nouse_install will fail if we are using latest pip (23.1.0), more detail can be found at #213