### PR TITLE
The node order of the second face of prism is wrong

### DIFF
--- a/cpp/modmesh/mesh/StaticMesh_interior.cpp
+++ b/cpp/modmesh/mesh/StaticMesh_interior.cpp
@@ -254,8 +254,8 @@ struct FaceBuilder
         // face 2.
         clfcs(icl, 2) = ifc;
         fcnds(ifc, 1) = clnds(icl, 4);
-        fcnds(ifc, 2) = clnds(icl, 5);
-        fcnds(ifc, 3) = clnds(icl, 6);
+        fcnds(ifc, 2) = clnds(icl, 6);
+        fcnds(ifc, 3) = clnds(icl, 5);
         ++ifc;
         // face 3.
         clfcs(icl, 3) = ifc;


### PR DESCRIPTION
The node order of the second face of prism shoud be 4, 6, 5 (1-based index).  It was correct in SOLVCON: https://github.com/solvcon/solvcon/blob/bd9d3915dfd8b1c639e4fc8f733ecb93cedb80f3/solvcon/src/sc_mesh_extract_faces_from_cells.c#L256 , but a typo was introduced when it was ported to C++.