### PR TITLE
implement constructors for SimpleArrayPlex

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.cpp
+++ b/cpp/modmesh/buffer/SimpleArray.cpp
@@ -146,7 +146,10 @@ DataType get_data_type_from_type<double>()
     return DataType::Float64;
 }
 
-#define CREATE_SIMPLE_ARRAY(DataType, ArrayType, ...)                          \
+// According to the `DataType`, create the corresponding `SimpleArray<T>` instance
+// and assign it to `m_instance_ptr`. The `m_instance_ptr` is a void pointer, so
+// we need to use `reinterpret_cast` to convert the pointer of the array instance.
+#define MM_DECL_CREATE_SIMPLE_ARRAY(DataType, ArrayType, ...)                  \
     case DataType:                                                             \
         /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) */      \
         m_instance_ptr = reinterpret_cast<void *>(new ArrayType(__VA_ARGS__)); \
@@ -158,17 +161,17 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const DataType data_t
 {
     switch (data_type)
     {
-        CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape)
-        CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape)
-        CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape)
-        CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape)
-        CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape)
-        CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape)
-        CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape)
-        CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape)
-        CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape)
-        CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape)
-        CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape)
     default:
         throw std::runtime_error("Unsupported datatype");
     }
@@ -180,17 +183,17 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const double & value,
 {
     switch (data_type)
     {
-        CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape, value)
-        CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape, value)
-        CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape, value)
-        CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape, value)
-        CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape, value)
-        CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape, value)
-        CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape, value)
-        CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape, value)
-        CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape, value)
-        CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape, value)
-        CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape, value)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape, value)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape, value)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape, value)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape, value)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape, value)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape, value)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape, value)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape, value)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape, value)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape, value)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape, value)
     default:
         throw std::runtime_error("Unsupported datatype");
     }
@@ -202,21 +205,23 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const std::shared_ptr
 {
     switch (data_type)
     {
-        CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape, buffer)
-        CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape, buffer)
-        CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape, buffer)
-        CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape, buffer)
-        CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape, buffer)
-        CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape, buffer)
-        CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape, buffer)
-        CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape, buffer)
-        CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape, buffer)
-        CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape, buffer)
-        CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape, buffer)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape, buffer)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape, buffer)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape, buffer)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape, buffer)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape, buffer)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape, buffer)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape, buffer)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape, buffer)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape, buffer)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape, buffer)
+        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape, buffer)
     default:
         throw std::runtime_error("Unsupported datatype");
     }
 }
+
+#undef MM_DECL_CREATE_SIMPLE_ARRAY
 
 SimpleArrayPlex::SimpleArrayPlex(SimpleArrayPlex const & other)
     : m_data_type(other.m_data_type)

--- a/cpp/modmesh/buffer/SimpleArray.cpp
+++ b/cpp/modmesh/buffer/SimpleArray.cpp
@@ -148,6 +148,7 @@ DataType get_data_type_from_type<double>()
 
 #define CREATE_SIMPLE_ARRAY(DataType, ArrayType, ...)                          \
     case DataType:                                                             \
+        /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) */      \
         m_instance_ptr = reinterpret_cast<void *>(new ArrayType(__VA_ARGS__)); \
         break;
 
@@ -195,7 +196,7 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const double & value,
     }
 }
 
-SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const std::shared_ptr<ConcreteBuffer> buffer, const DataType data_type)
+SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const std::shared_ptr<ConcreteBuffer> & buffer, const DataType data_type)
     : m_data_type(data_type)
     , m_has_instance_ownership(true)
 {

--- a/cpp/modmesh/buffer/SimpleArray.cpp
+++ b/cpp/modmesh/buffer/SimpleArray.cpp
@@ -146,82 +146,74 @@ DataType get_data_type_from_type<double>()
     return DataType::Float64;
 }
 
-SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, DataType data_type)
+#define CREATE_SIMPLE_ARRAY(DataType, ArrayType, ...)                          \
+    case DataType:                                                             \
+        m_instance_ptr = reinterpret_cast<void *>(new ArrayType(__VA_ARGS__)); \
+        break;
+
+SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const DataType data_type)
     : m_data_type(data_type)
     , m_has_instance_ownership(true)
 {
     switch (data_type)
     {
-    case DataType::Bool:
-    {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayBool(shape));
-        break;
-    }
-    case DataType::Int8:
-    {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayInt8(shape));
-        break;
-    }
-    case DataType::Int16:
-    {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayInt16(shape));
-        break;
-    }
-    case DataType::Int32:
-    {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayInt32(shape));
-        break;
-    }
-    case DataType::Int64:
-    {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayInt64(shape));
-        break;
-    }
-    case DataType::Uint8:
-    {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayUint8(shape));
-        break;
-    }
-    case DataType::Uint16:
-    {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayUint16(shape));
-        break;
-    }
-    case DataType::Uint32:
-    {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayUint32(shape));
-        break;
-    }
-    case DataType::Uint64:
-    {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayUint64(shape));
-        break;
-    }
-    case DataType::Float32:
-    {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayFloat32(shape));
-        break;
-    }
-    case DataType::Float64:
-    {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayFloat64(shape));
-        break;
-    }
+        CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape)
+        CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape)
+        CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape)
+        CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape)
+        CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape)
+        CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape)
+        CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape)
+        CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape)
+        CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape)
+        CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape)
+        CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape)
     default:
-    {
         throw std::runtime_error("Unsupported datatype");
     }
+}
+
+SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const double & value, const DataType data_type)
+    : m_data_type(data_type)
+    , m_has_instance_ownership(true)
+{
+    switch (data_type)
+    {
+        CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape, value)
+        CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape, value)
+        CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape, value)
+        CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape, value)
+        CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape, value)
+        CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape, value)
+        CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape, value)
+        CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape, value)
+        CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape, value)
+        CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape, value)
+        CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape, value)
+    default:
+        throw std::runtime_error("Unsupported datatype");
+    }
+}
+
+SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const std::shared_ptr<ConcreteBuffer> buffer, const DataType data_type)
+    : m_data_type(data_type)
+    , m_has_instance_ownership(true)
+{
+    switch (data_type)
+    {
+        CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape, buffer)
+        CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape, buffer)
+        CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape, buffer)
+        CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape, buffer)
+        CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape, buffer)
+        CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape, buffer)
+        CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape, buffer)
+        CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape, buffer)
+        CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape, buffer)
+        CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape, buffer)
+        CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape, buffer)
+    default:
+        throw std::runtime_error("Unsupported datatype");
     }
 }
 

--- a/cpp/modmesh/buffer/SimpleArray.cpp
+++ b/cpp/modmesh/buffer/SimpleArray.cpp
@@ -177,28 +177,6 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const DataType data_t
     }
 }
 
-SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const double & value, const DataType data_type)
-    : m_data_type(data_type)
-    , m_has_instance_ownership(true)
-{
-    switch (data_type)
-    {
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape, value)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape, value)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape, value)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape, value)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape, value)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape, value)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape, value)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape, value)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape, value)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape, value)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape, value)
-    default:
-        throw std::runtime_error("Unsupported datatype");
-    }
-}
-
 SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const std::shared_ptr<ConcreteBuffer> & buffer, const DataType data_type)
     : m_data_type(data_type)
     , m_has_instance_ownership(true)

--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -706,14 +706,14 @@ public:
     {
     }
 
-    explicit SimpleArrayPlex(const shape_type & shape, const std::shared_ptr<ConcreteBuffer> buffer, const std::string & data_type)
+    explicit SimpleArrayPlex(const shape_type & shape, const std::shared_ptr<ConcreteBuffer> & buffer, const std::string & data_type)
         : SimpleArrayPlex(shape, buffer, get_data_type_from_string(data_type))
     {
     }
 
     explicit SimpleArrayPlex(const shape_type & shape, const DataType data_type);
     explicit SimpleArrayPlex(const shape_type & shape, const double & value, const DataType data_type);
-    explicit SimpleArrayPlex(const shape_type & shape, const std::shared_ptr<ConcreteBuffer> buffer, const DataType data_type);
+    explicit SimpleArrayPlex(const shape_type & shape, const std::shared_ptr<ConcreteBuffer> & buffer, const DataType data_type);
 
     template <typename T>
     SimpleArrayPlex(const SimpleArray<T> & array)

--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -701,18 +701,12 @@ public:
     {
     }
 
-    explicit SimpleArrayPlex(const shape_type & shape, const double & value, const std::string & data_type)
-        : SimpleArrayPlex(shape, value, get_data_type_from_string(data_type))
-    {
-    }
-
     explicit SimpleArrayPlex(const shape_type & shape, const std::shared_ptr<ConcreteBuffer> & buffer, const std::string & data_type)
         : SimpleArrayPlex(shape, buffer, get_data_type_from_string(data_type))
     {
     }
 
     explicit SimpleArrayPlex(const shape_type & shape, const DataType data_type);
-    explicit SimpleArrayPlex(const shape_type & shape, const double & value, const DataType data_type);
     explicit SimpleArrayPlex(const shape_type & shape, const std::shared_ptr<ConcreteBuffer> & buffer, const DataType data_type);
 
     template <typename T>
@@ -735,7 +729,14 @@ public:
         return m_data_type;
     }
 
+    /// Get the pointer to the const instance of SimpleArray<T>.
     const void * instance_ptr() const
+    {
+        return m_instance_ptr;
+    }
+
+    /// Get the pointer to the mutable instance of SimpleArray<T>.
+    void * mutable_instance_ptr() const
     {
         return m_instance_ptr;
     }

--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -701,7 +701,19 @@ public:
     {
     }
 
-    explicit SimpleArrayPlex(const shape_type & shape, DataType data_type);
+    explicit SimpleArrayPlex(const shape_type & shape, const double & value, const std::string & data_type)
+        : SimpleArrayPlex(shape, value, get_data_type_from_string(data_type))
+    {
+    }
+
+    explicit SimpleArrayPlex(const shape_type & shape, const std::shared_ptr<ConcreteBuffer> buffer, const std::string & data_type)
+        : SimpleArrayPlex(shape, buffer, get_data_type_from_string(data_type))
+    {
+    }
+
+    explicit SimpleArrayPlex(const shape_type & shape, const DataType data_type);
+    explicit SimpleArrayPlex(const shape_type & shape, const double & value, const DataType data_type);
+    explicit SimpleArrayPlex(const shape_type & shape, const std::shared_ptr<ConcreteBuffer> buffer, const DataType data_type);
 
     template <typename T>
     SimpleArrayPlex(const SimpleArray<T> & array)

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -79,7 +79,8 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
             ;
     }
 
-    /// initialize the arrayplex with the given value
+    /// Initialize the arrayplex with the given value
+    /// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     static wrapped_type init_array_plex_with_value(pybind11::object const & shape_in, pybind11::object const & value, std::string const & datatype)
     {
         shape_type shape = make_shape(shape_in);
@@ -204,7 +205,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
         return array_plex;
     }
 
-    /// return the typed function from the arrayplex
+    /// Return the typed function from the arrayplex
     static pybind11::object
     get_typed_array(wrapped_type const & array_plex)
     {

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -54,12 +54,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
                 pybind11::arg("shape"),
                 pybind11::arg("dtype"))
             .def_timed(
-                // Note we use double instead of T to avoid the template (,which is not supported by pybind11::init)
-                // Value will later be converted to the correct datatype in the constructor
-                // This may cause the loss of precision, but should be fine to most cases
-                pybind11::init(
-                    [](pybind11::object const & shape, double const & value, std::string const & datatype)
-                    { return wrapped_type(make_shape(shape), value, datatype); }),
+                pybind11::init(&init_array_plex_with_value),
                 pybind11::arg("shape"),
                 pybind11::arg("value"),
                 pybind11::arg("dtype"))
@@ -84,8 +79,134 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
             ;
     }
 
+    /// initialize the arrayplex with the given value
+    static wrapped_type init_array_plex_with_value(pybind11::object const & shape_in, pybind11::object const & value, std::string const & datatype)
+    {
+        shape_type shape = make_shape(shape_in);
+        wrapped_type array_plex(shape, datatype);
+
+        // cast value to correct type based on the datatype
+        switch (array_plex.data_type())
+        {
+        case DataType::Bool:
+        {
+            if (!pybind11::isinstance<pybind11::bool_>(value))
+            {
+                throw std::runtime_error("Data type mismatch, expected Python bool");
+            }
+            auto * array = static_cast<SimpleArrayBool *>(array_plex.mutable_instance_ptr());
+            array->fill(value.cast<bool>());
+            break;
+        }
+        case DataType::Int8:
+        {
+            if (!pybind11::isinstance<pybind11::int_>(value))
+            {
+                throw std::runtime_error("Data type mismatch, expected Python int");
+            }
+            auto * array = static_cast<SimpleArrayInt8 *>(array_plex.mutable_instance_ptr());
+            array->fill(value.cast<int8_t>());
+            break;
+        }
+        case DataType::Int16:
+        {
+            if (!pybind11::isinstance<pybind11::int_>(value))
+            {
+                throw std::runtime_error("Data type mismatch, expected Python int");
+            }
+            auto * array = static_cast<SimpleArrayInt16 *>(array_plex.mutable_instance_ptr());
+            array->fill(value.cast<int16_t>());
+            break;
+        }
+        case DataType::Int32:
+        {
+            if (!pybind11::isinstance<pybind11::int_>(value))
+            {
+                throw std::runtime_error("Data type mismatch, expected Python int");
+            }
+            auto * array = static_cast<SimpleArrayInt32 *>(array_plex.mutable_instance_ptr());
+            array->fill(value.cast<int32_t>());
+            break;
+        }
+        case DataType::Int64:
+        {
+            if (!pybind11::isinstance<pybind11::int_>(value))
+            {
+                throw std::runtime_error("Data type mismatch, expected Python int");
+            }
+            auto * array = static_cast<SimpleArrayInt64 *>(array_plex.mutable_instance_ptr());
+            array->fill(value.cast<int64_t>());
+            break;
+        }
+        case DataType::Uint8:
+        {
+            if (!pybind11::isinstance<pybind11::int_>(value))
+            {
+                throw std::runtime_error("Data type mismatch, expected Python int");
+            }
+            auto * array = static_cast<SimpleArrayUint8 *>(array_plex.mutable_instance_ptr());
+            array->fill(value.cast<uint8_t>());
+            break;
+        }
+        case DataType::Uint16:
+        {
+            if (!pybind11::isinstance<pybind11::int_>(value))
+            {
+                throw std::runtime_error("Data type mismatch, expected Python int");
+            }
+            auto * array = static_cast<SimpleArrayUint16 *>(array_plex.mutable_instance_ptr());
+            array->fill(value.cast<uint16_t>());
+            break;
+        }
+        case DataType::Uint32:
+        {
+            if (!pybind11::isinstance<pybind11::int_>(value))
+            {
+                throw std::runtime_error("Data type mismatch, expected Python int");
+            }
+            auto * array = static_cast<SimpleArrayUint32 *>(array_plex.mutable_instance_ptr());
+            array->fill(value.cast<int32_t>());
+            break;
+        }
+        case DataType::Uint64:
+        {
+            if (!pybind11::isinstance<pybind11::int_>(value))
+            {
+                throw std::runtime_error("Data type mismatch, expected Python int");
+            }
+            auto * array = static_cast<SimpleArrayUint64 *>(array_plex.mutable_instance_ptr());
+            array->fill(value.cast<int64_t>());
+            break;
+        }
+        case DataType::Float32:
+        {
+            if (!pybind11::isinstance<pybind11::float_>(value))
+            {
+                throw std::runtime_error("Data type mismatch, expected Python float");
+            }
+            auto * array = static_cast<SimpleArrayFloat32 *>(array_plex.mutable_instance_ptr());
+            array->fill(value.cast<float>());
+            break;
+        }
+        case DataType::Float64:
+        {
+            if (!pybind11::isinstance<pybind11::float_>(value))
+            {
+                throw std::runtime_error("Data type mismatch, expected Python float");
+            }
+            auto * array = static_cast<SimpleArrayFloat64 *>(array_plex.mutable_instance_ptr());
+            array->fill(value.cast<double>());
+            break;
+        }
+        default:
+            throw std::runtime_error("Unsupported datatype");
+        }
+        return array_plex;
+    }
+
     /// return the typed function from the arrayplex
-    static pybind11::object get_typed_array(wrapped_type const & array_plex)
+    static pybind11::object
+    get_typed_array(wrapped_type const & array_plex)
     {
         switch (array_plex.data_type())
         {

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -80,7 +80,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
     }
 
     /// Initialize the arrayplex with the given value
-    /// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     static wrapped_type init_array_plex_with_value(pybind11::object const & shape_in, pybind11::object const & value, std::string const & datatype)
     {
         const shape_type shape = make_shape(shape_in);

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -83,7 +83,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
     /// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     static wrapped_type init_array_plex_with_value(pybind11::object const & shape_in, pybind11::object const & value, std::string const & datatype)
     {
-        shape_type shape = make_shape(shape_in);
+        const shape_type shape = make_shape(shape_in);
         wrapped_type array_plex(shape, datatype);
 
         // cast value to correct type based on the datatype

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -700,4 +700,29 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         sarr = sarr.abs()
         self.assertEqual(sarr.sum(), True)
 
+
+class SimpleArrayPlexTC(unittest.TestCase):
+
+    def test_SimpleArrayPlex_constructor(self):
+        # 1. shape constructor
+        dtype_list = [
+            "bool", "int8", "uint8", "int16", "uint16", "int32", "uint32",
+            "int64", "uint64", "float32", "float64"
+        ]
+        for dtype in dtype_list:
+            modmesh.SimpleArray((2, 3, 4), dtype=dtype)
+
+        # 2. shape and value constructor
+        for dtype in dtype_list:
+            modmesh.SimpleArray((2, 3, 4), dtype=dtype, value=1.111)
+
+        # 3. np.ndarray constructor
+        # exclude bool, since it cannot use np.arange
+        dtype_list_no_bool = dtype_list[1:]
+        for dtype in dtype_list_no_bool:
+            ndarr = np.arange(2 * 3 * 4, dtype=dtype)
+            modmesh.SimpleArray(ndarr)
+        boolean_array = np.array([True, False, True], dtype='bool')
+        modmesh.SimpleArray(boolean_array)
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -714,12 +714,40 @@ class SimpleArrayPlexTC(unittest.TestCase):
             modmesh.SimpleArray((2, 3, 4), dtype=dtype)
 
         # 2. shape and value constructor
-        for dtype in dtype_list:
-            modmesh.SimpleArray((2, 3, 4), dtype=dtype, value=1.111)
+        modmesh.SimpleArray((2, 3, 4), dtype="bool", value=True)
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r"Data type mismatch, expected Python bool"
+        ):
+            modmesh.SimpleArray((2, 3, 4), dtype="bool", value=3.3)
+
+        dtype_list_int = [
+            "int8", "uint8", "int16", "uint16", "int32", "uint32",
+            "int64", "uint64"
+        ]
+        for dtype in dtype_list_int:
+            modmesh.SimpleArray((2, 3, 4), dtype=dtype, value=3)
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"Data type mismatch, expected Python int"
+            ):
+                modmesh.SimpleArray((2, 3, 4), dtype=dtype, value=3.3)
+
+        dtype_list_float = ["float32", "float64"]
+        for dtype in dtype_list_float:
+            modmesh.SimpleArray((2, 3, 4), dtype=dtype, value=3.0)
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"Data type mismatch, expected Python float"
+            ):
+                modmesh.SimpleArray((2, 3, 4), dtype=dtype, value=3)
 
         # 3. np.ndarray constructor
         # exclude bool, since it cannot use np.arange
-        dtype_list_no_bool = dtype_list[1:]
+        dtype_list_no_bool = [
+            "int8", "uint8", "int16", "uint16", "int32", "uint32",
+            "int64", "uint64", "float32", "float64"
+        ]
         for dtype in dtype_list_no_bool:
             ndarr = np.arange(2 * 3 * 4, dtype=dtype)
             modmesh.SimpleArray(ndarr)


### PR DESCRIPTION
Support all constructors in `WrapSimpleArray` for `WrapSimpleArrayPlex` 

Now in Python, we can use the same way to construct `modmesh.SimpleArray` as `modmesh.SimpleArrayInt`