### PR TITLE
Fix euler1d not responding on Windows

### DIFF
--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -727,6 +727,7 @@ class Euler1DApp():
 
         :return: None
         """
+        # stdout can be None under some conditions, ref: https://github.com/solvcon/modmesh/issues/334
         if sys.stdout is not None:
             sys.stdout.write(msg)
             sys.stdout.write('\n')

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -727,7 +727,7 @@ class Euler1DApp():
 
         :return: None
         """
-        if sys.stdout != None:
+        if sys.stdout is not None:
             sys.stdout.write(msg)
             sys.stdout.write('\n')
         view.mgr.pycon.writeToHistory(msg)

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -727,7 +727,8 @@ class Euler1DApp():
 
         :return: None
         """
-        # stdout can be None under some conditions, ref: https://github.com/solvcon/modmesh/issues/334
+        # stdout can be None under some conditions
+        # ref: https://github.com/solvcon/modmesh/issues/334
         if sys.stdout is not None:
             sys.stdout.write(msg)
             sys.stdout.write('\n')

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -727,8 +727,9 @@ class Euler1DApp():
 
         :return: None
         """
-        sys.stdout.write(msg)
-        sys.stdout.write('\n')
+        if sys.stdout != None:
+            sys.stdout.write(msg)
+            sys.stdout.write('\n')
         view.mgr.pycon.writeToHistory(msg)
         view.mgr.pycon.writeToHistory('\n')
 


### PR DESCRIPTION
This PR is a simple fix for #334.

According to #334, under some conditions `sys.stdout` can be `None`, which is usually the case for Windows GUI apps that aren't connected to a console.

Added a single line to check the value of `sys.stdout` before writing to fix the issue.