### PR TITLE
Temporarily turn off the linter run on macos-14

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -177,7 +177,12 @@ jobs:
     strategy:
       matrix:
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
-        os: [macos-13, macos-14]
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
+        # 20240811: clang-tidy (llvm@16) runs extremely slowly on macos-14
+        # (i.e., macos-14-arm64), but not macos-13. Temporarily turn off the
+        # linter run on macos-14 and revisit in the future.
+        #os: [macos-13, macos-14]
+        os: [macos-13]
         cmake_build_type: [Debug]
 
       fail-fast: false


### PR DESCRIPTION
On 20240811, for a while (weeks or months), clang-tidy (llvm@16) runs extremely slowly on macos-14 (i.e., macos-14-arm64), but not macos-13.  If the tidy runs for 8 minutes with macos-13, it may take 28 minutes with macos-14.

It is quite annoying.  Waiting for 30 or 40 minutes for CI to complete is too long.  I temporarily turn off the linter run on macos-14 and revisit in the future.