### PR TITLE
Implement `BufferBase` for the common part between `ConcreteBuffer` and `BufferExpander`

### DIFF
--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -102,4 +102,4 @@ protected:
 }; /* end class BufferBase */
 } /* end namespace modmesh */
 
-/* vim: set et ts=4 sw=4: */
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -41,17 +41,7 @@ public:
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
 
-    BufferBase() = default;
-    BufferBase(int8_t * begin, int8_t * end)
-        : m_begin(begin)
-        , m_end(end)
-    {
-    }
-
-    explicit operator bool() const
-    {
-        return bool(m_begin);
-    }
+    explicit operator bool() const { return bool(m_begin); }
     size_type size() const
     {
         return static_cast<size_type>(this->m_end - this->m_begin);
@@ -102,6 +92,8 @@ public:
     }
 
 protected:
+    virtual ~BufferBase() = default;
+
     void validate_range(size_t it) const
     {
         if (it >= size())

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -40,9 +40,7 @@ public:
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
 
-    virtual ~BufferBase() = default;
-
-    virtual explicit operator bool() const { return bool(m_begin); }
+    explicit operator bool() const { return bool(m_begin); }
     size_type size() const
     {
         return static_cast<size_type>(this->m_end - this->m_begin);

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -34,7 +34,7 @@ namespace modmesh
 
 /// Base class for buffer-like objects.
 template <typename Derived>
-class BufferBase : public std::enable_shared_from_this<BufferBase<Derived>>
+class BufferBase
 {
 public:
 

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -38,7 +38,11 @@ template <typename Derived>
 class BufferBase
 {
 public:
-    BufferBase() = default;
+    BufferBase(int8_t * begin, int8_t * end)
+        : m_begin(begin)
+        , m_end(end)
+    {
+    }
 
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
@@ -102,8 +106,8 @@ protected:
         }
     }
 
-    int8_t * m_begin = nullptr;
-    int8_t * m_end = nullptr;
+    int8_t * m_begin; // don't initialize, must be set by derived class
+    int8_t * m_end; // don't initialize, must be set by derived class
 
 }; /* end class BufferBase */
 

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -93,6 +93,11 @@ public:
 
 protected:
     BufferBase() = default;
+
+    BufferBase(int8_t * start, int8_t * end)
+        : m_begin(start)
+        , m_end(end){};
+
     BufferBase(BufferBase const &) = delete;
     BufferBase(BufferBase &&) = delete;
     BufferBase & operator=(BufferBase const &) = delete;

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -38,12 +38,6 @@ template <typename Derived>
 class BufferBase
 {
 public:
-    BufferBase(int8_t * begin, int8_t * end)
-        : m_begin(begin)
-        , m_end(end)
-    {
-    }
-
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
 

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -88,6 +88,8 @@ protected:
         }
     }
 
-    virtual constexpr const char* name() const { return "BufferBase"; }
-};
-} // namespace modmesh
+    virtual constexpr const char * name() const { return "BufferBase"; }
+}; /* end class BufferBase */
+} /* end namespace modmesh */
+
+/* vim: set et ts=4 sw=4: */

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -92,6 +92,13 @@ public:
     }
 
 protected:
+    BufferBase() = default;
+    BufferBase(BufferBase const &) = delete;
+    BufferBase(BufferBase &&) = delete;
+    BufferBase & operator=(BufferBase const &) = delete;
+    BufferBase & operator=(BufferBase &&) = delete;
+    ~BufferBase() = default;
+
     void validate_range(size_t it) const
     {
         if (it >= size())

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -92,7 +92,7 @@ public:
     }
 
 protected:
-    // virtual ~BufferBase() = default;
+    virtual ~BufferBase() = default;
 
     void validate_range(size_t it) const
     {

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -88,6 +88,6 @@ protected:
         }
     }
 
-    virtual constexpr std::string const & name() const { return "BufferBase"; }
+    virtual constexpr const char* name() const { return "BufferBase"; }
 };
 } // namespace modmesh

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -92,8 +92,6 @@ public:
     }
 
 protected:
-    virtual ~BufferBase() = default;
-
     void validate_range(size_t it) const
     {
         if (it >= size())

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -98,7 +98,7 @@ public:
 
     constexpr const char * name() const
     {
-        return static_cast<const Derived *>(this)->name();
+        return Derived::name();
     }
 
 protected:

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -33,7 +33,8 @@ namespace modmesh
 {
 
 /// Base class for buffer-like objects.
-class BufferBase : public std::enable_shared_from_this<BufferBase>
+template <typename Derived>
+class BufferBase : public std::enable_shared_from_this<BufferBase<Derived>>
 {
 public:
 
@@ -85,7 +86,14 @@ public:
     template <typename T> T * data() noexcept { return reinterpret_cast<T *>(m_begin); }
     // clang-format on
 
+    constexpr const char * name() const
+    {
+        return static_cast<const Derived *>(this)->name();
+    }
+
 protected:
+    // virtual ~BufferBase() = default;
+
     void validate_range(size_t it) const
     {
         if (it >= size())
@@ -93,9 +101,6 @@ protected:
             throw std::out_of_range(Formatter() << name() << ": index " << it << " is out of bounds with size " << size());
         }
     }
-
-    // TODO: make this constexpr virtual once C++20 is available
-    virtual const char * name() const { return "BufferBase"; }
 
     int8_t * m_begin = nullptr;
     int8_t * m_end = nullptr;

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -41,7 +41,17 @@ public:
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
 
-    explicit operator bool() const { return bool(m_begin); }
+    BufferBase() = default;
+    BufferBase(int8_t * begin, int8_t * end)
+        : m_begin(begin)
+        , m_end(end)
+    {
+    }
+
+    explicit operator bool() const
+    {
+        return bool(m_begin);
+    }
     size_type size() const
     {
         return static_cast<size_type>(this->m_end - this->m_begin);
@@ -92,8 +102,6 @@ public:
     }
 
 protected:
-    virtual ~BufferBase() = default;
-
     void validate_range(size_t it) const
     {
         if (it >= size())

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -96,7 +96,8 @@ protected:
         }
     }
 
-    virtual constexpr const char * name() const { return "BufferBase"; }
+    // TODO: make this constexpr virtual once C++20 is available
+    virtual const char * name() const { return "BufferBase"; }
 
     int8_t * m_begin = nullptr;
     int8_t * m_end = nullptr;

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 /*
  * Copyright (c) 2024, An-Chi Liu <phy.tiger@gmail.com>
  *
@@ -37,6 +38,7 @@ template <typename Derived>
 class BufferBase
 {
 public:
+    BufferBase() = default;
 
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
@@ -102,7 +104,9 @@ protected:
 
     int8_t * m_begin = nullptr;
     int8_t * m_end = nullptr;
+
 }; /* end class BufferBase */
+
 } /* end namespace modmesh */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -46,8 +46,6 @@ public:
 
     virtual size_type size() const noexcept = 0;
     virtual size_t nbytes() const noexcept = 0;
-    virtual size_type capacity() const noexcept = 0;
-    virtual void reserve(size_type cap) = 0;
 
     int8_t operator[](size_t it) const { return data(it); }
     int8_t & operator[](size_t it) { return data(it); }

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -42,10 +42,12 @@ public:
 
     virtual ~BufferBase() = default;
 
-    virtual explicit operator bool() const noexcept = 0;
-
-    virtual size_type size() const noexcept = 0;
-    virtual size_t nbytes() const noexcept = 0;
+    virtual explicit operator bool() const { return bool(m_begin); }
+    size_type size() const
+    {
+        return static_cast<size_type>(this->m_end - this->m_begin);
+    }
+    size_t nbytes() const { return size() * sizeof(int8_t); }
 
     int8_t operator[](size_t it) const { return data(it); }
     int8_t & operator[](size_t it) { return data(it); }
@@ -65,17 +67,25 @@ public:
     using iterator = int8_t *;
     using const_iterator = int8_t const *;
 
-    virtual iterator begin() noexcept = 0;
-    virtual iterator end() noexcept = 0;
-    virtual const_iterator begin() const noexcept = 0;
-    virtual const_iterator end() const noexcept = 0;
-    virtual const_iterator cbegin() const noexcept = 0;
-    virtual const_iterator cend() const noexcept = 0;
+    iterator begin() noexcept { return m_begin; }
+    iterator end() noexcept { return m_end; }
+    const_iterator begin() const noexcept { return m_begin; }
+    const_iterator end() const noexcept { return m_end; }
+    const_iterator cbegin() const noexcept { return m_begin; }
+    const_iterator cend() const noexcept { return m_end; }
 
-    virtual int8_t data(size_type it) const = 0;
-    virtual int8_t & data(size_type it) = 0;
-    virtual int8_t const * data() const noexcept = 0;
-    virtual int8_t * data() noexcept = 0;
+    /* Backdoor */
+    int8_t data(size_type it) const { return data()[it]; }
+    int8_t & data(size_type it) { return data()[it]; }
+    int8_t const * data() const noexcept { return data<int8_t>(); }
+    int8_t * data() noexcept { return data<int8_t>(); }
+
+    // clang-format off
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    template <typename T> T const * data() const noexcept { return reinterpret_cast<T *>(m_begin); }
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    template <typename T> T * data() noexcept { return reinterpret_cast<T *>(m_begin); }
+    // clang-format on
 
 protected:
     void validate_range(size_t it) const
@@ -87,6 +97,9 @@ protected:
     }
 
     virtual constexpr const char * name() const { return "BufferBase"; }
+
+    int8_t * m_begin = nullptr;
+    int8_t * m_end = nullptr;
 }; /* end class BufferBase */
 } /* end namespace modmesh */
 

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -33,7 +33,7 @@ namespace modmesh
 {
 
 /// Base class for buffer-like objects.
-class BufferBase
+class BufferBase : public std::enable_shared_from_this<BufferBase>
 {
 public:
 

--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -88,8 +88,6 @@ protected:
         }
     }
 
-    virtual std::string const & name() const { return m_name; }
-
-    std::string m_name = "BufferBase"; ///< Name of the buffer object.
+    virtual constexpr std::string const & name() const { return "BufferBase"; }
 };
 } // namespace modmesh

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -45,8 +45,8 @@ namespace modmesh
  * expandable memory buffer cannot be used externally.
  */
 class BufferExpander
-    : public BufferBase<BufferExpander>
-    , public std::enable_shared_from_this<BufferExpander>
+    : public std::enable_shared_from_this<BufferExpander>
+    , public BufferBase<BufferExpander>
 {
 
 private:

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -72,7 +72,8 @@ public:
     }
 
     BufferExpander(std::shared_ptr<ConcreteBuffer> const & buf, bool clone, ctor_passkey const &)
-        : m_concrete_buffer(clone ? buf->clone() : buf)
+        : BufferBase<BufferExpander>(nullptr, nullptr) //  initialize m_begin and m_end, but since we don't have the data yet, we set them to nullptr
+        , m_concrete_buffer(clone ? buf->clone() : buf)
     {
         m_begin = m_concrete_buffer->data();
         m_end = m_begin + m_concrete_buffer->size();
@@ -80,11 +81,15 @@ public:
     }
 
     BufferExpander(size_type nbyte, ctor_passkey const &)
+        : BufferBase<BufferExpander>(nullptr, nullptr) //  initialize m_begin and m_end, but since we don't have the data yet, we set them to nullptr
     {
         expand(nbyte);
     }
 
-    BufferExpander(ctor_passkey const &) {}
+    BufferExpander(ctor_passkey const &)
+        : BufferBase<BufferExpander>(nullptr, nullptr) //  initialize m_begin and m_end, but since we don't have the data yet, we set them to nullptr
+    {
+    }
 
     BufferExpander() = delete;
     BufferExpander(BufferExpander const &) = delete;

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -72,9 +72,10 @@ public:
 
     BufferExpander(std::shared_ptr<ConcreteBuffer> const & buf, bool clone, ctor_passkey const &)
         : m_concrete_buffer(clone ? buf->clone() : buf)
-        , BufferBase<BufferExpander>(m_concrete_buffer->data(), m_begin + m_concrete_buffer->size())
-        , m_end_cap(m_begin + m_concrete_buffer->size())
     {
+        m_begin = m_concrete_buffer->data();
+        m_end = m_begin + m_concrete_buffer->size();
+        m_end_cap = m_begin + m_concrete_buffer->size();
     }
 
     BufferExpander(size_type nbyte, ctor_passkey const &)

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -102,12 +102,12 @@ public:
 
     size_t nbytes() const noexcept override { return size(); }
 
-    size_type capacity() const noexcept override
+    size_type capacity() const noexcept
     {
         return static_cast<size_type>(this->m_end_cap - this->m_begin);
     }
 
-    void reserve(size_type cap) override;
+    void reserve(size_type cap);
 
     void expand(size_type length)
     {
@@ -150,7 +150,7 @@ private:
         return ret;
     }
 
-    constexpr const char* name() const override { return "BufferExpander"; }
+    constexpr const char * name() const override { return "BufferExpander"; }
 
     std::unique_ptr<int8_t> m_data_holder = nullptr;
     std::shared_ptr<ConcreteBuffer> m_concrete_buffer = nullptr;

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -119,7 +119,7 @@ private:
         return ret;
     }
 
-    constexpr const char * name() const override { return "BufferExpander"; }
+    const char * name() const override { return "BufferExpander"; }
 
     std::unique_ptr<int8_t> m_data_holder = nullptr;
     std::shared_ptr<ConcreteBuffer> m_concrete_buffer = nullptr;

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -81,13 +81,13 @@ public:
     }
 
     BufferExpander(size_type nbyte, ctor_passkey const &)
-        : BufferBase<BufferExpander>() // don't delegate m_begin and m_end, which will be overwritten later
+        : BufferBase<BufferExpander>(nullptr, nullptr) // initialize m_begin and m_end to nullptr, which will be overwritten later
     {
         expand(nbyte); // override m_begin and m_end once we have the data
     }
 
     BufferExpander(ctor_passkey const &)
-        : BufferBase<BufferExpander>(nullptr, nullptr)
+        : BufferBase<BufferExpander>(nullptr, nullptr) // initialize m_begin and m_end to nullptr, which will be overwritten later
     {
     }
 
@@ -100,6 +100,10 @@ public:
 
     size_type capacity() const noexcept
     {
+        if (!m_begin) // no data hence no capacity
+        {
+            return 0;
+        }
         return static_cast<size_type>(this->m_end_cap - this->m_begin);
     }
 

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -107,7 +107,7 @@ public:
     std::shared_ptr<ConcreteBuffer> const & as_concrete(size_type cap = 0);
     bool is_concrete() const { return bool(m_concrete_buffer); }
 
-    constexpr const char * name() const { return "BufferExpander"; }
+    static constexpr const char * name() { return "BufferExpander"; }
 
 private:
     static std::unique_ptr<int8_t> allocate(size_type nbytes)

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -83,11 +83,11 @@ public:
     BufferExpander(size_type nbyte, ctor_passkey const &)
         : BufferBase<BufferExpander>() // don't delegate m_begin and m_end, which will be overwritten later
     {
-        expand(nbyte);
+        expand(nbyte); // override m_begin and m_end once we have the data
     }
 
     BufferExpander(ctor_passkey const &)
-        : BufferBase<BufferExpander>() // don't delegate m_begin and m_end, which will be overwritten later
+        : BufferBase<BufferExpander>(nullptr, nullptr)
     {
     }
 

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -44,7 +44,8 @@ namespace modmesh
  * Untyped and growing memory buffer for contiguous data storage.  The internal
  * expandable memory buffer cannot be used externally.
  */
-class BufferExpander : public BufferBase<BufferExpander>
+class BufferExpander
+    : public BufferBase<BufferExpander>
     , public std::enable_shared_from_this<BufferExpander>
 {
 

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -72,7 +72,7 @@ public:
     }
 
     BufferExpander(std::shared_ptr<ConcreteBuffer> const & buf, bool clone, ctor_passkey const &)
-        : BufferBase<BufferExpander>(nullptr, nullptr) //  initialize m_begin and m_end, but since we don't have the data yet, we set them to nullptr
+        : BufferBase<BufferExpander>() // don't delegate m_begin and m_end, which will be overwritten later
         , m_concrete_buffer(clone ? buf->clone() : buf)
     {
         m_begin = m_concrete_buffer->data(); // override m_begin and m_end once we have the data
@@ -81,13 +81,13 @@ public:
     }
 
     BufferExpander(size_type nbyte, ctor_passkey const &)
-        : BufferBase<BufferExpander>(nullptr, nullptr) //  initialize m_begin and m_end, but since we don't have the data yet, we set them to nullptr
+        : BufferBase<BufferExpander>() // don't delegate m_begin and m_end, which will be overwritten later
     {
         expand(nbyte);
     }
 
     BufferExpander(ctor_passkey const &)
-        : BufferBase<BufferExpander>(nullptr, nullptr) //  initialize m_begin and m_end, but since we don't have the data yet, we set them to nullptr
+        : BufferBase<BufferExpander>() // don't delegate m_begin and m_end, which will be overwritten later
     {
     }
 

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -71,10 +71,10 @@ public:
 
     BufferExpander(std::shared_ptr<ConcreteBuffer> const & buf, bool clone, ctor_passkey const &)
         : m_concrete_buffer(clone ? buf->clone() : buf)
-        , m_begin(m_concrete_buffer->data())
-        , m_end(m_begin + m_concrete_buffer->size())
-        , m_end_cap(m_begin + m_concrete_buffer->size())
     {
+        m_begin = m_concrete_buffer->data();
+        m_end = m_begin + m_concrete_buffer->size();
+        m_end_cap = m_begin + m_concrete_buffer->size();
     }
 
     BufferExpander(size_type nbyte, ctor_passkey const &)
@@ -90,15 +90,6 @@ public:
     BufferExpander & operator=(BufferExpander const &) = delete;
     BufferExpander & operator=(BufferExpander &&) = delete;
     ~BufferExpander() = default;
-
-    explicit operator bool() const noexcept override { return bool(m_begin); }
-
-    size_type size() const noexcept override
-    {
-        return static_cast<size_type>(this->m_end - this->m_begin);
-    }
-
-    size_t nbytes() const noexcept override { return size(); }
 
     size_type capacity() const noexcept
     {
@@ -117,26 +108,6 @@ public:
     std::shared_ptr<ConcreteBuffer> const & as_concrete(size_type cap = 0);
     bool is_concrete() const { return bool(m_concrete_buffer); }
 
-    iterator begin() noexcept override { return m_begin; }
-    iterator end() noexcept override { return m_end; }
-    const_iterator begin() const noexcept override { return m_begin; }
-    const_iterator end() const noexcept override { return m_end; }
-    const_iterator cbegin() const noexcept override { return m_begin; }
-    const_iterator cend() const noexcept override { return m_end; }
-
-    /* Backdoor */
-    int8_t data(size_type it) const override { return data()[it]; }
-    int8_t & data(size_type it) override { return data()[it]; }
-    int8_t const * data() const noexcept override { return data<int8_t>(); }
-    int8_t * data() noexcept override { return data<int8_t>(); }
-
-    // clang-format off
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    template <typename T> T const * data() const noexcept { return reinterpret_cast<T *>(m_begin); }
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    template <typename T> T * data() noexcept { return reinterpret_cast<T *>(m_begin); }
-    // clang-format on
-
 private:
     static std::unique_ptr<int8_t> allocate(size_type nbytes)
     {
@@ -153,8 +124,6 @@ private:
     std::unique_ptr<int8_t> m_data_holder = nullptr;
     std::shared_ptr<ConcreteBuffer> m_concrete_buffer = nullptr;
 
-    int8_t * m_begin = nullptr;
-    int8_t * m_end = nullptr;
     int8_t * m_end_cap = nullptr;
 }; /* end class BufferExpander */
 

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -71,10 +71,9 @@ public:
 
     BufferExpander(std::shared_ptr<ConcreteBuffer> const & buf, bool clone, ctor_passkey const &)
         : m_concrete_buffer(clone ? buf->clone() : buf)
+        , BufferBase<BufferExpander>(m_concrete_buffer->data(), m_begin + m_concrete_buffer->size())
+        , m_end_cap(m_begin + m_concrete_buffer->size())
     {
-        m_begin = m_concrete_buffer->data();
-        m_end = m_begin + m_concrete_buffer->size();
-        m_end_cap = m_begin + m_concrete_buffer->size();
     }
 
     BufferExpander(size_type nbyte, ctor_passkey const &)

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -29,7 +29,7 @@
  */
 
 #include <modmesh/base.hpp>
-#include <modmesh/buffer/bufferbase.hpp>
+#include <modmesh/buffer/BufferBase.hpp>
 #include <modmesh/buffer/ConcreteBuffer.hpp>
 
 #include <algorithm>
@@ -150,7 +150,7 @@ private:
         return ret;
     }
 
-    std::string const & name() const override { return m_name; }
+    constexpr const char* name() const override { return "BufferExpander"; }
 
     std::unique_ptr<int8_t> m_data_holder = nullptr;
     std::shared_ptr<ConcreteBuffer> m_concrete_buffer = nullptr;
@@ -158,8 +158,6 @@ private:
     int8_t * m_begin = nullptr;
     int8_t * m_end = nullptr;
     int8_t * m_end_cap = nullptr;
-
-    std::string m_name = "BufferExpander";
 }; /* end class BufferExpander */
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -45,6 +45,7 @@ namespace modmesh
  * expandable memory buffer cannot be used externally.
  */
 class BufferExpander : public BufferBase<BufferExpander>
+    , public std::enable_shared_from_this<BufferExpander>
 {
 
 private:

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -44,9 +44,7 @@ namespace modmesh
  * Untyped and growing memory buffer for contiguous data storage.  The internal
  * expandable memory buffer cannot be used externally.
  */
-class BufferExpander
-    : public BufferBase
-    , public std::enable_shared_from_this<BufferExpander>
+class BufferExpander : public BufferBase
 {
 
 private:

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -75,7 +75,7 @@ public:
         : BufferBase<BufferExpander>(nullptr, nullptr) //  initialize m_begin and m_end, but since we don't have the data yet, we set them to nullptr
         , m_concrete_buffer(clone ? buf->clone() : buf)
     {
-        m_begin = m_concrete_buffer->data();
+        m_begin = m_concrete_buffer->data(); // override m_begin and m_end once we have the data
         m_end = m_begin + m_concrete_buffer->size();
         m_end_cap = m_begin + m_concrete_buffer->size();
     }

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -29,6 +29,7 @@
  */
 
 #include <modmesh/base.hpp>
+#include <modmesh/buffer/bufferbase.hpp>
 #include <modmesh/buffer/ConcreteBuffer.hpp>
 
 #include <algorithm>
@@ -44,7 +45,8 @@ namespace modmesh
  * expandable memory buffer cannot be used externally.
  */
 class BufferExpander
-    : public std::enable_shared_from_this<BufferExpander>
+    : public BufferBase
+    , public std::enable_shared_from_this<BufferExpander>
 {
 
 private:
@@ -91,21 +93,21 @@ public:
     BufferExpander & operator=(BufferExpander &&) = delete;
     ~BufferExpander() = default;
 
-    explicit operator bool() const noexcept { return bool(m_begin); }
+    explicit operator bool() const noexcept override { return bool(m_begin); }
 
-    size_type size() const noexcept
+    size_type size() const noexcept override
     {
         return static_cast<size_type>(this->m_end - this->m_begin);
     }
 
-    size_t nbytes() const noexcept { return size(); }
+    size_t nbytes() const noexcept override { return size(); }
 
-    size_type capacity() const noexcept
+    size_type capacity() const noexcept override
     {
         return static_cast<size_type>(this->m_end_cap - this->m_begin);
     }
 
-    void reserve(size_type cap);
+    void reserve(size_type cap) override;
 
     void expand(size_type length)
     {
@@ -117,35 +119,19 @@ public:
     std::shared_ptr<ConcreteBuffer> const & as_concrete(size_type cap = 0);
     bool is_concrete() const { return bool(m_concrete_buffer); }
 
-    int8_t operator[](size_t it) const { return data(it); }
-    int8_t & operator[](size_t it) { return data(it); }
-
-    int8_t at(size_t it) const
-    {
-        validate_range(it);
-        return data(it);
-    }
-    int8_t & at(size_t it)
-    {
-        validate_range(it);
-        return data(it);
-    }
-
-    using iterator = int8_t *;
-    using const_iterator = int8_t const *;
-
-    iterator begin() noexcept { return m_begin; }
-    iterator end() noexcept { return m_end; }
-    const_iterator begin() const noexcept { return m_begin; }
-    const_iterator end() const noexcept { return m_end; }
-    const_iterator cbegin() const noexcept { return m_begin; }
-    const_iterator cend() const noexcept { return m_end; }
+    iterator begin() noexcept override { return m_begin; }
+    iterator end() noexcept override { return m_end; }
+    const_iterator begin() const noexcept override { return m_begin; }
+    const_iterator end() const noexcept override { return m_end; }
+    const_iterator cbegin() const noexcept override { return m_begin; }
+    const_iterator cend() const noexcept override { return m_end; }
 
     /* Backdoor */
-    int8_t data(size_type it) const { return data()[it]; }
-    int8_t & data(size_type it) { return data()[it]; }
-    int8_t const * data() const noexcept { return data<int8_t>(); }
-    int8_t * data() noexcept { return data<int8_t>(); }
+    int8_t data(size_type it) const override { return data()[it]; }
+    int8_t & data(size_type it) override { return data()[it]; }
+    int8_t const * data() const noexcept override { return data<int8_t>(); }
+    int8_t * data() noexcept override { return data<int8_t>(); }
+
     // clang-format off
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     template <typename T> T const * data() const noexcept { return reinterpret_cast<T *>(m_begin); }
@@ -154,15 +140,6 @@ public:
     // clang-format on
 
 private:
-
-    void validate_range(size_type it) const
-    {
-        if (it >= size())
-        {
-            throw std::out_of_range(Formatter() << "BufferExpander: index " << it << " is out of bounds with size " << size());
-        }
-    }
-
     static std::unique_ptr<int8_t> allocate(size_type nbytes)
     {
         std::unique_ptr<int8_t> ret(nullptr);
@@ -173,6 +150,8 @@ private:
         return ret;
     }
 
+    std::string const & name() const override { return m_name; }
+
     std::unique_ptr<int8_t> m_data_holder = nullptr;
     std::shared_ptr<ConcreteBuffer> m_concrete_buffer = nullptr;
 
@@ -180,6 +159,7 @@ private:
     int8_t * m_end = nullptr;
     int8_t * m_end_cap = nullptr;
 
+    std::string m_name = "BufferExpander";
 }; /* end class BufferExpander */
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -44,7 +44,7 @@ namespace modmesh
  * Untyped and growing memory buffer for contiguous data storage.  The internal
  * expandable memory buffer cannot be used externally.
  */
-class BufferExpander : public BufferBase
+class BufferExpander : public BufferBase<BufferExpander>
 {
 
 private:
@@ -108,6 +108,8 @@ public:
     std::shared_ptr<ConcreteBuffer> const & as_concrete(size_type cap = 0);
     bool is_concrete() const { return bool(m_concrete_buffer); }
 
+    constexpr const char * name() const { return "BufferExpander"; }
+
 private:
     static std::unique_ptr<int8_t> allocate(size_type nbytes)
     {
@@ -118,8 +120,6 @@ private:
         }
         return ret;
     }
-
-    const char * name() const override { return "BufferExpander"; }
 
     std::unique_ptr<int8_t> m_data_holder = nullptr;
     std::shared_ptr<ConcreteBuffer> m_concrete_buffer = nullptr;

--- a/cpp/modmesh/buffer/CMakeLists.txt
+++ b/cpp/modmesh/buffer/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.16)
 
 set(MODMESH_BUFFER_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/buffer.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/bufferbase.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/small_vector.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ConcreteBuffer.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BufferExpander.hpp

--- a/cpp/modmesh/buffer/CMakeLists.txt
+++ b/cpp/modmesh/buffer/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.16)
 
 set(MODMESH_BUFFER_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/buffer.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/bufferbase.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/BufferBase.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/small_vector.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ConcreteBuffer.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BufferExpander.hpp

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -170,7 +170,7 @@ public:
      *      Size of the memory buffer in bytes.
      */
     ConcreteBuffer(size_t nbytes, const ctor_passkey &)
-        : BufferBase<ConcreteBuffer>(nullptr, nullptr) //  initialize m_begin and m_end, but since we don't have the data yet, we set them to nullptr
+        : BufferBase<ConcreteBuffer>() // don't delegate m_begin and m_end, which will be overwritten later
         , m_nbytes(nbytes)
         , m_data(allocate(nbytes))
     {
@@ -189,7 +189,7 @@ public:
      */
     // NOLINTNEXTLINE(readability-non-const-parameter)
     ConcreteBuffer(size_t nbytes, int8_t * data, std::unique_ptr<remover_type> && remover, const ctor_passkey &)
-        : BufferBase<ConcreteBuffer>(nullptr, nullptr) //  initialize m_begin and m_end, but since we don't have the data yet, we set them to nullptr
+        : BufferBase<ConcreteBuffer>() // don't delegate m_begin and m_end, which will be overwritten later
         , m_nbytes(nbytes)
         , m_data(data, data_deleter_type(std::move(remover)))
     {
@@ -209,7 +209,7 @@ public:
     // Avoid enabled_shared_from_this copy constructor
     // NOLINTNEXTLINE(bugprone-copy-constructor-init)
     ConcreteBuffer(ConcreteBuffer const & other)
-        : BufferBase<ConcreteBuffer>(nullptr, nullptr) //  initialize m_begin and m_end, but since we don't have the data yet, we set them to nullptr
+        : BufferBase<ConcreteBuffer>() // don't delegate m_begin and m_end, which will be overwritten later
         , m_nbytes(other.m_nbytes)
         , m_data(allocate(other.m_nbytes))
     {

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -171,6 +171,8 @@ public:
         : m_nbytes(nbytes)
         , m_data(allocate(nbytes))
     {
+        m_begin = m_data.get();
+        m_end = m_begin + m_nbytes;
     }
 
     /**
@@ -187,6 +189,8 @@ public:
         : m_nbytes(nbytes)
         , m_data(data, data_deleter_type(std::move(remover)))
     {
+        m_begin = m_data.get();
+        m_end = m_begin + m_nbytes;
     }
 
     ~ConcreteBuffer() = default;
@@ -209,6 +213,9 @@ public:
             throw std::out_of_range("Buffer size mismatch");
         }
         std::copy_n(other.data(), size(), data());
+
+        m_begin = m_data.get();
+        m_end = m_begin + m_nbytes;
     }
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
@@ -225,31 +232,6 @@ public:
         }
         return *this;
     }
-
-    explicit operator bool() const noexcept override { return bool(m_data); }
-
-    size_t nbytes() const noexcept override { return m_nbytes; }
-    size_t size() const noexcept override { return nbytes(); }
-
-    iterator begin() noexcept override { return data(); }
-    iterator end() noexcept override { return data() + size(); }
-    const_iterator begin() const noexcept override { return data(); }
-    const_iterator end() const noexcept override { return data() + size(); }
-    const_iterator cbegin() const noexcept override { return begin(); }
-    const_iterator cend() const noexcept override { return end(); }
-
-    /* Backdoor */
-    int8_t data(size_t it) const override { return data()[it]; }
-    int8_t & data(size_t it) override { return data()[it]; }
-    int8_t const * data() const noexcept override { return data<int8_t>(); }
-    int8_t * data() noexcept override { return data<int8_t>(); }
-
-    // clang-format off
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    template <typename T> T const * data() const noexcept { return reinterpret_cast<T *>(m_data.get()); }
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    template <typename T> T * data() noexcept { return reinterpret_cast<T *>(m_data.get()); }
-    // clang-format on
 
     bool has_remover() const noexcept { return bool(m_data.get_deleter().remover); }
     remover_type const & get_remover() const { return *m_data.get_deleter().remover; }

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -118,7 +118,7 @@ struct ConcreteBufferDataDeleter
 /**
  * Untyped and unresizeable memory buffer for contiguous data storage.
  */
-class ConcreteBuffer : public BufferBase
+class ConcreteBuffer : public BufferBase<ConcreteBuffer>
 {
 
 private:
@@ -240,6 +240,8 @@ public:
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     using unique_ptr_type = std::unique_ptr<int8_t, data_deleter_type>;
 
+    constexpr const char * name() const { return "ConcreteBuffer"; }
+
 private:
     static unique_ptr_type allocate(size_t nbytes)
     {
@@ -250,8 +252,6 @@ private:
         }
         return ret;
     }
-
-    const char * name() const override { return "ConcreteBuffer"; }
 
     size_t m_nbytes;
     unique_ptr_type m_data;

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -174,7 +174,7 @@ public:
         , m_nbytes(nbytes)
         , m_data(allocate(nbytes))
     {
-        m_begin = m_data.get();
+        m_begin = m_data.get(); // override m_begin and m_end once we have the data
         m_end = m_begin + m_nbytes;
     }
 
@@ -193,7 +193,7 @@ public:
         , m_nbytes(nbytes)
         , m_data(data, data_deleter_type(std::move(remover)))
     {
-        m_begin = m_data.get();
+        m_begin = m_data.get(); // override m_begin and m_end once we have the data
         m_end = m_begin + m_nbytes;
     }
 
@@ -219,7 +219,7 @@ public:
         }
         std::copy_n(other.data(), size(), data());
 
-        m_begin = m_data.get();
+        m_begin = m_data.get(); // override m_begin and m_end once we have the data
         m_end = m_begin + m_nbytes;
     }
 #ifdef __GNUC__

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -29,13 +29,13 @@
  */
 
 #include <modmesh/base.hpp>
-#include <modmesh/buffer/bufferbase.hpp>
+#include <modmesh/buffer/BufferBase.hpp>
 #include <modmesh/buffer/small_vector.hpp>
 
-#include <stdexcept>
-#include <memory>
 #include <algorithm>
+#include <memory>
 #include <sstream>
+#include <stdexcept>
 
 namespace modmesh
 {
@@ -273,12 +273,10 @@ private:
         return ret;
     }
 
-    std::string const & name() const override { return m_name; }
+    constexpr const char * name() const override { return "ConcreteBuffer"; }
 
     size_t m_nbytes;
     unique_ptr_type m_data;
-
-    std::string m_name = "ConcreteBuffer";
 }; /* end class ConcreteBuffer */
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -170,7 +170,8 @@ public:
      *      Size of the memory buffer in bytes.
      */
     ConcreteBuffer(size_t nbytes, const ctor_passkey &)
-        : m_nbytes(nbytes)
+        : BufferBase<ConcreteBuffer>(nullptr, nullptr) //  initialize m_begin and m_end, but since we don't have the data yet, we set them to nullptr
+        , m_nbytes(nbytes)
         , m_data(allocate(nbytes))
     {
         m_begin = m_data.get();
@@ -188,7 +189,8 @@ public:
      */
     // NOLINTNEXTLINE(readability-non-const-parameter)
     ConcreteBuffer(size_t nbytes, int8_t * data, std::unique_ptr<remover_type> && remover, const ctor_passkey &)
-        : m_nbytes(nbytes)
+        : BufferBase<ConcreteBuffer>(nullptr, nullptr) //  initialize m_begin and m_end, but since we don't have the data yet, we set them to nullptr
+        , m_nbytes(nbytes)
         , m_data(data, data_deleter_type(std::move(remover)))
     {
         m_begin = m_data.get();
@@ -207,7 +209,8 @@ public:
     // Avoid enabled_shared_from_this copy constructor
     // NOLINTNEXTLINE(bugprone-copy-constructor-init)
     ConcreteBuffer(ConcreteBuffer const & other)
-        : m_nbytes(other.m_nbytes)
+        : BufferBase<ConcreteBuffer>(nullptr, nullptr) //  initialize m_begin and m_end, but since we don't have the data yet, we set them to nullptr
+        , m_nbytes(other.m_nbytes)
         , m_data(allocate(other.m_nbytes))
     {
         if (size() != other.size())

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -251,7 +251,7 @@ private:
         return ret;
     }
 
-    constexpr const char * name() const override { return "ConcreteBuffer"; }
+    const char * name() const override { return "ConcreteBuffer"; }
 
     size_t m_nbytes;
     unique_ptr_type m_data;

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -118,7 +118,8 @@ struct ConcreteBufferDataDeleter
 /**
  * Untyped and unresizeable memory buffer for contiguous data storage.
  */
-class ConcreteBuffer : public BufferBase<ConcreteBuffer>, public std::enable_shared_from_this<ConcreteBuffer>
+class ConcreteBuffer : public BufferBase<ConcreteBuffer>
+    , public std::enable_shared_from_this<ConcreteBuffer>
 {
 
 private:

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -118,7 +118,7 @@ struct ConcreteBufferDataDeleter
 /**
  * Untyped and unresizeable memory buffer for contiguous data storage.
  */
-class ConcreteBuffer : public BufferBase<ConcreteBuffer>
+class ConcreteBuffer : public BufferBase<ConcreteBuffer>, public std::enable_shared_from_this<ConcreteBuffer>
 {
 
 private:

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -118,9 +118,7 @@ struct ConcreteBufferDataDeleter
 /**
  * Untyped and unresizeable memory buffer for contiguous data storage.
  */
-class ConcreteBuffer
-    : public BufferBase
-    , public std::enable_shared_from_this<ConcreteBuffer>
+class ConcreteBuffer : public BufferBase
 {
 
 private:

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -232,8 +232,6 @@ public:
 
     size_t nbytes() const noexcept override { return m_nbytes; }
     size_t size() const noexcept override { return nbytes(); }
-    size_type capacity() const noexcept override { return nbytes(); };
-    void reserve(size_type) override{/* do nothing */};
 
     iterator begin() noexcept override { return data(); }
     iterator end() noexcept override { return data() + size(); }

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -118,7 +118,8 @@ struct ConcreteBufferDataDeleter
 /**
  * Untyped and unresizeable memory buffer for contiguous data storage.
  */
-class ConcreteBuffer : public BufferBase<ConcreteBuffer>
+class ConcreteBuffer
+    : public BufferBase<ConcreteBuffer>
     , public std::enable_shared_from_this<ConcreteBuffer>
 {
 

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -170,9 +170,8 @@ public:
     ConcreteBuffer(size_t nbytes, const ctor_passkey &)
         : m_nbytes(nbytes)
         , m_data(allocate(nbytes))
+        , BufferBase<ConcreteBuffer>(m_data.get(), m_data.get() + m_nbytes)
     {
-        m_begin = m_data.get();
-        m_end = m_begin + m_nbytes;
     }
 
     /**
@@ -188,9 +187,8 @@ public:
     ConcreteBuffer(size_t nbytes, int8_t * data, std::unique_ptr<remover_type> && remover, const ctor_passkey &)
         : m_nbytes(nbytes)
         , m_data(data, data_deleter_type(std::move(remover)))
+        , BufferBase<ConcreteBuffer>(m_data.get(), m_data.get() + m_nbytes)
     {
-        m_begin = m_data.get();
-        m_end = m_begin + m_nbytes;
     }
 
     ~ConcreteBuffer() = default;
@@ -207,15 +205,13 @@ public:
     ConcreteBuffer(ConcreteBuffer const & other)
         : m_nbytes(other.m_nbytes)
         , m_data(allocate(other.m_nbytes))
+        , BufferBase<ConcreteBuffer>(m_data.get(), m_data.get() + m_nbytes)
     {
         if (size() != other.size())
         {
             throw std::out_of_range("Buffer size mismatch");
         }
         std::copy_n(other.data(), size(), data());
-
-        m_begin = m_data.get();
-        m_end = m_begin + m_nbytes;
     }
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -119,8 +119,8 @@ struct ConcreteBufferDataDeleter
  * Untyped and unresizeable memory buffer for contiguous data storage.
  */
 class ConcreteBuffer
-    : public BufferBase<ConcreteBuffer>
-    , public std::enable_shared_from_this<ConcreteBuffer>
+    : public std::enable_shared_from_this<ConcreteBuffer>
+    , public BufferBase<ConcreteBuffer>
 {
 
 private:

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -236,7 +236,7 @@ public:
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     using unique_ptr_type = std::unique_ptr<int8_t, data_deleter_type>;
 
-    constexpr const char * name() const { return "ConcreteBuffer"; }
+    static constexpr const char * name() { return "ConcreteBuffer"; }
 
 private:
     static unique_ptr_type allocate(size_t nbytes)

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -170,8 +170,9 @@ public:
     ConcreteBuffer(size_t nbytes, const ctor_passkey &)
         : m_nbytes(nbytes)
         , m_data(allocate(nbytes))
-        , BufferBase<ConcreteBuffer>(m_data.get(), m_data.get() + m_nbytes)
     {
+        m_begin = m_data.get();
+        m_end = m_begin + m_nbytes;
     }
 
     /**
@@ -187,8 +188,9 @@ public:
     ConcreteBuffer(size_t nbytes, int8_t * data, std::unique_ptr<remover_type> && remover, const ctor_passkey &)
         : m_nbytes(nbytes)
         , m_data(data, data_deleter_type(std::move(remover)))
-        , BufferBase<ConcreteBuffer>(m_data.get(), m_data.get() + m_nbytes)
     {
+        m_begin = m_data.get();
+        m_end = m_begin + m_nbytes;
     }
 
     ~ConcreteBuffer() = default;
@@ -205,13 +207,15 @@ public:
     ConcreteBuffer(ConcreteBuffer const & other)
         : m_nbytes(other.m_nbytes)
         , m_data(allocate(other.m_nbytes))
-        , BufferBase<ConcreteBuffer>(m_data.get(), m_data.get() + m_nbytes)
     {
         if (size() != other.size())
         {
             throw std::out_of_range("Buffer size mismatch");
         }
         std::copy_n(other.data(), size(), data());
+
+        m_begin = m_data.get();
+        m_end = m_begin + m_nbytes;
     }
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/cpp/modmesh/buffer/bufferbase.hpp
+++ b/cpp/modmesh/buffer/bufferbase.hpp
@@ -1,0 +1,95 @@
+#pragma once
+/*
+ * Copyright (c) 2024, An-Chi Liu <phy.tiger@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <modmesh/base.hpp>
+
+namespace modmesh
+{
+
+/// Base class for buffer-like objects.
+class BufferBase
+{
+public:
+
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+
+    virtual ~BufferBase() = default;
+
+    virtual explicit operator bool() const noexcept = 0;
+
+    virtual size_type size() const noexcept = 0;
+    virtual size_t nbytes() const noexcept = 0;
+    virtual size_type capacity() const noexcept = 0;
+    virtual void reserve(size_type cap) = 0;
+
+    int8_t operator[](size_t it) const { return data(it); }
+    int8_t & operator[](size_t it) { return data(it); }
+
+    int8_t at(size_t it) const
+    {
+        validate_range(it);
+        return data(it);
+    }
+
+    int8_t & at(size_t it)
+    {
+        validate_range(it);
+        return data(it);
+    }
+
+    using iterator = int8_t *;
+    using const_iterator = int8_t const *;
+
+    virtual iterator begin() noexcept = 0;
+    virtual iterator end() noexcept = 0;
+    virtual const_iterator begin() const noexcept = 0;
+    virtual const_iterator end() const noexcept = 0;
+    virtual const_iterator cbegin() const noexcept = 0;
+    virtual const_iterator cend() const noexcept = 0;
+
+    virtual int8_t data(size_type it) const = 0;
+    virtual int8_t & data(size_type it) = 0;
+    virtual int8_t const * data() const noexcept = 0;
+    virtual int8_t * data() noexcept = 0;
+
+protected:
+    void validate_range(size_t it) const
+    {
+        if (it >= size())
+        {
+            throw std::out_of_range(Formatter() << name() << ": index " << it << " is out of bounds with size " << size());
+        }
+    }
+
+    virtual std::string const & name() const { return m_name; }
+
+    std::string m_name = "BufferBase"; ///< Name of the buffer object.
+};
+} // namespace modmesh


### PR DESCRIPTION
part of https://github.com/solvcon/modmesh/issues/305

- Implemented the new `BufferBase` as the base class for all buffer-like type
- `ConcreteBuffer` and `BufferExpander` inherit the interface from `BufferBase` to ensure the interface's consistency.