### PR TITLE
remove DEBUG_BUILD_OPTIMIZATION_ONE

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -477,26 +477,24 @@ jobs:
           Get-Command clang-tidy
           Get-Command flake8
 
-      - name: cmake ALL_BUILD USE_PYTEST_HELPER_BINDING=OFF DEBUG_BUILD_OPTIMIZATION_ONE=ON
+      - name: cmake ALL_BUILD USE_PYTEST_HELPER_BINDING=OFF
         run: |
           cmake `
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} `
             -Dpybind11_DIR="$(pybind11-config --cmakedir)" `
-            -DDEBUG_BUILD_OPTIMIZATION_ONE=ON `
             -S${{ github.workspace }} `
             -B${{ github.workspace }}/build
           cmake --build ${{ github.workspace }}/build `
             --config ${{ matrix.cmake_build_type }} `
             --target ALL_BUILD
 
-      - name: cmake ALL_BUILD USE_PYTEST_HELPER_BINDING=ON DEBUG_BUILD_OPTIMIZATION_ONE=ON
+      - name: cmake ALL_BUILD USE_PYTEST_HELPER_BINDING=ON
         run: |
           Remove-Item -Path ${{ github.workspace }}/build -Recurse -Force
           cmake `
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} `
             -Dpybind11_DIR="$(pybind11-config --cmakedir)" `
             -DUSE_PYTEST_HELPER_BINDING=ON `
-            -DDEBUG_BUILD_OPTIMIZATION_ONE=ON `
             -S${{ github.workspace }} `
             -B${{ github.workspace }}/build
           cmake --build ${{ github.workspace }}/build `

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -224,20 +224,20 @@ jobs:
       - name: make cinclude (check_include)
         run: make cinclude
 
-      - name: make viewer USE_PYTEST_HELPER_BINDING=OFF DEBUG_BUILD_OPTIMIZATION_ONE=ON
+      - name: make viewer USE_PYTEST_HELPER_BINDING=OFF
         run: |
           make viewer \
             ${JOB_MAKE_ARGS} \
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON -DDEBUG_BUILD_OPTIMIZATION_ONE=ON"
+            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON"
 
-      - name: make viewer USE_PYTEST_HELPER_BINDING=ON DEBUG_BUILD_OPTIMIZATION_ONE=ON
+      - name: make viewer USE_PYTEST_HELPER_BINDING=ON
         run: |
           rm -f build/*/Makefile
           make viewer \
             ${JOB_MAKE_ARGS} \
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON -DDEBUG_BUILD_OPTIMIZATION_ONE=ON"
+            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON"
 
       - name: make run_viewer_pytest
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,6 @@ option(LINT_AS_ERRORS "clang-tidy warnings as errors" OFF)
 # - Address Sanitization: Protecting against address-related vulnerabilities. See https://clang.llvm.org/docs/AddressSanitizer.html
 option(USE_SANITIZER "use sanitizer (undefined, leak, address)" OFF)
 
-# FIXME: A workaround flag, check more on https://github.com/solvcon/modmesh/issues/283
-# For macOS and Windows development, please turn on this flag to avoid the issue.
-option(DEBUG_BUILD_OPTIMIZATION_ONE "use -O1 for debug build. This is a workaround for issue#283." OFF)
-message(STATUS "DEBUG_BUILD_OPTIMIZATION_ONE: ${DEBUG_BUILD_OPTIMIZATION_ONE}")
-
 option(USE_PYTEST_HELPER_BINDING "use helper bindings to run pytest. should be ON if the build is for pytest" OFF)
 if(USE_PYTEST_HELPER_BINDING)
     add_definitions(-D USE_PYTEST_HELPER_BINDING)
@@ -97,20 +92,8 @@ message(STATUS "DEBUG_SYMBOL: ${DEBUG_SYMBOL}")
 if(DEBUG_SYMBOL)
     if(MSVC)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DEBUG")
-        if(DEBUG_BUILD_OPTIMIZATION_ONE)
-            # MSVC optimization flags are different from GCC/Clang, so there is no -O1 in MSVC.
-            # /O1 means minimize size and /O2 means maximun speed.
-            # We found that only /O2 can have the correct behavior, so we set /O2 here.
-            # /Ob2 is the default value of /O2, but we found that it need to explicitly set /Ob2 to have the correct behavior.
-            # See more: https://learn.microsoft.com/en-us/cpp/build/reference/o1-o2-minimize-size-maximize-speed
-            add_compile_options(/O2 /Ob2)
-            string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}") # /RTC1 incompatible with /O1
-        endif()
     else()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
-        if(DEBUG_BUILD_OPTIMIZATION_ONE)
-            add_compile_options(-O1)
-        endif()
     endif()
 endif()
 

--- a/cpp/modmesh/buffer/pymod/array_common.hpp
+++ b/cpp/modmesh/buffer/pymod/array_common.hpp
@@ -33,6 +33,14 @@
 #include <modmesh/buffer/SimpleArray.hpp>
 #include <modmesh/buffer/pymod/TypeBroadcast.hpp>
 
+// We faced an issue where the template specialization for the caster of
+// SimpleArray<T> doesn't function correctly on both macOS and Windows.
+// While the root cause of the problem remains unclear, a workaround is
+// available by including the caster header in this file, impacting
+// wrap_SimpleArray.cpp.
+// See more details in the issue: https://github.com/solvcon/modmesh/issues/283
+#include <modmesh/buffer/pymod/SimpleArrayCaster.hpp>
+
 namespace modmesh
 {
 

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -152,7 +152,13 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
         namespace py = pybind11; // NOLINT(misc-unused-alias-decls)
 
         (*this)
-            .def("fill", &wrapped_type::fill, py::arg("value"))
+            .def(
+                // Use lambda to avoid bad implicit conversion of SimpleArray<T>in pybind11
+                // (see https://github.com/solvcon/modmesh/issues/283)
+                "fill",
+                [](wrapped_type & arr, value_type const value)
+                { arr.fill(value); },
+                py::arg("value"))
             //
             ;
 


### PR DESCRIPTION
To address #283, two steps should be applied.
- put the `SimpleArrayCaster.hpp` into `array_common.hpp` (check more at the comments in the code)
- refactored `wrap_modifiers()`, which leads some type issues for pybind11 when we introduce customized caster for the array.

close #283