### PR TITLE
Fix mesh

### DIFF
--- a/cpp/modmesh/mesh/StaticMesh_boundary.cpp
+++ b/cpp/modmesh/mesh/StaticMesh_boundary.cpp
@@ -261,7 +261,7 @@ inline void StaticMesh::fill_ghost()
                 }
                 for (size_t idm = 0; idm < m_ndim; ++idm)
                 {
-                    m_ndcrd(igcl, idm) = m_ndcrd(icl, idm) + 2 * dist * m_fcnml(ibfc, idm);
+                    m_ndcrd(ignd, idm) = m_ndcrd(ind, idm) + 2 * dist * m_fcnml(ibfc, idm);
                 }
                 // decrement ghost node counter.
                 ignd -= 1;

--- a/cpp/modmesh/mesh/StaticMesh_interior.cpp
+++ b/cpp/modmesh/mesh/StaticMesh_interior.cpp
@@ -46,6 +46,21 @@ struct FaceBuilder
     using uint_type = typename number_base::uint_type;
     using real_type = typename number_base::real_type;
 
+    size_t add_point(int_type icl, int_type ifc)
+    {
+        constexpr const size_t NFACE = 1;
+        clfcs(icl, 0) = NFACE;
+        for (size_t i = 0; i < NFACE; ++i)
+        {
+            fctpn(ifc + i) = CellType::NONCELLTYPE;
+            fcnds(ifc + i, 0) = 0; // number of nodes per face.
+        }
+        // face 1.
+        clfcs(icl, 1) = ifc;
+        fcnds(ifc, 1) = clnds(icl, 1);
+        return NFACE;
+    }
+
     size_t add_line(int_type icl, int_type ifc)
     {
         constexpr const size_t NFACE = 2;
@@ -361,6 +376,9 @@ struct FaceBuilder
         {
             switch (cltpn(icl))
             {
+            case CellType::POINT:
+                ifc += static_cast<int_type>(add_point(icl, ifc));
+                break;
             case CellType::LINE:
                 ifc += static_cast<int_type>(add_line(icl, ifc));
                 break;


### PR DESCRIPTION
There are 2 patch in this PR:

1. add point type face handler for Face builder:
The buffer used by mesh is pre-allocated when the `gmsh` parser parses the mesh. The buffer for faces is initialized to -1. If the Face builder does not handle point-type faces, then `make_ndfcs()` will get an index overflow because the initial value of -1 is used to calculate the pointer shift.

2. The index used by `m_ndcrd` in `StaticMesh::fill_ghost()` should be `node` index not `cell` index, this will cause index overflow.