### PR TITLE
Add a simple, demonstrative json schema in the unit tests for the toggle system

### DIFF
--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -439,7 +439,26 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
             {
                 HierarchicalToggleAccess access(self.dynamic());
                 return WrapHierarchicalToggleAccess::getattr(access, key);
-            })
+            },
+            py::arg("key"))
+        .def(
+            "get_value",
+            [](wrapped_type & self, std::string const & key, py::object & obj)
+            {
+                HierarchicalToggleAccess access(self.dynamic());
+                py::object ret;
+                if (access.get_index(key).type != DynamicToggleIndex::TYPE_NONE)
+                {
+                    ret = WrapHierarchicalToggleAccess::getattr(access, key);
+                }
+                else
+                {
+                    ret = obj;
+                }
+                return ret;
+            },
+            py::arg("key"),
+            py::arg("default"))
         .def(
             "__getattr__",
             [](wrapped_type & self, std::string const & key)

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -392,7 +392,8 @@ class Controller:
         self.current_step = 0
         self.timer = None
 
-        self.use_sub = use_sub
+        self.use_sub = mm.Toggle.instance.get_value('apps.euler1d.use_sub',
+                                                    False)
         if self.use_sub is None:
             self.use_sub = mm.Toggle.instance.solid.use_pyside
         self._main = QWidget()

--- a/modmesh/toggle.py
+++ b/modmesh/toggle.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
+# Copyright (c) 2022, Yung-Yu Chen <yyc@solvcon.net>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -26,24 +26,39 @@
 
 
 """
-modmesh: the description of the package is intentionally left blank
+High-level control of toggles.
 """
 
 
-# Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
-
+import json
 
 from . import core
-from .core import *  # noqa: F401, F403
-from . import apputil  # noqa: F401
-from . import view  # noqa: F401
-from . import spacetime  # noqa: F401
-from . import onedim  # noqa: F401
-from . import system  # noqa: F401
-from . import toggle  # noqa: F401
 
 
-clinfo = core.ProcessInfo.instance.command_line
+def load(data, toggle_instance=None):
+    tg = toggle_instance
+    if tg is None:
+        tg = core.Toggle.instance
+
+    # Parse the input JSON data
+    pdata = json.loads(data)
+    if len(pdata) != 2:
+        raise ValueError("input data must be 2 but get %d" % len(pdata))
+    # pfixed = pdata[0].get('fixed', {})
+    pdynamic = pdata[1].get('dynamic', {})
+
+    # Get the apps sub-section
+    papps = pdynamic.get('apps', {})
+    tg.add_subkey('apps')
+    ta = tg.apps
+
+    # App euler1d
+    ta.add_subkey('euler1d')
+    thisapp = ta.euler1d
+    thispdata = papps.get('euler1d', {})
+    thisapp.set_bool('use_sub', thispdata.get('use_sub', False))
+
+    return tg
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
The demonstrative json data are:

```json
[
  {
    "fixed":{
      "show_axis":false
    }
  },
  {
    "dynamic":{
      "apps":{
        "euler1d":{
          "use_sub":false
        }
      }
    }
  }
]
```