### PR TITLE
Fix Github Actions mac failure

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -57,8 +57,14 @@ jobs:
           echo "cmake version: $(cmake --version)"
           echo "python3 path: $(which python3)"
           echo "python3 version: $(python3 --version)"
+          echo "python3-config --prefix: $(python3-config --prefix)"
+          echo "python3-config --exec-prefix: $(python3-config --exec-prefix)"
+          echo "python3-config --includes: $(python3-config --includes)"
+          echo "python3-config --libs: $(python3-config --libs)"
+          echo "python3-config --cflags: $(python3-config --cflags)"
+          echo "python3-config --ldflags: $(python3-config --ldflags)"
           echo "pip3 path: $(which pip3)"
-          python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
+          python3 -c 'import numpy as np; print("np.__version__:", np.__version__, np.get_include())'
           echo "pytest path: $(which pytest)"
           echo "pytest version: $(pytest --version)"
           echo "clang-tidy path: $(which clang-tidy)"
@@ -137,8 +143,14 @@ jobs:
         echo "cmake version: $(cmake --version)"
         echo "python3 path: $(which python3)"
         echo "python3 version: $(python3 --version)"
+        echo "python3-config --prefix: $(python3-config --prefix)"
+        echo "python3-config --exec-prefix: $(python3-config --exec-prefix)"
+        echo "python3-config --includes: $(python3-config --includes)"
+        echo "python3-config --libs: $(python3-config --libs)"
+        echo "python3-config --cflags: $(python3-config --cflags)"
+        echo "python3-config --ldflags: $(python3-config --ldflags)"
         echo "pip3 path: $(which pip3)"
-        python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
+        python3 -c 'import numpy as np; print("np.__version__:", np.__version__, np.get_include())'
         echo "pytest path: $(which pytest)"
         echo "pytest version: $(pytest --version)"
         echo "clang-tidy path: $(which clang-tidy)"
@@ -249,15 +261,13 @@ jobs:
       - name: event name
         run: |
           echo "github.event_name: ${{ github.event_name }}"
+          # Some mac runner does not have /usr/local/include and cmake sometimes crashes
+          sudo mkdir -p /usr/local/include
 
       - name: dependency by homebrew
         run: |
           export HOMEBREW_NO_AUTO_UPDATE=1
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-          if [ "${{ matrix.os }}" == "macos-13" ] ; then
-            # GitHub Action macOS 13 has a problem with python3
-            brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done;
-          fi
           brew install qt6
 
       - name: dependency by pip
@@ -279,10 +289,8 @@ jobs:
 
       - name: dependency by manual script
         run: |
-          sudo ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
-          if [ "${{ matrix.os }}" == "macos-13" ] || [ "${{ matrix.os }}" == "macos-14" ] ; then \
-            thirdparty/metal-cpp.sh ; \
-          fi
+          sudo NO_INSTALL_PREFIX=1 ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
+          thirdparty/metal-cpp.sh
 
       - name: show dependency
         # Copy the commands from contrib/dependency/showdep.sh
@@ -293,8 +301,14 @@ jobs:
           echo "cmake version: $(cmake --version)"
           echo "python3 path: $(which python3)"
           echo "python3 version: $(python3 --version)"
+          echo "python3-config --prefix: $(python3-config --prefix)"
+          echo "python3-config --exec-prefix: $(python3-config --exec-prefix)"
+          echo "python3-config --includes: $(python3-config --includes)"
+          echo "python3-config --libs: $(python3-config --libs)"
+          echo "python3-config --cflags: $(python3-config --cflags)"
+          echo "python3-config --ldflags: $(python3-config --ldflags)"
           echo "pip3 path: $(which pip3)"
-          python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
+          python3 -c 'import numpy as np; print("np.__version__:", np.__version__, np.get_include())'
           echo "pytest path: $(which pytest)"
           echo "pytest version: $(pytest --version)"
           echo "clang-tidy path: $(which clang-tidy)"
@@ -456,7 +470,7 @@ jobs:
           Get-Command cmake
           Get-Command python3
           Get-Command pip3
-          python3 -c "import numpy ; print('numpy.__version__:', numpy.__version__)"
+          python3 -c 'import numpy as np; print("np.__version__:", np.__version__, np.get_include())'
           python3 -c "import pybind11 ; print('pybind11.__version__:', pybind11.__version__)"
           pybind11-config --cmakedir
           Get-Command pytest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -101,8 +101,14 @@ jobs:
         echo "cmake version: $(cmake --version)"
         echo "python3 path: $(which python3)"
         echo "python3 version: $(python3 --version)"
+        echo "python3-config --prefix: $(python3-config --prefix)"
+        echo "python3-config --exec-prefix: $(python3-config --exec-prefix)"
+        echo "python3-config --includes: $(python3-config --includes)"
+        echo "python3-config --libs: $(python3-config --libs)"
+        echo "python3-config --cflags: $(python3-config --cflags)"
+        echo "python3-config --ldflags: $(python3-config --ldflags)"
         echo "pip3 path: $(which pip3)"
-        python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
+        python3 -c 'import numpy as np; print("np.__version__:", np.__version__, np.get_include())'
         echo "pytest path: $(which pytest)"
         echo "pytest version: $(pytest --version)"
         echo "clang-tidy path: $(which clang-tidy)"
@@ -162,15 +168,13 @@ jobs:
       - name: event name
         run: |
           echo "github.event_name: ${{ github.event_name }}"
+          # Some mac runner does not have /usr/local/include and cmake sometimes crashes
+          sudo mkdir -p /usr/local/include
 
       - name: dependency by homebrew
         run: |
           export HOMEBREW_NO_AUTO_UPDATE=1
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-          if [ "${{ matrix.os }}" == "macos-13" ] ; then
-            # GitHub Action macOS 13 has a problem with python3
-            brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done;
-          fi
           brew install llvm@16 qt6
           ln -s "$(brew --prefix llvm@16)/bin/clang-format" "/usr/local/bin/clang-format"
           ln -s "$(brew --prefix llvm@16)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
@@ -191,7 +195,7 @@ jobs:
           fi
   
       - name: dependency (manual)
-        run: sudo ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
+        run: sudo NO_INSTALL_PREFIX=1 ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
 
       - name: show dependency
         # Copy the commands from contrib/dependency/showdep.sh
@@ -202,8 +206,14 @@ jobs:
           echo "cmake version: $(cmake --version)"
           echo "python3 path: $(which python3)"
           echo "python3 version: $(python3 --version)"
+          echo "python3-config --prefix: $(python3-config --prefix)"
+          echo "python3-config --exec-prefix: $(python3-config --exec-prefix)"
+          echo "python3-config --includes: $(python3-config --includes)"
+          echo "python3-config --libs: $(python3-config --libs)"
+          echo "python3-config --cflags: $(python3-config --cflags)"
+          echo "python3-config --ldflags: $(python3-config --ldflags)"
           echo "pip3 path: $(which pip3)"
-          python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
+          python3 -c 'import numpy as np; print("np.__version__:", np.__version__, np.get_include())'
           echo "pytest path: $(which pytest)"
           echo "pytest version: $(pytest --version)"
           echo "clang-tidy path: $(which clang-tidy)"

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -59,8 +59,14 @@ jobs:
         echo "cmake version: $(cmake --version)"
         echo "python3 path: $(which python3)"
         echo "python3 version: $(python3 --version)"
+        echo "python3-config --prefix: $(python3-config --prefix)"
+        echo "python3-config --exec-prefix: $(python3-config --exec-prefix)"
+        echo "python3-config --includes: $(python3-config --includes)"
+        echo "python3-config --libs: $(python3-config --libs)"
+        echo "python3-config --cflags: $(python3-config --cflags)"
+        echo "python3-config --ldflags: $(python3-config --ldflags)"
         echo "pip3 path: $(which pip3)"
-        python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
+        python3 -c 'import numpy as np; print("np.__version__:", np.__version__, np.get_include())'
         echo "pytest path: $(which pytest)"
         echo "pytest version: $(pytest --version)"
         echo "clang-tidy path: $(which clang-tidy)"
@@ -143,8 +149,14 @@ jobs:
           echo "cmake version: $(cmake --version)"
           echo "python3 path: $(which python3)"
           echo "python3 version: $(python3 --version)"
+          echo "python3-config --prefix: $(python3-config --prefix)"
+          echo "python3-config --exec-prefix: $(python3-config --exec-prefix)"
+          echo "python3-config --includes: $(python3-config --includes)"
+          echo "python3-config --libs: $(python3-config --libs)"
+          echo "python3-config --cflags: $(python3-config --cflags)"
+          echo "python3-config --ldflags: $(python3-config --ldflags)"
           echo "pip3 path: $(which pip3)"
-          python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
+          python3 -c 'import numpy as np; print("np.__version__:", np.__version__, np.get_include())'
           echo "pytest path: $(which pytest)"
           echo "pytest version: $(pytest --version)"
           echo "clang-tidy path: $(which clang-tidy)"

--- a/contrib/dependency/install.sh
+++ b/contrib/dependency/install.sh
@@ -38,19 +38,25 @@ install() {
 
 pybind11() {
 
-  cmakeargs=("-DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}")
-  cmakeargs+=("-DCMAKE_BUILD_TYPE=Release")
+  cmakeargs=("-DCMAKE_BUILD_TYPE=Release")
+  if [ -z "${NO_INSTALL_PREFIX}" ] ; then
+  cmakeargs+=("-DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}")
+  fi
+  cmakeargs+=("-DUSE_PYTHON_INCLUDE_DIR=ON")
   cmakeargs+=("-DPYTHON_EXECUTABLE:FILEPATH=`which python3`")
   cmakeargs+=("-DPYBIND11_TEST=OFF")
-  install ${PYBIND_ORG:-pybind} pybind11 ${PYBIND_BRANCH:-v2.11.1} \
-    ${PYBIND_LOCAL:-pybind11-2.11.1} "${cmakeargs[@]}"
+  echo "cmakeargs: ${cmakeargs[@]}"
+  install ${PYBIND_ORG:-pybind} pybind11 ${PYBIND_BRANCH:-v2.12.0} \
+    ${PYBIND_LOCAL:-pybind11-2.12.0} "${cmakeargs[@]}"
 
 }
 
 xtl() {
 
-  cmakeargs=("-DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}")
-  cmakeargs+=("-DCMAKE_BUILD_TYPE=Release")
+  cmakeargs=("-DCMAKE_BUILD_TYPE=Release")
+  if [ -z "${NO_INSTALL_PREFIX}" ] ; then
+  cmakeargs+=("-DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}")
+  fi
   install ${XTL_ORG:-xtensor-stack} xtl ${XTL_BRANCH:-0.6.9} \
     ${XTL_LOCAL:-xtl-0.6.9} "${cmakeargs[@]}"
 
@@ -58,8 +64,10 @@ xtl() {
 
 xsimd() {
 
-  cmakeargs=("-DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}")
-  cmakeargs+=("-DCMAKE_BUILD_TYPE=Release")
+  cmakeargs=("-DCMAKE_BUILD_TYPE=Release")
+  if [ -z "${NO_INSTALL_PREFIX}" ] ; then
+  cmakeargs+=("-DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}")
+  fi
   cmakeargs+=("-DBUILD_TESTS=OFF")
   install ${XSIMD_ORG:-xtensor-stack} xsimd ${XSIMD_BRANCH:-7.4.4} \
     ${XSIMD_LOCAL:-xsimd-7.4.4} "${cmakeargs[@]}"
@@ -68,8 +76,10 @@ xsimd() {
 
 xtensor() {
 
-  cmakeargs=("-DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}")
-  cmakeargs+=("-DCMAKE_BUILD_TYPE=Release")
+  cmakeargs=("-DCMAKE_BUILD_TYPE=Release")
+  if [ -z "${NO_INSTALL_PREFIX}" ] ; then
+  cmakeargs+=("-DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}")
+  fi
   install ${XTENSOR_ORG:-xtensor-stack} xtensor ${XTENSOR_BRANCH:-0.21.2} \
     ${XTENSOR_LOCAL:-xtensor-0.21.2} "${cmakeargs[@]}"
 
@@ -77,8 +87,10 @@ xtensor() {
 
 xtensor_python() {
 
-  cmakeargs=("-DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}")
-  cmakeargs+=("-DCMAKE_BUILD_TYPE=Release")
+  cmakeargs=("-DCMAKE_BUILD_TYPE=Release")
+  if [ -z "${NO_INSTALL_PREFIX}" ] ; then
+  cmakeargs+=("-DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}")
+  fi
   install ${XTENSOR_PYTHON_ORG:-xtensor-stack} xtensor-python \
     ${XTENSOR_PYTHON_BRANCH:-0.24.1} \
     ${XTENSOR_PYTHON_LOCAL:-xtensor-python-0.24.1} "${cmakeargs[@]}"


### PR DESCRIPTION
GHA CI mac runs failed with [inability to find `pybind11/pybind11.h` include file](https://github.com/solvcon/modmesh/actions/runs/8665855764/job/23765404198#step:9:65).  The root cause could be the change of the GHA mac image.  This PR fixes the failure by the following measures:

* pybind11 installs in `/usr/local/include` which MacOS Github Actions does not include.
  * Use `-DUSE_PYTHON_INCLUDE_DIR=ON` to change the installation path to Python include directory which is already picked up by the modmesh cmake configuration.
  * Create `/usr/local/include` for mac
* Improve `contrib/install.sh`
  * pybind11 uses `-DUSE_PYTHON_INCLUDE_DIR=ON`
  * Upgrade pybind11 from 2.11.1 to 2.12.0
  * Allow skipping `INSTALL_PREFIX`
  * Print cmakeargs