### PR TITLE
define buffer for simple array plex wrapper and other refactoring

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.cpp
+++ b/cpp/modmesh/buffer/SimpleArray.cpp
@@ -172,7 +172,7 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const DataType data_t
         DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape)
         DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape)
     default:
-        throw std::runtime_error("Unsupported datatype");
+        throw std::invalid_argument("Unsupported datatype");
     }
 }
 
@@ -194,7 +194,7 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const std::shared_ptr
         DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape, buffer)
         DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape, buffer)
     default:
-        throw std::runtime_error("Unsupported datatype");
+        throw std::invalid_argument("Unsupported datatype");
     }
 }
 
@@ -291,7 +291,7 @@ SimpleArrayPlex::SimpleArrayPlex(SimpleArrayPlex const & other)
     }
     default:
     {
-        throw std::runtime_error("Unsupported datatype");
+        throw std::invalid_argument("Unsupported datatype");
     }
     }
 }
@@ -408,7 +408,7 @@ SimpleArrayPlex & SimpleArrayPlex::operator=(SimpleArrayPlex const & other)
     }
     default:
     {
-        throw std::runtime_error("Unsupported datatype");
+        throw std::invalid_argument("Unsupported datatype");
     }
     }
     return *this;

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -35,87 +35,43 @@ namespace python
 {
 
 /// Execute the callback function with the typed array
-/// @tparam Callable the type of the callback function
+/// @tparam C the type of the callback function
 /// @param arrayplex the plex array, which is the wrapper of the typed array
 /// @param callback the callback function, which has the typed array as the argument
 /// @return the return type of the callback function
-template <typename Callable>
+template <typename C>
 // NOLINTNEXTLINE(misc-use-anonymous-namespace)
-static auto execute_callback_with_typed_array(SimpleArrayPlex & arrayplex, Callable && callback)
+static auto execute_callback_with_typed_array(SimpleArrayPlex & arrayplex, C && callback)
 {
+// We get the typed array from the arrayplex and call the callback function with the typed array.
+#define DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType, ArrayType)                 \
+    case DataType:                                                                 \
+    {                                                                              \
+        auto * array = static_cast<ArrayType *>(arrayplex.mutable_instance_ptr()); \
+        return callback(*array);                                                   \
+        break;                                                                     \
+    }
+
     switch (arrayplex.data_type())
     {
-    case DataType::Bool:
-    {
-        auto * array = static_cast<SimpleArrayBool *>(arrayplex.mutable_instance_ptr());
-        return callback(*array);
-        break;
-    }
-    case DataType::Int8:
-    {
-        auto * array = static_cast<SimpleArrayInt8 *>(arrayplex.mutable_instance_ptr());
-        return callback(*array);
-        break;
-    }
-    case DataType::Int16:
-    {
-        auto * array = static_cast<SimpleArrayInt16 *>(arrayplex.mutable_instance_ptr());
-        return callback(*array);
-        break;
-    }
-    case DataType::Int32:
-    {
-        auto * array = static_cast<SimpleArrayInt32 *>(arrayplex.mutable_instance_ptr());
-        return callback(*array);
-        break;
-    }
-    case DataType::Int64:
-    {
-        auto * array = static_cast<SimpleArrayInt64 *>(arrayplex.mutable_instance_ptr());
-        return callback(*array);
-        break;
-    }
-    case DataType::Uint8:
-    {
-        auto * array = static_cast<SimpleArrayUint8 *>(arrayplex.mutable_instance_ptr());
-        return callback(*array);
-        break;
-    }
-    case DataType::Uint16:
-    {
-        auto * array = static_cast<SimpleArrayUint16 *>(arrayplex.mutable_instance_ptr());
-        return callback(*array);
-        break;
-    }
-    case DataType::Uint32:
-    {
-        auto * array = static_cast<SimpleArrayUint32 *>(arrayplex.mutable_instance_ptr());
-        return callback(*array);
-        break;
-    }
-    case DataType::Uint64:
-    {
-        auto * array = static_cast<SimpleArrayUint64 *>(arrayplex.mutable_instance_ptr());
-        return callback(*array);
-        break;
-    }
-    case DataType::Float32:
-    {
-        auto * array = static_cast<SimpleArrayFloat32 *>(arrayplex.mutable_instance_ptr());
-        return callback(*array);
-        break;
-    }
-    case DataType::Float64:
-    {
-        auto * array = static_cast<SimpleArrayFloat64 *>(arrayplex.mutable_instance_ptr());
-        return callback(*array);
-        break;
-    }
+        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Bool, SimpleArrayBool)
+        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Int8, SimpleArrayInt8)
+        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Int16, SimpleArrayInt16)
+        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Int32, SimpleArrayInt32)
+        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Int64, SimpleArrayInt64)
+        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Uint8, SimpleArrayUint8)
+        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Uint16, SimpleArrayUint16)
+        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Uint32, SimpleArrayUint32)
+        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Uint64, SimpleArrayUint64)
+        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Float32, SimpleArrayFloat32)
+        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Float64, SimpleArrayFloat64)
     default:
     {
         throw std::invalid_argument("Unsupported datatype");
     }
     }
+
+#undef DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY
 }
 
 /// Check the data type of the python value match the given data type. If not, throw a type error.

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -716,7 +716,7 @@ class SimpleArrayPlexTC(unittest.TestCase):
         # 2. shape and value constructor
         modmesh.SimpleArray((2, 3, 4), dtype="bool", value=True)
         with self.assertRaisesRegex(
-                RuntimeError,
+                TypeError,
                 r"Data type mismatch, expected Python bool"
         ):
             modmesh.SimpleArray((2, 3, 4), dtype="bool", value=3.3)
@@ -728,7 +728,7 @@ class SimpleArrayPlexTC(unittest.TestCase):
         for dtype in dtype_list_int:
             modmesh.SimpleArray((2, 3, 4), dtype=dtype, value=3)
             with self.assertRaisesRegex(
-                RuntimeError,
+                TypeError,
                 r"Data type mismatch, expected Python int"
             ):
                 modmesh.SimpleArray((2, 3, 4), dtype=dtype, value=3.3)
@@ -737,7 +737,7 @@ class SimpleArrayPlexTC(unittest.TestCase):
         for dtype in dtype_list_float:
             modmesh.SimpleArray((2, 3, 4), dtype=dtype, value=3.0)
             with self.assertRaisesRegex(
-                RuntimeError,
+                TypeError,
                 r"Data type mismatch, expected Python float"
             ):
                 modmesh.SimpleArray((2, 3, 4), dtype=dtype, value=3)
@@ -753,5 +753,13 @@ class SimpleArrayPlexTC(unittest.TestCase):
             modmesh.SimpleArray(ndarr)
         boolean_array = np.array([True, False, True], dtype='bool')
         modmesh.SimpleArray(boolean_array)
+
+    def test_SimpleArrayPlex_buffer(self):
+        magic_number = 3.1415
+        sarr = modmesh.SimpleArray(
+            (2, 3, 4), value=magic_number, dtype='float64')
+        ndarr = np.array(sarr, copy=False)
+        self.assertEqual((2, 3, 4), ndarr.shape)
+        self.assertEqual((ndarr == magic_number).all(), True)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
In this PR there are 3 major changes:
- defined simple array plex wrapper's buffer
- fixed all incorrect exception types
- refactored the code using typed arrays with `execute_callback_with_typed_array`