### PR TITLE
Implement the third set of NRBC treatment for 1D Euler solver

### DIFF
--- a/cpp/modmesh/onedim/Euler1DCore.cpp
+++ b/cpp/modmesh/onedim/Euler1DCore.cpp
@@ -153,39 +153,43 @@ void Euler1DCore::march_half_so0(bool odd_plane)
 
 void Euler1DCore::treat_boundary_so0()
 {
+    /* Non-reflecting boundary condition (NRBC) type 3 with $\lambda=0$
+     * (the third set in Chang 05) */
     // Set outside value from inside value.
     {
         // Left boundary.
-        size_t const ic = 0;
-        m_so0(ic, 0) = m_so0(ic + 2, 0);
-        m_so0(ic, 1) = m_so0(ic + 2, 1);
-        m_so0(ic, 2) = m_so0(ic + 2, 2);
+        size_t const ic = 1;
+        m_so0(ic, 0) = m_so0(ic + 1, 0);
+        m_so0(ic, 1) = m_so0(ic + 1, 1);
+        m_so0(ic, 2) = m_so0(ic + 1, 2);
     }
     {
         // Right boundary.
-        size_t const ic = ncoord() - 1;
-        m_so0(ic, 0) = m_so0(ic - 2, 0);
-        m_so0(ic, 1) = m_so0(ic - 2, 1);
-        m_so0(ic, 2) = m_so0(ic - 2, 2);
+        size_t const ic = ncoord() - 2;
+        m_so0(ic, 0) = m_so0(ic - 1, 0);
+        m_so0(ic, 1) = m_so0(ic - 1, 1);
+        m_so0(ic, 2) = m_so0(ic - 1, 2);
     }
 }
 
 void Euler1DCore::treat_boundary_so1()
 {
+    /* Non-reflecting boundary condition (NRBC) type 3 with $\lambda=0$
+     * (the third set in Chang 05) */
     // Set outside value from inside value.
     {
         // Left boundary.
-        size_t const ic = 0;
-        m_so1(ic, 0) = m_so1(ic + 2, 0);
-        m_so1(ic, 1) = m_so1(ic + 2, 1);
-        m_so1(ic, 2) = m_so1(ic + 2, 2);
+        size_t const ic = 1;
+        m_so1(ic, 0) = m_so1(ic + 1, 0);
+        m_so1(ic, 1) = m_so1(ic + 1, 1);
+        m_so1(ic, 2) = m_so1(ic + 1, 2);
     }
     {
         // Right boundary.
-        size_t const ic = ncoord() - 1;
-        m_so1(ic, 0) = m_so1(ic - 2, 0);
-        m_so1(ic, 1) = m_so1(ic - 2, 1);
-        m_so1(ic, 2) = m_so1(ic - 2, 2);
+        size_t const ic = ncoord() - 2;
+        m_so1(ic, 0) = m_so1(ic - 1, 0);
+        m_so1(ic, 1) = m_so1(ic - 1, 1);
+        m_so1(ic, 2) = m_so1(ic - 1, 2);
     }
 }
 

--- a/cpp/modmesh/onedim/Euler1DCore.hpp
+++ b/cpp/modmesh/onedim/Euler1DCore.hpp
@@ -338,8 +338,8 @@ inline void Euler1DCore::march_alpha(size_t steps)
     {
         march_half1_alpha<ALPHA>();
         treat_boundary_so0();
-        march_half2_alpha<ALPHA>();
         treat_boundary_so1();
+        march_half2_alpha<ALPHA>();
     }
 }
 


### PR DESCRIPTION
For the 1D Euler solver, implement the third set of NRBC treatment documented in [NASA/TM-2003-212495-REV1](https://ntrs.nasa.gov/citations/20150012291), i.e., NRBC type 3.  $\lambda$ is chosen to be 0.

Here copying the type-3 NRBC treatment (the third set of NRBC in section 4.3 in page 15 of the TM) at the right and left boundaries, respectively:

```math
u_{A_l} = u_{B_{l-1}} \quad \mathrm{and} \quad (u_x^+)_{A_l} = (1-2\lambda)(u_x^+)_{B_{l-1}}, \, l = 2, 4, 6, \ldots
```
```math
u_{A'_l} = u_{B'_{l-1}} \quad \mathrm{and} \quad (u_x^+)_{A'_l} = (1-2\lambda)(u_x^+)_{B'_{l-1}}, \, l = 2, 4, 6, \ldots
```

Choosing $\lambda=0$, the treatment becomes:

```math
u_{A_l} = u_{B_{l-1}} \quad \mathrm{and} \quad (u_x^+)_{A_l} = (u_x^+)_{B_{l-1}}, \, l = 2, 4, 6, \ldots
```
```math
u_{A'_l} = u_{B'_{l-1}} \quad \mathrm{and} \quad (u_x^+)_{A'_l} = (u_x^+)_{B'_{l-1}}, \, l = 2, 4, 6, \ldots
```

After implementing the type-3 NRBC treatment, waves go outside the boundary:

![image](https://github.com/solvcon/modmesh/assets/399122/804f5f48-e1e6-4e0b-b29c-5a8cc38b41e4)

Comparing with the result with the tentatively implemented (and wrong) BC treatment:

![image](https://github.com/solvcon/modmesh/assets/399122/4450b967-eaec-4000-99e2-59a5e0232de5)
