### PR TITLE
[CI] enable macOS-14 runner

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -223,7 +223,7 @@ jobs:
     strategy:
       matrix:
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
-        os: [macos-13]
+        os: [macos-13, macos-14]
         cmake_build_type: [Release]
 
       fail-fast: false
@@ -256,7 +256,7 @@ jobs:
       - name: dependency by manual script
         run: |
           sudo ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
-          if [ "${{ matrix.os }}" == "macos-13" ] ; then \
+          if [ "${{ matrix.os }}" == "macos-13" ] || [ "${{ matrix.os }}" == "macos-14" ] ; then \
             thirdparty/metal-cpp.sh ; \
           fi
 
@@ -297,7 +297,7 @@ jobs:
       - name: make pytest BUILD_QT=OFF
         run: |
           JOB_MAKE_ARGS="VERBOSE=1"
-          if [ "${{ matrix.os }}" == "macos-13" ] ; then \
+          if [ "${{ matrix.os }}" == "macos-13" ] || [ "${{ matrix.os }}" == "macos-14" ] ; then \
             JOB_MAKE_ARGS="${JOB_MAKE_ARGS} BUILD_METAL=ON" ; \
           fi
           make pytest ${JOB_MAKE_ARGS}
@@ -319,7 +319,7 @@ jobs:
           # Solve this issue by removed PySide6 prebuilt Qt library
           rm -rf $(python3 -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))")/Qt/lib/*.framework
           JOB_MAKE_ARGS="VERBOSE=1"
-          if [ "${{ matrix.os }}" == "macos-13" ] ; then \
+          if [ "${{ matrix.os }}" == "macos-13" ] || [ "${{ matrix.os }}" == "macos-14" ] ; then \
             JOB_MAKE_ARGS="${JOB_MAKE_ARGS} BUILD_METAL=ON" ; \
           fi
           make pytest ${JOB_MAKE_ARGS}

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -223,6 +223,7 @@ jobs:
     strategy:
       matrix:
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
         os: [macos-13, macos-14]
         cmake_build_type: [Release]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -148,7 +148,7 @@ jobs:
     strategy:
       matrix:
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
-        os: [macos-13, macos-14]
+        os: [macos-13]
         cmake_build_type: [Debug]
 
       fail-fast: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -148,7 +148,7 @@ jobs:
     strategy:
       matrix:
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
-        os: [macos-13]
+        os: [macos-13, macos-14]
         cmake_build_type: [Debug]
 
       fail-fast: false

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -105,7 +105,7 @@ jobs:
       matrix:
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
-        os: [macos-13]
+        os: [macos-13, macos-14]
 
       fail-fast: false
 

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -103,9 +103,8 @@ jobs:
 
     strategy:
       matrix:
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
-        os: [macos-13, macos-14]
+        os: [macos-13]
 
       fail-fast: false
 

--- a/thirdparty/metal-cpp.sh
+++ b/thirdparty/metal-cpp.sh
@@ -27,14 +27,35 @@ download_md5 () {
   fi
 }
 
-filename=metal-cpp_macOS12_iOS15.zip
+if [ $(uname) == Darwin ] ; then
+  ver=$(sw_vers -productVersion)
+  if [ ${ver:0:2} == "12" ] ; then
+    filename=metal-cpp_macOS12_iOS15.zip
+    url=https://developer.apple.com/metal/cpp/files/metal-cpp_macOS12_iOS15.zip
+    checksum=8faab6897ba1f62e87076f153e036a58
+  elif [ ${ver:0:2} == "13" ] ; then
+    filename=metal-cpp_macOS13_iOS16.zip
+    url=https://developer.apple.com/metal/cpp/files/metal-cpp_macOS13.3_iOS16.4.zip
+    checksum=771a496981fb79dbd11d8bb128f19158
+  elif [ ${ver:0:2} == "14" ] ; then
+    filename=metal-cpp_macOS14_iOS17.zip
+    url=https://developer.apple.com/metal/cpp/files/metal-cpp_macOS14.2_iOS17.2.zip
+    checksum=8ec6c894233c834f7c611c575be72315
+  else
+    echo "Unsupported macOS version $ver"
+    exit 1
+  fi
+else
+  echo "Unsupported OS $(uname)"
+  exit 1
+fi
 
 pushd ${script_root}
 
 download_md5 \
   ${script_root}/archive/${filename} \
-  https://developer.apple.com/metal/cpp/files/metal-cpp_macOS12_iOS15.zip \
-  8faab6897ba1f62e87076f153e036a58
+  ${url} \
+  ${checksum}
 
 unzip ${script_root}/archive/${filename} -d install -x __MACOSX/\*
 


### PR DESCRIPTION
In this PR, there are two changes:
1. Enable the macOS-14 runner.
2. In thirdparty/metal-cpp.sh, download the metal-cpp version based on the OS version.