### PR TITLE
Label the executed commands with serial number

### DIFF
--- a/cpp/modmesh/view/RPythonConsoleDockWidget.cpp
+++ b/cpp/modmesh/view/RPythonConsoleDockWidget.cpp
@@ -155,8 +155,17 @@ void RPythonConsoleDockWidget::printCommandHistory()
     QTextCursor cursor = m_history_edit->textCursor();
     cursor.movePosition(QTextCursor::End);
     m_history_edit->setTextCursor(cursor);
+    std::string lead;
+    if (m_past_command_strings.size() > 1)
+    {
+        lead = Formatter() << "\n[";
+    }
+    else
+    {
+        lead = Formatter() << "[";
+    }
     m_history_edit->insertPlainText(QString::fromStdString(
-        Formatter() << "[" << m_last_command_serial << "] "
+        Formatter() << lead << m_last_command_serial << "] "
                     << m_command_edit->toPlainText().toStdString() << "\n"));
     cursor.movePosition(QTextCursor::End);
     m_history_edit->setTextCursor(cursor);

--- a/cpp/modmesh/view/RPythonConsoleDockWidget.cpp
+++ b/cpp/modmesh/view/RPythonConsoleDockWidget.cpp
@@ -133,6 +133,7 @@ void RPythonConsoleDockWidget::executeCommand()
 {
     std::string const code = m_command_edit->toPlainText().toStdString();
     appendPastCommand(code);
+    ++m_last_command_serial;
     printCommandHistory();
     m_command_edit->setPlainText("");
     m_command_string = "";
@@ -154,7 +155,9 @@ void RPythonConsoleDockWidget::printCommandHistory()
     QTextCursor cursor = m_history_edit->textCursor();
     cursor.movePosition(QTextCursor::End);
     m_history_edit->setTextCursor(cursor);
-    m_history_edit->insertHtml(m_commandHtml + m_command_edit->toPlainText() + m_endHtml);
+    m_history_edit->insertPlainText(QString::fromStdString(
+        Formatter() << "[" << m_last_command_serial << "] "
+                    << m_command_edit->toPlainText().toStdString() << "\n"));
     cursor.movePosition(QTextCursor::End);
     m_history_edit->setTextCursor(cursor);
 }
@@ -164,7 +167,7 @@ void RPythonConsoleDockWidget::printCommandStdout(const std::string & stdout_mes
     QTextCursor cursor = m_history_edit->textCursor();
     cursor.movePosition(QTextCursor::End);
     m_history_edit->setTextCursor(cursor);
-    m_history_edit->insertHtml(m_stdoutHtml + QString::fromStdString(stdout_message).toHtmlEscaped() + m_endHtml);
+    m_history_edit->insertPlainText(QString::fromStdString(stdout_message));
     cursor.movePosition(QTextCursor::End);
     m_history_edit->setTextCursor(cursor);
 }
@@ -174,7 +177,7 @@ void RPythonConsoleDockWidget::printCommandStderr(const std::string & stderr_mes
     QTextCursor cursor = m_history_edit->textCursor();
     cursor.movePosition(QTextCursor::End);
     m_history_edit->setTextCursor(cursor);
-    m_history_edit->insertHtml(m_stderrHtml + QString::fromStdString(stderr_message).toHtmlEscaped() + m_endHtml);
+    m_history_edit->insertPlainText(QString::fromStdString(stderr_message));
     cursor.movePosition(QTextCursor::End);
     m_history_edit->setTextCursor(cursor);
 }

--- a/cpp/modmesh/view/RPythonConsoleDockWidget.hpp
+++ b/cpp/modmesh/view/RPythonConsoleDockWidget.hpp
@@ -115,14 +115,9 @@ private:
     std::deque<std::string> m_past_command_strings;
     int m_current_command_index = 0;
     size_t m_past_limit = 1024;
+    int m_last_command_serial = 0;
 
     python::PythonStreamRedirect m_python_redirect;
-
-    QString m_commandHtml = "<p style=\"color:Black;white-space:pre\"><b>&#62;&#62;&#62;</b> ";
-    QString m_stderrHtml = "<p style=\"color:Red;white-space:pre\">";
-    QString m_stdoutHtml = "<p style=\"color:Blue;white-space:pre\">";
-    QString m_endHtml = "</p><br>";
-
 }; /* end class RPythonConsoleDockWidget */
 
 } /* end namespace modmesh */


### PR DESCRIPTION
Also switch back to use plain text for showing the text, instead of HTML.

After the change, the Python console looks like:

![image](https://github.com/solvcon/modmesh/assets/399122/acf8941e-dd5d-40b1-b052-b26ad47093d1)

The HTML style looks like:

![image](https://github.com/solvcon/modmesh/assets/399122/e9820ebf-dc91-4d78-965c-bbf5742280ea)

The HTML style has unnecessary blank lines between the Python command and its output.  I am not sure how to get rid of it.  It is also getting in my way of inserting the command serial number.  The best way seems to be switching back to use plain text for showing the text.

If coloring is needed, we may study how to use Qt native way to do it.