### PR TITLE
add gtest for ConcreteBuffer, SimpleArray and BufferExpander

### DIFF
--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -62,6 +62,24 @@ TEST(SimpleArray, abs)
     EXPECT_EQ(brr.sum(), 10.0);
 }
 
+TEST(SimpleArray, iterator)
+{
+    using namespace modmesh;
+
+    SimpleArray<double> arr(10);
+    int8_t i = 0;
+    for (auto & it : arr)
+    {
+        it = i++;
+    }
+
+    i = 0;
+    for (const auto it : arr)
+    {
+        EXPECT_EQ(it, i++);
+    }
+}
+
 TEST(SimpleArray_DataType, from_type)
 {
     modmesh::DataType dt_double = modmesh::DataType::from<double>();
@@ -81,6 +99,24 @@ TEST(SimpleArray_DataType, from_string)
 
     EXPECT_THROW(modmesh::DataType("float16"), std::invalid_argument); // float16 does not exist
     EXPECT_THROW(modmesh::DataType("bool8"), std::invalid_argument); // bool8 does not exist
+}
+
+TEST(BufferExpander, iterator)
+{
+    using namespace modmesh;
+
+    auto buffer = BufferExpander::construct(10);
+    int8_t i = 0;
+    for (auto & it : *buffer)
+    {
+        it = i++;
+    }
+
+    i = 0;
+    for (const auto it : *buffer)
+    {
+        EXPECT_EQ(it, i++);
+    }
 }
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -6,9 +6,22 @@
 #error "Python.h should not be included."
 #endif
 
-TEST(nopython_buffer, dummy)
+TEST(ConcreteBuffer, iterator)
 {
-    EXPECT_TRUE(true);
+    using namespace modmesh;
+
+    auto buffer = ConcreteBuffer::construct(10);
+    int8_t i = 0;
+    for (auto & it : *buffer)
+    {
+        it = i++;
+    }
+
+    i = 0;
+    for (const auto it : *buffer)
+    {
+        EXPECT_EQ(it, i++);
+    }
 }
 
 TEST(SimpleArray, construction)


### PR DESCRIPTION
This PR aims to close https://github.com/solvcon/modmesh/issues/306.

- After reading the source code of `ConcreteBuffer`, I think we don't need to align the iterator implementation between `ConcreteBuffer` and `BufferExpander`. In `ConcreteBuffer`, there are no `m_begin` and `m_end`, and only has a `std::unique_ptr<int8_t, data_deleter_type>` type `m_data`, so I think we can keep it as it is.
- Added iterator tests in gtest for `ConcreteBuffer`, `SimpleArray`, and `BufferExpander`.

p.s. Seems that `SimpleCollector.hpp` also misses the implementation of iterator, but let's make it in another PR.