### PR TITLE
Use toggle for python_redirect

### DIFF
--- a/cpp/modmesh/python/common.cpp
+++ b/cpp/modmesh/python/common.cpp
@@ -208,7 +208,7 @@ void Interpreter::exec_code(std::string const & code)
 
 PythonStreamRedirect & PythonStreamRedirect::activate()
 {
-    if (m_enabled)
+    if (is_enabled())
     {
         auto sys_module = pybind11::module::import("sys");
         // Back up old streams.

--- a/cpp/modmesh/python/common.hpp
+++ b/cpp/modmesh/python/common.hpp
@@ -511,8 +511,8 @@ class PythonStreamRedirect
 public:
 
     PythonStreamRedirect(bool enabled)
-        : m_enabled(enabled)
     {
+        set_enabled(enabled);
     }
 
     std::string stdout_string() const;
@@ -520,12 +520,12 @@ public:
 
     PythonStreamRedirect & set_enabled(bool enabled)
     {
-        m_enabled = enabled;
+        Toggle::instance().fixed().set_python_redirect(enabled);
         return *this;
     }
 
-    bool is_enabled() const { return m_enabled; }
-    bool is_disabled() const { return !m_enabled; }
+    bool is_enabled() const { return Toggle::instance().fixed().get_python_redirect(); }
+    bool is_disabled() const { return !is_enabled(); }
 
     PythonStreamRedirect & activate();
     PythonStreamRedirect & deactivate();
@@ -535,7 +535,6 @@ public:
 
 private:
 
-    bool m_enabled;
     pybind11::object m_stdout_backup;
     pybind11::object m_stderr_backup;
     pybind11::object m_stdout_buffer;

--- a/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/modmesh/toggle/pymod/wrap_Toggle.cpp
@@ -121,6 +121,7 @@ WrapFixedToggle::WrapFixedToggle(pybind11::module & mod, const char * pyname, co
     // Instance properties.
     (*this)
         .def_property("show_axis", &wrapped_type::get_show_axis, &wrapped_type::set_show_axis)
+        .def_property("python_redirect", &wrapped_type::get_python_redirect, &wrapped_type::set_python_redirect)
         //
         ;
 }

--- a/cpp/modmesh/toggle/toggle.hpp
+++ b/cpp/modmesh/toggle/toggle.hpp
@@ -212,6 +212,7 @@ class FixedToggle
 public:
 
     MM_TOGGLE_FIXED_BOOL(show_axis, false)
+    MM_TOGGLE_FIXED_BOOL(python_redirect, true)
 
 }; /* end class FixedToggle */
 

--- a/cpp/modmesh/view/RPythonConsoleDockWidget.cpp
+++ b/cpp/modmesh/view/RPythonConsoleDockWidget.cpp
@@ -81,6 +81,7 @@ RPythonConsoleDockWidget::RPythonConsoleDockWidget(const QString & title, QWidge
     : QDockWidget(title, parent, flags)
     , m_history_edit(new RPythonHistoryTextEdit)
     , m_command_edit(new RPythonCommandTextEdit)
+    , m_python_redirect(Toggle::instance().fixed().get_python_redirect())
 {
     setWidget(new QWidget);
     widget()->setLayout(new QVBoxLayout);

--- a/cpp/modmesh/view/RPythonConsoleDockWidget.hpp
+++ b/cpp/modmesh/view/RPythonConsoleDockWidget.hpp
@@ -116,7 +116,7 @@ private:
     int m_current_command_index = 0;
     size_t m_past_limit = 1024;
 
-    python::PythonStreamRedirect m_python_redirect{/* enabled */ true};
+    python::PythonStreamRedirect m_python_redirect;
 
     QString m_commandHtml = "<p style=\"color:Black;white-space:pre\"><b>&#62;&#62;&#62;</b> ";
     QString m_stderrHtml = "<p style=\"color:Red;white-space:pre\">";


### PR DESCRIPTION
The `PythonStreamRedirect` object now uses toggle to check for its enablement.