### PR TITLE
add missing cancel() for CallProfiler

### DIFF
--- a/cpp/modmesh/toggle/RadixTree.cpp
+++ b/cpp/modmesh/toggle/RadixTree.cpp
@@ -43,6 +43,7 @@ void CallProfiler::reset()
         m_radix_tree.move_current_to_parent();
     }
     m_radix_tree.reset();
+    m_cancel_callbacks.clear();
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)

--- a/gtests/test_nopython_callprofiler.cpp
+++ b/gtests/test_nopython_callprofiler.cpp
@@ -191,5 +191,26 @@ TEST_F(CallProfilerTest, simple_case_2)
     }
 }
 
+TEST_F(CallProfilerTest, cancel)
+{
+    pProfiler->reset();
+
+    auto test1 = [&]()
+    {
+        USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+
+        auto test2 = [&]()
+        {
+            USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+            pProfiler->cancel();
+        };
+
+        test2();
+    };
+    test1();
+
+    EXPECT_EQ(radix_tree().get_unique_node(), 0);
+}
+
 } // namespace detail
 } // namespace modmesh


### PR DESCRIPTION
add the missing `cancel()` for `CallProfiler`.

This PR should be merged before #315.