### PR TITLE
Remove ubuntu-20.04 and macos-11 from nouse_install.yml

### DIFF
--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
         matrix:
-          os: [ubuntu-20.04, ubuntu-22.04]
+          os: [ubuntu-22.04]
 
         fail-fast: false
 
@@ -101,7 +101,7 @@ jobs:
       matrix:
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
-        os: [macos-11, macos-12]
+        os: [macos-12]
 
       fail-fast: false
 


### PR DESCRIPTION
ubuntu-20.04 and macos-11 are older arches that modmesh devs are not using.  They can be removed from the CI to save waiting time.