### PR TITLE
SerializableItem: implement JSON from string

### DIFF
--- a/cpp/modmesh/base.hpp
+++ b/cpp/modmesh/base.hpp
@@ -72,6 +72,11 @@ struct is_specialization_of<Template, Template<Args...>> : std::true_type
 template <template <typename...> class Template, typename T>
 inline constexpr bool is_specialization_of_v = is_specialization_of<Template, T>::value;
 
+inline bool is_whitespace(char c)
+{
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+
 } /* end namespace detail */
 
 using real_type = double;

--- a/cpp/modmesh/serialization/SerializableItem.cpp
+++ b/cpp/modmesh/serialization/SerializableItem.cpp
@@ -34,6 +34,16 @@ namespace modmesh
 namespace detail
 {
 
+inline bool is_json_number(char c)
+{
+    return std::isdigit(c) || c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-';
+}
+
+inline void throw_serialization_error(Formatter & formatter, int line, int column)
+{
+    throw std::runtime_error(formatter << " (line: " << line << ", column: " << column << ")");
+}
+
 std::string escape_string(std::string_view str_view)
 {
     std::ostringstream oss;
@@ -75,6 +85,442 @@ std::string escape_string(std::string_view str_view)
     }
     return oss.str();
 }
+
+std::string trim_string(const std::string & str)
+{
+    const char * whitespace = " \t\n\r\f\v";
+    const size_t start = str.find_first_not_of(whitespace);
+    const size_t end = str.find_last_not_of(whitespace);
+    return (start == std::string::npos) ? "" : str.substr(start, end - start + 1);
+}
+
+#define MM_DECL_CACULATE_LINE_COLUMN(CH) \
+    if (CH == '\n')                      \
+    {                                    \
+        line += 1;                       \
+        column = 1;                      \
+    }                                    \
+    else                                 \
+    {                                    \
+        column += 1;                     \
+    }
+
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+// NOLINTNEXTLINE(misc-no-recursion)
+JsonArray JsonNode::parse_array(const std::string & json)
+{
+    JsonArray json_array;
+    JsonState state = JsonState::Start;
+    std::string value_expression;
+
+    int depth = 0;
+
+    int line = 1;
+    int column = 1;
+
+    if (json.empty())
+    {
+        throw_serialization_error(Formatter() << "Invalid JSON format: empty JSON string.", 0, 0);
+    }
+
+    for (size_t index = 0; index < json.size(); index++)
+    {
+        const char c = json[index];
+
+        if (is_whitespace(c))
+        {
+            MM_DECL_CACULATE_LINE_COLUMN(c)
+            continue;
+        }
+
+        switch (state)
+        {
+        case JsonState::Start:
+            if (index > 0 || c != '[')
+            {
+                throw_serialization_error(Formatter() << "Invalid JSON format: missing opening bracket.", line, column);
+            }
+
+            state = JsonState::ObjectValue;
+            break; /* end case JsonState::Start */
+        case JsonState::ObjectValue:
+            value_expression.clear();
+
+            if (c == '{')
+            {
+                // go to the end of the object
+                while (index < json.size())
+                {
+                    value_expression.push_back(json[index]);
+
+                    if (json[index] == '{')
+                    {
+                        depth += 1;
+                    }
+                    else if (json[index] == '}')
+                    {
+                        depth -= 1;
+                    }
+
+                    if (depth == 0)
+                    {
+                        break;
+                    }
+
+                    MM_DECL_CACULATE_LINE_COLUMN(json[index])
+                    index += 1;
+                }
+
+                if (depth != 0)
+                {
+                    throw_serialization_error(Formatter() << "Invalid JSON format: missing closing bracket.", line, column);
+                }
+
+                // NOLINTNEXTLINE(misc-no-recursion)
+                json_array.emplace_back(std::make_unique<JsonNode>(JsonType::Object, value_expression));
+            }
+            else if (c == '[')
+            {
+                // array in array is valid in JSON, but we do not support it yet
+                throw_serialization_error(Formatter() << "Invalid JSON format: unexpected array in array.", line, column);
+            }
+            else
+            {
+                if (!std::isalpha(c) && !is_json_number(c) && c != '"') // check if the value is a string, number, boolean, or null
+                {
+                    throw_serialization_error(Formatter() << "Invalid JSON format: invalid value expression: " << value_expression, line, column);
+                }
+
+                // we assume the value is a string, number, boolean, or null, and the expression is correct
+                // if the expression is not correct, the exception will be thrown when parsing the value later
+                while (index < json.size() - 1)
+                {
+                    value_expression.push_back(json[index]);
+
+                    const char c_next = json[index + 1];
+                    if (c_next == ',' || c_next == ']')
+                    {
+                        break;
+                    }
+
+                    MM_DECL_CACULATE_LINE_COLUMN(json[index])
+                    index += 1;
+                }
+
+                value_expression = trim_string(value_expression);
+
+                JsonType type = JsonType::Unknown;
+                if (value_expression == "true" || value_expression == "false")
+                {
+                    type = JsonType::Boolean;
+                }
+                else if (value_expression == "null")
+                {
+                    type = JsonType::Null;
+                }
+                else if (value_expression[0] == '"' && value_expression[value_expression.size() - 1] == '"')
+                {
+                    type = JsonType::String;
+                }
+                else
+                {
+                    bool is_number = true;
+                    for (const char c : value_expression)
+                    {
+                        if (!is_json_number(c))
+                        {
+                            is_number = false;
+                            break;
+                        }
+                    }
+                    if (is_number)
+                    {
+                        type = JsonType::Number;
+                    }
+                    else
+                    {
+                        throw_serialization_error(Formatter() << "Invalid JSON format: invalid value expression: " << value_expression, line, column);
+                    }
+                }
+
+                json_array.emplace_back(std::make_unique<JsonNode>(type, value_expression));
+            }
+
+            state = JsonState::Comma;
+
+            break; /* end case JsonState::ObjectValue */
+        case JsonState::Comma:
+            if (c == ',')
+            {
+                state = JsonState::ObjectValue;
+            }
+            else if (c == ']')
+            {
+                state = JsonState::End;
+            }
+            break; /* end case JsonState::Comma */
+        case JsonState::End:
+            if (index != json.size() - 1)
+            {
+                throw_serialization_error(Formatter() << "Invalid JSON format: extra characters after closing bracket.", line, column);
+            }
+            break; /* end case JsonState::End */
+        case JsonState::ObjectKey:
+            throw_serialization_error(Formatter() << "Invalid JSON format: unexpected key in array.", line, column);
+            break; /* end case JsonState::ObjectKey */
+        case JsonState::Column:
+            throw_serialization_error(Formatter() << "Invalid JSON format: unexpected column in array.", line, column);
+            break; /* end case JsonState::Column */
+        }
+    }
+
+    if (state != JsonState::End)
+    {
+        throw_serialization_error(Formatter() << "Invalid JSON format: missing closing bracket.", line, column);
+    }
+
+    return json_array;
+}
+// NOLINTEND(readability-function-cognitive-complexity)
+
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+// NOLINTNEXTLINE(misc-no-recursion)
+JsonMap JsonNode::parse_object(const std::string & json)
+{
+    JsonMap json_map;
+    JsonState state = JsonState::Start;
+    std::string key;
+    std::string value_expression;
+
+    int depth = 0;
+    int line = 1;
+    int column = 1;
+
+    if (json.empty())
+    {
+        throw_serialization_error(Formatter() << "Invalid JSON format: empty JSON string.", 0, 0);
+    }
+
+    for (size_t index = 0; index < json.size(); index++)
+    {
+        const char c = json[index];
+
+        if (is_whitespace(c))
+        {
+            MM_DECL_CACULATE_LINE_COLUMN(c)
+            continue;
+        }
+
+        switch (state)
+        {
+        case JsonState::Start:
+            if (index > 0 || c != '{')
+            {
+                throw_serialization_error(Formatter() << "Invalid JSON format: missing opening bracket.", line, column);
+            }
+
+            state = JsonState::ObjectKey;
+            break; /* end case JsonState::Start */
+        case JsonState::ObjectKey:
+            if (c == '"')
+            {
+                key.clear();
+                bool close = false; // get the key string directly
+
+                index += 1;
+                while (index < json.size())
+                {
+                    if (json[index] == '"')
+                    {
+                        close = true;
+                        break;
+                    }
+                    key.push_back(json[index]);
+                    MM_DECL_CACULATE_LINE_COLUMN(json[index])
+                    index += 1;
+                }
+                if (!close)
+                {
+                    throw_serialization_error(Formatter() << "Invalid JSON format: missing closing quote for key.", line, column);
+                }
+
+                key = trim_string(key);
+                state = JsonState::Column;
+            }
+            else
+            {
+                throw_serialization_error(Formatter() << "Invalid JSON format: missing opening quote for key.", line, column);
+            }
+            break; /* end case JsonState::ObjectKey */
+        case JsonState::Column:
+            if (c == ':')
+            {
+                state = JsonState::ObjectValue;
+            }
+            break; /* end case JsonState::Column */
+        case JsonState::ObjectValue:
+            value_expression.clear();
+
+            if (c == '{')
+            {
+                // go to the end of the object
+                while (index < json.size())
+                {
+                    value_expression.push_back(json[index]);
+
+                    if (json[index] == '{')
+                    {
+                        depth += 1;
+                    }
+                    else if (json[index] == '}')
+                    {
+                        depth -= 1;
+                    }
+
+                    if (depth == 0)
+                    {
+                        break;
+                    }
+
+                    MM_DECL_CACULATE_LINE_COLUMN(json[index])
+                    index += 1;
+                }
+
+                if (depth != 0)
+                {
+                    throw_serialization_error(Formatter() << "Invalid JSON format: missing closing bracket.", line, column);
+                }
+
+                // NOLINTNEXTLINE(misc-no-recursion)
+                json_map.emplace(key, std::make_unique<JsonNode>(JsonType::Object, value_expression));
+            }
+            else if (c == '[')
+            {
+                // go to the end of the array
+                while (index < json.size())
+                {
+                    value_expression.push_back(json[index]);
+
+                    if (json[index] == '[')
+                    {
+                        depth += 1;
+                    }
+                    else if (json[index] == ']')
+                    {
+                        depth -= 1;
+                    }
+
+                    if (depth == 0)
+                    {
+                        break;
+                    }
+
+                    MM_DECL_CACULATE_LINE_COLUMN(json[index])
+                    index += 1;
+                }
+
+                if (depth != 0)
+                {
+                    throw_serialization_error(Formatter() << "Invalid JSON format: missing closing bracket.", line, column);
+                }
+
+                // NOLINTNEXTLINE(misc-no-recursion)
+                json_map.emplace(key, std::make_unique<JsonNode>(JsonType::Array, value_expression));
+            }
+            else
+            {
+                if (!std::isalpha(c) && !is_json_number(c) && c != '"') // check if the value is a string, number, boolean, or null
+                {
+                    throw_serialization_error(Formatter() << "Invalid JSON format: invalid value expression: " << value_expression, line, column);
+                }
+
+                // we assume the value is a string, number, boolean, or null, and the expression is correct
+                // if the expression is not correct, the exception will be thrown when parsing the value later
+                while (index < json.size() - 1)
+                {
+                    value_expression.push_back(json[index]);
+
+                    const char c_next = json[index + 1];
+                    if (c_next == ',' || c_next == '}')
+                    {
+                        break;
+                    }
+
+                    MM_DECL_CACULATE_LINE_COLUMN(json[index])
+                    index += 1;
+                }
+
+                value_expression = trim_string(value_expression);
+
+                JsonType type = JsonType::Unknown;
+                if (value_expression == "true" || value_expression == "false")
+                {
+                    type = JsonType::Boolean;
+                }
+                else if (value_expression == "null")
+                {
+                    type = JsonType::Null;
+                }
+                else if (value_expression[0] == '"' && value_expression[value_expression.size() - 1] == '"')
+                {
+                    type = JsonType::String;
+                }
+                else
+                {
+                    bool is_number = true;
+                    for (const char c : value_expression)
+                    {
+                        if (!is_json_number(c))
+                        {
+                            is_number = false;
+                            break;
+                        }
+                    }
+                    if (is_number)
+                    {
+                        type = JsonType::Number;
+                    }
+                    else
+                    {
+                        throw_serialization_error(Formatter() << "Invalid JSON format: invalid value expression: " << value_expression, line, column);
+                    }
+                }
+
+                json_map.emplace(key, std::make_unique<JsonNode>(type, value_expression));
+            }
+
+            state = JsonState::Comma;
+
+            break; /* end case JsonState::ObjectValue */
+        case JsonState::Comma:
+            if (c == ',')
+            {
+                state = JsonState::ObjectKey;
+            }
+            else if (c == '}')
+            {
+                state = JsonState::End;
+            }
+            break; /* end case JsonState::Comma */
+        case JsonState::End:
+            if (index != json.size() - 1)
+            {
+                throw_serialization_error(Formatter() << "Invalid JSON format: extra characters after closing bracket.", line, column);
+            }
+            break; /* end case JsonState::End */
+        }
+    }
+
+    if (state != JsonState::End)
+    {
+        throw_serialization_error(Formatter() << "Invalid JSON format: missing closing bracket.", line, column);
+    }
+
+    return json_map;
+}
+// NOLINTEND(readability-function-cognitive-complexity)
+
+#undef MM_DECL_CACULATE_LINE_COLUMN
 
 } /* end namespace detail */
 

--- a/cpp/modmesh/serialization/SerializableItem.hpp
+++ b/cpp/modmesh/serialization/SerializableItem.hpp
@@ -33,6 +33,7 @@
 #include <string_view>
 #include <type_traits>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 #include <modmesh/base.hpp> // for helper macros
@@ -55,11 +56,94 @@ namespace detail
 /// Escape special characters in a string.
 std::string escape_string(std::string_view str_view);
 
+/// Trim leading and trailing whitespaces and control characters.
+std::string trim_string(const std::string & str);
+
+/// State of the JSON parser.
+enum class JsonState
+{
+    Start,
+    ObjectKey,
+    Column,
+    Comma,
+    ObjectValue,
+    End,
+}; /* end enum class JsonState */
+
+/// Type of JSON token.
+enum class JsonType
+{
+    Object,
+    Array,
+    String,
+    Number,
+    Boolean,
+    Null,
+    Unknown,
+}; /* end enum class JsonType */
+
+struct JsonNode; // Forward declaration
+using JsonMap = std::unordered_map<std::string, std::unique_ptr<JsonNode>>;
+using JsonArray = std::vector<std::unique_ptr<JsonNode>>;
+
+struct JsonNode
+{
+    using JsonValue = std::variant<JsonMap, JsonArray, std::string>;
+
+    JsonType type;
+    JsonValue value;
+
+    JsonNode(JsonType type, const std::string & expression)
+        : type(type)
+    {
+        parse(expression);
+    }
+
+private:
+
+    void parse(const std::string & expression)
+    {
+        if (type == JsonType::Object)
+        {
+            value = std::move(parse_object(expression));
+        }
+        else if (type == JsonType::Array)
+        {
+            value = std::move(parse_array(expression));
+        }
+        else
+        {
+            value = expression;
+        }
+    }
+
+    static JsonMap parse_object(const std::string & json);
+
+    static JsonArray parse_array(const std::string & json);
+
+}; /* end struct JsonNode */
+
+/// Helper class for JSON serialization and deserialization.
+class JsonHelper
+{
+public:
+    template <typename T>
+    static std::string to_json_string(const T & value);
+
+    template <typename T>
+    static void from_json_string(const std::unique_ptr<JsonNode> & node, T & value);
+
+    template <typename T>
+    static void from_json_string(const std::unique_ptr<JsonNode> & node, std::vector<T> & vec);
+
+}; /* end class JsonHelper */
+
 template <typename T>
-std::string to_json_string(const T & value)
+std::string JsonHelper::to_json_string(const T & value)
 {
     if constexpr (std::is_base_of_v<SerializableItem, T>)
     {
+        // NOLINTNEXTLINE(misc-no-recursion)
         return value.to_json(); /* recursive here */
     }
     else if constexpr (std::is_convertible_v<T, std::string>)
@@ -77,6 +161,7 @@ std::string to_json_string(const T & value)
         const char * separator = "";
         for (const auto & item : value)
         {
+            // NOLINTNEXTLINE(misc-no-recursion)
             oss << separator << to_json_string(item); /* recursive here */
             separator = ",";
         }
@@ -89,31 +174,160 @@ std::string to_json_string(const T & value)
     }
 }
 
-}; /* end namespace detail */
+template <typename T>
+void JsonHelper::from_json_string(const std::unique_ptr<JsonNode> & node, T & value)
+{
+    if (node->type == detail::JsonType::Null)
+    {
+        return; /* TODO: properly handle null case */
+    }
 
-/// Serialize a class with member variables.
+    if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>)
+    {
+        if (node->type != detail::JsonType::Number)
+        {
+            throw std::runtime_error("Invalid JSON format: invalid integer type.");
+        }
+        value = std::stoll(std::get<std::string>(node->value));
+    }
+    else if constexpr (std::is_floating_point_v<T>)
+    {
+        if (node->type != detail::JsonType::Number)
+        {
+            throw std::runtime_error("Invalid JSON format: invalid floating number type.");
+        }
+        value = std::stod(std::get<std::string>(node->value));
+    }
+    else if constexpr (std::is_same_v<T, std::string>)
+    {
+        if (node->type != detail::JsonType::String)
+        {
+            throw std::runtime_error("Invalid JSON format: invalid number type.");
+        }
+        auto & str = std::get<std::string>(node->value);
+        value = str.substr(1, str.size() - 2); /* Remove quotes */
+    }
+    else if constexpr (std::is_same_v<T, bool>)
+    {
+        if (node->type != detail::JsonType::Boolean)
+        {
+            throw std::runtime_error("Invalid JSON format: invalid boolean type.");
+        }
+        if (std::get<std::string>(node->value) == "false")
+        {
+            value = false;
+        }
+        else
+        {
+            value = true;
+        }
+    }
+    else if constexpr (std::is_same_v<T, std::string>)
+    {
+        if (node->type != detail::JsonType::String)
+        {
+            throw std::runtime_error("Invalid JSON format: invalid number type.");
+        }
+        auto & str = std::get<std::string>(node->value);
+        value = str.substr(1, str.size() - 2); /* Remove quotes */
+    }
+    else if constexpr (std::is_base_of_v<SerializableItem, T>)
+    {
+        if (node->type != detail::JsonType::Object)
+        {
+            throw std::runtime_error("Invalid JSON format: invalid object type.");
+        }
+        // NOLINTNEXTLINE(misc-no-recursion)
+        value.from_json(std::get<JsonMap>(node->value)); /* recursive here */
+    }
+    else
+    {
+        throw std::runtime_error("Invalid JSON format: invalid type.");
+    }
+}
+
+template <typename T>
+void JsonHelper::from_json_string(const std::unique_ptr<JsonNode> & node, std::vector<T> & vec)
+{
+    if (node->type == JsonType::Null)
+    {
+        return; /* TODO: properly handle null case */
+    }
+
+    if (node->type != JsonType::Array)
+    {
+        throw std::runtime_error("Invalid JSON format: invalid array type.");
+    }
+
+    vec.clear();
+
+    auto & array = std::get<JsonArray>(node->value);
+    vec.resize(array.size());
+
+    for (size_t i = 0; i < vec.size(); ++i)
+    {
+        // NOLINTNEXTLINE(misc-no-recursion)
+        from_json_string(array[i], vec[i]); /* recursive here */
+    }
+}
+
+} /* end namespace detail */
+
+/// The macro to declare a class as serializable.
 /// Use `register_member("key", class.member);` to add members when using this macro
-/// Note that the order of members in the JSON string is based on the order of `register_member` calls.
-#define MM_DECL_SERIALIZABLE(...)                                                       \
-public:                                                                                 \
-    std::string to_json() const override                                                \
-    {                                                                                   \
-        std::ostringstream oss;                                                         \
-        oss << "{";                                                                     \
-        const char * separator = "";                                                    \
-        auto register_member = [&](const char * name, auto && value)                    \
-        {                                                                               \
-            oss << separator << "\"" << name << "\":" << detail::to_json_string(value); \
-            separator = ",";                                                            \
-        };                                                                              \
-        __VA_ARGS__                                                                     \
-        oss << "}";                                                                     \
-        return oss.str();                                                               \
-    }                                                                                   \
-                                                                                        \
-    void from_json(const std::string & json) override                                   \
-    {                                                                                   \
-        /* TODO: The implemenation is in the next PR */                                 \
+/// The order of members in the JSON string is based on the order of `register_member` calls.
+/// The access modifier of the members can be public or private.
+/// The access modifier will be changed to private after the macro.
+#define MM_DECL_SERIALIZABLE(...)                                                                   \
+public:                                                                                             \
+    std::string to_json() const override                                                            \
+    {                                                                                               \
+        std::ostringstream oss;                                                                     \
+        oss << "{";                                                                                 \
+        const char * separator = "";                                                                \
+        auto register_member = [&](const char * name, auto && value)                                \
+        {                                                                                           \
+            oss << separator << "\"" << name << "\":" << detail::JsonHelper::to_json_string(value); \
+            separator = ",";                                                                        \
+        };                                                                                          \
+        __VA_ARGS__                                                                                 \
+        oss << "}";                                                                                 \
+        return oss.str();                                                                           \
+    }                                                                                               \
+                                                                                                    \
+    void from_json(const std::string & json) override                                               \
+    {                                                                                               \
+        auto jsonNode = std::make_unique<detail::JsonNode>(detail::JsonType::Object, json);         \
+        auto register_member = [&](const char * name, auto && value)                                \
+        {                                                                                           \
+            if (jsonNode->type == detail::JsonType::Object)                                         \
+            {                                                                                       \
+                auto & obj = std::get<detail::JsonMap>(jsonNode->value);                            \
+                auto it = obj.find(name);                                                           \
+                if (it != obj.end())                                                                \
+                {                                                                                   \
+                    detail::JsonHelper::from_json_string(it->second, value);                        \
+                }                                                                                   \
+            }                                                                                       \
+        };                                                                                          \
+        __VA_ARGS__                                                                                 \
+    }                                                                                               \
+                                                                                                    \
+private:                                                                                            \
+    friend class detail::JsonHelper;                                                                \
+                                                                                                    \
+    /* for the nested object, we already parsed the json */                                         \
+    void from_json(const detail::JsonMap & json_map)                                                \
+    {                                                                                               \
+        auto register_member = [&](const char * name, auto && value)                                \
+        {                                                                                           \
+            auto it = json_map.find(name);                                                          \
+            if (it != json_map.end())                                                               \
+            {                                                                                       \
+                detail::JsonHelper::from_json_string(it->second, value);                            \
+            }                                                                                       \
+        };                                                                                          \
+        __VA_ARGS__                                                                                 \
     } /* end MM_DECL_SERIALIZABLE*/
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/serialization/SerializableItem.hpp
+++ b/cpp/modmesh/serialization/SerializableItem.hpp
@@ -131,10 +131,10 @@ public:
     static std::string to_json_string(const T & value);
 
     template <typename T>
-    static void from_json_string(const std::unique_ptr<JsonNode> & node, T & value);
+    static void from_json_string(const std::unique_ptr<JsonNode> & node, T & value); // TODO: have a design that can remove the output argument to increase the maintainability
 
     template <typename T>
-    static void from_json_string(const std::unique_ptr<JsonNode> & node, std::vector<T> & vec);
+    static void from_json_string(const std::unique_ptr<JsonNode> & node, std::vector<T> & vec); // TODO: have a design that can remove the output argument to increase the maintainability
 
 }; /* end class JsonHelper */
 

--- a/cpp/modmesh/serialization/SerializableItem.hpp
+++ b/cpp/modmesh/serialization/SerializableItem.hpp
@@ -131,10 +131,12 @@ public:
     static std::string to_json_string(const T & value);
 
     template <typename T>
-    static void from_json_string(const std::unique_ptr<JsonNode> & node, T & value); // TODO: have a design that can remove the output argument to increase the maintainability
+    // TODO: have a design that can remove the output argument to increase the maintainability
+    static void from_json_string(const std::unique_ptr<JsonNode> & node, T & value);
 
     template <typename T>
-    static void from_json_string(const std::unique_ptr<JsonNode> & node, std::vector<T> & vec); // TODO: have a design that can remove the output argument to increase the maintainability
+    // TODO: have a design that can remove the output argument to increase the maintainability
+    static void from_json_string(const std::unique_ptr<JsonNode> & node, std::vector<T> & vec);
 
 }; /* end class JsonHelper */
 


### PR DESCRIPTION
Support JSON from string
- add `from_json` into `MM_DECL_SERIALIZABLE`
- implemented `JsonNode`, which is the token of JSON
- implemented JSON parser: `parse_array`, `parse_object`
- added a helper class: `JsonHelper`