### PR TITLE
Add the directive for the direct download link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,8 @@ An experimental Windows binary (portable) can be downloaded from the `devbuild
 Github Action
 <https://github.com/solvcon/modmesh/actions/workflows/devbuild.yml?query=event%3Aschedule+is%3Asuccess+branch%3Amaster>`__.
 Click the Windows release run and scroll down to the "artifacts" section to
-download the ZIP file (Login is required).
+download the zip file (login to `GitHub <https://github.com/>`__ is required).
+A direct download link can be found in https://doc.solvcon.net/.
 
 Refenreces
 ==========


### PR DESCRIPTION
The [solvcon document site](https://doc.solvcon.net/) has been updated to include the direct download link of the Windows nightly build in the document front page https://doc.solvcon.net/en/latest/ through the changeset https://github.com/solvcon/solvcon/commit/1e0eb87ac5ef17f8a478f7e1f199605358f55fb8 .

This PR points users to the solvcon document page for the direct download link in the README file.

This PR fixed the mistake I made and described in https://github.com/solvcon/modmesh/pull/381#issuecomment-2241023538.

With the change https://github.com/solvcon/solvcon/commit/1e0eb87ac5ef17f8a478f7e1f199605358f55fb8 in [the solvcon repository](https://github.com/solvcon/solvcon), [the solvcon-doc repository along with the PR#1](https://github.com/solvcon/solvcon-doc/pull/1) is no longer needed.  I will delete the solvcon-doc repo.  Subsequent to the document and download should go to [the solvcon repo](https://github.com/solvcon/solvcon).  FYI, @terrychan999.

This PR is for issue #371.