### PR TITLE
use systematic way to locate third-party lib

### DIFF
--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -35,7 +35,7 @@ three-dimensional space.
 
 import os
 
-from .pylibmgr import search_library_root
+from . import pylibmgr
 
 __all__ = [  # noqa: F822
     'WrapperProfilerStatus',
@@ -110,7 +110,7 @@ def _load():
 
     # Walk through the thirdparty folder and register all library
     # into a dictionary.
-    search_library_root(os.getcwd(), 'thirdparty')
+    pylibmgr.search_library_root(os.getcwd(), 'thirdparty')
 
 
 _load()

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -33,6 +33,8 @@ three-dimensional space.
 
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
 
+import sys
+import os
 
 __all__ = [  # noqa: F822
     'WrapperProfilerStatus',
@@ -104,6 +106,34 @@ except ImportError:
 def _load():
     for name in __all__:
         globals()[name] = getattr(_impl, name)
+
+    # Try to find the thirdparty, if failed to find it
+    # modmesh will raise ImportError and remind the user.
+    filename = os.path.join('thirdparty')
+    path = os.getcwd()
+    try:
+        while True:
+            if os.path.exists(os.path.join(path, filename)):
+                break
+            if path == os.path.dirname(path):
+                path = None
+                break
+            else:
+                path = os.path.dirname(path)
+        if path is None or not os.path.exists(os.path.join(path,
+                                                           filename)):
+            raise ImportError
+    except ImportError:
+        sys.stderr.write('Can not find thirdparty.\n')
+        sys.stderr.write('No python 3rd-party library will be imported\n')
+
+    path = os.path.join(path, filename)
+    sys.path.append(path)
+
+    # Walk through the thirdparty folder and register all library
+    # into a dictionary.
+    from python_lib_management import register_library
+    register_library()
 
 
 _load()

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -33,8 +33,9 @@ three-dimensional space.
 
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
 
-import sys
 import os
+
+from .pylibmgr import search_library_root
 
 __all__ = [  # noqa: F822
     'WrapperProfilerStatus',
@@ -107,33 +108,9 @@ def _load():
     for name in __all__:
         globals()[name] = getattr(_impl, name)
 
-    # Try to find the thirdparty, if failed to find it
-    # modmesh will raise ImportError and remind the user.
-    filename = os.path.join('thirdparty')
-    path = os.getcwd()
-    try:
-        while True:
-            if os.path.exists(os.path.join(path, filename)):
-                break
-            if path == os.path.dirname(path):
-                path = None
-                break
-            else:
-                path = os.path.dirname(path)
-        if path is None or not os.path.exists(os.path.join(path,
-                                                           filename)):
-            raise ImportError
-    except ImportError:
-        sys.stderr.write('Can not find thirdparty.\n')
-        sys.stderr.write('No python 3rd-party library will be imported\n')
-
-    path = os.path.join(path, filename)
-    sys.path.append(path)
-
     # Walk through the thirdparty folder and register all library
     # into a dictionary.
-    from python_lib_management import register_library
-    register_library()
+    search_library_root(os.getcwd(), 'thirdparty')
 
 
 _load()

--- a/modmesh/pylibmgr.py
+++ b/modmesh/pylibmgr.py
@@ -31,12 +31,18 @@ import time
 lib_path = {}
 
 
-def search_library_root(curr_path, lib_root_name, timeout=1):
+def search_library_root(curr_path, lib_root_name, timeout=1.0):
     """
     Walk through the thridparty library and register all third-party
     library folder path into a dictionary with library name as the key,
     user can select which library need to be imported by library name.
 
+    :param curr_path: The path to start searching from.
+    :type curr_path: str
+    :param lib_root_name: The name of the root folder containing libraries.
+    :type lib_root_name: str
+    :param timeout: Maximum time for root path searching. Default is 1.0 sec.
+    :type timeout: float
     :return: None
     """
     # Try to find the library root, if failed to find it

--- a/modmesh/view.py
+++ b/modmesh/view.py
@@ -32,8 +32,7 @@ Viewer
 
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
 
-import sys
-import os
+from . import core
 
 _from_impl = [  # noqa: F822
     'R3DWidget',
@@ -53,6 +52,7 @@ __all__ = _from_impl + [  # noqa: F822
 enable = False
 try:
     from _modmesh import view as _vimpl  # noqa: F401
+    from python_lib_management import load_library
     enable = True
 except ImportError:
     pass
@@ -62,30 +62,15 @@ def _load():
     if enable:
         for name in _from_impl:
             globals()[name] = getattr(_vimpl, name)
-        # Try to find the PUI in thirdparty, if failed to find PUI
-        # modmesh will raise ImportError and terminate itself.
-        filename = os.path.join('thirdparty', 'PUI')
-        path = os.getcwd()
-        try:
-            while True:
-                if os.path.exists(os.path.join(path, filename)):
-                    break
-                if path == os.path.dirname(path):
-                    path = None
-                    break
-                else:
-                    path = os.path.dirname(path)
-            if path is None or not os.path.exists(os.path.join(path,
-                                                               filename,
-                                                               'PUI')):
-                raise ImportError
-        except ImportError:
-            sys.stderr.write('Can not find PUI in your environment.\n')
-            sys.stderr.write('Please run git submodule update --init\n')
-            sys.exit(0)
+    if core.HAS_VIEW:
+        # The viewer is using PUI as a third-party library,
+        # registering it into toggle system
+        tg = core.Toggle.instance
+        tg.add_subkey("viewer")
+        tv = tg.viewer
+        tv.set_string("library", "PUI")
 
-        path = os.path.join(path, filename)
-        sys.path.append(path)
+        load_library(tv.library)
 
 
 _load()

--- a/modmesh/view.py
+++ b/modmesh/view.py
@@ -52,7 +52,7 @@ __all__ = _from_impl + [  # noqa: F822
 enable = False
 try:
     from _modmesh import view as _vimpl  # noqa: F401
-    from .pylibmgr import load_library
+    from . import pylibmgr
     enable = True
 except ImportError:
     pass
@@ -70,7 +70,7 @@ def _load():
         tv = tg.viewer
         tv.set_string("library", "PUI")
 
-        load_library(tv.library)
+        pylibmgr.load_library(tv.library)
 
 
 _load()

--- a/modmesh/view.py
+++ b/modmesh/view.py
@@ -52,7 +52,7 @@ __all__ = _from_impl + [  # noqa: F822
 enable = False
 try:
     from _modmesh import view as _vimpl  # noqa: F401
-    from python_lib_management import load_library
+    from .pylibmgr import load_library
     enable = True
 except ImportError:
     pass

--- a/tests/test_pylibmgr.py
+++ b/tests/test_pylibmgr.py
@@ -34,6 +34,8 @@ import modmesh
 class pylibmgrTC(unittest.TestCase):
 
     def test_pylibmgr_search_library_root(self):
+        # This test case assumes that modmesh third-party lib root's name is
+        # thirdparty, it is located at modmesh project root: /path/to/modmesh.
         modmesh.pylibmgr.search_library_root(os.getcwd(), 'thirdparty')
         lib_path = modmesh.pylibmgr.lib_path
         self.assertNotEqual(lib_path, {})

--- a/tests/test_pylibmgr.py
+++ b/tests/test_pylibmgr.py
@@ -36,7 +36,7 @@ class pylibmgrTC(unittest.TestCase):
     def test_pylibmgr_search_library_root(self):
         modmesh.pylibmgr.search_library_root(os.getcwd(), 'thirdparty')
         lib_path = modmesh.pylibmgr.lib_path
-        self.assertIn("PUI", lib_path.keys())
+        self.assertNotEqual(lib_path, {})
 
         # Reset library patch record
         lib_path = {}

--- a/tests/test_pylibmgr.py
+++ b/tests/test_pylibmgr.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2024, Chunhsu Lai <as2266317@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+import os
+
+import modmesh
+
+
+class pylibmgrTC(unittest.TestCase):
+
+    def test_pylibmgr_search_library_root(self):
+        modmesh.pylibmgr.search_library_root(os.getcwd(), 'thirdparty')
+        lib_path = modmesh.pylibmgr.lib_path
+        self.assertIn("PUI", lib_path.keys())
+
+        # Reset library patch record
+        lib_path = {}
+
+        modmesh.pylibmgr.search_library_root(os.getcwd(), "Can_not_find")
+        self.assertEqual(lib_path, {})
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/thirdparty/python_lib_management.py
+++ b/thirdparty/python_lib_management.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2024, Chun-Hsu Lai <as2266317@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+import os
+
+lib_path = {}
+
+
+def register_library():
+    """
+    Walk through the thridparty library and register all third-party
+    library folder path into a dictionary with library name as the key,
+    user can select which library need to be imported by library name.
+
+    :return: None
+    """
+    dirName = os.path.dirname(__file__)
+    for item in os.listdir(dirName):
+        if os.path.isdir(os.path.join(dirName, item)):
+            lib_path[item] = os.path.join(dirName, item)
+
+
+def load_library(lib_name):
+    """
+    Append library path into python path by user input library name
+
+    :param lib_name: library name that need to be imported.
+    :return: None
+    """
+    try:
+        if lib_name in lib_path:
+            sys.path.append(lib_path[lib_name])
+        else:
+            raise ImportError
+    except ImportError:
+        sys.stderr.write(f'Can not find {lib_name} in thirdparty library.\n')
+        sys.exit(0)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
I added a python script in `thirdparty` folder that provides `register_library` and `load_library` for modmesh to select which  library to load.