### PR TITLE
add Qt main window module level handler in view module

### DIFF
--- a/modmesh/view.py
+++ b/modmesh/view.py
@@ -52,6 +52,13 @@ enable = False
 try:
     from _modmesh import view as _vimpl  # noqa: F401
     enable = True
+    # Before using _modmesh mianWindow api, the QMainWindow signature need
+    # to be imported or will get type error:
+    # TypeError: Unable to convert function return value to a Python type!
+    # Creating variable to handle Qt MainWindow which is created by c++ and
+    # registered it to Shiboken6 to prevent runtime error occured:
+    # RuntimeError:
+    # Internal C++ object (PySide6.QtGui.QWindow) already deleted.
     from PySide6.QtWidgets import QMainWindow
     _main_window = _vimpl.RManager.instance.mainWindow
 except ImportError:

--- a/modmesh/view.py
+++ b/modmesh/view.py
@@ -59,7 +59,7 @@ try:
     # registered it to Shiboken6 to prevent runtime error occured:
     # RuntimeError:
     # Internal C++ object (PySide6.QtGui.QWindow) already deleted.
-    from PySide6.QtWidgets import QMainWindow
+    from PySide6.QtWidgets import QMainWindow  # noqa: F401
     _main_window = _vimpl.RManager.instance.mainWindow
 except ImportError:
     pass

--- a/modmesh/view.py
+++ b/modmesh/view.py
@@ -52,6 +52,8 @@ enable = False
 try:
     from _modmesh import view as _vimpl  # noqa: F401
     enable = True
+    from PySide6.QtWidgets import QMainWindow
+    _main_window = _vimpl.RManager.instance.mainWindow
 except ImportError:
     pass
 


### PR DESCRIPTION
If a Qt object is created and managed by C++, when python needs to access it via `PySide6`, it needs to create a variable first to handle it first.

During python create a `PySide6` variable to handle c++ Qt object instance, it also register this Qt object to `Shiboken6` resource manager, once python need to access this Qt object, `Shiboken6` will check this c++ object valid or not, if user not register this Qt object to `Shiboken6` first it will raise runtime error.

`mainWindow` is parent node of `modmesh viewer`, therefore modems apps or widgets usually set `mainWindow` as parent, therefore it is high probability that `mainWindow` will be accessed by python.

Here is the runtime error message:
```
Traceback (most recent call last):
  File "path/to/usr/lib/python3.10/site-packages/matplotlib/backends/backend_qt.py", line 239, in showEvent
    window.screenChanged.connect(self._update_screen)
RuntimeError: Internal C++ object (PySide6.QtGui.QWindow) already deleted.
```