### PR TITLE
fix the incorrect constructor initialization

### DIFF
--- a/cpp/modmesh/buffer/BufferBase.hpp
+++ b/cpp/modmesh/buffer/BufferBase.hpp
@@ -96,7 +96,9 @@ protected:
 
     BufferBase(int8_t * start, int8_t * end)
         : m_begin(start)
-        , m_end(end){};
+        , m_end(end)
+    {
+    }
 
     BufferBase(BufferBase const &) = delete;
     BufferBase(BufferBase &&) = delete;

--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -75,7 +75,7 @@ public:
         : BufferBase<BufferExpander>() // don't delegate m_begin and m_end, which will be overwritten later
         , m_concrete_buffer(clone ? buf->clone() : buf)
     {
-        m_begin = m_concrete_buffer->data(); // override m_begin and m_end once we have the data
+        m_begin = m_concrete_buffer->data(); // overwrite m_begin and m_end once we have the data
         m_end = m_begin + m_concrete_buffer->size();
         m_end_cap = m_begin + m_concrete_buffer->size();
     }
@@ -83,7 +83,7 @@ public:
     BufferExpander(size_type nbyte, ctor_passkey const &)
         : BufferBase<BufferExpander>(nullptr, nullptr) // initialize m_begin and m_end to nullptr, which will be overwritten later
     {
-        expand(nbyte); // override m_begin and m_end once we have the data
+        expand(nbyte); // overwrite m_begin and m_end once we have the data
     }
 
     BufferExpander(ctor_passkey const &)

--- a/cpp/modmesh/buffer/ConcreteBuffer.hpp
+++ b/cpp/modmesh/buffer/ConcreteBuffer.hpp
@@ -174,7 +174,7 @@ public:
         , m_nbytes(nbytes)
         , m_data(allocate(nbytes))
     {
-        m_begin = m_data.get(); // override m_begin and m_end once we have the data
+        m_begin = m_data.get(); // overwrite m_begin and m_end once we have the data
         m_end = m_begin + m_nbytes;
     }
 
@@ -193,7 +193,7 @@ public:
         , m_nbytes(nbytes)
         , m_data(data, data_deleter_type(std::move(remover)))
     {
-        m_begin = m_data.get(); // override m_begin and m_end once we have the data
+        m_begin = m_data.get(); // overwrite m_begin and m_end once we have the data
         m_end = m_begin + m_nbytes;
     }
 
@@ -213,14 +213,13 @@ public:
         , m_nbytes(other.m_nbytes)
         , m_data(allocate(other.m_nbytes))
     {
+        m_begin = m_data.get(); // overwrite m_begin and m_end once we have the data
+        m_end = m_begin + m_nbytes;
         if (size() != other.size())
         {
             throw std::out_of_range("Buffer size mismatch");
         }
         std::copy_n(other.data(), size(), data());
-
-        m_begin = m_data.get(); // override m_begin and m_end once we have the data
-        m_end = m_begin + m_nbytes;
     }
 #ifdef __GNUC__
 #pragma GCC diagnostic pop


### PR DESCRIPTION
fix #365

after allocating the new buffer, the old buffer may be an invalid memory address.

setting `m_begin` and `m_end` before calling `size()`