### PR TITLE
Fix cmake warning issued by pybind11 FindPythonLibsNew.cmake due to CMP0148

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(modmesh)
 
+cmake_policy(SET CMP0148 OLD)
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
 
 if(NOT SKIP_PYTHON_EXECUTABLE)


### PR DESCRIPTION
pybind11 still depends on older cmake behavior CMP0148.  The warning messages are:

```
CMake Warning (dev) at /usr/local/share/cmake/pybind11/FindPythonLibsNew.cmake:98 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  /usr/local/share/cmake/pybind11/pybind11Tools.cmake:50 (find_package)
  /usr/local/share/cmake/pybind11/pybind11Common.cmake:188 (include)
  /usr/local/share/cmake/pybind11/pybind11Config.cmake:250 (include)
  CMakeLists.txt:103 (find_package)
```

Example of the error log can be found at https://github.com/solvcon/modmesh/actions/runs/7433024685/job/20225498699#step:8:34