### PR TITLE
Fix 1d cell type nface return value

### DIFF
--- a/cpp/modmesh/mesh/StaticMesh.hpp
+++ b/cpp/modmesh/mesh/StaticMesh.hpp
@@ -92,7 +92,15 @@ struct CellType : NumberBase<int32_t, double>
     uint8_t nedge() const { return m_nedge; }
     uint8_t nsurface() const { return m_nsurface; }
 
-    uint8_t nface() const { return 2 == m_ndim ? nedge() : nsurface(); }
+    uint8_t nface() const
+    {
+        switch (m_ndim)
+        {
+        case 1: return nnode(); break;
+        case 2: return nedge(); break;
+        default: return nsurface(); break;
+        }
+    }
 
     const char * name() const
     {

--- a/cpp/modmesh/mesh/StaticMesh.hpp
+++ b/cpp/modmesh/mesh/StaticMesh.hpp
@@ -75,10 +75,10 @@ struct CellType : NumberBase<int32_t, double>
     CellType(uint8_t id_in, uint8_t ndim_in, uint8_t nnode_in, uint8_t nedge_in, uint8_t nsurface_in)
         : m_id(id_in)
         , m_ndim(ndim_in)
-        , m_nnode(nnode_in)
-        , m_nedge(nedge_in)
-        , m_nsurface(nsurface_in)
     {
+        m_attrs[NNODE_IDX] = nnode_in;
+        m_attrs[NEDGE_IDX] = nedge_in;
+        m_attrs[NSURFACE_IDX] = nsurface_in;
     }
 
     CellType()
@@ -88,19 +88,10 @@ struct CellType : NumberBase<int32_t, double>
 
     uint8_t id() const { return m_id; }
     uint8_t ndim() const { return m_ndim; }
-    uint8_t nnode() const { return m_nnode; }
-    uint8_t nedge() const { return m_nedge; }
-    uint8_t nsurface() const { return m_nsurface; }
-
-    uint8_t nface() const
-    {
-        switch (m_ndim)
-        {
-        case 1: return nnode(); break;
-        case 2: return nedge(); break;
-        default: return nsurface(); break;
-        }
-    }
+    uint8_t nnode() const { return m_attrs[NNODE_IDX]; }
+    uint8_t nedge() const { return m_attrs[NEDGE_IDX]; }
+    uint8_t nsurface() const { return m_attrs[NSURFACE_IDX]; }
+    uint8_t nface() const { return m_attrs[m_ndim % 3]; } // Using mod can prevent idx out-of-boundary occurs.
 
     const char * name() const
     {
@@ -120,12 +111,13 @@ struct CellType : NumberBase<int32_t, double>
     }
 
 private:
+    static constexpr const uint8_t NNODE_IDX = 1;
+    static constexpr const uint8_t NEDGE_IDX = 2;
+    static constexpr const uint8_t NSURFACE_IDX = 0;
 
     uint8_t m_id : 6;
     uint8_t m_ndim : 2;
-    uint8_t m_nnode = 0;
-    uint8_t m_nedge = 0;
-    uint8_t m_nsurface = 0;
+    uint8_t m_attrs[3] = {0};
 
 }; /* end struct CellType */
 

--- a/cpp/modmesh/mesh/StaticMesh.hpp
+++ b/cpp/modmesh/mesh/StaticMesh.hpp
@@ -75,10 +75,8 @@ struct CellType : NumberBase<int32_t, double>
     CellType(uint8_t id_in, uint8_t ndim_in, uint8_t nnode_in, uint8_t nedge_in, uint8_t nsurface_in)
         : m_id(id_in)
         , m_ndim(ndim_in)
+        , m_attrs{nnode_in, nedge_in, nsurface_in}
     {
-        m_attrs[NNODE_IDX] = nnode_in;
-        m_attrs[NEDGE_IDX] = nedge_in;
-        m_attrs[NSURFACE_IDX] = nsurface_in;
     }
 
     CellType()
@@ -91,7 +89,7 @@ struct CellType : NumberBase<int32_t, double>
     uint8_t nnode() const { return m_attrs[NNODE_IDX]; }
     uint8_t nedge() const { return m_attrs[NEDGE_IDX]; }
     uint8_t nsurface() const { return m_attrs[NSURFACE_IDX]; }
-    uint8_t nface() const { return m_attrs[m_ndim % 3]; } // Using mod can prevent idx out-of-boundary occurs.
+    uint8_t nface() const { return m_attrs[m_ndim - 1]; }
 
     const char * name() const
     {
@@ -111,13 +109,13 @@ struct CellType : NumberBase<int32_t, double>
     }
 
 private:
-    static constexpr const uint8_t NNODE_IDX = 1;
-    static constexpr const uint8_t NEDGE_IDX = 2;
-    static constexpr const uint8_t NSURFACE_IDX = 0;
+    static constexpr const uint8_t NNODE_IDX = 0;
+    static constexpr const uint8_t NEDGE_IDX = 1;
+    static constexpr const uint8_t NSURFACE_IDX = 2;
 
     uint8_t m_id : 6;
     uint8_t m_ndim : 2;
-    uint8_t m_attrs[3] = {0};
+    uint8_t m_attrs[3] = {0, 0, 0};
 
 }; /* end struct CellType */
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -225,4 +225,6 @@ class StaticMeshTC(unittest.TestCase):
 
         # _do_metric do nothing due to dim == 1
         self._check_metric_trivial(mh)
+        # TODO: Need to add build_boundary and build_ghost to make sure
+        #       Line type behavior.
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -201,4 +201,28 @@ class StaticMeshTC(unittest.TestCase):
                           nbound=4, ngstnode=4, ngstface=12, ngstcell=4,
                           nedge=6)
 
+    def test_1d_single_line(self):
+        mh = modmesh.StaticMesh(ndim=1, nnode=2, nface=0, ncell=1)
+        mh.ndcrd.ndarray[:] = [[0], [1]]
+        mh.cltpn.ndarray[:] = modmesh.StaticMesh.LINE
+        mh.clnds.ndarray[:, :3] = [(2, 0, 1)]
+
+        self._check_shape(mh, ndim=1, nnode=2, nface=0, ncell=1,
+                          nbound=0, ngstnode=0, ngstface=0, ngstcell=0,
+                          nedge=0)
+        self._check_metric_trivial(mh)
+
+        mh.build_interior(_do_metric=False, _build_edge=False)
+        self._check_shape(mh, ndim=1, nnode=2, nface=2, ncell=1,
+                          nbound=0, ngstnode=0, ngstface=0, ngstcell=0,
+                          nedge=0)
+        self._check_metric_trivial(mh)
+
+        mh.build_interior()  # _do_metric=True, _build_edge=True
+        self._check_shape(mh, ndim=1, nnode=2, nface=2, ncell=1,
+                          nbound=0, ngstnode=0, ngstface=0, ngstcell=0,
+                          nedge=2)
+
+        # _do_metric do nothing due to dim == 1
+        self._check_metric_trivial(mh)
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`CellType` `nface()` only considers 2, 3 dimension, however `CellType` also contains 1 dimension cell type,
`face()` should considering 1 dimension case.

In this PR I also updated a test case to test 1 dimension cell type behavior.