### PR TITLE
[hotfix] reopen brew update

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -227,7 +227,9 @@ jobs:
 
       - name: dependency by homebrew
         run: |
-          # brew update  # No update because it is slow
+          # Reopen for runner image v20231029.1
+          # old homebrew/core cause brew link and unlink not working
+          brew update  # No update because it is slow
           # Force using python 3.10 from homebrew
           brew unlink python
           brew link --force --overwrite python@3.10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -165,7 +165,9 @@ jobs:
 
       - name: dependency by homebrew
         run: |
-          # brew update  # No update because it is slow
+          # Reopen for runner image v20231029.1
+          # old homebrew/core cause brew link and unlink not working
+          brew update  # No update because it is slow
           # Force using python 3.10 from homebrew
           brew unlink python
           brew link --force --overwrite python@3.10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -171,9 +171,9 @@ jobs:
           # Force using python 3.10 from homebrew
           brew unlink python
           brew link --force --overwrite python@3.10
-          brew install llvm qt6
-          ln -s "$(brew --prefix llvm)/bin/clang-format" "/usr/local/bin/clang-format"
-          ln -s "$(brew --prefix llvm)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
+          brew install llvm@16 qt6
+          ln -s "$(brew --prefix llvm@16)/bin/clang-format" "/usr/local/bin/clang-format"
+          ln -s "$(brew --prefix llvm@16)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
 
       - name: dependency by pip
         run: |


### PR DESCRIPTION
macOS CI image version update, now ships with Python 3.12.
`brew link` and `brew unlink` does not work properly with old verion of homebrew.
The wheel of PySide6 6.5.2 from PyPI does not support Python 3.12 yet, which causes the error.

Passing job
https://github.com/solvcon/modmesh/actions/runs/6736224421/job/18311095744#step:5:13
Image Version: 20230921.1

Failing job
https://github.com/solvcon/modmesh/actions/runs/6748500321/job/18361376864#step:5:13
Image Version: 20231029.1

By reopening `brew update`, `homebrew/core` gets updated, fixes the problem.