### PR TITLE
Add download description for Windows nightly build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 Check the Github Actions workflow for how to build the code.
 Check https://github.com/solvcon/mmnote for the theoretical and numerical notes.
 
-## Binaries
-A portable version of the modmesh viewer for Windows is now available for download from the Actions: [**devbuild**](https://github.com/solvcon/modmesh/actions/workflows/devbuild.yml?query=event%3Aschedule+is%3Asuccess+branch%3Amaster) (login required).
+## Download
 
-> Click on a run result and scroll down to the Artifacts section to download the ZIP file.
+Windows portable binaries are now available for download from the Actions:
+[**devbuild**\
+](https://github.com/solvcon/modmesh/actions/workflows/devbuild.yml?query=event%3Aschedule+is%3Asuccess+branch%3Amaster)
+> Click on a run result and scroll down to the Artifacts section to download the ZIP file. (Login is required.)
 
 <!-- vim: set ft=markdown ff=unix tw=79: -->

--- a/README.md
+++ b/README.md
@@ -3,4 +3,9 @@
 Check the Github Actions workflow for how to build the code.
 Check https://github.com/solvcon/mmnote for the theoretical and numerical notes.
 
+## Binaries
+A portable version of the modmesh viewer for Windows is now available for download from the Actions: [**devbuild**](https://github.com/solvcon/modmesh/actions/workflows/devbuild.yml?query=event%3Aschedule+is%3Asuccess+branch%3Amaster) (login required).
+
+> Click on a run result and scroll down to the Artifacts section to download the ZIP file.
+
 <!-- vim: set ft=markdown ff=unix tw=79: -->


### PR DESCRIPTION
This is a preliminary PR for https://github.com/solvcon/modmesh/issues/371
The url query string is helpful for filtering the successful nightly build on master branch:
```
?query=event%3Aschedule+is%3Asuccess+branch%3Amaster
```