### PR TITLE
Hide boundary points in figure

### DIFF
--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -743,19 +743,30 @@ class Euler1DApp():
         :return: None
         """
         if self.use_grid_layout:
-            self.density.update(adata=self.st.density_field,
-                                ndata=self.st.svr.density[self.st.svr.xindices])
-            self.pressure.update(adata=self.st.pressure_field,
-                                 ndata=self.st.svr.pressure[self.st.svr.xindices])
-            self.velocity.update(adata=self.st.velocity_field,
-                                 ndata=self.st.svr.velocity[self.st.svr.xindices])
-            self.temperature.update(adata=self.st.temperature_field,
-                                    ndata=self.st.svr.temperature[self.st.svr.xindices])
-            self.internal_energy.update(adata=(self.st.internal_energy_field),
-                                        ndata=(self.st.svr.
-                                               internal_energy[self.st.svr.xindices]))
-            self.entropy.update(adata=self.st.entropy_field,
-                                ndata=self.st.svr.entropy[self.st.svr.xindices])
+            self.density.update(
+                adata=self.st.density_field,
+                ndata=self.st.svr.density[self.st.svr.xindices]
+            )
+            self.pressure.update(
+                adata=self.st.pressure_field,
+                ndata=self.st.svr.pressure[self.st.svr.xindices]
+            )
+            self.velocity.update(
+                adata=self.st.velocity_field,
+                ndata=self.st.svr.velocity[self.st.svr.xindices]
+            )
+            self.temperature.update(
+                adata=self.st.temperature_field,
+                ndata=self.st.svr.temperature[self.st.svr.xindices]
+            )
+            self.internal_energy.update(
+                adata=(self.st.internal_energy_field),
+                ndata=(self.st.svr.internal_energy[self.st.svr.xindices])
+            )
+            self.entropy.update(
+                adata=self.st.entropy_field,
+                ndata=self.st.svr.entropy[self.st.svr.xindices]
+            )
         else:
             for name, is_selected, *_ in self.plot_config.state:
                 if is_selected:

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -530,7 +530,7 @@ class Euler1DApp():
 
         :return: FigureCanvas
         """
-        x = self.st.svr.coord[self.st.xindices]
+        x = self.st.svr.coord[self.st.svr.xindices]
         fig = Figure()
         canvas = FigureCanvas(fig)
         ax = canvas.figure.subplots(3, 2)
@@ -574,7 +574,7 @@ class Euler1DApp():
 
         :return: FigureCanvas
         """
-        x = self.st.svr.coord[self.st.xindices]
+        x = self.st.svr.coord[self.st.svr.xindices]
         fig = Figure()
         canvas = FigureCanvas(fig)
         ax = canvas.figure.subplots()
@@ -744,23 +744,23 @@ class Euler1DApp():
         """
         if self.use_grid_layout:
             self.density.update(adata=self.st.density_field,
-                                ndata=self.st.svr.density[self.st.xindices])
+                                ndata=self.st.svr.density[self.st.svr.xindices])
             self.pressure.update(adata=self.st.pressure_field,
-                                 ndata=self.st.svr.pressure[self.st.xindices])
+                                 ndata=self.st.svr.pressure[self.st.svr.xindices])
             self.velocity.update(adata=self.st.velocity_field,
-                                 ndata=self.st.svr.velocity[self.st.xindices])
+                                 ndata=self.st.svr.velocity[self.st.svr.xindices])
             self.temperature.update(adata=self.st.temperature_field,
-                                    ndata=self.st.svr.temperature[self.st.xindices])
+                                    ndata=self.st.svr.temperature[self.st.svr.xindices])
             self.internal_energy.update(adata=(self.st.internal_energy_field),
                                         ndata=(self.st.svr.
-                                               internal_energy[self.st.xindices]))
+                                               internal_energy[self.st.svr.xindices]))
             self.entropy.update(adata=self.st.entropy_field,
-                                ndata=self.st.svr.entropy[self.st.xindices])
+                                ndata=self.st.svr.entropy[self.st.svr.xindices])
         else:
             for name, is_selected, *_ in self.plot_config.state:
                 if is_selected:
                     eval(f'(self.{name}.update(adata=self.st.{name}_field,'
-                         f' ndata=self.st.svr.{name}[self.st.xindices]))')
+                         f' ndata=self.st.svr.{name}[self.st.svr.xindices]))')
 
 
 class PlotArea(PuiInQt):

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -511,6 +511,8 @@ class Euler1DApp():
         self.interval = self.solver_config.get_var("timer_interval", "value")
         self.max_steps = self.solver_config.get_var("max_steps", "value")
         self.profiling = self.solver_config.get_var("profiling", "value")
+        ncoord = self.solver_config.get_var("ncoord", "value")
+        self.plot_point = np.linspace(2, (ncoord - 3), num=((ncoord - 3) // 2), dtype=int)
 
     def setup_timer(self):
         """
@@ -530,7 +532,7 @@ class Euler1DApp():
 
         :return: FigureCanvas
         """
-        x = self.st.svr.coord[::2]
+        x = self.st.svr.coord[self.plot_point]
         fig = Figure()
         canvas = FigureCanvas(fig)
         ax = canvas.figure.subplots(3, 2)
@@ -574,7 +576,7 @@ class Euler1DApp():
 
         :return: FigureCanvas
         """
-        x = self.st.svr.coord[::2]
+        x = self.st.svr.coord[self.plot_point]
         fig = Figure()
         canvas = FigureCanvas(fig)
         ax = canvas.figure.subplots()
@@ -744,23 +746,23 @@ class Euler1DApp():
         """
         if self.use_grid_layout:
             self.density.update(adata=self.st.density_field,
-                                ndata=self.st.svr.density[::2])
+                                ndata=self.st.svr.density[self.plot_point])
             self.pressure.update(adata=self.st.pressure_field,
-                                 ndata=self.st.svr.pressure[::2])
+                                 ndata=self.st.svr.pressure[self.plot_point])
             self.velocity.update(adata=self.st.velocity_field,
-                                 ndata=self.st.svr.velocity[::2])
+                                 ndata=self.st.svr.velocity[self.plot_point])
             self.temperature.update(adata=self.st.temperature_field,
-                                    ndata=self.st.svr.temperature[::2])
+                                    ndata=self.st.svr.temperature[self.plot_point])
             self.internal_energy.update(adata=(self.st.internal_energy_field),
                                         ndata=(self.st.svr.
-                                               internal_energy[::2]))
+                                               internal_energy[self.plot_point]))
             self.entropy.update(adata=self.st.entropy_field,
-                                ndata=self.st.svr.entropy[::2])
+                                ndata=self.st.svr.entropy[self.plot_point])
         else:
             for name, is_selected, *_ in self.plot_config.state:
                 if is_selected:
                     eval(f'(self.{name}.update(adata=self.st.{name}_field,'
-                         f' ndata=self.st.svr.{name}[::2]))')
+                         f' ndata=self.st.svr.{name}[self.plot_point]))')
 
 
 class PlotArea(PuiInQt):

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -744,30 +744,19 @@ class Euler1DApp():
         """
         if self.use_grid_layout:
             _s = self.st.svr.xindices
-            self.density.update(
-                adata=self.st.density_field,
-                ndata=self.st.svr.density[_s]
-            )
-            self.pressure.update(
-                adata=self.st.pressure_field,
-                ndata=self.st.svr.pressure[_s]
-            )
-            self.velocity.update(
-                adata=self.st.velocity_field,
-                ndata=self.st.svr.velocity[_s]
-            )
-            self.temperature.update(
-                adata=self.st.temperature_field,
-                ndata=self.st.svr.temperature[_s]
-            )
-            self.internal_energy.update(
-                adata=(self.st.internal_energy_field),
-                ndata=(self.st.svr.internal_energy[_s])
-            )
-            self.entropy.update(
-                adata=self.st.entropy_field,
-                ndata=self.st.svr.entropy[_s]
-            )
+            self.density.update(adata=self.st.density_field,
+                                ndata=self.st.svr.density[_s])
+            self.pressure.update(adata=self.st.pressure_field,
+                                 ndata=self.st.svr.pressure[_s])
+            self.velocity.update(adata=self.st.velocity_field,
+                                 ndata=self.st.svr.velocity[_s])
+            self.temperature.update(adata=self.st.temperature_field,
+                                    ndata=self.st.svr.temperature[_s])
+            self.internal_energy.update(adata=(self.st.internal_energy_field),
+                                        ndata=(self.st.svr.
+                                               internal_energy[_s]))
+            self.entropy.update(adata=self.st.entropy_field,
+                                ndata=self.st.svr.entropy[_s])
         else:
             for name, is_selected, *_ in self.plot_config.state:
                 if is_selected:

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -743,29 +743,30 @@ class Euler1DApp():
         :return: None
         """
         if self.use_grid_layout:
+            _s = self.st.svr.xindices
             self.density.update(
                 adata=self.st.density_field,
-                ndata=self.st.svr.density[self.st.svr.xindices]
+                ndata=self.st.svr.density[_s]
             )
             self.pressure.update(
                 adata=self.st.pressure_field,
-                ndata=self.st.svr.pressure[self.st.svr.xindices]
+                ndata=self.st.svr.pressure[_s]
             )
             self.velocity.update(
                 adata=self.st.velocity_field,
-                ndata=self.st.svr.velocity[self.st.svr.xindices]
+                ndata=self.st.svr.velocity[_s]
             )
             self.temperature.update(
                 adata=self.st.temperature_field,
-                ndata=self.st.svr.temperature[self.st.svr.xindices]
+                ndata=self.st.svr.temperature[_s]
             )
             self.internal_energy.update(
                 adata=(self.st.internal_energy_field),
-                ndata=(self.st.svr.internal_energy[self.st.svr.xindices])
+                ndata=(self.st.svr.internal_energy[_s])
             )
             self.entropy.update(
                 adata=self.st.entropy_field,
-                ndata=self.st.svr.entropy[self.st.svr.xindices]
+                ndata=self.st.svr.entropy[_s]
             )
         else:
             for name, is_selected, *_ in self.plot_config.state:

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -511,8 +511,6 @@ class Euler1DApp():
         self.interval = self.solver_config.get_var("timer_interval", "value")
         self.max_steps = self.solver_config.get_var("max_steps", "value")
         self.profiling = self.solver_config.get_var("profiling", "value")
-        ncoord = self.solver_config.get_var("ncoord", "value")
-        self.plot_point = np.linspace(2, (ncoord - 3), num=((ncoord - 3) // 2), dtype=int)
 
     def setup_timer(self):
         """
@@ -532,7 +530,7 @@ class Euler1DApp():
 
         :return: FigureCanvas
         """
-        x = self.st.svr.coord[self.plot_point]
+        x = self.st.svr.coord[self.st.xindices]
         fig = Figure()
         canvas = FigureCanvas(fig)
         ax = canvas.figure.subplots(3, 2)
@@ -576,7 +574,7 @@ class Euler1DApp():
 
         :return: FigureCanvas
         """
-        x = self.st.svr.coord[self.plot_point]
+        x = self.st.svr.coord[self.st.xindices]
         fig = Figure()
         canvas = FigureCanvas(fig)
         ax = canvas.figure.subplots()
@@ -746,23 +744,23 @@ class Euler1DApp():
         """
         if self.use_grid_layout:
             self.density.update(adata=self.st.density_field,
-                                ndata=self.st.svr.density[self.plot_point])
+                                ndata=self.st.svr.density[self.st.xindices])
             self.pressure.update(adata=self.st.pressure_field,
-                                 ndata=self.st.svr.pressure[self.plot_point])
+                                 ndata=self.st.svr.pressure[self.st.xindices])
             self.velocity.update(adata=self.st.velocity_field,
-                                 ndata=self.st.svr.velocity[self.plot_point])
+                                 ndata=self.st.svr.velocity[self.st.xindices])
             self.temperature.update(adata=self.st.temperature_field,
-                                    ndata=self.st.svr.temperature[self.plot_point])
+                                    ndata=self.st.svr.temperature[self.st.xindices])
             self.internal_energy.update(adata=(self.st.internal_energy_field),
                                         ndata=(self.st.svr.
-                                               internal_energy[self.plot_point]))
+                                               internal_energy[self.st.xindices]))
             self.entropy.update(adata=self.st.entropy_field,
-                                ndata=self.st.svr.entropy[self.plot_point])
+                                ndata=self.st.svr.entropy[self.st.xindices])
         else:
             for name, is_selected, *_ in self.plot_config.state:
                 if is_selected:
                     eval(f'(self.{name}.update(adata=self.st.{name}_field,'
-                         f' ndata=self.st.svr.{name}[self.plot_point]))')
+                         f' ndata=self.st.svr.{name}[self.st.xindices]))')
 
 
 class PlotArea(PuiInQt):

--- a/modmesh/onedim/euler1d.py
+++ b/modmesh/onedim/euler1d.py
@@ -24,10 +24,16 @@ class Euler1DSolver:
     method.
     """
 
-    def __init__(self, xmin, xmax, ncoord, time_increment=0.05):
+    def __init__(self, xmin, xmax, ncoord, time_increment=0.05,
+                 keep_edge=False):
         self._core = self.init_solver(xmin, xmax, ncoord, time_increment,
                                       gamma=1.4)
         # gamma is 1.4 for air.
+        _ = self.ncoord - 1
+        start = 0 if keep_edge else 2
+        stop = _ if keep_edge else (_ - 2)
+        num = (stop - start) // 2 + 1
+        self.xindices = np.linspace(start, stop, num, dtype='int32')
 
     def __getattr__(self, name):
         return getattr(self._core, name)
@@ -310,18 +316,13 @@ class ShockTube:
         :param coord: If None, take the coordinate from the numerical solver.
         :return: None
         """
-
-        if None is coord:
-            _ = self.svr.ncoord
-            if keep_edge:
-                self.svr.xindices = np.linspace(
-                    0, (_ - 1), num=((_ + 1) // 2), dtype=int
-                )
-            else:
-                self.svr.xindices = np.linspace(
-                    2, (_ - 3), num=((_ - 3) // 2), dtype=int
-                )
-            # Use the numerical solver.
+        if coord is None:
+            _ = self.svr.ncoord - 1
+            start = 0 if keep_edge else 2
+            stop = _ if keep_edge else (_ - 2)
+            num = (stop - start) // 2 + 1
+            self.svr.xindices = np.linspace(start, stop, num, dtype='int32')
+            # set the x-coordinate for numerical solver.
             coord = self.svr.coord[self.svr.xindices]
         self.coord = coord.copy()  # Make a copy; no write back to argument.
 

--- a/modmesh/onedim/euler1d.py
+++ b/modmesh/onedim/euler1d.py
@@ -122,7 +122,7 @@ class ShockTube:
         self.svr = None
 
     def build_numerical(self, xmin, xmax, ncoord, time_increment=0.05,
-                        xdiaphragm=0.0):
+                        xdiaphragm=0.0, keep_edge=False):
         """
         After :py:meth:`build_constant` is done, optionally build the
         numerical solver :py:attr:`svr`.
@@ -139,7 +139,8 @@ class ShockTube:
 
         # Initialize the numerical solver.
         self.svr = Euler1DSolver(xmin, xmax, ncoord,
-                                 time_increment=time_increment)
+                                 time_increment=time_increment,
+                                 keep_edge=keep_edge)
 
         # Fill gamma.
         self.svr.gamma.fill(self.gamma)
@@ -308,7 +309,7 @@ class ShockTube:
     def calc_entropy(self, pressure, density):
         return pressure / (density ** self.gamma)
 
-    def build_field(self, t, coord=None, keep_edge=False):
+    def build_field(self, t, coord=None):
         """
         Populate the field data using the analytical solution.
 
@@ -317,11 +318,6 @@ class ShockTube:
         :return: None
         """
         if coord is None:
-            _ = self.svr.ncoord - 1
-            start = 0 if keep_edge else 2
-            stop = _ if keep_edge else (_ - 2)
-            num = (stop - start) // 2 + 1
-            self.svr.xindices = np.linspace(start, stop, num, dtype='int32')
             # set the x-coordinate for numerical solver.
             coord = self.svr.coord[self.svr.xindices]
         self.coord = coord.copy()  # Make a copy; no write back to argument.

--- a/modmesh/onedim/euler1d.py
+++ b/modmesh/onedim/euler1d.py
@@ -314,10 +314,15 @@ class ShockTube:
         if None is coord:
             _ = self.svr.ncoord
             if keep_edge:
-                self.svr.xindices = np.linspace(0, (_ - 1), num=((_ + 1) // 2), dtype=int)
+                self.svr.xindices = np.linspace(
+                    0, (_ - 1), num=((_ + 1) // 2), dtype=int
+                )
             else:
-                self.svr.xindices = np.linspace(2, (_ - 3), num=((_ - 3) // 2), dtype=int)
-            coord = self.svr.coord[self.svr.xindices]  # Use the numerical solver.
+                self.svr.xindices = np.linspace(
+                    2, (_ - 3), num=((_ - 3) // 2), dtype=int
+                )
+            # Use the numerical solver.
+            coord = self.svr.coord[self.svr.xindices]
         self.coord = coord.copy()  # Make a copy; no write back to argument.
 
         # Determine the zone location and the Boolean selection arrays.

--- a/modmesh/onedim/euler1d.py
+++ b/modmesh/onedim/euler1d.py
@@ -302,7 +302,7 @@ class ShockTube:
     def calc_entropy(self, pressure, density):
         return pressure / (density ** self.gamma)
 
-    def build_field(self, t, coord=None):
+    def build_field(self, t, coord=None, keep_edge=False):
         """
         Populate the field data using the analytical solution.
 
@@ -310,9 +310,13 @@ class ShockTube:
         :param coord: If None, take the coordinate from the numerical solver.
         :return: None
         """
+        _ = self.svr.ncoord
+        if keep_edge:
+            self.xindices = np.linspace(0, (_ - 1), num=((_ + 1) // 2), dtype=int)
+        else:
+            self.xindices = np.linspace(2, (_ - 3), num=((_ - 3) // 2), dtype=int) 
         if None is coord:
-            plot_point = np.linspace(2, (self.svr.ncoord - 3), num=((self.svr.ncoord - 3) // 2), dtype=int)
-            coord = self.svr.coord[plot_point]  # Use the numerical solver.
+            coord = self.svr.coord[self.xindices]  # Use the numerical solver.
         self.coord = coord.copy()  # Make a copy; no write back to argument.
 
         # Determine the zone location and the Boolean selection arrays.

--- a/modmesh/onedim/euler1d.py
+++ b/modmesh/onedim/euler1d.py
@@ -311,7 +311,8 @@ class ShockTube:
         :return: None
         """
         if None is coord:
-            coord = self.svr.coord[::2]  # Use the numerical solver.
+            plot_point = np.linspace(2, (self.svr.ncoord - 3), num=((self.svr.ncoord - 3) // 2), dtype=int)
+            coord = self.svr.coord[plot_point]  # Use the numerical solver.
         self.coord = coord.copy()  # Make a copy; no write back to argument.
 
         # Determine the zone location and the Boolean selection arrays.

--- a/modmesh/onedim/euler1d.py
+++ b/modmesh/onedim/euler1d.py
@@ -310,13 +310,14 @@ class ShockTube:
         :param coord: If None, take the coordinate from the numerical solver.
         :return: None
         """
-        _ = self.svr.ncoord
-        if keep_edge:
-            self.xindices = np.linspace(0, (_ - 1), num=((_ + 1) // 2), dtype=int)
-        else:
-            self.xindices = np.linspace(2, (_ - 3), num=((_ - 3) // 2), dtype=int) 
+
         if None is coord:
-            coord = self.svr.coord[self.xindices]  # Use the numerical solver.
+            _ = self.svr.ncoord
+            if keep_edge:
+                self.svr.xindices = np.linspace(0, (_ - 1), num=((_ + 1) // 2), dtype=int)
+            else:
+                self.svr.xindices = np.linspace(2, (_ - 3), num=((_ - 3) // 2), dtype=int)
+            coord = self.svr.coord[self.svr.xindices]  # Use the numerical solver.
         self.coord = coord.copy()  # Make a copy; no write back to argument.
 
         # Determine the zone location and the Boolean selection arrays.

--- a/startup.py
+++ b/startup.py
@@ -1,0 +1,3 @@
+import modmesh.view as mv
+
+mv.launch()

--- a/startup.py
+++ b/startup.py
@@ -1,3 +1,0 @@
-import modmesh.view as mv
-
-mv.launch()

--- a/tests/test_onedim_euler.py
+++ b/tests/test_onedim_euler.py
@@ -105,7 +105,7 @@ class ShockTubeTC(unittest.TestCase):
     def test_field_with_numerical(self):
         self.st.build_numerical(xmin=-1, xmax=1, ncoord=21,
                                 time_increment=0.05)
-        self.st.build_field(t=0.0)
+        self.st.build_field(t=0.0, keep_edge=True)
         self.assertIsInstance(self.st.svr, euler1d.Euler1DSolver)
         self.assertEqual(len(self.st.coord), 11)
         self._check_field_value_at_t0()

--- a/tests/test_onedim_euler.py
+++ b/tests/test_onedim_euler.py
@@ -104,8 +104,8 @@ class ShockTubeTC(unittest.TestCase):
 
     def test_field_with_numerical(self):
         self.st.build_numerical(xmin=-1, xmax=1, ncoord=21,
-                                time_increment=0.05)
-        self.st.build_field(t=0.0, keep_edge=True)
+                                time_increment=0.05, keep_edge=True)
+        self.st.build_field(t=0.0)
         self.assertIsInstance(self.st.svr, euler1d.Euler1DSolver)
         self.assertEqual(len(self.st.coord), 11)
         self._check_field_value_at_t0()


### PR DESCRIPTION
Following the issue https://github.com/solvcon/modmesh/pull/361
The PR hides the boundary points.

Features: The plotting hides the unreasonable points on the boundary.
Strength: It makes the figure look nicer without changing the solution data.
Weakness: It is better to calculate the correct values on the boundary and show them on the boundary.