### PR TITLE
[CI] Force mac use Python 3.11 from homebrew

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -230,9 +230,9 @@ jobs:
           # Reopen for runner image v20231029.1
           # old homebrew/core cause brew link and unlink not working
           brew update  # No update because it is slow
-          # Force using python 3.10 from homebrew
+          # Force using python 3.11 from homebrew
           brew unlink python
-          brew link --force --overwrite python@3.10
+          brew link --force --overwrite python@3.11
           brew install qt6
 
       - name: dependency by pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -168,9 +168,9 @@ jobs:
           # Reopen for runner image v20231029.1
           # old homebrew/core cause brew link and unlink not working
           brew update  # No update because it is slow
-          # Force using python 3.10 from homebrew
+          # Force using python 3.11 from homebrew
           brew unlink python
-          brew link --force --overwrite python@3.10
+          brew link --force --overwrite python@3.11
           brew install llvm@16 qt6
           ln -s "$(brew --prefix llvm@16)/bin/clang-format" "/usr/local/bin/clang-format"
           ln -s "$(brew --prefix llvm@16)/bin/clang-tidy" "/usr/local/bin/clang-tidy"


### PR DESCRIPTION
The macos CI fails at linking Python 3.10, which is not available in the home brew installation anymore (https://github.com/solvcon/modmesh/actions/runs/6990491463/job/19020046164#step:4:127):

```
You have 27 outdated formulae and 1 outdated cask installed.
You can upgrade them with brew upgrade
or list them with brew outdated.
Unlinking /usr/local/Cellar/python@3.11/3.11.6_1... 13 symlinks removed.
Error: No such keg: /usr/local/Cellar/python@3.10
Error: Process completed with exit code 1.
```