### PR TITLE
fix macos-14 ci

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -264,8 +264,8 @@ jobs:
         run: |
           echo "which python3: $(which python3)"
           ls -al $(which python3)
-          if [ "${{ matrix.os }}" == "macos-13" ] ; then
-            # suppress the warning of pip because of python link issue of brew
+          if [ "${{ matrix.os }}" == "macos-13" ] || [ "${{ matrix.os }}" == "macos-14" ] ; then
+            # suppress the warning of pip because brew forces PEP668 since python3.12
             python3 -m pip -v install --upgrade setuptools  --break-system-packages
             python3 -m pip -v install --upgrade pip  --break-system-packages
             python3 -m pip -v install --upgrade numpy pytest flake8  --break-system-packages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -179,8 +179,8 @@ jobs:
         run: |
           echo "which python3: $(which python3)"
           ls -al $(which python3)
-          if [ "${{ matrix.os }}" == "macos-13" ] ; then
-            # suppress the warning of pip because of python link issue of brew
+          if [ "${{ matrix.os }}" == "macos-13" ] || [ "${{ matrix.os }}" == "macos-14" ] ; then
+            # suppress the warning of pip because brew forces PEP668 since python3.12
             python3 -m pip -v install --upgrade setuptools --break-system-packages
             python3 -m pip -v install --upgrade pip --break-system-packages
             python3 -m pip -v install --upgrade numpy pytest flake8 pyside6==$(qmake -query QT_VERSION) --break-system-packages


### PR DESCRIPTION
This is a temporary fix of macOS-14 CI, similar to the previous PR https://github.com/solvcon/modmesh/pull/293.

The error happens during pip install:
https://github.com/solvcon/modmesh/actions/runs/8483820632/job/23245585597

The root cause is Homebrew's enforcement of PEP668 policy, which prohibits the direct installation of python packages not managed by Homebrew.
https://docs.brew.sh/Homebrew-and-Python#pep-668-python312-and-virtual-environments

@yungyuc @tigercosmos ready for review, thanks.