### PR TITLE
Use the NRBC type 2 with $\lambda=0$ #1

### DIFF
--- a/cpp/modmesh/onedim/Euler1DCore.cpp
+++ b/cpp/modmesh/onedim/Euler1DCore.cpp
@@ -153,19 +153,19 @@ void Euler1DCore::march_half_so0(bool odd_plane)
 
 void Euler1DCore::treat_boundary_so0()
 {
-    /* Non-reflecting boundary condition (NRBC) type 3 with $\lambda=0$
+    /* Non-reflecting boundary condition (NRBC) type 2 with $\lambda=0$
      * (the third set in Chang 05) */
     // Set outside value from inside value.
     {
         // Left boundary.
-        size_t const ic = 1;
+        size_t const ic = 0;
         m_so0(ic, 0) = m_so0(ic + 1, 0);
         m_so0(ic, 1) = m_so0(ic + 1, 1);
         m_so0(ic, 2) = m_so0(ic + 1, 2);
     }
     {
         // Right boundary.
-        size_t const ic = ncoord() - 2;
+        size_t const ic = ncoord() - 1;
         m_so0(ic, 0) = m_so0(ic - 1, 0);
         m_so0(ic, 1) = m_so0(ic - 1, 1);
         m_so0(ic, 2) = m_so0(ic - 1, 2);
@@ -174,19 +174,19 @@ void Euler1DCore::treat_boundary_so0()
 
 void Euler1DCore::treat_boundary_so1()
 {
-    /* Non-reflecting boundary condition (NRBC) type 3 with $\lambda=0$
+    /* Non-reflecting boundary condition (NRBC) type 2 with $\lambda=0$
      * (the third set in Chang 05) */
     // Set outside value from inside value.
     {
         // Left boundary.
-        size_t const ic = 1;
+        size_t const ic = 0;
         m_so1(ic, 0) = m_so1(ic + 1, 0);
         m_so1(ic, 1) = m_so1(ic + 1, 1);
         m_so1(ic, 2) = m_so1(ic + 1, 2);
     }
     {
         // Right boundary.
-        size_t const ic = ncoord() - 2;
+        size_t const ic = ncoord() - 1;
         m_so1(ic, 0) = m_so1(ic - 1, 0);
         m_so1(ic, 1) = m_so1(ic - 1, 1);
         m_so1(ic, 2) = m_so1(ic - 1, 2);

--- a/cpp/modmesh/onedim/pymod/wrap_onedim.cpp
+++ b/cpp/modmesh/onedim/pymod/wrap_onedim.cpp
@@ -128,9 +128,9 @@ protected:
 
         (*this)
             .def_timed("update_cfl", &wrapped_type::update_cfl, py::arg("odd_plane"))
-            .def_timed("march_half_so0", &wrapped_type::march_half_so0, py::arg("odd_plane"))
             .def_timed("treat_boundary_so0", &wrapped_type::treat_boundary_so0)
             .def_timed("treat_boundary_so1", &wrapped_type::treat_boundary_so1)
+            .def_timed("march_half_so0", &wrapped_type::march_half_so0, py::arg("odd_plane"))
             .def_timed("setup_march", &wrapped_type::setup_march);
 
         (*this)

--- a/cpp/modmesh/spacetime/core.hpp
+++ b/cpp/modmesh/spacetime/core.hpp
@@ -1004,11 +1004,11 @@ template <typename ST, typename CE, typename SE>
 template <size_t ALPHA>
 inline void SolverBase<ST, CE, SE>::march_half1_alpha()
 {
-    march_half_so0(false);
     treat_boundary_so0();
+    treat_boundary_so1();
+    march_half_so0(false);
     update_cfl(true);
     march_half_so1_alpha<ALPHA>(false);
-    treat_boundary_so1();
 }
 
 template <typename ST, typename CE, typename SE>

--- a/cpp/modmesh/spacetime/kernel/BadEuler1DSolver.hpp
+++ b/cpp/modmesh/spacetime/kernel/BadEuler1DSolver.hpp
@@ -273,11 +273,11 @@ inline void BadEuler1DSolver::march_half_so1_alpha(bool odd_plane)
 template <size_t ALPHA>
 inline void BadEuler1DSolver::march_half1_alpha()
 {
-    march_half_so0(false);
     treat_boundary_so0();
+    treat_boundary_so1();
+    march_half_so0(false);
     update_cfl(true);
     march_half_so1_alpha<ALPHA>(false);
-    treat_boundary_so1();
 }
 
 template <size_t ALPHA>

--- a/cpp/modmesh/spacetime/pymod/wrap_spacetime.cpp
+++ b/cpp/modmesh/spacetime/pymod/wrap_spacetime.cpp
@@ -537,12 +537,12 @@ protected:
     wrapper_type & def_group_march()
     {
         namespace py = pybind11;
-
+        
         (*this)
             .def_timed("update_cfl", &wrapped_type::update_cfl, py::arg("odd_plane"))
-            .def_timed("march_half_so0", &wrapped_type::march_half_so0, py::arg("odd_plane"))
             .def_timed("treat_boundary_so0", &wrapped_type::treat_boundary_so0)
             .def_timed("treat_boundary_so1", &wrapped_type::treat_boundary_so1)
+            .def_timed("march_half_so0", &wrapped_type::march_half_so0, py::arg("odd_plane"))
             .def_timed("setup_march", &wrapped_type::setup_march);
 
         (*this)

--- a/cpp/modmesh/spacetime/pymod/wrap_spacetime.hpp
+++ b/cpp/modmesh/spacetime/pymod/wrap_spacetime.hpp
@@ -415,9 +415,9 @@ protected:
 
         (*this)
             .def("update_cfl", &wrapped_type::update_cfl, py::arg("odd_plane"))
-            .def("march_half_so0", &wrapped_type::march_half_so0, py::arg("odd_plane"))
             .def("treat_boundary_so0", &wrapped_type::treat_boundary_so0)
             .def("treat_boundary_so1", &wrapped_type::treat_boundary_so1)
+            .def("march_half_so0", &wrapped_type::march_half_so0, py::arg("odd_plane"))
             .def("setup_march", &wrapped_type::setup_march);
 
 // clang-format off

--- a/tests/test_onedim_euler.py
+++ b/tests/test_onedim_euler.py
@@ -52,12 +52,11 @@ class Euler1DSolverTC(unittest.TestCase):
 
     def test_march_fine_interface(self):
         def _march():
-            # first half step.
-            self.svr.march_half_so0(odd_plane=False)
             self.svr.treat_boundary_so0()
+            self.svr.treat_boundary_so1()
+            self.svr.march_half_so0(odd_plane=False)
             self.svr.update_cfl(odd_plane=True)
             self.svr.march_half_so1_alpha2(odd_plane=False)
-            self.svr.treat_boundary_so1()
             # second half step.
             self.svr.march_half_so0(odd_plane=True)
             self.svr.update_cfl(odd_plane=False)

--- a/tests/test_spacetime_solution.py
+++ b/tests/test_spacetime_solution.py
@@ -338,12 +338,11 @@ class PythonCustomSolverTC(unittest.TestCase):
 
     def test_march_fine_interface(self):
         def _march():
-            # first half step.
-            self.svr.march_half_so0(odd_plane=False)
             self.svr.treat_boundary_so0()
+            self.svr.treat_boundary_so1()
+            self.svr.march_half_so0(odd_plane=False)
             self.svr.update_cfl(odd_plane=True)
             self.svr.march_half_so1_alpha2(odd_plane=False)
-            self.svr.treat_boundary_so1()
             # second half step.
             self.svr.march_half_so0(odd_plane=True)
             self.svr.update_cfl(odd_plane=False)
@@ -439,11 +438,11 @@ class SolverProxyTC(unittest.TestCase):
     def test_march_fine_interface(self):
         def _march():
             # first half step.
-            self.svr.march_half_so0(odd_plane=False)
             self.svr.treat_boundary_so0()
+            self.svr.treat_boundary_so1()
+            self.svr.march_half_so0(odd_plane=False)
             self.svr.update_cfl(odd_plane=True)
             self.svr.march_half_so1_alpha2(odd_plane=False)
-            self.svr.treat_boundary_so1()
             # second half st
             self.svr.march_half_so0(odd_plane=True)
             self.svr.update_cfl(odd_plane=False)


### PR DESCRIPTION
Following the issue [#330](https://github.com/solvcon/modmesh/issues/330) 

This PR includes:
1. the NRBC type 2
2. the sequences of "march_half_so0", "treat_boundary_so0", and "treat_boundary_so1".

Obviously, the result shows that there must be something wrong in the code. 
<img width="795" alt="截圖 2024-05-31 中午12 41 15" src="https://github.com/solvcon/modmesh/assets/165459695/1c35d05e-266c-4a95-a3fc-75676520f24c">
