### PR TITLE
rename macro

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.cpp
+++ b/cpp/modmesh/buffer/SimpleArray.cpp
@@ -149,7 +149,7 @@ DataType get_data_type_from_type<double>()
 // According to the `DataType`, create the corresponding `SimpleArray<T>` instance
 // and assign it to `m_instance_ptr`. The `m_instance_ptr` is a void pointer, so
 // we need to use `reinterpret_cast` to convert the pointer of the array instance.
-#define MM_DECL_CREATE_SIMPLE_ARRAY(DataType, ArrayType, ...)                  \
+#define DECL_MM_CREATE_SIMPLE_ARRAY(DataType, ArrayType, ...)                  \
     case DataType:                                                             \
         /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) */      \
         m_instance_ptr = reinterpret_cast<void *>(new ArrayType(__VA_ARGS__)); \
@@ -161,17 +161,17 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const DataType data_t
 {
     switch (data_type)
     {
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape)
     default:
         throw std::runtime_error("Unsupported datatype");
     }
@@ -183,23 +183,23 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const std::shared_ptr
 {
     switch (data_type)
     {
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape, buffer)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape, buffer)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape, buffer)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape, buffer)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape, buffer)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape, buffer)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape, buffer)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape, buffer)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape, buffer)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape, buffer)
-        MM_DECL_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape, buffer)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape, buffer)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape, buffer)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape, buffer)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape, buffer)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape, buffer)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape, buffer)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape, buffer)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape, buffer)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape, buffer)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape, buffer)
+        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape, buffer)
     default:
         throw std::runtime_error("Unsupported datatype");
     }
 }
 
-#undef MM_DECL_CREATE_SIMPLE_ARRAY
+#undef DECL_MM_CREATE_SIMPLE_ARRAY
 
 SimpleArrayPlex::SimpleArrayPlex(SimpleArrayPlex const & other)
     : m_data_type(other.m_data_type)

--- a/cpp/modmesh/buffer/pymod/SimpleArrayCaster.hpp
+++ b/cpp/modmesh/buffer/pymod/SimpleArrayCaster.hpp
@@ -43,7 +43,7 @@ namespace detail
 {
 
 // Define the Pybind11 caster for SimpleArray<T>
-#define SIMPLE_ARRAY_CASTER(DATATYPE)                                                                                                                         \
+#define DECL_MM_SIMPLE_ARRAY_CASTER(DATATYPE)                                                                                                                 \
     template <> /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                                                                                              \
     struct type_caster<modmesh::SimpleArray##DATATYPE> : public type_caster_base<modmesh::SimpleArray##DATATYPE>                                              \
     {                                                                                                                                                         \
@@ -86,17 +86,19 @@ namespace detail
         }                                                                                                                                                     \
     }
 
-SIMPLE_ARRAY_CASTER(Bool);
-SIMPLE_ARRAY_CASTER(Int8);
-SIMPLE_ARRAY_CASTER(Int16);
-SIMPLE_ARRAY_CASTER(Int32);
-SIMPLE_ARRAY_CASTER(Int64);
-SIMPLE_ARRAY_CASTER(Uint8);
-SIMPLE_ARRAY_CASTER(Uint16);
-SIMPLE_ARRAY_CASTER(Uint32);
-SIMPLE_ARRAY_CASTER(Uint64);
-SIMPLE_ARRAY_CASTER(Float32);
-SIMPLE_ARRAY_CASTER(Float64);
+DECL_MM_SIMPLE_ARRAY_CASTER(Bool);
+DECL_MM_SIMPLE_ARRAY_CASTER(Int8);
+DECL_MM_SIMPLE_ARRAY_CASTER(Int16);
+DECL_MM_SIMPLE_ARRAY_CASTER(Int32);
+DECL_MM_SIMPLE_ARRAY_CASTER(Int64);
+DECL_MM_SIMPLE_ARRAY_CASTER(Uint8);
+DECL_MM_SIMPLE_ARRAY_CASTER(Uint16);
+DECL_MM_SIMPLE_ARRAY_CASTER(Uint32);
+DECL_MM_SIMPLE_ARRAY_CASTER(Uint64);
+DECL_MM_SIMPLE_ARRAY_CASTER(Float32);
+DECL_MM_SIMPLE_ARRAY_CASTER(Float64);
+
+#undef DECL_MM_SIMPLE_ARRAY_CASTER
 
 } /* end namespace detail */
 } /* end namespace pybind11 */


### PR DESCRIPTION
a short fix for macro renaming with the prefix `DECL_MM_`