### PR TITLE
Add new menu to draw a mesh

### DIFF
--- a/cpp/modmesh/view/R3DWidget.cpp
+++ b/cpp/modmesh/view/R3DWidget.cpp
@@ -44,7 +44,7 @@ R3DWidget::R3DWidget(Qt3DExtras::Qt3DWindow * window, RScene * scene, QWidget * 
     // Set up the camera.
     Qt3DRender::QCamera * camera = m_view->camera();
     camera->lens()->setPerspectiveProjection(45.0f, 16.0f / 9.0f, 0.1f, 1000.0f);
-    camera->setPosition(QVector3D(0.0f, 0.0f, 10.0f));
+    camera->setPosition(QVector3D(1.0f, 2.0f, 8.0f));
     camera->setViewCenter(QVector3D(0.0f, 0.0f, 0.0f));
 
     // Set up the camera control.

--- a/cpp/modmesh/view/R3DWidget.cpp
+++ b/cpp/modmesh/view/R3DWidget.cpp
@@ -44,7 +44,7 @@ R3DWidget::R3DWidget(Qt3DExtras::Qt3DWindow * window, RScene * scene, QWidget * 
     // Set up the camera.
     Qt3DRender::QCamera * camera = m_view->camera();
     camera->lens()->setPerspectiveProjection(45.0f, 16.0f / 9.0f, 0.1f, 1000.0f);
-    camera->setPosition(QVector3D(1.0f, 2.0f, 8.0f));
+    camera->setPosition(QVector3D(0.0f, 0.0f, 10.0f));
     camera->setViewCenter(QVector3D(0.0f, 0.0f, 0.0f));
 
     // Set up the camera control.

--- a/cpp/modmesh/view/RManager.cpp
+++ b/cpp/modmesh/view/RManager.cpp
@@ -91,7 +91,7 @@ R3DWidget * RManager::add3DWidget()
         viewer->setWindowTitle("3D viewer");
         viewer->show();
         auto * subwin = this->addSubWindow(viewer);
-        subwin->resize(300, 200);
+        subwin->resize(400, 300);
     }
     return viewer;
 }
@@ -211,6 +211,12 @@ void RManager::setUpMenu()
         this->addApplication(QString("euler1d"));
         this->addApplication(QString("linear_wave"));
         this->addApplication(QString("bad_euler1d"));
+    }
+
+    {
+        m_appMenu = m_mainWindow->menuBar()->addMenu(QString("Mesh"));
+
+        this->addApplication(QString("mh_3dmix"));
     }
 
     {

--- a/cpp/modmesh/view/RManager.cpp
+++ b/cpp/modmesh/view/RManager.cpp
@@ -149,6 +149,12 @@ void RManager::setUpMenu()
     }
 
     {
+        m_appMenu = m_mainWindow->menuBar()->addMenu(QString("Mesh"));
+
+        this->addApplication(QString("mh_3dmix"));
+    }
+
+    {
         m_cameraMenu = m_mainWindow->menuBar()->addMenu(QString("Camera"));
 
         auto * use_orbit_camera = new RAction(
@@ -211,12 +217,6 @@ void RManager::setUpMenu()
         this->addApplication(QString("euler1d"));
         this->addApplication(QString("linear_wave"));
         this->addApplication(QString("bad_euler1d"));
-    }
-
-    {
-        m_appMenu = m_mainWindow->menuBar()->addMenu(QString("Mesh"));
-
-        this->addApplication(QString("mh_3dmix"));
     }
 
     {

--- a/modmesh/app/mh_3dmix.py
+++ b/modmesh/app/mh_3dmix.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2021, Yung-Yu Chen <yyc@solvcon.net>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+Show sample mesh
+"""
+
+from .. import core
+from .. import view
+from .. import apputil
+
+
+def help_3dmix(set_command=False):
+    cmd = """
+# Open a sub window for triangles and quadrilaterals:
+w_3dmix = add3DWidget()
+mh_3dmix = make_3dmix()
+w_3dmix.updateMesh(mh_3dmix)
+w_3dmix.showMark()
+print("3dmix nedge:", mh_3dmix.nedge)
+"""
+    view.mgr.pycon.writeToHistory(cmd)
+    if set_command:
+        view.mgr.pycon.command = cmd.strip()
+
+
+def make_3dmix():
+    HEX = core.StaticMesh.HEXAHEDRON
+    TET = core.StaticMesh.TETRAHEDRON
+    PSM = core.StaticMesh.PRISM
+    PYR = core.StaticMesh.PYRAMID
+
+    mh = core.StaticMesh(ndim=3, nnode=11, nface=0, ncell=4)
+    mh.ndcrd.ndarray[:, :] = [
+        (0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0),
+        (0, 0, 1), (1, 0, 1), (1, 1, 1), (0, 1, 1),
+        (0.5, 1.5, 0.5),
+        (1.5, 1, 0.5), (1.5, 0, 0.5),
+    ]
+    mh.cltpn.ndarray[:] = [
+        HEX, PYR, TET, PSM,
+    ]
+    mh.clnds.ndarray[:, :9] = [
+        (8, 0, 1, 2, 3, 4, 5, 6, 7), (5, 2, 3, 7, 6, 8, -1, -1, -1),
+        (4, 2, 6, 9, 8, -1, -1, -1, -1), (6, 2, 6, 9, 1, 5, 10, -1, -1),
+    ]
+    mh.build_interior()
+    mh.build_boundary()
+    mh.build_ghost()
+    return mh
+
+
+def load_app():
+    aenv = apputil.get_current_appenv()
+    symbols = (
+        'help_3dmix',
+        'make_3dmix',
+    )
+    for k in symbols:
+        if isinstance(k, tuple):
+            k, o = k
+        else:
+            o = globals().get(k, None)
+            if o is None:
+                o = locals().get(k, None)
+        view.mgr.pycon.writeToHistory(f"Adding symbol {k}\n")
+        aenv.globals[k] = o
+    # Open a sub window for triangles and quadrilaterals:
+    w_3dmix = view.mgr.add3DWidget()
+    mh_3dmix = make_3dmix()
+    w_3dmix.updateMesh(mh_3dmix)
+    w_3dmix.showMark()
+    print("3dmix nedge:", mh_3dmix.nedge)   
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/app/mh_3dmix.py
+++ b/modmesh/app/mh_3dmix.py
@@ -26,26 +26,12 @@
 
 
 """
-Show sample mesh
+Show 3D mixed mesh
 """
 
 from .. import core
 from .. import view
 from .. import apputil
-
-
-def help_3dmix(set_command=False):
-    cmd = """
-# Open a sub window for triangles and quadrilaterals:
-w_3dmix = add3DWidget()
-mh_3dmix = make_3dmix()
-w_3dmix.updateMesh(mh_3dmix)
-w_3dmix.showMark()
-print("3dmix nedge:", mh_3dmix.nedge)
-"""
-    view.mgr.pycon.writeToHistory(cmd)
-    if set_command:
-        view.mgr.pycon.command = cmd.strip()
 
 
 def make_3dmix():
@@ -77,7 +63,6 @@ def make_3dmix():
 def load_app():
     aenv = apputil.get_current_appenv()
     symbols = (
-        'help_3dmix',
         'make_3dmix',
     )
     for k in symbols:
@@ -94,6 +79,6 @@ def load_app():
     mh_3dmix = make_3dmix()
     w_3dmix.updateMesh(mh_3dmix)
     w_3dmix.showMark()
-    print("3dmix nedge:", mh_3dmix.nedge)   
+    view.mgr.pycon.writeToHistory(f"3dmix nedge: {mh_3dmix.nedge}\n")
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
This PR is related with #276

There are 3 changes: 
1. created a new menu called `Mesh` to  collect the mesh example. Currently, it only has one item `load_mh_3dmix`. 
2. enlarge sub-window size to make it view easier.
3. change the camera position to have a good view initially.
 
When selecting the menu item, the mesh will be drawn in a sub-window in the viewer.

- Select `load_mh_3dmix` then draw the mesh in sub-window. 
<img width="1510" alt="Screenshot 2024-03-04 at 9 21 16 AM" src="https://github.com/solvcon/modmesh/assets/55582907/f84c4c89-3632-41e8-ae64-aabb1e995e1f">

- Load the mesh again. Manually adjust right sub-window size to check out the result.
<img width="1510" alt="Screenshot 2024-03-04 at 9 21 43 AM" src="https://github.com/solvcon/modmesh/assets/55582907/96e13b1d-349c-400c-a7bc-b84b187c9e9a">

