### PR TITLE
`BufferExpander::m_end` is used before initialization

### DIFF
--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -72,7 +72,7 @@ public:
     BufferExpander(std::shared_ptr<ConcreteBuffer> const & buf, bool clone, ctor_passkey const &)
         : m_concrete_buffer(clone ? buf->clone() : buf)
         , m_begin(m_concrete_buffer->data())
-        , m_end(m_begin + size())
+        , m_end(m_begin + m_concrete_buffer->size())
         , m_end_cap(m_begin + m_concrete_buffer->size())
     {
     }

--- a/cpp/modmesh/buffer/pymod/wrap_ConcreteBuffer.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_ConcreteBuffer.cpp
@@ -133,6 +133,8 @@ WrapBufferExpander::WrapBufferExpander(pybind11::module & mod, char const * pyna
             py::arg("length"))
         .def_timed(py::init([]()
                             { return wrapped_type::construct(); }))
+        .def_timed(py::init([](std::shared_ptr<ConcreteBuffer> const & buf)
+                            { return wrapped_type::construct(buf, /*clone*/ true); }))
         .def_timed("reserve", &wrapped_type::reserve, py::arg("cap"))
         .def_timed("expand", &wrapped_type::expand, py::arg("length"))
         .def_property_readonly("capacity", &wrapped_type::capacity)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -139,6 +139,20 @@ class BufferExpanderBasicTC(unittest.TestCase):
             cbuf[it] = it + 10
         self.assertEqual(list(i + 10 for i in range(10)), list(ep))
 
+    def test_BufferExpanderFromConcreteBuffer(self):
+        buf = modmesh.ConcreteBuffer(10)
+        for it in range(len(buf)):
+            buf[it] = it
+
+        ep = modmesh.BufferExpander(buf)
+        self.assertEqual(10, ep.capacity)
+        self.assertEqual(10, len(ep))
+        for it in range(len(ep)):
+            ep[it] = it + 100
+
+        for it in range(len(buf)):
+            self.assertEqual(buf[it] + 100, ep[it])
+
 
 class SimpleArrayBasicTC(unittest.TestCase):
 


### PR DESCRIPTION
`BufferExpander::size()` is wrongly called when initializing `m_end`