### PR TITLE
Viewer Windows Nightly Build

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -552,3 +552,61 @@ jobs:
           cmake --build ${{ github.workspace }}/build `
             --config ${{ matrix.cmake_build_type }} `
             --target run_viewer_pytest
+
+      - name: generate portable
+        if: ${{ matrix.cmake_build_type == 'Release' }}
+        run: |
+          # Get the Python version installed and extract the major+minor version components
+          $py_ver=$(python3 -V | awk '{print $2}')
+          $py_main_ver=$(echo $py_ver | awk -F. '{print $1$2}')
+          $destination=".\modmesh-viewer-win64\modmesh-viewer-win64"
+          $py_exec="$destination\python.exe"
+
+          # Create the destination directory
+          New-Item -ItemType Directory -Path $destination
+
+          # Download and extract the Python embeddable package
+          $pyembed_url="https://www.python.org/ftp/python/$py_ver/python-$py_ver-embed-amd64.zip"
+          $pyembed_dl="python-$py_ver-embed-amd64.zip"
+          Invoke-WebRequest -Uri $pyembed_url -OutFile $pyembed_dl
+          Expand-Archive -Path $pyembed_dl -DestinationPath $destination
+
+          # Patch the .pth file to enable 'site' package (required for using pip)
+          $pth_file="$destination\python$py_main_ver._pth"
+          (Get-Content $pth_file) -replace '#import site', 'import site' | Set-Content $pth_file
+
+          # Download and setup pip installation script
+          $get_pip_url="https://bootstrap.pypa.io/get-pip.py"
+          $get_pip_script="$destination\get-pip.py"
+          Invoke-WebRequest -Uri $get_pip_url -OutFile $get_pip_script
+          & $py_exec $get_pip_script
+
+          # Install necessary packages for the viewer
+          $qt_ver=$(qmake -query QT_VERSION)
+          & $py_exec -m pip install numpy matplotlib PySide6==$qt_ver shiboken6-generator==$qt_ver
+
+          # Copy pyside6 and shiboken6 DLLs alongside the viewer executable
+          $pyside6_path=$(& $py_exec -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))") 
+          $shiboken6_path=$(& $py_exec -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
+          copy "$pyside6_path\pyside6.abi3.dll" $destination
+          copy "$shiboken6_path\shiboken6.abi3.dll" $destination
+          # Remove redundant Qt DLLs from PySide6
+          Remove-Item -Path $pyside6_path\Qt*.dll
+
+          # Configure and build the viewer
+          cmake -Dpybind11_DIR="$(pybind11-config --cmakedir)" -S . -B build
+          cmake --build build --config Release --target viewer
+
+          # Deploy the Qt environment for the viewer executable and copy necessary files
+          Copy-Item -Path ".\build\cpp\binary\viewer\Release\viewer.exe" -Destination $destination
+          windeployqt --release "$destination\viewer.exe"
+          Copy-Item -Path ".\modmesh" -Destination $destination -Recurse
+          # PUI is necessary
+          Copy-Item -Path ".\thirdparty" -Destination $destination -Recurse
+
+      - name: archive portable artifacts
+        if: ${{ matrix.cmake_build_type == 'Release' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: modmesh-viewer-win64
+          path: modmesh-viewer-win64/


### PR DESCRIPTION
In this PR, the POC for a portable viewer on Windows https://github.com/solvcon/modmesh/issues/194#issuecomment-2158610271 has been implemented into the `devbuild` CI, enabling the nightly build process.

The artifact size is now ~210MB compressed and ~530MB after extraction, with the PySide6 shipped Qt DLLs removed.