### PR TITLE
add clone for SimpleArray

### DIFF
--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -87,6 +87,8 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                     }),
                 py::arg("array"))
             .def_buffer(&property_helper::get_buffer_info)
+            .def("clone", [](wrapped_type const & self)
+                 { return wrapped_type(self); }) // cloning the object using the copy constructor. never add the clone method to the C++ class.
             .def_property_readonly(
                 "ndarray",
                 [](wrapped_type & self)

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -87,7 +87,8 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                     }),
                 py::arg("array"))
             .def_buffer(&property_helper::get_buffer_info)
-            .def("clone", [](wrapped_type const & self)
+            .def("clone",
+                 [](wrapped_type const & self)
                  { return wrapped_type(self); }) // cloning the object using the copy constructor. never add the clone method to the C++ class.
             .def_property_readonly(
                 "ndarray",

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -231,6 +231,8 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
                         return wrapped_type(shape, buffer, pybind11::str(arr_in.dtype()));
                     }),
                 pybind11::arg("array"))
+            .def("clone", [](wrapped_type const & self)
+                 { return wrapped_type(self); }) // cloning the object using the copy constructor. never add the clone method to the C++ class.
             .def_property_readonly("typed", &get_typed_array)
             .def_buffer(
                 [](wrapped_type & self)

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -231,7 +231,8 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
                         return wrapped_type(shape, buffer, pybind11::str(arr_in.dtype()));
                     }),
                 pybind11::arg("array"))
-            .def("clone", [](wrapped_type const & self)
+            .def("clone",
+                 [](wrapped_type const & self)
                  { return wrapped_type(self); }) // cloning the object using the copy constructor. never add the clone method to the C++ class.
             .def_property_readonly("typed", &get_typed_array)
             .def_buffer(

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -205,6 +205,14 @@ class SimpleArrayBasicTC(unittest.TestCase):
         self.assertEqual((1, 24), sarr.reshape((1, 24)).shape)
         self.assertEqual((12, 2), sarr.reshape((12, 2)).shape)
 
+    def test_SimpleArray_clone(self):
+        sarr = modmesh.SimpleArrayFloat64((2, 3, 4))
+        sarr_ref = sarr
+        sarr_clone = sarr.clone()
+
+        self.assertTrue(sarr_ref is sarr)
+        self.assertFalse(sarr_clone is sarr)
+
     def test_SimpleArray_ghost_1d(self):
 
         sarr = modmesh.SimpleArrayFloat64(4 * 3 * 2)
@@ -858,6 +866,14 @@ class SimpleArrayPlexTC(unittest.TestCase):
             modmesh.SimpleArray(ndarr)
         boolean_array = np.array([True, False, True], dtype='bool')
         modmesh.SimpleArray(boolean_array)
+
+    def test_SimpleArray_clone(self):
+        sarr = modmesh.SimpleArray((2, 3, 4), value=2.0, dtype='float64')
+        sarr_ref = sarr
+        sarr_clone = sarr.clone()
+
+        self.assertTrue(sarr_ref is sarr)
+        self.assertFalse(sarr_clone is sarr)
 
     def test_SimpleArrayPlex_buffer(self):
         magic_number = 3.1415

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -881,10 +881,14 @@ class SimpleArrayPlexTC(unittest.TestCase):
         sarr_clone = sarr.clone()
 
         self.assertTrue(sarr_ref is sarr)
-        np.testing.assert_equal(sarr_ref.typed.ndarray[...], sarr.typed.ndarray[...])
+        ref_ndarr = sarr_ref.typed.ndarray[...]
+        ndarr = sarr.typed.ndarray[...]
+        np.testing.assert_equal(ref_ndarr, ndarr)
 
         self.assertFalse(sarr_clone is sarr)
-        np.testing.assert_equal(sarr_clone.typed.ndarray[...], sarr.typed.ndarray[...])
+        clone_ndarr = sarr_clone.typed.ndarray[...]
+        ndarr = sarr.typed.ndarray[...]
+        np.testing.assert_equal(clone_ndarr, ndarr)
 
         sarr[3] = 3.0
         self.assertEqual(sarr_ref[3], 3.0)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -207,11 +207,19 @@ class SimpleArrayBasicTC(unittest.TestCase):
 
     def test_SimpleArray_clone(self):
         sarr = modmesh.SimpleArrayFloat64((2, 3, 4))
+        sarr.fill(2.0)
         sarr_ref = sarr
         sarr_clone = sarr.clone()
 
         self.assertTrue(sarr_ref is sarr)
+        np.testing.assert_equal(sarr_ref.ndarray[...], sarr.ndarray[...])
+
         self.assertFalse(sarr_clone is sarr)
+        np.testing.assert_equal(sarr_clone.ndarray[...], sarr.ndarray[...])
+
+        sarr[3] = 3.0
+        self.assertEqual(sarr_ref[3], 3.0)
+        self.assertEqual(sarr_clone[3], 2.0)  # should be the original value
 
     def test_SimpleArray_ghost_1d(self):
 
@@ -873,7 +881,14 @@ class SimpleArrayPlexTC(unittest.TestCase):
         sarr_clone = sarr.clone()
 
         self.assertTrue(sarr_ref is sarr)
+        np.testing.assert_equal(sarr_ref.typed.ndarray[...], sarr.typed.ndarray[...])
+
         self.assertFalse(sarr_clone is sarr)
+        np.testing.assert_equal(sarr_clone.typed.ndarray[...], sarr.typed.ndarray[...])
+
+        sarr[3] = 3.0
+        self.assertEqual(sarr_ref[3], 3.0)
+        self.assertEqual(sarr_clone[3], 2.0)  # should be the original value
 
     def test_SimpleArrayPlex_buffer(self):
         magic_number = 3.1415


### PR DESCRIPTION
per conversation in [Discord](https://discord.com/channels/730297880140578906/978989059844214784/1261223700770848768), adding the missing `clone` method for `SimpArray` and `SimpleArrayPlex`

the usage:
```py
        sarr = modmesh.SimpleArrayFloat64((2, 3, 4))
        sarr_ref = sarr
        sarr_clone = sarr.clone()

        self.assertTrue(sarr_ref is sarr)
        self.assertFalse(sarr_clone is sarr)
```