### PR TITLE
Add a basic drawer for the NACA 4-digit airfoil

### DIFF
--- a/cpp/modmesh/universe/World.hpp
+++ b/cpp/modmesh/universe/World.hpp
@@ -57,6 +57,7 @@ public:
     using real_type = T;
     using value_type = T;
     using vector_type = Vector3d<T>;
+    using edge_type = Edge3d<T>;
     using bezier_type = Bezier3d<T>;
 
     template <typename... Args>
@@ -73,6 +74,25 @@ public:
     World & operator=(World const &) = delete;
     World & operator=(World &&) = delete;
     ~World() = default;
+
+    void add_edge(edge_type const & edge);
+    void add_edge(value_type x0, value_type y0, value_type z0, value_type x1, value_type y1, value_type z1)
+    {
+        add_edge(edge_type(x0, y0, z0, x1, y1, z1));
+    }
+    size_t nedge() const { return m_edges.size(); }
+    edge_type const & edge(size_t i) const { return m_edges[i]; }
+    edge_type & edge(size_t i) { return m_edges[i]; }
+    edge_type const & edge_at(size_t i) const
+    {
+        check_size(i, m_edges.size(), "edge");
+        return m_edges[i];
+    }
+    edge_type & edge_at(size_t i)
+    {
+        check_size(i, m_edges.size(), "edge");
+        return m_edges[i];
+    }
 
     void add_bezier(std::vector<vector_type> const & controls);
     size_t nbezier() const { return m_beziers.size(); }
@@ -99,9 +119,16 @@ private:
         }
     }
 
+    std::deque<Edge3d<T>> m_edges;
     std::deque<Bezier3d<T>> m_beziers;
 
 }; /* end class World */
+
+template <typename T>
+void World<T>::add_edge(edge_type const & edge)
+{
+    m_edges.emplace_back(edge);
+}
 
 template <typename T>
 void World<T>::add_bezier(std::vector<vector_type> const & controls)

--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -125,8 +125,8 @@ public:
     using vector_type = Vector3d<T>;
     using value_type = typename vector_type::value_type;
 
-    Edge3d(vector_type const & tail, vector_type const & head)
-        : m_vec{tail, head}
+    Edge3d(vector_type const & v0, vector_type const & v1)
+        : m_vec{v0, v1}
     {
     }
 
@@ -144,8 +144,10 @@ public:
 
     vector_type const & v0() const { return m_vec[0]; }
     vector_type & v0() { return m_vec[0]; }
+    void set_v0(vector_type const & v) { m_vec[0] = v; }
     vector_type const & v1() const { return m_vec[1]; }
     vector_type & v1() { return m_vec[1]; }
+    void set_v1(vector_type const & v) { m_vec[1] = v; }
 
     value_type x0() const { return m_vec[0].x(); }
     value_type & x0() { return m_vec[0].x(); }

--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -29,6 +29,7 @@
  */
 
 #include <modmesh/base.hpp>
+#include <modmesh/buffer/buffer.hpp>
 #include <modmesh/universe/bernstein.hpp>
 
 #include <deque>
@@ -108,6 +109,100 @@ private:
 
 using Vector3dFp32 = Vector3d<float>;
 using Vector3dFp64 = Vector3d<double>;
+
+/**
+ * Vector or point in three-dimensional space.
+ *
+ * @tparam T floating-point type
+ */
+template <typename T>
+class Edge3d
+    : public NumberBase<int32_t, T>
+{
+
+public:
+
+    using vector_type = Vector3d<T>;
+    using value_type = typename vector_type::value_type;
+
+    Edge3d(vector_type const & tail, vector_type const & head)
+        : m_vec{tail, head}
+    {
+    }
+
+    Edge3d(value_type x0, value_type y0, value_type z0, value_type x1, value_type y1, value_type z1)
+        : m_vec{vector_type{x0, y0, z0}, vector_type{x1, y1, z1}}
+    {
+    }
+
+    Edge3d() = default;
+    Edge3d(Edge3d const &) = default;
+    Edge3d & operator=(Edge3d const &) = default;
+    Edge3d(Edge3d &&) = default;
+    Edge3d & operator=(Edge3d &&) = default;
+    ~Edge3d() = default;
+
+    vector_type const & v0() const { return m_vec[0]; }
+    vector_type & v0() { return m_vec[0]; }
+    vector_type const & v1() const { return m_vec[1]; }
+    vector_type & v1() { return m_vec[1]; }
+
+    value_type x0() const { return m_vec[0].x(); }
+    value_type & x0() { return m_vec[0].x(); }
+    void set_x0(value_type v) { m_vec[0].set_x(v); }
+
+    value_type y0() const { return m_vec[0].y(); }
+    value_type & y0() { return m_vec[0].y(); }
+    void set_y0(value_type v) { m_vec[0].set_y(v); }
+
+    value_type z0() const { return m_vec[0].z(); }
+    value_type & z0() { return m_vec[0].z(); }
+    void set_z0(value_type v) { m_vec[0].set_z(v); }
+
+    value_type x1() const { return m_vec[1].x(); }
+    value_type & x1() { return m_vec[1].x(); }
+    void set_x1(value_type v) { m_vec[1].set_x(v); }
+
+    value_type y1() const { return m_vec[1].y(); }
+    value_type & y1() { return m_vec[1].y(); }
+    void set_y1(value_type v) { m_vec[1].set_y(v); }
+
+    value_type z1() const { return m_vec[1].z(); }
+    value_type & z1() { return m_vec[1].z(); }
+    void set_z1(value_type v) { m_vec[1].set_z(v); }
+
+    vector_type const & operator[](size_t i) const { return m_vec[i]; }
+    vector_type & operator[](size_t i) { return m_vec[i]; }
+
+    vector_type const & at(size_t i) const
+    {
+        check_size(i, 2);
+        return m_vec[i];
+    }
+    vector_type & at(size_t i)
+    {
+        check_size(i, 2);
+        return m_vec[i];
+    }
+
+    size_t size() const { return 2; }
+
+private:
+
+    void check_size(size_t i, size_t s) const
+    {
+        if (i >= s)
+        {
+            throw std::out_of_range(Formatter() << "Edge3d: i " << i << " >= size " << s);
+        }
+    }
+
+    vector_type m_vec[2];
+
+}; /* end class Edge3d */
+
+using Edge3dFp32 = Edge3d<float>;
+using Edge3dFp64 = Edge3d<double>;
 
 /**
  * Bezier curve in three-dimensional space.
@@ -210,6 +305,18 @@ void Bezier3d<T>::sample(size_t nlocus)
 
 using Bezier3dFp32 = Bezier3d<float>;
 using Bezier3dFp64 = Bezier3d<double>;
+
+class PointCloud
+{
+
+public:
+private:
+
+    SimpleCollector<double> m_x;
+    SimpleCollector<double> m_y;
+    SimpleCollector<double> m_z;
+
+}; /* end class PointCloud */
 
 } /* end namespace modmesh */
 

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -132,6 +132,9 @@ WrapEdge3d<T>::WrapEdge3d(pybind11::module & mod, const char * pyname, const cha
     namespace py = pybind11;
 
     (*this)
+        .def(py::init<vector_type const &, vector_type const &>(),
+             py::arg("v0"),
+             py::arg("v1"))
         .def(py::init<value_type, value_type, value_type, value_type, value_type, value_type>(),
              py::arg("x0"),
              py::arg("y0"),

--- a/cpp/modmesh/view/RManager.cpp
+++ b/cpp/modmesh/view/RManager.cpp
@@ -162,6 +162,7 @@ void RManager::setUpMenu()
         m_appMenu = m_mainWindow->menuBar()->addMenu(QString("Mesh"));
 
         this->addApplication(QString("mh_3dmix"));
+        this->addApplication(QString("naca"));
     }
 
     {

--- a/cpp/modmesh/view/RWorld.cpp
+++ b/cpp/modmesh/view/RWorld.cpp
@@ -49,7 +49,7 @@ RWorld::RWorld(std::shared_ptr<WorldFp64> const & world, Qt3DCore::QNode * paren
 
 void RWorld::update_geometry()
 {
-    size_t npoint = 0;
+    size_t npoint = m_world->nedge() * 2;
     for (size_t i = 0; i < m_world->nbezier(); ++i)
     {
         npoint += m_world->bezier(i).nlocus();
@@ -75,6 +75,18 @@ void RWorld::update_geometry()
                 barray.resize(npoint * 3 * sizeof(float));
                 SimpleArray<float> sarr = makeSimpleArray<float>(barray, small_vector<size_t>{npoint, 3}, /*view*/ true);
                 size_t ipt = 0;
+                for (size_t i = 0; i < m_world->nedge(); i++)
+                {
+                    Edge3dFp64 const & e = m_world->edge(i);
+                    sarr(ipt, 0) = e.v0()[0];
+                    sarr(ipt, 1) = e.v0()[1];
+                    sarr(ipt, 2) = e.v0()[2];
+                    ++ipt;
+                    sarr(ipt, 0) = e.v1()[0];
+                    sarr(ipt, 1) = e.v1()[1];
+                    sarr(ipt, 2) = e.v1()[2];
+                    ++ipt;
+                }
                 for (size_t i = 0; i < m_world->nbezier(); ++i)
                 {
                     Bezier3dFp64 const & b = m_world->bezier(i);
@@ -103,7 +115,7 @@ void RWorld::update_geometry()
             indices->setVertexBaseType(Qt3DCore::QAttribute::UnsignedInt);
             indices->setAttributeType(Qt3DCore::QAttribute::IndexAttribute);
 
-            size_t nedge = 0;
+            size_t nedge = m_world->nedge();
             {
                 for (size_t i = 0; i < m_world->nbezier(); ++i)
                 {
@@ -119,6 +131,12 @@ void RWorld::update_geometry()
                 SimpleArray<uint32_t> sarr = makeSimpleArray<uint32_t>(barray, small_vector<size_t>{nedge, 2}, /*view*/ true);
                 size_t ied = 0;
                 size_t ipt = 0;
+                for (size_t i = 0; i < m_world->nedge(); ++i)
+                {
+                    sarr(ied, 0) = ipt++;
+                    sarr(ied, 1) = ipt++;
+                    ++ied;
+                }
                 for (size_t i = 0; i < m_world->nbezier(); ++i)
                 {
                     Bezier3dFp64 const & b = m_world->bezier(i);

--- a/modmesh/app/naca.py
+++ b/modmesh/app/naca.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2021, Yung-Yu Chen <yyc@solvcon.net>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+Show NACA airfoil shape
+"""
+
+import numpy as np
+
+from .. import core
+from .. import view
+from .. import apputil
+
+
+def calc_naca4_points(number, npoint, open_trailing_edge=False,
+                      cosine_spacing=False):
+    """
+    Returns points in [0 1] for the given 4 digit NACA number string.
+    Reference from
+    https://ntrs.nasa.gov/api/citations/19930091108/downloads/19930091108.pdf
+    and https://github.com/dgorissen/naca
+    """
+
+    camber = float(number[0]) / 100.0
+    pos = float(number[1]) / 10.0
+    thick = float(number[2:]) / 100.0
+
+    a0 = +0.2969
+    a1 = -0.1260
+    a2 = -0.3516
+    a3 = +0.2843
+    a4 = -0.1015 if open_trailing_edge else -0.1036
+
+    if cosine_spacing:
+        xc = 0.5 * (1.0 - np.cos(np.linspace(0.0, np.pi, npoint + 1)))
+    else:
+        xc = np.linspace(0.0, 1.0, npoint + 1)
+
+    xh = np.sqrt(xc)
+    x2 = np.power(xc, 2)
+    x3 = np.power(xc, 3)
+    x4 = np.power(xc, 4)
+    yt = 5.0 * thick * (a0 * xh + a1 * xc + a2 * x2 + a3 * x3 + a4 * x4)
+
+    if pos == 0:
+        xu = xc
+        yu = yt
+        xl = xc
+        yl = -yt
+    else:
+        xc1 = xc[xc <= pos]
+        yc1 = camber / np.power(pos, 2) * xc1 * (2 * pos - xc1)
+        dyc1_dx = camber / np.power(pos, 2) * (2 * pos - 2 * xc1)
+
+        xc2 = xc[xc > pos]
+        yc2 = camber / np.power(1 - pos, 2) * (1 - 2 * pos + xc2) * (1 - xc2)
+        dyc2_dx = camber / np.power(1 - pos, 2) * (2 * pos - 2 * xc2)
+
+        yc = np.concatenate([yc1, yc2])
+        dyc_dx = np.concatenate([dyc1_dx, dyc2_dx])
+        theta = np.arctan(dyc_dx)
+
+        xu = xc - yt * np.sin(theta)
+        yu = yc + yt * np.cos(theta)
+        xl = xc + yt * np.sin(theta)
+        yl = yc - yt * np.cos(theta)
+
+    xr = np.concatenate([xu[::-1], xl[1:]])
+    yr = np.concatenate([yu[::-1], yl[1:]])
+    ret = np.vstack([xr, yr]).T.copy()
+    return ret
+
+
+def draw_naca4(world, number, npoint, fac, off_x, off_y, **kw):
+    crds = calc_naca4_points(number=number, npoint=npoint, **kw)
+    crds *= fac  # scaling factor
+    crds[:, 0] += off_x  # offset in x
+    crds[:, 1] += off_y  # offset in y
+    for it in range(crds.shape[0] - 1):
+        e = world.add_edge(crds[it, 0], crds[it, 1], 0,
+                           crds[it + 1, 0], crds[it + 1, 1], 0)
+        print(f"{it}: {e}")
+    print("nedge:", world.nedge)
+    return crds
+
+
+def app_main():
+    """
+    A simple example for drawing a couple of cubic Bezier curves.
+    """
+    w = core.WorldFp64()
+    draw_naca4(w, number='0012', npoint=101, fac=5.0, off_x=0.0, off_y=2.0,
+               open_trailing_edge=False, cosine_spacing=True)
+    return w
+
+
+def load_app():
+    aenv = apputil.get_current_appenv()
+    w = app_main()
+    wid = view.mgr.add3DWidget()
+    wid.updateWorld(w)
+    wid.showMark()
+    symbols = (
+        'calc_naca4_points',
+        'draw_naca4',
+        ('w', w),
+        ('wid', wid),
+        ('add3DWidget', view.mgr.add3DWidget),
+    )
+    for k in symbols:
+        if isinstance(k, tuple):
+            k, o = k
+        else:
+            o = globals().get(k, None)
+            if o is None:
+                o = locals().get(k, None)
+        view.mgr.pycon.writeToHistory(f"Adding symbol {k}\n")
+        aenv.globals[k] = o
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -82,6 +82,8 @@ __all__ = [  # noqa: F822
     'interpolate_bernstein',
     'Vector3dFp32',
     'Vector3dFp64',
+    'Edge3dFp32',
+    'Edge3dFp64',
     'Bezier3dFp32',
     'Bezier3dFp64',
     'WorldFp32',

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -231,6 +231,55 @@ class Vector3dFp64TC(Vector3dTB, unittest.TestCase):
         self.assertIs(modmesh.Vector3dFp64, self.kls)
 
 
+class Edge3dTB(ModMeshTB):
+
+    def test_construct(self):
+        Vector = self.vkls
+        Edge = self.ekls
+
+        e = Edge(x0=0, y0=0, z0=0, x1=1, y1=1, z1=1)
+        self.assertEqual(len(e), 2)
+        self.assertEqual(tuple(e.v0), (0.0, 0.0, 0.0))
+        self.assertEqual(tuple(e.v1), (1.0, 1.0, 1.0))
+
+        e.v0 = Vector(x=3, y=7, z=0)
+        e.v1 = Vector(x=-1, y=-4, z=9)
+        self.assertEqual(e.x0, 3)
+        self.assertEqual(e.y0, 7)
+        self.assertEqual(e.z0, 0)
+        self.assertEqual(e.x1, -1)
+        self.assertEqual(e.y1, -4)
+        self.assertEqual(e.z1, 9)
+
+        e = Edge(Vector(x=3.1, y=7.4, z=0.6), Vector(x=-1.2, y=-4.1, z=9.2))
+        self.assert_allclose(tuple(e.v0), (3.1, 7.4, 0.6))
+        self.assert_allclose(tuple(e.v1), (-1.2, -4.1, 9.2))
+
+
+class Edge3dFp32TC(Edge3dTB, unittest.TestCase):
+
+    def setUp(self):
+        self.vkls = modmesh.Vector3dFp32
+        self.ekls = modmesh.Edge3dFp32
+
+    def assert_allclose(self, *args, **kw):
+        if 'rtol' not in kw:
+            kw['rtol'] = 1.e-7
+        return super().assert_allclose(*args, **kw)
+
+
+class Edge3dFp64TC(Edge3dTB, unittest.TestCase):
+
+    def setUp(self):
+        self.vkls = modmesh.Vector3dFp64
+        self.ekls = modmesh.Edge3dFp64
+
+    def assert_allclose(self, *args, **kw):
+        if 'rtol' not in kw:
+            kw['rtol'] = 1.e-15
+        return super().assert_allclose(*args, **kw)
+
+
 class Bezier3dTB(ModMeshTB):
 
     def test_control_points(self):
@@ -327,8 +376,8 @@ class Bezier3dFp32TC(Bezier3dTB, unittest.TestCase):
 class Bezier3dFp64TC(Bezier3dTB, unittest.TestCase):
 
     def setUp(self):
-        self.vkls = modmesh.Vector3dFp32
-        self.bkls = modmesh.Bezier3dFp32
+        self.vkls = modmesh.Vector3dFp64
+        self.bkls = modmesh.Bezier3dFp64
 
     def assert_allclose(self, *args, **kw):
         if 'rtol' not in kw:


### PR DESCRIPTION
* In the simple NACA app, add `draw_naca4()` and `calc_naca4_points()`.
* Add `Edge3d` class template and allow `RWorld` to render it.
  * Add basic unit tests for constructing `Edge3d` objects in Python.

A NACA0012 airfoil is drawn like:
<img width="376" alt="image" src="https://github.com/solvcon/modmesh/assets/399122/0c2d90e2-38d9-4dd0-ae86-33f2e591b0ea">
