### PR TITLE
[CI] add qt action to all platform

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -113,19 +113,22 @@ jobs:
         sudo apt-get -qy install \
             sudo curl git build-essential make cmake libc6-dev gcc g++ \
             python3 python3-dev python3-venv
-        # Install qt6 only with ubuntu-22.04
-        # This page explains why we need libgl1-mesa-dev
-        # https://doc-snapshots.qt.io/qt6-dev/linux.html
-        #
-        # In short, OpenGL libraries and headers are required. Without
-        # installing this package, cmake won't find out the correct lib path.
+        # # Install qt6 only with ubuntu-22.04
+        # # This page explains why we need libgl1-mesa-dev
+        # # https://doc-snapshots.qt.io/qt6-dev/linux.html
+        # #
+        # # In short, OpenGL libraries and headers are required. Without
+        # # installing this package, cmake won't find out the correct lib path.
+
         # if [ "${{ matrix.os }}" == "ubuntu-22.04" ] ; then \
         #   sudo apt-get -qy install \
         #       qt6-3d-dev xvfb \
         #       libgl1-mesa-dev
         # fi
 
-    - name: install qt
+        # # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
+
+    - name: Install Qt
       uses: jurplel/install-qt-action@v3
       with:
         aqtversion: '==3.1.*'
@@ -280,6 +283,7 @@ jobs:
           export HOMEBREW_NO_AUTO_UPDATE=1
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
           # brew install qt6
+          # # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
@@ -458,7 +462,7 @@ jobs:
         run: |
           echo "github.event_name: ${{ github.event_name }}"
 
-      - name: install qt
+      - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
           aqtversion: '==3.1.*'

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -113,20 +113,19 @@ jobs:
         sudo apt-get -qy install \
             sudo curl git build-essential make cmake libc6-dev gcc g++ \
             python3 python3-dev python3-venv
-        # # Install qt6 only with ubuntu-22.04
-        # # This page explains why we need libgl1-mesa-dev
-        # # https://doc-snapshots.qt.io/qt6-dev/linux.html
-        # #
-        # # In short, OpenGL libraries and headers are required. Without
-        # # installing this package, cmake won't find out the correct lib path.
+        # Install qt6 only with ubuntu-22.04
+        # This page explains why we need libgl1-mesa-dev
+        # https://doc-snapshots.qt.io/qt6-dev/linux.html
+        #
+        # In short, OpenGL libraries and headers are required. Without
+        # installing this package, cmake won't find the correct lib path.
+        # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
 
         # if [ "${{ matrix.os }}" == "ubuntu-22.04" ] ; then \
         #   sudo apt-get -qy install \
         #       qt6-3d-dev xvfb \
         #       libgl1-mesa-dev
         # fi
-
-        # # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
@@ -282,8 +281,8 @@ jobs:
         run: |
           export HOMEBREW_NO_AUTO_UPDATE=1
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+          # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
           # brew install qt6
-          # # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -119,7 +119,8 @@ jobs:
         #
         # In short, OpenGL libraries and headers are required. Without
         # installing this package, cmake won't find the correct lib path.
-        # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
+        # This has been replaced by the 'install qt' section below to manage
+        # qt6 versioning independently from the OS.
 
         # if [ "${{ matrix.os }}" == "ubuntu-22.04" ] ; then \
         #   sudo apt-get -qy install \
@@ -127,7 +128,7 @@ jobs:
         #       libgl1-mesa-dev
         # fi
 
-    - name: Install Qt
+    - name: install qt
       uses: jurplel/install-qt-action@v3
       with:
         aqtversion: '==3.1.*'
@@ -282,10 +283,11 @@ jobs:
         run: |
           export HOMEBREW_NO_AUTO_UPDATE=1
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-          # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
+          # This has been replaced by the 'install qt' section below to manage
+          # qt6 versioning independently from the OS.
           # brew install qt6
 
-      - name: Install Qt
+      - name: install qt
         uses: jurplel/install-qt-action@v3
         with:
           aqtversion: '==3.1.*'
@@ -462,7 +464,7 @@ jobs:
         run: |
           echo "github.event_name: ${{ github.event_name }}"
 
-      - name: Install Qt
+      - name: install qt
         uses: jurplel/install-qt-action@v3
         with:
           aqtversion: '==3.1.*'

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -131,7 +131,7 @@ jobs:
       uses: jurplel/install-qt-action@v3
       with:
         aqtversion: '==3.1.*'
-        version: '6.5.3'
+        version: '6.6.3'
         host: 'linux'
         target: 'desktop'
         arch: 'gcc_64'
@@ -255,6 +255,7 @@ jobs:
 
     env:
       QT_DEBUG_PLUGINS: 1
+      PIP_BREAK_SYSTEM_PACKAGES: 1 # disabling PEP668
 
     strategy:
       matrix:
@@ -288,7 +289,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           aqtversion: '==3.1.*'
-          version: '6.5.3'
+          version: '6.6.3'
           host: 'mac'
           target: 'desktop'
           arch: 'clang_64'
@@ -465,7 +466,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           aqtversion: '==3.1.*'
-          version: '6.5.3'
+          version: '6.6.3'
           host: 'windows'
           target: 'desktop'
           arch: 'win64_msvc2019_64'

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -119,11 +119,22 @@ jobs:
         #
         # In short, OpenGL libraries and headers are required. Without
         # installing this package, cmake won't find out the correct lib path.
-        if [ "${{ matrix.os }}" == "ubuntu-22.04" ] ; then \
-          sudo apt-get -qy install \
-              qt6-3d-dev xvfb \
-              libgl1-mesa-dev
-        fi
+        # if [ "${{ matrix.os }}" == "ubuntu-22.04" ] ; then \
+        #   sudo apt-get -qy install \
+        #       qt6-3d-dev xvfb \
+        #       libgl1-mesa-dev
+        # fi
+
+    - name: install qt
+      uses: jurplel/install-qt-action@v3
+      with:
+        aqtversion: '==3.1.*'
+        version: '6.5.3'
+        host: 'linux'
+        target: 'desktop'
+        arch: 'gcc_64'
+        modules: 'qt3d'
+        setup-python: 'false'
 
     - name: dependency by pip
       run: |
@@ -268,7 +279,18 @@ jobs:
         run: |
           export HOMEBREW_NO_AUTO_UPDATE=1
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-          brew install qt6
+          # brew install qt6
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          aqtversion: '==3.1.*'
+          version: '6.5.3'
+          host: 'mac'
+          target: 'desktop'
+          arch: 'clang_64'
+          modules: 'qt3d'
+          setup-python: 'false'
 
       - name: dependency by pip
         run: |
@@ -439,14 +461,14 @@ jobs:
       - name: install qt
         uses: jurplel/install-qt-action@v3
         with:
-          aqtversion: '==2.1.*'
-          version: '6.3.1'
+          aqtversion: '==3.1.*'
+          version: '6.5.3'
           host: 'windows'
           target: 'desktop'
           arch: 'win64_msvc2019_64'
           modules: 'qt3d'
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10' 
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -77,7 +77,8 @@ jobs:
         #
         # In short, OpenGL libraries and headers are required. Without
         # installing this package, cmake won't find the correct lib path.
-        # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
+        # This has been replaced by the 'install qt' section below to manage
+        # qt6 versioning independently from the OS.
 
         # if [ "${{ matrix.os }}" == "ubuntu-22.04" ] ; then \
         #   sudo apt-get -qy install \
@@ -85,7 +86,7 @@ jobs:
         #       libgl1-mesa-dev
         # fi
 
-    - name: Install Qt
+    - name: install qt
       uses: jurplel/install-qt-action@v3
       with:
         aqtversion: '==3.1.*'
@@ -188,13 +189,14 @@ jobs:
         run: |
           export HOMEBREW_NO_AUTO_UPDATE=1
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-          # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
+          # This has been replaced by the 'install qt' section below to manage
+          # qt6 versioning independently from the OS.
           # brew install llvm@16 qt6
           brew install llvm@16
           ln -s "$(brew --prefix llvm@16)/bin/clang-format" "/usr/local/bin/clang-format"
           ln -s "$(brew --prefix llvm@16)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
 
-      - name: Install Qt
+      - name: install qt
         uses: jurplel/install-qt-action@v3
         with:
           aqtversion: '==3.1.*'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,12 +71,12 @@ jobs:
             clang-tidy-${CLANG_TIDY_VERSION} \
             python3 python3-dev python3-venv
         sudo ln -fs "$(which clang-tidy-${CLANG_TIDY_VERSION})" "$(dirname $(which clang-tidy-${CLANG_TIDY_VERSION}))/clang-tidy"
-        # Install qt6 only with ubuntu-22.04
-        # This page explains why we need libgl1-mesa-dev
-        # https://doc-snapshots.qt.io/qt6-dev/linux.html
-        #
-        # In short, OpenGL libraries and headers are required. Without
-        # installing this package, cmake won't find out the correct lib path.
+        # # Install qt6 only with ubuntu-22.04
+        # # This page explains why we need libgl1-mesa-dev
+        # # https://doc-snapshots.qt.io/qt6-dev/linux.html
+        # #
+        # # In short, OpenGL libraries and headers are required. Without
+        # # installing this package, cmake won't find out the correct lib path.
 
         # if [ "${{ matrix.os }}" == "ubuntu-22.04" ] ; then \
         #   sudo apt-get -qy install \
@@ -84,7 +84,10 @@ jobs:
         #       libgl1-mesa-dev
         # fi
 
-    - name: install qt
+        # # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
+
+
+    - name: Install Qt
       uses: jurplel/install-qt-action@v3
       with:
         aqtversion: '==3.1.*'
@@ -187,6 +190,8 @@ jobs:
           export HOMEBREW_NO_AUTO_UPDATE=1
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
           # brew install llvm@16 qt6
+          # # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
+
           brew install llvm@16
           ln -s "$(brew --prefix llvm@16)/bin/clang-format" "/usr/local/bin/clang-format"
           ln -s "$(brew --prefix llvm@16)/bin/clang-tidy" "/usr/local/bin/clang-tidy"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,11 +78,22 @@ jobs:
         # In short, OpenGL libraries and headers are required. Without
         # installing this package, cmake won't find out the correct lib path.
 
-        if [ "${{ matrix.os }}" == "ubuntu-22.04" ] ; then \
-          sudo apt-get -qy install \
-              qt6-3d-dev xvfb \
-              libgl1-mesa-dev
-        fi
+        # if [ "${{ matrix.os }}" == "ubuntu-22.04" ] ; then \
+        #   sudo apt-get -qy install \
+        #       qt6-3d-dev xvfb \
+        #       libgl1-mesa-dev
+        # fi
+
+    - name: install qt
+      uses: jurplel/install-qt-action@v3
+      with:
+        aqtversion: '==3.1.*'
+        version: '6.5.3'
+        host: 'linux'
+        target: 'desktop'
+        arch: 'gcc_64'
+        modules: 'qt3d'
+        setup-python: 'false'
 
     - name: dependency by pip
       run: |
@@ -175,9 +186,21 @@ jobs:
         run: |
           export HOMEBREW_NO_AUTO_UPDATE=1
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-          brew install llvm@16 qt6
+          # brew install llvm@16 qt6
+          brew install llvm@16
           ln -s "$(brew --prefix llvm@16)/bin/clang-format" "/usr/local/bin/clang-format"
           ln -s "$(brew --prefix llvm@16)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          aqtversion: '==3.1.*'
+          version: '6.5.3'
+          host: 'mac'
+          target: 'desktop'
+          arch: 'clang_64'
+          modules: 'qt3d'
+          setup-python: 'false'
 
       - name: dependency by pip
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,21 +71,19 @@ jobs:
             clang-tidy-${CLANG_TIDY_VERSION} \
             python3 python3-dev python3-venv
         sudo ln -fs "$(which clang-tidy-${CLANG_TIDY_VERSION})" "$(dirname $(which clang-tidy-${CLANG_TIDY_VERSION}))/clang-tidy"
-        # # Install qt6 only with ubuntu-22.04
-        # # This page explains why we need libgl1-mesa-dev
-        # # https://doc-snapshots.qt.io/qt6-dev/linux.html
-        # #
-        # # In short, OpenGL libraries and headers are required. Without
-        # # installing this package, cmake won't find out the correct lib path.
+        # Install qt6 only with ubuntu-22.04
+        # This page explains why we need libgl1-mesa-dev
+        # https://doc-snapshots.qt.io/qt6-dev/linux.html
+        #
+        # In short, OpenGL libraries and headers are required. Without
+        # installing this package, cmake won't find the correct lib path.
+        # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
 
         # if [ "${{ matrix.os }}" == "ubuntu-22.04" ] ; then \
         #   sudo apt-get -qy install \
         #       qt6-3d-dev xvfb \
         #       libgl1-mesa-dev
         # fi
-
-        # # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
-
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
@@ -189,9 +187,8 @@ jobs:
         run: |
           export HOMEBREW_NO_AUTO_UPDATE=1
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+          # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
           # brew install llvm@16 qt6
-          # # This has been replaced by the 'Install Qt' section below to manage qt6 versioning independently from the OS.
-
           brew install llvm@16
           ln -s "$(brew --prefix llvm@16)/bin/clang-format" "/usr/local/bin/clang-format"
           ln -s "$(brew --prefix llvm@16)/bin/clang-tidy" "/usr/local/bin/clang-tidy"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -89,7 +89,7 @@ jobs:
       uses: jurplel/install-qt-action@v3
       with:
         aqtversion: '==3.1.*'
-        version: '6.5.3'
+        version: '6.6.3'
         host: 'linux'
         target: 'desktop'
         arch: 'gcc_64'
@@ -162,6 +162,7 @@ jobs:
     env:
       JOB_MAKE_ARGS: VERBOSE=1 BUILD_QT=ON USE_CLANG_TIDY=ON LINT_AS_ERRORS=ON
       QT_DEBUG_PLUGINS: 1
+      PIP_BREAK_SYSTEM_PACKAGES: 1 # disabling PEP668
 
     strategy:
       matrix:
@@ -197,7 +198,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           aqtversion: '==3.1.*'
-          version: '6.5.3'
+          version: '6.6.3'
           host: 'mac'
           target: 'desktop'
           arch: 'clang_64'


### PR DESCRIPTION
In this PR, we manage Qt installation for all platforms using `jurplel/install-qt-action@v3`.
All the Qt versions are fixed to 6.5.3 LTS.
Also, `jurplel/install-qt-action@v3` has built-in `actions/setup-python@v4`, so we can avoid `brew unlink && brew link` issues like those in https://github.com/solvcon/modmesh/issues/289.