### PR TITLE
update minimum cmake version to 3.27 due to CMP0148

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
 # BSD-style license; see COPYING
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.27)
 project(modmesh)
 
 cmake_policy(SET CMP0148 OLD)


### PR DESCRIPTION
According to make official document, the CMP0148 policy was introduced in CMake version 3.27, therefore we need to set the minimum version to 3.27

Ref: https://cmake.org/cmake/help/latest/policy/CMP0148.html