### PR TITLE
use custom meta path finder to import 3rd library

### DIFF
--- a/modmesh/pylibmgr.py
+++ b/modmesh/pylibmgr.py
@@ -33,7 +33,7 @@ import importlib.machinery
 lib_path = {}
 
 
-class mm_path_finder(importlib.abc.MetaPathFinder):
+class MMPathFinder(importlib.abc.MetaPathFinder):
     def find_spec(self, lib_name, path, target=None):
         if lib_name in lib_path:
             _ = os.path.abspath(lib_path[lib_name])
@@ -45,11 +45,7 @@ class mm_path_finder(importlib.abc.MetaPathFinder):
 
             loader = importlib.machinery.SourceFileLoader(lib_name, init_path)
             spec = importlib.machinery.ModuleSpec(
-                                                  lib_name,
-                                                  loader,
-                                                  origin=init_path,
-                                                  is_package=True
-                                                 )
+                    lib_name, loader, origin=init_path, is_package=True)
             spec.submodule_search_locations = [pkg_path]
             return spec
 
@@ -96,7 +92,7 @@ def search_library_root(curr_path, lib_root_name, timeout=1.0):
 
 
 def _register_mm_path_finder():
-    sys.meta_path.append(mm_path_finder())
+    sys.meta_path.append(MMPathFinder())
 
 
 _register_mm_path_finder()

--- a/modmesh/pylibmgr.py
+++ b/modmesh/pylibmgr.py
@@ -33,7 +33,7 @@ import importlib.machinery
 lib_path = {}
 
 
-class MMPathFinder(importlib.abc.MetaPathFinder):
+class ModmeshPathFinder(importlib.abc.MetaPathFinder):
     def find_spec(self, lib_name, path, target=None):
         if lib_name in lib_path:
             _ = os.path.abspath(lib_path[lib_name])
@@ -43,9 +43,26 @@ class MMPathFinder(importlib.abc.MetaPathFinder):
             if not os.path.exists(init_path):
                 return None
 
+            # Create a loader instance for the given package name and
+            # it's __init__.py
             loader = importlib.machinery.SourceFileLoader(lib_name, init_path)
+
+            # Create a module spec instance for the given module name,
+            # specific loader and the path of module file.
+            # If the module is a package the argument is_package should be
+            # set to True.
+            # Ref:
+            # https://docs.python.org/3/library/importlib.html#importlib.
+            # machinery.ModuleSpec
             spec = importlib.machinery.ModuleSpec(
                     lib_name, loader, origin=init_path, is_package=True)
+
+            # This attribute tells the import system where to look for
+            # submodules or subpackages, it should not be set to None
+            # for a package modules.
+            # Ref:
+            # https://docs.python.org/3/library/importlib.html#importlib.
+            # machinery.ModuleSpec.submodule_search_locations
             spec.submodule_search_locations = [pkg_path]
             return spec
 
@@ -92,7 +109,7 @@ def search_library_root(curr_path, lib_root_name, timeout=1.0):
 
 
 def _register_mm_path_finder():
-    sys.meta_path.append(MMPathFinder())
+    sys.meta_path.append(ModmeshPathFinder())
 
 
 _register_mm_path_finder()

--- a/modmesh/pylibmgr.py
+++ b/modmesh/pylibmgr.py
@@ -30,13 +30,14 @@ import time
 import importlib.abc
 import importlib.machinery
 
-lib_path = {}
-
 
 class ModmeshPathFinder(importlib.abc.MetaPathFinder):
+    def __init__(self, lib_paths):
+        self.lib_paths = lib_paths
+
     def find_spec(self, lib_name, path, target=None):
-        if lib_name in lib_path:
-            _ = os.path.abspath(lib_path[lib_name])
+        if lib_name in self.lib_paths:
+            _ = os.path.abspath(self.lib_paths[lib_name])
             pkg_path = os.path.join(_, lib_name)
             init_path = os.path.join(pkg_path, '__init__.py')
 
@@ -56,7 +57,6 @@ class ModmeshPathFinder(importlib.abc.MetaPathFinder):
             # machinery.ModuleSpec
             spec = importlib.machinery.ModuleSpec(
                     lib_name, loader, origin=init_path, is_package=True)
-
             # This attribute tells the import system where to look for
             # submodules or subpackages, it should not be set to None
             # for a package modules.
@@ -67,6 +67,11 @@ class ModmeshPathFinder(importlib.abc.MetaPathFinder):
             return spec
 
         return None
+
+
+def is_modmesh_meta_path_finder_registered():
+    return any(isinstance(finder, ModmeshPathFinder)
+               for finder in sys.meta_path)
 
 
 def search_library_root(curr_path, lib_root_name, timeout=1.0):
@@ -85,6 +90,7 @@ def search_library_root(curr_path, lib_root_name, timeout=1.0):
     """
     # Try to find the library root, if failed to find it
     # modmesh will raise ImportError and remind the user.
+    lib_path = {}
     folder_name = os.path.join(lib_root_name)
     _path = curr_path
     start_time = time.time()
@@ -107,11 +113,6 @@ def search_library_root(curr_path, lib_root_name, timeout=1.0):
         if os.path.isdir(os.path.join(_path, item)):
             lib_path[item] = os.path.join(_path, item)
 
-
-def _register_mm_path_finder():
-    sys.meta_path.append(ModmeshPathFinder())
-
-
-_register_mm_path_finder()
-del _register_mm_path_finder
+    if not is_modmesh_meta_path_finder_registered():
+        sys.meta_path.append(ModmeshPathFinder(lib_path))
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/view.py
+++ b/modmesh/view.py
@@ -32,7 +32,6 @@ Viewer
 
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
 
-from . import core
 
 _from_impl = [  # noqa: F822
     'R3DWidget',
@@ -52,7 +51,6 @@ __all__ = _from_impl + [  # noqa: F822
 enable = False
 try:
     from _modmesh import view as _vimpl  # noqa: F401
-    from . import pylibmgr
     enable = True
 except ImportError:
     pass
@@ -62,15 +60,6 @@ def _load():
     if enable:
         for name in _from_impl:
             globals()[name] = getattr(_vimpl, name)
-    if core.HAS_VIEW:
-        # The viewer is using PUI as a third-party library,
-        # registering it into toggle system
-        tg = core.Toggle.instance
-        tg.add_subkey("viewer")
-        tv = tg.viewer
-        tv.set_string("library", "PUI")
-
-        pylibmgr.load_library(tv.library)
 
 
 _load()

--- a/tests/test_pylibmgr.py
+++ b/tests/test_pylibmgr.py
@@ -28,7 +28,9 @@ import unittest
 
 import os
 
-import modmesh
+import sys
+
+from modmesh import pylibmgr
 
 
 class pylibmgrTC(unittest.TestCase):
@@ -36,14 +38,15 @@ class pylibmgrTC(unittest.TestCase):
     def test_pylibmgr_search_library_root(self):
         # This test case assumes that modmesh third-party lib root's name is
         # thirdparty, it is located at modmesh project root: /path/to/modmesh.
-        modmesh.pylibmgr.search_library_root(os.getcwd(), 'thirdparty')
-        lib_path = modmesh.pylibmgr.lib_path
-        self.assertNotEqual(lib_path, {})
+        pylibmgr.search_library_root(os.getcwd(), 'thirdparty')
+        finder = next(finder for finder in sys.meta_path
+                      if isinstance(finder, pylibmgr.ModmeshPathFinder))
+        self.assertNotEqual(finder.lib_paths, {})
 
         # Reset library patch record
-        lib_path = {}
+        finder.lib_paths = {}
 
-        modmesh.pylibmgr.search_library_root(os.getcwd(), "Can_not_find")
-        self.assertEqual(lib_path, {})
+        pylibmgr.search_library_root(os.getcwd(), "Can_not_find")
+        self.assertEqual(finder.lib_paths, {})
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Using custom meta path finder instead of modifying `sys.path` to import 3rd python library into modmesh.

Link to #378