### PR TITLE
Use the repository variable MMGH_NIGHTLY to control scheduled Github Actions run

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -10,7 +10,7 @@ jobs:
 
   standalone_buffer:
 
-    if: ${{ github.event_name != '' || (github.event_name == '' && github.repository_owner == 'solvcon') }}
+    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
 
     name: standalone_buffer_${{ matrix.os }}
 
@@ -79,7 +79,7 @@ jobs:
 
   build_ubuntu:
 
-    if: ${{ github.event_name != '' || (github.event_name == '' && github.repository_owner == 'solvcon') }}
+    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
 
     name: build_${{ matrix.os }}_${{ matrix.cmake_build_type }}
 
@@ -252,7 +252,7 @@ jobs:
 
   build_macos:
 
-    if: ${{ github.event_name != '' || (github.event_name == '' && github.repository_owner == 'solvcon') }}
+    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
 
     name: build_${{ matrix.os }}_${{ matrix.cmake_build_type }}
 
@@ -443,7 +443,7 @@ jobs:
 
   build_windows:
 
-    if: ${{ github.event_name != '' || (github.event_name == '' && github.repository_owner == 'solvcon') }}
+    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
 
     name: build_${{ matrix.os }}_${{ matrix.cmake_build_type }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
+
     strategy:
       matrix:
         path:
@@ -35,7 +37,7 @@ jobs:
 
   tidy_flake8_ubuntu:
 
-    if: ${{ github.event_name != '' || (github.event_name == '' && github.repository_owner == 'solvcon') }}
+    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
 
     runs-on: ${{ matrix.os }}
 
@@ -160,7 +162,7 @@ jobs:
 
   tidy_flake8_macos:
 
-    if: ${{ github.event_name != '' || (github.event_name == '' && github.repository_owner == 'solvcon') }}
+    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -10,7 +10,7 @@ jobs:
 
   nouse_install_ubuntu:
 
-    if: ${{ github.event_name != '' || (github.event_name == '' && github.repository_owner == 'solvcon') }}
+    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
 
     name: nouse_install_${{ matrix.os }}_Release
 
@@ -98,7 +98,7 @@ jobs:
 
   nouse_install_macos:
 
-    if: ${{ github.event_name != '' || (github.event_name == '' && github.repository_owner == 'solvcon') }}
+    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
 
     name: nouse_install_${{ matrix.os }}_Release
 


### PR DESCRIPTION
If the repository variable `MMGH_NIGHTLY` is set to `enable`, the Github Actions will run at the scheduled time point.  Otherwise the scheduled runs will not take place.

This PR is to implement the enhancement requested in issue #286.

References:
* Repository configuration variables: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/variables#defining-configuration-variables-for-multiple-workflows
* Access variables from actions: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/contexts#vars-context