### PR TITLE
Adjust the boundary plotting

### DIFF
--- a/cpp/modmesh/onedim/Euler1DCore.cpp
+++ b/cpp/modmesh/onedim/Euler1DCore.cpp
@@ -170,6 +170,22 @@ void Euler1DCore::treat_boundary_so0()
         m_so0(ic, 1) = m_so0(ic - 1, 1);
         m_so0(ic, 2) = m_so0(ic - 1, 2);
     }
+
+    // Set the boundary point eqaul to the inside point.
+    {
+        // Left boundary.
+        size_t const ic = 0;
+        m_so0(ic, 0) = m_so0(ic + 2, 0);
+        m_so0(ic, 1) = m_so0(ic + 2, 1);
+        m_so0(ic, 2) = m_so0(ic + 2, 2);
+    }
+    {
+        // Right boundary.
+        size_t const ic = ncoord() - 1;
+        m_so0(ic, 0) = m_so0(ic - 2, 0);
+        m_so0(ic, 1) = m_so0(ic - 2, 1);
+        m_so0(ic, 2) = m_so0(ic - 2, 2);
+    }
 }
 
 void Euler1DCore::treat_boundary_so1()
@@ -190,6 +206,22 @@ void Euler1DCore::treat_boundary_so1()
         m_so1(ic, 0) = m_so1(ic - 1, 0);
         m_so1(ic, 1) = m_so1(ic - 1, 1);
         m_so1(ic, 2) = m_so1(ic - 1, 2);
+    }
+
+    // Set the boundary point eqaul to the inside point.
+    {
+        // Left boundary.
+        size_t const ic = 0;
+        m_so1(ic, 0) = m_so1(ic + 2, 0);
+        m_so1(ic, 1) = m_so1(ic + 2, 1);
+        m_so1(ic, 2) = m_so1(ic + 2, 2);
+    }
+    {
+        // Right boundary.
+        size_t const ic = ncoord() - 1;
+        m_so1(ic, 0) = m_so1(ic - 2, 0);
+        m_so1(ic, 1) = m_so1(ic - 2, 1);
+        m_so1(ic, 2) = m_so1(ic - 2, 2);
     }
 }
 


### PR DESCRIPTION
Following the issue https://github.com/solvcon/modmesh/discussions/335
The PR sets the value at boundary point equal to the inside one.

Features: The plotting looks more reasonable than the original one.
Strength: The adjustment is simple and makes the result look nicer.
Weakness: This way is too artificial and simplified and lack of physical basis. The result shows that there is still something wrong on the boundary, especially the left boundary.

<img width="736" alt="截圖 2024-06-01 下午2 42 33" src="https://github.com/solvcon/modmesh/assets/165459695/ce79e197-1478-4764-9944-39907e197b2f">
