### PR TITLE
Add Reset within View menu

### DIFF
--- a/cpp/modmesh/view/R3DWidget.cpp
+++ b/cpp/modmesh/view/R3DWidget.cpp
@@ -103,11 +103,14 @@ void R3DWidget::resizeEvent(QResizeEvent * event)
     m_container->resize(event->size());
 }
 
-void R3DWidget::resetCamera(Qt3DRender::QCamera * camera)
+void R3DWidget::resetCamera(Qt3DRender::QCamera * camera,
+                            float positionX,
+                            float positionY,
+                            float positionZ)
 {
     // Set up the camera.
     camera->lens()->setPerspectiveProjection(45.0f, 16.0f / 9.0f, 0.1f, 1000.0f);
-    camera->setPosition(QVector3D(0.0f, 0.0f, 10.0f));
+    camera->setPosition(QVector3D(positionX, positionY, positionZ));
     camera->setViewCenter(QVector3D(0.0f, 0.0f, 0.0f));
 
     // Set up the camera control.

--- a/cpp/modmesh/view/R3DWidget.cpp
+++ b/cpp/modmesh/view/R3DWidget.cpp
@@ -103,6 +103,20 @@ void R3DWidget::resizeEvent(QResizeEvent * event)
     m_container->resize(event->size());
 }
 
+void R3DWidget::resetCamera(Qt3DRender::QCamera * camera)
+{
+    // Set up the camera.
+    camera->lens()->setPerspectiveProjection(45.0f, 16.0f / 9.0f, 0.1f, 1000.0f);
+    camera->setPosition(QVector3D(0.0f, 0.0f, 10.0f));
+    camera->setViewCenter(QVector3D(0.0f, 0.0f, 0.0f));
+
+    // Set up the camera control.
+    auto * control = m_scene->controller();
+    control->setCamera(camera);
+    control->setLinearSpeed(50.0f);
+    control->setLookSpeed(180.0f);
+}
+
 } /* end namespace modmesh */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/view/R3DWidget.hpp
+++ b/cpp/modmesh/view/R3DWidget.hpp
@@ -111,7 +111,10 @@ public:
     Qt3DExtras::Qt3DWindow * view() { return m_view; }
     RScene * scene() { return m_scene; }
     Qt3DRender::QCamera * camera() { return m_view->camera(); }
-    void resetCamera(Qt3DRender::QCamera * camera);
+    void resetCamera(Qt3DRender::QCamera * camera,
+                     float positionX = 0.0f,
+                     float positionY = 0.0f,
+                     float positionZ = 10.0f);
 
     QPixmap grabPixmap() const { return m_view->screen()->grabWindow(m_view->winId()); }
 

--- a/cpp/modmesh/view/R3DWidget.hpp
+++ b/cpp/modmesh/view/R3DWidget.hpp
@@ -111,7 +111,7 @@ public:
     Qt3DExtras::Qt3DWindow * view() { return m_view; }
     RScene * scene() { return m_scene; }
     Qt3DRender::QCamera * camera() { return m_view->camera(); }
-    void resetCamera(Qt3DRender::QCamera * camera); 
+    void resetCamera(Qt3DRender::QCamera * camera);
 
     QPixmap grabPixmap() const { return m_view->screen()->grabWindow(m_view->winId()); }
 

--- a/cpp/modmesh/view/R3DWidget.hpp
+++ b/cpp/modmesh/view/R3DWidget.hpp
@@ -111,6 +111,7 @@ public:
     Qt3DExtras::Qt3DWindow * view() { return m_view; }
     RScene * scene() { return m_scene; }
     Qt3DRender::QCamera * camera() { return m_view->camera(); }
+    void resetCamera(Qt3DRender::QCamera * camera); 
 
     QPixmap grabPixmap() const { return m_view->screen()->grabWindow(m_view->winId()); }
 

--- a/cpp/modmesh/view/RManager.cpp
+++ b/cpp/modmesh/view/RManager.cpp
@@ -212,7 +212,7 @@ void RManager::setUpMenu()
                     {
                         R3DWidget * viewer = dynamic_cast<R3DWidget *>(subwin->widget());
                         Qt3DRender::QCamera * camera = viewer->camera();
-                        if(camera)
+                        if (camera)
                         {
                             viewer->resetCamera(camera);
                         }
@@ -231,6 +231,7 @@ void RManager::setUpMenu()
 
         use_orbit_camera->setCheckable(true);
         use_fps_camera->setCheckable(true);
+        use_orbit_camera->setChecked(true);
 
         reset_camera->setShortcut(QKeySequence(Qt::Key_Escape));
 

--- a/cpp/modmesh/view/RManager.cpp
+++ b/cpp/modmesh/view/RManager.cpp
@@ -199,15 +199,44 @@ void RManager::setUpMenu()
                 }
             });
 
+        auto * reset_camera = new RAction(
+            QString("Reset (esc)"),
+            QString("Reset (esc)"),
+            [this]()
+            {
+                // implement resetting camera contorl
+                qDebug() << "Reset to initial status.";
+                for (auto subwin : m_mdiArea->subWindowList())
+                {
+                    try
+                    {
+                        R3DWidget * viewer = dynamic_cast<R3DWidget *>(subwin->widget());
+                        Qt3DRender::QCamera * camera = viewer->camera();
+                        if(camera)
+                        {
+                            viewer->resetCamera(camera);
+                        }
+                    }
+                    catch (std::bad_cast & e)
+                    {
+                        std::cerr << e.what() << std::endl;
+                    }
+                }
+            });
+
         auto * cameraGroup = new QActionGroup(m_mainWindow);
         cameraGroup->addAction(use_orbit_camera);
         cameraGroup->addAction(use_fps_camera);
+        cameraGroup->addAction(reset_camera);
+
         use_orbit_camera->setCheckable(true);
         use_fps_camera->setCheckable(true);
-        use_orbit_camera->setChecked(true);
+
+        reset_camera->setShortcut(QKeySequence(Qt::Key_Escape));
 
         m_viewMenu->addAction(use_orbit_camera);
         m_viewMenu->addAction(use_fps_camera);
+        m_viewMenu->addAction(reset_camera);
     }
 
     m_oneMenu = m_mainWindow->menuBar()->addMenu(QString("One"));

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -192,6 +192,19 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapR3DWidget
                     }
                 },
                 py::arg("name"))
+            .def(
+                "resetCamera",
+                [](wrapped_type & self, float const & positionX, float const & positionY, float const & positionZ)
+                {
+                    Qt3DRender::QCamera * camera = self.camera();
+                    if (camera)
+                    {
+                        self.resetCamera(camera, positionX, positionY, positionZ);
+                    }
+                },
+                py::arg("positionX") = 0.0f,
+                py::arg("positionY") = 0.0f,
+                py::arg("positionZ") = 10.0f)
             //
             ;
 


### PR DESCRIPTION
Hi @yungyuc and @tychuang1211,

This PR is related to camera improvement in #70. 

I added a Reset menu item under View menu. When clicking it (or pressing `esc` key), objects in all subwindows will be reset to initial state. 

Here are some demo images:

<img width="1510" alt="Screenshot 2024-06-23 at 3 44 22 PM" src="https://github.com/solvcon/modmesh/assets/55582907/37bf1619-0a47-481d-a3ca-484bccc99cae">

The initial mesh object:
<img width="1512" alt="Screenshot 2024-06-23 at 3 16 34 PM" src="https://github.com/solvcon/modmesh/assets/55582907/d3026041-5f2c-48bd-ab88-dea182a70ecb">

Reset to initial state:
<img width="1512" alt="Screenshot 2024-06-23 at 3 16 56 PM" src="https://github.com/solvcon/modmesh/assets/55582907/c91ed05b-00bf-487d-80f8-b8f915be5dac">