### PR TITLE
move pyside6 module init flow to pybind11

### DIFF
--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -483,6 +483,21 @@ void wrap_view(pybind11::module & mod)
     WrapRManagerProxy::commit(mod, "RManagerProxy", "RManagerProxy");
 
     mod.attr("mgr") = RManagerProxy();
+
+    try
+    {
+        // Creating module level variable to handle Qt MainWindow which is
+        // created by c++ and registered it to Shiboken6 to prevent runtime
+        // error occured.
+        // RuntimeError:
+        // Internal C++ object (PySide6.QtGui.QWindow) already deleted.
+        // py::module::import("PySide6.QtWidgets");
+        py::globals()["_mainWindow"] = RManager::instance().mainWindow();
+    }
+    catch (const pybind11::error_already_set & e)
+    {
+        std::cerr << e.what() << std::endl;
+    }
 }
 
 struct view_pymod_tag;
@@ -505,7 +520,10 @@ void initialize_view(pybind11::module & mod)
     {
         try
         {
-            pybind11::module::import("PySide6");
+            // Before using PySide6 api, the function signature need
+            // to be imported or will get type error:
+            // TypeError: Unable to convert function return value to a Python type!
+            pybind11::module::import("PySide6.QtWidgets");
         }
         catch (const pybind11::error_already_set & e)
         {

--- a/modmesh/view.py
+++ b/modmesh/view.py
@@ -52,15 +52,6 @@ enable = False
 try:
     from _modmesh import view as _vimpl  # noqa: F401
     enable = True
-    # Before using _modmesh mianWindow api, the QMainWindow signature need
-    # to be imported or will get type error:
-    # TypeError: Unable to convert function return value to a Python type!
-    # Creating variable to handle Qt MainWindow which is created by c++ and
-    # registered it to Shiboken6 to prevent runtime error occured:
-    # RuntimeError:
-    # Internal C++ object (PySide6.QtGui.QWindow) already deleted.
-    from PySide6.QtWidgets import QMainWindow  # noqa: F401
-    _main_window = _vimpl.RManager.instance.mainWindow
 except ImportError:
     pass
 


### PR DESCRIPTION
Based on PR #216 moved pyside6 module init flow
to pybnid11 wrapper.