### PR TITLE
move Parameters QAction into file menu

### DIFF
--- a/cpp/modmesh/view/RManager.cpp
+++ b/cpp/modmesh/view/RManager.cpp
@@ -226,7 +226,7 @@ void RManager::setUpMenu()
                 addParam(params, "global.a.b.double_bar", &doubleV);
                 openParameterView(params);
             });
-        m_mainWindow->menuBar()->addAction(params);
+        m_fileMenu->addAction(params);
     }
 }
 


### PR DESCRIPTION
move Parameters QAction into file menu: macOS doesn't allow QAction to be directly under QMenuBar