### PR TITLE
Remove modmesh use pyside

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -123,7 +123,7 @@ jobs:
       run: |
         sudo pip3 install setuptools
         sudo pip3 install numpy pytest flake8
-        sudo pip3 install pyside6 shiboken6
+        sudo pip3 install pyside6==$(qmake6 -query QT_VERSION)
 
     - name: dependency by manual script
       run: sudo ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
@@ -193,7 +193,8 @@ jobs:
 
     - name: make run_viewer_pytest
       run: |
-        make run_viewer_pytest VERBOSE=1
+        export LD_LIBRARY_PATH=$(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
+        make run_viewer_pytest VERBOSE=0
 
   build_macos:
 
@@ -239,7 +240,7 @@ jobs:
           python3 -m pip -v install --upgrade setuptools
           python3 -m pip -v install --upgrade pip
           python3 -m pip -v install --upgrade numpy pytest flake8
-          python3 -m pip -v install --upgrade pyside6 shiboken6
+          python3 -m pip -v install --upgrade pyside6==$(qmake -query QT_VERSION)
 
       - name: dependency by manual script
         run: |
@@ -279,7 +280,7 @@ jobs:
             VERBOSE=1 USE_CLANG_TIDY=OFF \
             BUILD_QT=OFF \
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DMODMESH_USE_PYSIDE:BOOL=OFF"
+            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
           make buildext VERBOSE=1
 
       - name: make pytest BUILD_QT=OFF
@@ -297,14 +298,18 @@ jobs:
             VERBOSE=1 USE_CLANG_TIDY=OFF \
             BUILD_QT=ON \
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DMODMESH_USE_PYSIDE:BOOL=ON"
+            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
           make buildext VERBOSE=1
 
       - name: make pytest BUILD_QT=ON
         run: |
+          # PySide6 installed by pip will bundle with a prebuilt Qt,
+          # this will cause duplicated symbol.
+          # Solve this issue by removed PySide6 prebuilt Qt library
+          rm -rf $(python3 -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))")/Qt/lib/*.framework
           JOB_MAKE_ARGS="VERBOSE=1"
           if [ "${{ matrix.os }}" == "macos-12" ] ; then \
-            JOB_MAKE_ARGS="${JOB_MAKE_ARGS} BUILD_METAL=ON MODMESH_USE_PYSIDE=ON" ; \
+            JOB_MAKE_ARGS="${JOB_MAKE_ARGS} BUILD_METAL=ON" ; \
           fi
           make pytest ${JOB_MAKE_ARGS}
 
@@ -315,7 +320,7 @@ jobs:
             VERBOSE=1 USE_CLANG_TIDY=OFF \
             BUILD_QT=ON \
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DMODMESH_USE_PYSIDE:BOOL=ON"
+            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
 
       - name: make run_viewer_pytest
         run: |
@@ -367,7 +372,7 @@ jobs:
           python-version: '3.10' 
 
       - name: dependency by pip
-        run: pip3 install -U numpy pytest flake8 pybind11
+        run: pip3 install -U numpy pytest flake8 pybind11 pyside6==$(qmake -query QT_VERSION)
 
       - name: show dependency
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,7 +87,7 @@ jobs:
     - name: dependency by pip
       run: |
         sudo pip3 install setuptools
-        sudo pip3 install numpy pytest flake8
+        sudo pip3 install numpy pytest flake8 pyside6==$(qmake6 -query QT_VERSION)
 
     - name: dependency (manual)
       run: sudo ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
@@ -122,6 +122,7 @@ jobs:
 
     - name: make run_viewer_pytest
       run: |
+        export LD_LIBRARY_PATH=$(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
         make run_viewer_pytest \
           ${JOB_MAKE_ARGS} \
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
@@ -178,7 +179,7 @@ jobs:
           ls -al $(which python3)
           python3 -m pip -v install --upgrade setuptools
           python3 -m pip -v install --upgrade pip
-          python3 -m pip -v install --upgrade numpy pytest flake8
+          python3 -m pip -v install --upgrade numpy pytest flake8 pyside6==$(qmake -query QT_VERSION)
 
       - name: dependency (manual)
         run: sudo ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
@@ -213,6 +214,10 @@ jobs:
 
       - name: make run_viewer_pytest
         run: |
+          # PySide6 installed by pip will bundle with a prebuilt Qt,
+          # this will cause duplicated symbol.
+          # Solve this issue by removed PySide6 prebuilt Qt library
+          rm -rf $(python3 -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))")/Qt/lib/*.framework
           make run_viewer_pytest \
             ${JOB_MAKE_ARGS} \
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,13 +95,6 @@ set(MODMESH_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/cpp" CACHE INTERNAL "")
 
 include_directories(${MODMESH_INCLUDE_DIR})
 
-set(MODMESH_USE_PYSIDE False CACHE BOOL "Choose to build with pyside or not")
-message(STATUS "MODMESH_USE_PYSIDE: ${MODMESH_USE_PYSIDE}")
-
-if (MODMESH_USE_PYSIDE)
-    add_compile_definitions(MODMESH_USE_PYSIDE)
-endif () # MODMESH_USE_PYSIDE
-
 execute_process(
     COMMAND python3 -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))"
     OUTPUT_VARIABLE PYSIDE6_PYTHON_PACKAGE_PATH

--- a/cpp/modmesh/CMakeLists.txt
+++ b/cpp/modmesh/CMakeLists.txt
@@ -105,13 +105,11 @@ if (BUILD_QT)
         Qt::Gui
     )
 
-    if (MODMESH_USE_PYSIDE)
-        target_link_libraries(
-            modmesh_primary PUBLIC
-            ${PYSIDE6_LIBFILE}
-            ${SHIBOKEN6_LIBFILE}
-        )
-    endif () # MODMESH_USE_PYSIDE
+    target_link_libraries(
+        modmesh_primary PUBLIC
+        ${PYSIDE6_LIBFILE}
+        ${SHIBOKEN6_LIBFILE}
+    )
 else () # BUILD_QT
     add_library(
         modmesh_primary

--- a/cpp/modmesh/toggle/toggle.cpp
+++ b/cpp/modmesh/toggle/toggle.cpp
@@ -64,13 +64,7 @@ Toggle & Toggle::instance()
 }
 
 SolidToggle::SolidToggle()
-    : m_use_pyside(
-#ifdef MODMESH_USE_PYSIDE
-          true
-#else
-          false
-#endif
-      )
+    : m_use_pyside(true)
 {
 }
 

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -35,7 +35,6 @@
 #include <QPointer>
 #include <QClipboard>
 
-#ifdef MODMESH_USE_PYSIDE
 
 // Usually MODMESH_PYSIDE6_FULL is not defined unless for debugging.
 #ifdef MODMESH_PYSIDE6_FULL
@@ -132,7 +131,6 @@ QT_TYPE_CASTER(QMdiSubWindow, _("QMdiSubWindow"));
 } /* end namespace detail */
 
 } /* end namespace pybind11 */
-#endif // MODMESH_USE_PYSIDE
 
 PYBIND11_DECLARE_HOLDER_TYPE(T, QPointer<T>);
 

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -35,7 +35,6 @@
 #include <QPointer>
 #include <QClipboard>
 
-
 // Usually MODMESH_PYSIDE6_FULL is not defined unless for debugging.
 #ifdef MODMESH_PYSIDE6_FULL
 #include <pyside.h>


### PR DESCRIPTION
#210 has mentioned `PySide6` is mandatory, I removed `MODMESH_USE_PYSIDE` in modmesh project.

This patch encounter `PySide6` symbol resolution issue in GitHub Actions `windows` environment.

link to #220 