### PR TITLE
Add placeholder for the 2/3D Euler CESE solver

### DIFF
--- a/cpp/modmesh/CMakeLists.txt
+++ b/cpp/modmesh/CMakeLists.txt
@@ -35,6 +35,7 @@ add_subdirectory(mesh)
 add_subdirectory(toggle)
 add_subdirectory(universe)
 add_subdirectory(onedim)
+add_subdirectory(multidim)
 add_subdirectory(python)
 add_subdirectory(spacetime)
 add_subdirectory(view)
@@ -84,6 +85,7 @@ set(MODMESH_TERMINAL_FILES
     ${MODMESH_TOGGLE_FILES}
     ${MODMESH_UNIVERSE_FILES}
     ${MODMESH_MESH_FILES}
+    ${MODMESH_MULTIDIM_FILES}
     ${MODMESH_DEVICE_FILES}
     ${MODMESH_ONEDIM_FILES}
     ${MODMESH_SPACETIME_FILES}

--- a/cpp/modmesh/multidim/CMakeLists.txt
+++ b/cpp/modmesh/multidim/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
+# BSD-style license; see COPYING
+
+cmake_minimum_required(VERSION 3.16)
+
+set(MODMESH_MULTIDIM_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/multidim.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/euler.hpp
+    CACHE FILEPATH "" FORCE)
+
+set(MODMESH_MULTIDIM_SOURCES
+    CACHE FILEPATH "" FORCE)
+
+set(MODMESH_MULTIDIM_PYMODHEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/multidim_pymod.hpp
+    CACHE FILEPATH "" FORCE)
+
+set(MODMESH_MULTIDIM_PYMODSOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/multidim_pymod.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_multidim.cpp
+    CACHE FILEPATH "" FORCE)
+
+set(MODMESH_MULTIDIM_FILES
+    ${MODMESH_MULTIDIM_HEADERS}
+    ${MODMESH_MULTIDIM_SOURCES}
+    ${MODMESH_MULTIDIM_PYMODHEADERS}
+    ${MODMESH_MULTIDIM_PYMODSOURCES}
+    CACHE FILEPATH "" FORCE)
+
+# vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/multidim/euler.hpp
+++ b/cpp/modmesh/multidim/euler.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+/*
+ * Copyright (c) 2024, Yung-Yu Chen <yyc@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * The space-time CESE solver for the Euler equation.
+ */
+
+#include <modmesh/mesh/mesh.hpp>
+
+namespace modmesh
+{
+
+class EulerCore
+    : public NumberBase<int32_t, double>
+    , public std::enable_shared_from_this<EulerCore>
+{
+
+private:
+
+    class ctor_passkey
+    {
+    };
+
+public:
+
+    using number_base = NumberBase<int32_t, double>;
+    using int_type = typename number_base::int_type;
+    using uint_type = typename number_base::uint_type;
+    using real_type = typename number_base::real_type;
+
+    template <typename... Args>
+    static std::shared_ptr<EulerCore> construct(Args &&... args)
+    {
+        return std::make_shared<EulerCore>(std::forward<Args>(args)..., ctor_passkey());
+    }
+
+    EulerCore(std::shared_ptr<StaticMesh> const & mesh, real_type time_increment, ctor_passkey const &)
+        : m_mesh(mesh)
+        , m_time_increment(time_increment)
+    {
+    }
+
+    EulerCore() = delete;
+    EulerCore(EulerCore const &) = delete;
+    EulerCore(EulerCore &&) = delete;
+    EulerCore operator=(EulerCore const &) = delete;
+    EulerCore operator=(EulerCore &&) = delete;
+    ~EulerCore() = default;
+
+private:
+
+    std::shared_ptr<StaticMesh> m_mesh;
+    real_type m_time_increment = 0.0;
+
+}; /* end class EulerCore */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/multidim/multidim.hpp
+++ b/cpp/modmesh/multidim/multidim.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+/*
+ * Copyright (c) 2024, Yung-Yu Chen <yyc@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Multi-dimensional space-time CESE solver.
+ */
+
+#include <modmesh/mesh/mesh.hpp>
+#include <modmesh/multidim/euler.hpp>
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/multidim/pymod/multidim_pymod.cpp
+++ b/cpp/modmesh/multidim/pymod/multidim_pymod.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024, Yung-Yu Chen <yyc@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <modmesh/multidim/pymod/multidim_pymod.hpp> // Must be the first include for Python.
+#include <pybind11/stl.h>
+
+#include <modmesh/modmesh.hpp>
+#include <modmesh/python/common.hpp>
+
+namespace modmesh
+{
+
+namespace python
+{
+
+struct multidim_pymod_tag
+{
+};
+
+template <>
+OneTimeInitializer<multidim_pymod_tag> & OneTimeInitializer<multidim_pymod_tag>::me()
+{
+    static OneTimeInitializer<multidim_pymod_tag> instance;
+    return instance;
+}
+
+void initialize_multidim(pybind11::module & mod)
+{
+    auto initialize_impl = [](pybind11::module & mod)
+    {
+        wrap_multidim(mod);
+    };
+
+    OneTimeInitializer<multidim_pymod_tag>::me()(mod, initialize_impl);
+}
+
+} /* end namespace python */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/multidim/pymod/multidim_pymod.hpp
+++ b/cpp/modmesh/multidim/pymod/multidim_pymod.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+/*
+ * Copyright (c) 2024, Yung-Yu Chen <yyc@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <modmesh/python/python.hpp> // Must be the first include.
+#include <pybind11/stl.h>
+
+#include <modmesh/modmesh.hpp>
+#include <modmesh/python/common.hpp>
+
+namespace modmesh
+{
+
+namespace python
+{
+
+void initialize_multidim(pybind11::module & mod);
+void wrap_multidim(pybind11::module & mod);
+
+} /* end namespace python */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/multidim/pymod/wrap_multidim.cpp
+++ b/cpp/modmesh/multidim/pymod/wrap_multidim.cpp
@@ -36,8 +36,6 @@ namespace modmesh
 namespace python
 {
 
-using namespace modmesh; // NOLINT(google-build-using-namespace)
-
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapEulerCore
     : public WrapBase<WrapEulerCore, EulerCore, std::shared_ptr<EulerCore>>
 {

--- a/cpp/modmesh/multidim/pymod/wrap_multidim.cpp
+++ b/cpp/modmesh/multidim/pymod/wrap_multidim.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024, Yung-Yu Chen <yyc@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <modmesh/python/common.hpp> // Must be the first include.
+
+#include <modmesh/multidim/multidim.hpp>
+
+namespace modmesh
+{
+
+namespace python
+{
+
+using namespace modmesh; // NOLINT(google-build-using-namespace)
+
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapEulerCore
+    : public WrapBase<WrapEulerCore, EulerCore, std::shared_ptr<EulerCore>>
+{
+
+public:
+
+    using base_type = WrapBase<WrapEulerCore, EulerCore, std::shared_ptr<EulerCore>>;
+    using wrapper_type = typename base_type::wrapper_type;
+    using wrapped_type = typename base_type::wrapped_type;
+
+    friend base_type;
+
+protected:
+
+    WrapEulerCore(pybind11::module & mod, const char * pyname, const char * clsdoc)
+        : base_type(mod, pyname, clsdoc)
+    {
+
+        namespace py = pybind11;
+
+        (*this)
+            .def(
+                py::init(
+                    [](std::shared_ptr<StaticMesh> const & mesh, wrapped_type::real_type time_increment)
+                    {
+                        return wrapped_type::construct(mesh, time_increment);
+                    }),
+                py::arg("mesh"),
+                py::arg("time_increment"));
+    }
+
+}; /* end class WrapEulerCore */
+
+void wrap_multidim(pybind11::module & mod)
+{
+    WrapEulerCore::commit(mod, "EulerCore", "Solve the Euler equation");
+}
+
+} /* end namespace python */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/python/module.cpp
+++ b/cpp/modmesh/python/module.cpp
@@ -25,6 +25,7 @@
 #include <modmesh/inout/pymod/inout_pymod.hpp>
 #include <modmesh/mesh/pymod/mesh_pymod.hpp>
 #include <modmesh/onedim/pymod/onedim_pymod.hpp>
+#include <modmesh/multidim/pymod/multidim_pymod.hpp>
 #include <modmesh/python/module.hpp>
 #include <modmesh/spacetime/pymod/spacetime_pymod.hpp>
 #include <modmesh/toggle/pymod/toggle_pymod.hpp>
@@ -48,6 +49,7 @@ void initialize(pybind11::module_ mod)
     initialize_buffer(mod);
     initialize_universe(mod);
     initialize_mesh(mod);
+    initialize_multidim(mod);
     initialize_inout(mod);
     pybind11::module_ spacetime_mod = mod.def_submodule("spacetime", "spacetime");
     initialize_spacetime(spacetime_mod);

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -78,6 +78,7 @@ __all__ = [  # noqa: F822
     'StaticGrid2d',
     'StaticGrid3d',
     'StaticMesh',
+    'EulerCore',
     'HierarchicalToggleAccess',
     'Toggle',
     'CommandLineInfo',

--- a/tests/test_euler.py
+++ b/tests/test_euler.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2024, Yung-Yu Chen <yyc@solvcon.net>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+import modmesh as mm
+
+
+class EulerCoreTC(unittest.TestCase):
+
+    def test_construct(self):
+        mh = mm.StaticMesh(ndim=2, nnode=0)
+        mm.EulerCore(mesh=mh, time_increment=0.0)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
* Add the the placeholder `modmesh::EulerCore` C++ class and wrap it to Python as `modmesh.EulerCore`.
* Add the test file `tests/test_euler.py`

This PR is for issue #404.