### PR TITLE
Camera: Add movement items to view menu

### DIFF
--- a/cpp/modmesh/view/R3DWidget.cpp
+++ b/cpp/modmesh/view/R3DWidget.cpp
@@ -41,7 +41,7 @@ R3DWidget::R3DWidget(Qt3DExtras::Qt3DWindow * window, RScene * scene, QWidget * 
 {
     m_view->setRootEntity(m_scene);
 
-    resetCamera(m_view->camera());
+    resetCamera();
 
     if (Toggle::instance().fixed().get_show_axis())
     {
@@ -99,14 +99,13 @@ void R3DWidget::resizeEvent(QResizeEvent * event)
     m_container->resize(event->size());
 }
 
-void R3DWidget::resetCamera(Qt3DRender::QCamera * camera,
-                            float positionX,
-                            float positionY,
-                            float positionZ)
+void R3DWidget::resetCamera() const
 {
+    Qt3DRender::QCamera * camera = m_view->camera();
+
     // Set up the camera.
     camera->lens()->setPerspectiveProjection(45.0f, 16.0f / 9.0f, 0.1f, 1000.0f);
-    camera->setPosition(QVector3D(positionX, positionY, positionZ));
+    camera->setPosition(QVector3D(0.0f, 0.0f, 10.0f));
     camera->setViewCenter(QVector3D(0.0f, 0.0f, 0.0f));
     camera->setUpVector(QVector3D(0.f, 1.f, 0.f));
 

--- a/cpp/modmesh/view/R3DWidget.hpp
+++ b/cpp/modmesh/view/R3DWidget.hpp
@@ -100,10 +100,7 @@ public:
     Qt3DExtras::QAbstractCameraController * qtCameraController() { return m_scene->controller(); }
     CameraController * cameraController() { return dynamic_cast<CameraController *>(m_scene->controller()); }
 
-    void resetCamera(Qt3DRender::QCamera * camera,
-                     float positionX = 0.0f,
-                     float positionY = 0.0f,
-                     float positionZ = 10.0f);
+    void resetCamera() const;
 
     QPixmap grabPixmap() const { return m_view->screen()->grabWindow(m_view->winId()); }
 

--- a/cpp/modmesh/view/RCameraController.cpp
+++ b/cpp/modmesh/view/RCameraController.cpp
@@ -287,11 +287,11 @@ void ROrbitCameraController::updateCameraPosition(const CameraInputState & input
     // keyboard Input
     if (input.altKeyActive)
     {
-        orbit(input.txAxisValue * dt, input.tzAxisValue * dt);
+        orbit(input.txAxisValue * dt, input.tyAxisValue * dt);
     }
     else if (input.shiftKeyActive)
     {
-        zoom(input.tzAxisValue * linearSpeed() * dt);
+        zoom(input.tyAxisValue * linearSpeed() * dt);
     }
     else
     {

--- a/cpp/modmesh/view/RCameraController.cpp
+++ b/cpp/modmesh/view/RCameraController.cpp
@@ -89,7 +89,7 @@ RCameraInputListener::RCameraInputListener(
             state.ryAxisValue = m_ry_axis->value();
             state.txAxisValue = m_tx_axis->value();
             state.tyAxisValue = isCtrlPressed ? 0.0f : m_ty_axis->value();
-            state.tzAxisValue = isCtrlPressed ? m_ty_axis->value() : 0.0f;
+            state.tzAxisValue = (isCtrlPressed ? m_ty_axis->value() : 0.0f) + m_tz_axis->value();
 
             state.leftMouseButtonActive = m_left_mouse_button_action->isActive();
             state.middleMouseButtonActive = m_middle_mouse_button_action->isActive();
@@ -182,7 +182,7 @@ void RCameraInputListener::initKeyboardListeners() const
     m_alt_button_input->setSourceDevice(m_keyboard_device);
     m_alt_button_action->addInput(m_alt_button_input);
 
-    // ctrl button
+    // ctrl button - On Windows Ctrl key, on Macs Cmd key
     m_ctrl_button_input->setButtons(QList<int>{Qt::Key_Control});
     m_ctrl_button_input->setSourceDevice(m_keyboard_device);
     m_ctrl_button_action->addInput(m_ctrl_button_input);
@@ -295,9 +295,9 @@ void ROrbitCameraController::updateCameraPosition(const CameraInputState & input
     }
     else
     {
-        const float x = clamp(input.txAxisValue + (input.leftMouseButtonActive ? input.rxAxisValue : 0));
-        const float y = clamp(input.tyAxisValue + (input.leftMouseButtonActive ? input.ryAxisValue : 0));
-        const auto translation = QVector3D(x, y, input.tzAxisValue) * linearSpeed() * dt;
+        const auto translation = QVector3D(
+                                     input.txAxisValue, input.tyAxisValue, input.tzAxisValue) *
+                                 linearSpeed() * dt;
 
         camera()->translate(translation);
     }

--- a/cpp/modmesh/view/RCameraController.cpp
+++ b/cpp/modmesh/view/RCameraController.cpp
@@ -28,12 +28,9 @@
 
 #include <modmesh/view/RCameraController.hpp>
 
-#include <QShortcut>
 #include <Qt3DInput/QKeyboardDevice>
 #include <Qt3DInput/QMouseDevice>
 #include <Qt3DRender/QCamera>
-
-#include "R3DWidget.hpp"
 
 namespace modmesh
 {

--- a/cpp/modmesh/view/RCameraController.cpp
+++ b/cpp/modmesh/view/RCameraController.cpp
@@ -85,7 +85,7 @@ RCameraInputListener::RCameraInputListener(
         this,
         [this](const float dt)
         {
-            Qt3DExtras::QAbstractCameraController::InputState state{};
+            CameraInputState state{};
             const bool isCtrlPressed = m_ctrl_button_action->isActive();
 
             state.rxAxisValue = m_rx_axis->value();
@@ -217,7 +217,7 @@ void RCameraInputListener::initKeyboardListeners() const
 RFirstPersonCameraController::RFirstPersonCameraController(QNode * parent)
     : QFirstPersonCameraController(parent)
 {
-    auto callback = [this](const InputState & state, const float dt)
+    auto callback = [this](const CameraInputState & state, const float dt)
     {
         updateCameraPosition(state, dt);
     };
@@ -225,7 +225,7 @@ RFirstPersonCameraController::RFirstPersonCameraController(QNode * parent)
     m_listener = new RCameraInputListener(keyboardDevice(), mouseDevice(), callback, this);
 }
 
-void RFirstPersonCameraController::updateCameraPosition(const InputState & input, const float dt)
+void RFirstPersonCameraController::updateCameraPosition(const CameraInputState & input, const float dt)
 {
     constexpr auto positiveY = QVector3D(0.f, 1.f, 0.f);
 
@@ -248,7 +248,7 @@ void RFirstPersonCameraController::updateCameraPosition(const InputState & input
 ROrbitCameraController::ROrbitCameraController(QNode * parent)
     : QOrbitCameraController(parent)
 {
-    auto callback = [this](const InputState & state, const float dt)
+    auto callback = [this](const CameraInputState & state, const float dt)
     {
         updateCameraPosition(state, dt);
     };
@@ -256,7 +256,7 @@ ROrbitCameraController::ROrbitCameraController(QNode * parent)
     m_listener = new RCameraInputListener(keyboardDevice(), mouseDevice(), callback, this);
 }
 
-void ROrbitCameraController::updateCameraPosition(const InputState & input, const float dt)
+void ROrbitCameraController::updateCameraPosition(const CameraInputState & input, const float dt)
 {
     if (camera() == nullptr)
         return;

--- a/cpp/modmesh/view/RCameraController.cpp
+++ b/cpp/modmesh/view/RCameraController.cpp
@@ -105,7 +105,8 @@ RCameraInputListener::RCameraInputListener(
         });
 }
 
-void RCameraInputListener::init() {
+void RCameraInputListener::init()
+{
     initMouseListeners();
     initKeyboardListeners();
 

--- a/cpp/modmesh/view/RCameraController.hpp
+++ b/cpp/modmesh/view/RCameraController.hpp
@@ -45,12 +45,32 @@
 namespace modmesh
 {
 
+struct CameraInputState {
+    float rxAxisValue = 0;
+    float ryAxisValue = 0;
+    float txAxisValue = 0;
+    float tyAxisValue = 0;
+    float tzAxisValue = 0;
+
+    bool leftMouseButtonActive = false;
+    bool middleMouseButtonActive = false;
+    bool rightMouseButtonActive = false;
+
+    bool altKeyActive = false;
+    bool shiftKeyActive = false;
+};
+
+enum class CameraControllerType {
+    FirstPerson,
+    Orbit
+};
+
 class RCameraInputListener : public Qt3DCore::QEntity
 {
     Q_OBJECT
 
 public:
-    using callback_type = std::function<void(const Qt3DExtras::QAbstractCameraController::InputState &, float)>;
+    using callback_type = std::function<void(const CameraInputState &, float)>;
 
     RCameraInputListener(
         Qt3DInput::QKeyboardDevice * keyboardDevice,
@@ -111,13 +131,15 @@ class CameraController
 public:
     virtual ~CameraController() = default;
 
-    virtual void updateCameraPosition(const Qt3DExtras::QAbstractCameraController::InputState & state, float dt) = 0;
+    virtual void updateCameraPosition(const CameraInputState & state, float dt) = 0;
 
     virtual Qt3DRender::QCamera * getCamera() = 0;
 
     virtual float getLinearSpeed() = 0;
 
     virtual float getLookSpeed() = 0;
+
+    virtual CameraControllerType getType() = 0;
 
     QVector3D position() { return getCamera()->position(); }
 
@@ -154,7 +176,9 @@ private:
 
     void moveCamera(const InputState & state, float dt) override {}
 
-    void updateCameraPosition(const InputState & input, float dt) override;
+    void updateCameraPosition(const CameraInputState & input, float dt) override;
+
+    CameraControllerType getType() override { return CameraControllerType::FirstPerson; }
 };
 
 class ROrbitCameraController : public Qt3DExtras::QOrbitCameraController
@@ -172,7 +196,7 @@ public:
 private:
     void moveCamera(const InputState & state, float dt) override {}
 
-    void updateCameraPosition(const InputState & input, float dt) override;
+    void updateCameraPosition(const CameraInputState & input, float dt) override;
 
     void zoom(float zoomValue) const;
 
@@ -181,6 +205,8 @@ private:
     static float clamp(float value);
 
     static float zoomDistanceSquared(QVector3D firstPoint, QVector3D secondPoint);
+
+    CameraControllerType getType() override { return CameraControllerType::Orbit; }
 };
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/view/RCameraController.hpp
+++ b/cpp/modmesh/view/RCameraController.hpp
@@ -84,11 +84,13 @@ private:
     Qt3DInput::QAction * m_right_mouse_button_action;
     Qt3DInput::QAction * m_shift_button_action;
     Qt3DInput::QAction * m_alt_button_action;
+    Qt3DInput::QAction * m_ctrl_button_action;
     Qt3DInput::QActionInput * m_left_mouse_button_input;
     Qt3DInput::QActionInput * m_middle_mouse_button_input;
     Qt3DInput::QActionInput * m_right_mouse_button_input;
     Qt3DInput::QActionInput * m_shift_button_input;
     Qt3DInput::QActionInput * m_alt_button_input;
+    Qt3DInput::QActionInput * m_ctrl_button_input;
     // mouse rotation input
     Qt3DInput::QAnalogAxisInput * m_mouse_rx_input;
     Qt3DInput::QAnalogAxisInput * m_mouse_ry_input;

--- a/cpp/modmesh/view/RCameraController.hpp
+++ b/cpp/modmesh/view/RCameraController.hpp
@@ -59,7 +59,7 @@ struct CameraInputState
 
     bool altKeyActive = false;
     bool shiftKeyActive = false;
-};
+}; /* end struct CameraInputState */
 
 enum class CameraControllerType
 {
@@ -126,7 +126,7 @@ private:
     Qt3DInput::QButtonAxisInput * m_keyboard_tx_neg_input;
     Qt3DInput::QButtonAxisInput * m_keyboard_ty_neg_input;
     Qt3DInput::QButtonAxisInput * m_keyboard_tz_neg_input;
-};
+}; /* end class RCameraInputListener */
 
 class CameraController
 {
@@ -159,7 +159,7 @@ private:
     {
         return dynamic_cast<Qt3DExtras::QAbstractCameraController *>(this);
     }
-};
+}; /* end class CameraController */
 
 class RFirstPersonCameraController : public Qt3DExtras::QFirstPersonCameraController
     , public CameraController
@@ -181,7 +181,7 @@ private:
     void updateCameraPosition(const CameraInputState & input, float dt) override;
 
     CameraControllerType getType() override { return CameraControllerType::FirstPerson; }
-};
+}; /* end class RFirstPersonCameraController */
 
 class ROrbitCameraController : public Qt3DExtras::QOrbitCameraController
     , public CameraController
@@ -209,7 +209,7 @@ private:
     static float zoomDistanceSquared(QVector3D firstPoint, QVector3D secondPoint);
 
     CameraControllerType getType() override { return CameraControllerType::Orbit; }
-};
+}; /* end class ROrbitCameraController */
 
 } /* end namespace modmesh */
 

--- a/cpp/modmesh/view/RCameraController.hpp
+++ b/cpp/modmesh/view/RCameraController.hpp
@@ -45,7 +45,8 @@
 namespace modmesh
 {
 
-struct CameraInputState {
+struct CameraInputState
+{
     float rxAxisValue = 0;
     float ryAxisValue = 0;
     float txAxisValue = 0;
@@ -60,7 +61,8 @@ struct CameraInputState {
     bool shiftKeyActive = false;
 };
 
-enum class CameraControllerType {
+enum class CameraControllerType
+{
     FirstPerson,
     Orbit
 };

--- a/cpp/modmesh/view/RManager.cpp
+++ b/cpp/modmesh/view/RManager.cpp
@@ -265,20 +265,15 @@ void RManager::setUpCameraMovementMenuItems() const
         QString("Reset (esc)"),
         [this]()
         {
-            qDebug() << "Reset to initial status.";
-            try
-            {
-                auto * viewer = dynamic_cast<R3DWidget *>(m_mdiArea->currentSubWindow()->widget());
-                Qt3DRender::QCamera * camera = viewer->camera();
-                if (camera)
-                {
-                    viewer->resetCamera(camera);
-                }
-            }
-            catch (std::bad_cast & e)
-            {
-                std::cerr << e.what() << std::endl;
-            }
+            const auto * subwin = m_mdiArea->currentSubWindow();
+            if (subwin == nullptr)
+                return;
+
+            auto * viewer = dynamic_cast<R3DWidget *>(subwin->widget());
+            if (viewer == nullptr || viewer->camera() == nullptr)
+                return;
+
+            viewer->resetCamera();
         });
 
     auto * move_camera_up = new RAction(

--- a/cpp/modmesh/view/RManager.cpp
+++ b/cpp/modmesh/view/RManager.cpp
@@ -212,16 +212,13 @@ void RManager::setUpCameraControllersMenuItems() const
             qDebug() << "Use Orbit Camera Controller (menu demo)";
             for (auto subwin : m_mdiArea->subWindowList())
             {
-                try
-                {
-                    R3DWidget * viewer = dynamic_cast<R3DWidget *>(subwin->widget());
-                    viewer->scene()->setOrbitCameraController();
-                    viewer->scene()->controller()->setCamera(viewer->camera());
-                }
-                catch (std::bad_cast & e)
-                {
-                    std::cerr << e.what() << std::endl;
-                }
+                auto * viewer = dynamic_cast<R3DWidget *>(subwin->widget());
+
+                if (viewer == nullptr)
+                    continue;
+
+                viewer->scene()->setOrbitCameraController();
+                viewer->scene()->controller()->setCamera(viewer->camera());
             }
         });
 
@@ -233,16 +230,13 @@ void RManager::setUpCameraControllersMenuItems() const
             qDebug() << "Use First Person Camera Controller (menu demo)";
             for (auto subwin : m_mdiArea->subWindowList())
             {
-                try
-                {
-                    R3DWidget * viewer = dynamic_cast<R3DWidget *>(subwin->widget());
-                    viewer->scene()->setFirstPersonCameraController();
-                    viewer->scene()->controller()->setCamera(viewer->camera());
-                }
-                catch (std::bad_cast & e)
-                {
-                    std::cerr << e.what() << std::endl;
-                }
+                auto * viewer = dynamic_cast<R3DWidget *>(subwin->widget());
+
+                if (viewer == nullptr)
+                    continue;
+
+                viewer->scene()->setFirstPersonCameraController();
+                viewer->scene()->controller()->setCamera(viewer->camera());
             }
         });
 

--- a/cpp/modmesh/view/RManager.cpp
+++ b/cpp/modmesh/view/RManager.cpp
@@ -301,8 +301,8 @@ void RManager::setUpCameraMovementMenuItems() const
                                         { input.tzAxisValue = 1.0; }));
 
     auto * move_camera_backward = new RAction(
-        QString("Move camera down (Ctrl+S/⬇)"),
-        QString("Move camera down (Ctrl+S/⬇)"),
+        QString("Move camera backward (Ctrl+S/⬇)"),
+        QString("Move camera backward (Ctrl+S/⬇)"),
         createCameraMovementItemHandler([](CameraInputState & input)
                                         { input.tzAxisValue = -1.0; }));
 
@@ -332,17 +332,18 @@ void RManager::setUpCameraMovementMenuItems() const
 
     reset_camera->setShortcut(QKeySequence(Qt::Key_Escape));
 
-    m_viewMenu->addAction(reset_camera);
-    m_viewMenu->addAction(move_camera_up);
-    m_viewMenu->addAction(move_camera_down);
-    m_viewMenu->addAction(move_camera_right);
-    m_viewMenu->addAction(move_camera_left);
-    m_viewMenu->addAction(move_camera_forward);
-    m_viewMenu->addAction(move_camera_backward);
-    m_viewMenu->addAction(rotate_camera_positive_yaw);
-    m_viewMenu->addAction(rotate_camera_negative_yaw);
-    m_viewMenu->addAction(rotate_camera_positive_pitch);
-    m_viewMenu->addAction(rotate_camera_negative_pitch);
+    auto cameraMoveSubmenu = m_viewMenu->addMenu("Camera move");
+    cameraMoveSubmenu->addAction(reset_camera);
+    cameraMoveSubmenu->addAction(move_camera_up);
+    cameraMoveSubmenu->addAction(move_camera_down);
+    cameraMoveSubmenu->addAction(move_camera_right);
+    cameraMoveSubmenu->addAction(move_camera_left);
+    cameraMoveSubmenu->addAction(move_camera_forward);
+    cameraMoveSubmenu->addAction(move_camera_backward);
+    cameraMoveSubmenu->addAction(rotate_camera_positive_yaw);
+    cameraMoveSubmenu->addAction(rotate_camera_negative_yaw);
+    cameraMoveSubmenu->addAction(rotate_camera_positive_pitch);
+    cameraMoveSubmenu->addAction(rotate_camera_negative_pitch);
 }
 
 std::function<void()> RManager::createCameraMovementItemHandler(const std::function<void(CameraInputState &)> & func) const
@@ -366,6 +367,10 @@ std::function<void()> RManager::createCameraMovementItemHandler(const std::funct
         {
             if (controllerType == CameraControllerType::Orbit)
             {
+                constexpr float orbitRotationSpeed = 5.0f;
+
+                input.rxAxisValue *= orbitRotationSpeed;
+                input.ryAxisValue *= orbitRotationSpeed;
                 input.rightMouseButtonActive = true;
             }
             else if (controllerType == CameraControllerType::FirstPerson)

--- a/cpp/modmesh/view/RManager.cpp
+++ b/cpp/modmesh/view/RManager.cpp
@@ -202,7 +202,8 @@ void RManager::setUpMenu()
             []() {}));
 }
 
-void RManager::setUpCameraControllersMenuItems() const {
+void RManager::setUpCameraControllersMenuItems() const
+{
     auto * use_orbit_camera = new RAction(
         QString("Use Orbit Camera Controller"),
         QString("Use Oribt Camera Controller"),
@@ -257,118 +258,89 @@ void RManager::setUpCameraControllersMenuItems() const {
     m_viewMenu->addAction(use_fps_camera);
 }
 
-void RManager::setUpCameraMovementsMenuItems() const {
+void RManager::setUpCameraMovementsMenuItems() const
+{
     auto * reset_camera = new RAction(
-         QString("Reset (esc)"),
-         QString("Reset (esc)"),
-         [this]()
-         {
-             // implement resetting camera control
-             qDebug() << "Reset to initial status.";
-             try
-             {
-                 auto * viewer = dynamic_cast<R3DWidget *>(m_mdiArea->currentSubWindow()->widget());
-                 Qt3DRender::QCamera * camera = viewer->camera();
-                 if (camera)
-                 {
-                     viewer->resetCamera(camera);
-                 }
-             }
-             catch (std::bad_cast & e)
-             {
-                 std::cerr << e.what() << std::endl;
-             }
-         });
+        QString("Reset (esc)"),
+        QString("Reset (esc)"),
+        [this]()
+        {
+            // implement resetting camera control
+            qDebug() << "Reset to initial status.";
+            try
+            {
+                auto * viewer = dynamic_cast<R3DWidget *>(m_mdiArea->currentSubWindow()->widget());
+                Qt3DRender::QCamera * camera = viewer->camera();
+                if (camera)
+                {
+                    viewer->resetCamera(camera);
+                }
+            }
+            catch (std::bad_cast & e)
+            {
+                std::cerr << e.what() << std::endl;
+            }
+        });
 
     auto * move_camera_up = new RAction(
         QString("Move camera up (W/⬆)"),
         QString("Move camera up (W/⬆)"),
         createCameraTranslateItemHandler([](CameraInputState & input)
-        {
-            input.tyAxisValue = 1.0;
-        })
-    );
+                                         { input.tyAxisValue = 1.0; }));
 
     auto * move_camera_down = new RAction(
         QString("Move camera down (S/⬇)"),
         QString("Move camera down (S/⬇)"),
         createCameraTranslateItemHandler([](CameraInputState & input)
-        {
-            input.tyAxisValue = -1.0;
-        })
-    );
+                                         { input.tyAxisValue = -1.0; }));
 
     auto * move_camera_right = new RAction(
         QString("Move camera right (D/➡)"),
         QString("Move camera right (D/➡)"),
         createCameraTranslateItemHandler([](CameraInputState & input)
-        {
-            input.txAxisValue = 1.0;
-        })
-    );
+                                         { input.txAxisValue = 1.0; }));
 
     auto * move_camera_left = new RAction(
         QString("Move camera left (A/⬅)"),
         QString("Move camera left (A/⬅)"),
         createCameraTranslateItemHandler([](CameraInputState & input)
-        {
-            input.txAxisValue = -1.0;
-        })
-    );
+                                         { input.txAxisValue = -1.0; }));
 
     auto * move_camera_forward = new RAction(
         QString("Move camera forward (Ctrl+W/⬆)"),
         QString("Move camera forward (Ctrl+W/⬆)"),
         createCameraTranslateItemHandler([](CameraInputState & input)
-        {
-            input.tzAxisValue = 1.0;
-        })
-    );
+                                         { input.tzAxisValue = 1.0; }));
 
     auto * move_camera_backward = new RAction(
         QString("Move camera down (Ctrl+S/⬇)"),
         QString("Move camera down (Ctrl+S/⬇)"),
         createCameraTranslateItemHandler([](CameraInputState & input)
-        {
-            input.tzAxisValue = -1.0;
-        })
-    );
+                                         { input.tzAxisValue = -1.0; }));
 
     auto * rotate_camera_positive_yaw = new RAction(
         QString("Rotate camera positive yaw"),
         QString("Rotate camera positive yaw"),
         createCameraRotateItemHandler([](CameraInputState & input)
-        {
-            input.rxAxisValue = 1.0;
-        })
-    );
+                                      { input.rxAxisValue = 1.0; }));
 
     auto * rotate_camera_negative_yaw = new RAction(
         QString("Rotate camera negative yaw"),
         QString("Rotate camera negative yaw"),
         createCameraRotateItemHandler([](CameraInputState & input)
-        {
-            input.rxAxisValue = -1.0;
-        })
-    );
+                                      { input.rxAxisValue = -1.0; }));
 
     auto * rotate_camera_positive_pitch = new RAction(
         QString("Rotate camera positive pitch"),
         QString("Rotate camera positive pitch"),
         createCameraRotateItemHandler([](CameraInputState & input)
-        {
-            input.ryAxisValue = 1.0;
-        })
-    );
+                                      { input.ryAxisValue = 1.0; }));
 
     auto * rotate_camera_negative_pitch = new RAction(
         QString("Rotate camera negative pitch"),
         QString("Rotate camera negative pitch"),
         createCameraRotateItemHandler([](CameraInputState & input)
-        {
-            input.ryAxisValue = -1.0;
-        })
-    );
+                                      { input.ryAxisValue = -1.0; }));
 
     reset_camera->setShortcut(QKeySequence(Qt::Key_Escape));
 
@@ -385,8 +357,10 @@ void RManager::setUpCameraMovementsMenuItems() const {
     m_viewMenu->addAction(rotate_camera_negative_pitch);
 }
 
-std::function<void()> RManager::createCameraTranslateItemHandler(const std::function<void(CameraInputState&)> &func) const {
-    return [this, func]() {
+std::function<void()> RManager::createCameraTranslateItemHandler(const std::function<void(CameraInputState &)> & func) const
+{
+    return [this, func]()
+    {
         try
         {
             auto * viewer = dynamic_cast<R3DWidget *>(m_mdiArea->currentSubWindow()->widget());
@@ -405,8 +379,10 @@ std::function<void()> RManager::createCameraTranslateItemHandler(const std::func
     };
 }
 
-std::function<void()> RManager::createCameraRotateItemHandler(const std::function<void(CameraInputState&)> &func) const {
-    return [this, func]() {
+std::function<void()> RManager::createCameraRotateItemHandler(const std::function<void(CameraInputState &)> & func) const
+{
+    return [this, func]()
+    {
         try
         {
             auto * viewer = dynamic_cast<R3DWidget *>(m_mdiArea->currentSubWindow()->widget());
@@ -418,11 +394,11 @@ std::function<void()> RManager::createCameraRotateItemHandler(const std::functio
                 CameraInputState input{};
                 func(input);
 
-                if(controller->getType() == CameraControllerType::Orbit)
+                if (controller->getType() == CameraControllerType::Orbit)
                 {
                     input.rightMouseButtonActive = true;
                 }
-                else if(controller->getType() == CameraControllerType::FirstPerson)
+                else if (controller->getType() == CameraControllerType::FirstPerson)
                 {
                     input.leftMouseButtonActive = true;
                 }

--- a/cpp/modmesh/view/RManager.cpp
+++ b/cpp/modmesh/view/RManager.cpp
@@ -157,87 +157,8 @@ void RManager::setUpMenu()
 
     m_viewMenu = m_mainWindow->menuBar()->addMenu(QString("View"));
     {
-        auto * use_orbit_camera = new RAction(
-            QString("Use Orbit Camera Controller"),
-            QString("Use Oribt Camera Controller"),
-            [this]()
-            {
-                qDebug() << "Use Orbit Camera Controller (menu demo)";
-                for (auto subwin : m_mdiArea->subWindowList())
-                {
-                    try
-                    {
-                        R3DWidget * viewer = dynamic_cast<R3DWidget *>(subwin->widget());
-                        viewer->scene()->setOrbitCameraController();
-                        viewer->scene()->controller()->setCamera(viewer->camera());
-                    }
-                    catch (std::bad_cast & e)
-                    {
-                        std::cerr << e.what() << std::endl;
-                    }
-                }
-            });
-
-        auto * use_fps_camera = new RAction(
-            QString("Use First Person Camera Controller"),
-            QString("Use First Person Camera Controller"),
-            [this]()
-            {
-                qDebug() << "Use First Person Camera Controller (menu demo)";
-                for (auto subwin : m_mdiArea->subWindowList())
-                {
-                    try
-                    {
-                        R3DWidget * viewer = dynamic_cast<R3DWidget *>(subwin->widget());
-                        viewer->scene()->setFirstPersonCameraController();
-                        viewer->scene()->controller()->setCamera(viewer->camera());
-                    }
-                    catch (std::bad_cast & e)
-                    {
-                        std::cerr << e.what() << std::endl;
-                    }
-                }
-            });
-
-        auto * reset_camera = new RAction(
-            QString("Reset (esc)"),
-            QString("Reset (esc)"),
-            [this]()
-            {
-                // implement resetting camera contorl
-                qDebug() << "Reset to initial status.";
-                for (auto subwin : m_mdiArea->subWindowList())
-                {
-                    try
-                    {
-                        R3DWidget * viewer = dynamic_cast<R3DWidget *>(subwin->widget());
-                        Qt3DRender::QCamera * camera = viewer->camera();
-                        if (camera)
-                        {
-                            viewer->resetCamera(camera);
-                        }
-                    }
-                    catch (std::bad_cast & e)
-                    {
-                        std::cerr << e.what() << std::endl;
-                    }
-                }
-            });
-
-        auto * cameraGroup = new QActionGroup(m_mainWindow);
-        cameraGroup->addAction(use_orbit_camera);
-        cameraGroup->addAction(use_fps_camera);
-        cameraGroup->addAction(reset_camera);
-
-        use_orbit_camera->setCheckable(true);
-        use_fps_camera->setCheckable(true);
-        use_orbit_camera->setChecked(true);
-
-        reset_camera->setShortcut(QKeySequence(Qt::Key_Escape));
-
-        m_viewMenu->addAction(use_orbit_camera);
-        m_viewMenu->addAction(use_fps_camera);
-        m_viewMenu->addAction(reset_camera);
+        setUpCameraControllersMenuItems();
+        setUpCameraMovementsMenuItems();
     }
 
     m_oneMenu = m_mainWindow->menuBar()->addMenu(QString("One"));
@@ -279,6 +200,241 @@ void RManager::setUpMenu()
             QString("(empty)"),
             QString("(empty)"),
             []() {}));
+}
+
+void RManager::setUpCameraControllersMenuItems() const {
+    auto * use_orbit_camera = new RAction(
+        QString("Use Orbit Camera Controller"),
+        QString("Use Oribt Camera Controller"),
+        [this]()
+        {
+            qDebug() << "Use Orbit Camera Controller (menu demo)";
+            for (auto subwin : m_mdiArea->subWindowList())
+            {
+                try
+                {
+                    R3DWidget * viewer = dynamic_cast<R3DWidget *>(subwin->widget());
+                    viewer->scene()->setOrbitCameraController();
+                    viewer->scene()->controller()->setCamera(viewer->camera());
+                }
+                catch (std::bad_cast & e)
+                {
+                    std::cerr << e.what() << std::endl;
+                }
+            }
+        });
+
+    auto * use_fps_camera = new RAction(
+        QString("Use First Person Camera Controller"),
+        QString("Use First Person Camera Controller"),
+        [this]()
+        {
+            qDebug() << "Use First Person Camera Controller (menu demo)";
+            for (auto subwin : m_mdiArea->subWindowList())
+            {
+                try
+                {
+                    R3DWidget * viewer = dynamic_cast<R3DWidget *>(subwin->widget());
+                    viewer->scene()->setFirstPersonCameraController();
+                    viewer->scene()->controller()->setCamera(viewer->camera());
+                }
+                catch (std::bad_cast & e)
+                {
+                    std::cerr << e.what() << std::endl;
+                }
+            }
+        });
+
+    auto * cameraGroup = new QActionGroup(m_mainWindow);
+    cameraGroup->addAction(use_orbit_camera);
+    cameraGroup->addAction(use_fps_camera);
+
+    use_orbit_camera->setCheckable(true);
+    use_fps_camera->setCheckable(true);
+    use_orbit_camera->setChecked(true);
+
+    m_viewMenu->addAction(use_orbit_camera);
+    m_viewMenu->addAction(use_fps_camera);
+}
+
+void RManager::setUpCameraMovementsMenuItems() const {
+    auto * reset_camera = new RAction(
+         QString("Reset (esc)"),
+         QString("Reset (esc)"),
+         [this]()
+         {
+             // implement resetting camera control
+             qDebug() << "Reset to initial status.";
+             try
+             {
+                 auto * viewer = dynamic_cast<R3DWidget *>(m_mdiArea->currentSubWindow()->widget());
+                 Qt3DRender::QCamera * camera = viewer->camera();
+                 if (camera)
+                 {
+                     viewer->resetCamera(camera);
+                 }
+             }
+             catch (std::bad_cast & e)
+             {
+                 std::cerr << e.what() << std::endl;
+             }
+         });
+
+    auto * move_camera_up = new RAction(
+        QString("Move camera up (W/⬆)"),
+        QString("Move camera up (W/⬆)"),
+        createCameraTranslateItemHandler([](CameraInputState & input)
+        {
+            input.tyAxisValue = 1.0;
+        })
+    );
+
+    auto * move_camera_down = new RAction(
+        QString("Move camera down (S/⬇)"),
+        QString("Move camera down (S/⬇)"),
+        createCameraTranslateItemHandler([](CameraInputState & input)
+        {
+            input.tyAxisValue = -1.0;
+        })
+    );
+
+    auto * move_camera_right = new RAction(
+        QString("Move camera right (D/➡)"),
+        QString("Move camera right (D/➡)"),
+        createCameraTranslateItemHandler([](CameraInputState & input)
+        {
+            input.txAxisValue = 1.0;
+        })
+    );
+
+    auto * move_camera_left = new RAction(
+        QString("Move camera left (A/⬅)"),
+        QString("Move camera left (A/⬅)"),
+        createCameraTranslateItemHandler([](CameraInputState & input)
+        {
+            input.txAxisValue = -1.0;
+        })
+    );
+
+    auto * move_camera_forward = new RAction(
+        QString("Move camera forward (Ctrl+W/⬆)"),
+        QString("Move camera forward (Ctrl+W/⬆)"),
+        createCameraTranslateItemHandler([](CameraInputState & input)
+        {
+            input.tzAxisValue = 1.0;
+        })
+    );
+
+    auto * move_camera_backward = new RAction(
+        QString("Move camera down (Ctrl+S/⬇)"),
+        QString("Move camera down (Ctrl+S/⬇)"),
+        createCameraTranslateItemHandler([](CameraInputState & input)
+        {
+            input.tzAxisValue = -1.0;
+        })
+    );
+
+    auto * rotate_camera_positive_yaw = new RAction(
+        QString("Rotate camera positive yaw"),
+        QString("Rotate camera positive yaw"),
+        createCameraRotateItemHandler([](CameraInputState & input)
+        {
+            input.rxAxisValue = 1.0;
+        })
+    );
+
+    auto * rotate_camera_negative_yaw = new RAction(
+        QString("Rotate camera negative yaw"),
+        QString("Rotate camera negative yaw"),
+        createCameraRotateItemHandler([](CameraInputState & input)
+        {
+            input.rxAxisValue = -1.0;
+        })
+    );
+
+    auto * rotate_camera_positive_pitch = new RAction(
+        QString("Rotate camera positive pitch"),
+        QString("Rotate camera positive pitch"),
+        createCameraRotateItemHandler([](CameraInputState & input)
+        {
+            input.ryAxisValue = 1.0;
+        })
+    );
+
+    auto * rotate_camera_negative_pitch = new RAction(
+        QString("Rotate camera negative pitch"),
+        QString("Rotate camera negative pitch"),
+        createCameraRotateItemHandler([](CameraInputState & input)
+        {
+            input.ryAxisValue = -1.0;
+        })
+    );
+
+    reset_camera->setShortcut(QKeySequence(Qt::Key_Escape));
+
+    m_viewMenu->addAction(reset_camera);
+    m_viewMenu->addAction(move_camera_up);
+    m_viewMenu->addAction(move_camera_down);
+    m_viewMenu->addAction(move_camera_right);
+    m_viewMenu->addAction(move_camera_left);
+    m_viewMenu->addAction(move_camera_forward);
+    m_viewMenu->addAction(move_camera_backward);
+    m_viewMenu->addAction(rotate_camera_positive_yaw);
+    m_viewMenu->addAction(rotate_camera_negative_yaw);
+    m_viewMenu->addAction(rotate_camera_positive_pitch);
+    m_viewMenu->addAction(rotate_camera_negative_pitch);
+}
+
+std::function<void()> RManager::createCameraTranslateItemHandler(const std::function<void(CameraInputState&)> &func) const {
+    return [this, func]() {
+        try
+        {
+            auto * viewer = dynamic_cast<R3DWidget *>(m_mdiArea->currentSubWindow()->widget());
+
+            if (viewer->camera())
+            {
+                CameraInputState input{};
+                func(input);
+                viewer->cameraController()->updateCameraPosition(input, 0.01);
+            }
+        }
+        catch (std::bad_cast & e)
+        {
+            std::cerr << e.what() << std::endl;
+        }
+    };
+}
+
+std::function<void()> RManager::createCameraRotateItemHandler(const std::function<void(CameraInputState&)> &func) const {
+    return [this, func]() {
+        try
+        {
+            auto * viewer = dynamic_cast<R3DWidget *>(m_mdiArea->currentSubWindow()->widget());
+
+            if (viewer->camera())
+            {
+                auto * controller = viewer->cameraController();
+
+                CameraInputState input{};
+                func(input);
+
+                if(controller->getType() == CameraControllerType::Orbit)
+                {
+                    input.rightMouseButtonActive = true;
+                }
+                else if(controller->getType() == CameraControllerType::FirstPerson)
+                {
+                    input.leftMouseButtonActive = true;
+                }
+
+                viewer->cameraController()->updateCameraPosition(input, 0.01);
+            }
+        }
+        catch (std::bad_cast & e)
+        {
+            std::cerr << e.what() << std::endl;
+        }
+    };
 }
 
 void RManager::clearApplications()

--- a/cpp/modmesh/view/RManager.hpp
+++ b/cpp/modmesh/view/RManager.hpp
@@ -85,8 +85,8 @@ private:
     void setUpCameraControllersMenuItems() const;
     void setUpCameraMovementsMenuItems() const;
 
-    std::function<void()> createCameraTranslateItemHandler(const std::function<void(CameraInputState&)> &) const;
-    std::function<void()> createCameraRotateItemHandler(const std::function<void(CameraInputState&)> &) const;
+    std::function<void()> createCameraTranslateItemHandler(const std::function<void(CameraInputState &)> &) const;
+    std::function<void()> createCameraRotateItemHandler(const std::function<void(CameraInputState &)> &) const;
 
     bool m_already_setup = false;
 

--- a/cpp/modmesh/view/RManager.hpp
+++ b/cpp/modmesh/view/RManager.hpp
@@ -82,6 +82,12 @@ private:
     void setUpCentral();
     void setUpMenu();
 
+    void setUpCameraControllersMenuItems() const;
+    void setUpCameraMovementsMenuItems() const;
+
+    std::function<void()> createCameraTranslateItemHandler(const std::function<void(CameraInputState&)> &) const;
+    std::function<void()> createCameraRotateItemHandler(const std::function<void(CameraInputState&)> &) const;
+
     bool m_already_setup = false;
 
     QCoreApplication * m_core = nullptr;

--- a/cpp/modmesh/view/RManager.hpp
+++ b/cpp/modmesh/view/RManager.hpp
@@ -83,10 +83,9 @@ private:
     void setUpMenu();
 
     void setUpCameraControllersMenuItems() const;
-    void setUpCameraMovementsMenuItems() const;
+    void setUpCameraMovementMenuItems() const;
 
-    std::function<void()> createCameraTranslateItemHandler(const std::function<void(CameraInputState &)> &) const;
-    std::function<void()> createCameraRotateItemHandler(const std::function<void(CameraInputState &)> &) const;
+    std::function<void()> createCameraMovementItemHandler(const std::function<void(CameraInputState &)> &) const;
 
     bool m_already_setup = false;
 

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -470,7 +470,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRCameraController
                     bool shift_key,
                     float dt)
                 {
-                    Qt3DExtras::QAbstractCameraController::InputState input{};
+                    CameraInputState input{};
                     input.txAxisValue = x;
                     input.tyAxisValue = y;
                     input.tzAxisValue = z;

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -198,17 +198,10 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapR3DWidget
                 py::arg("name"))
             .def(
                 "resetCamera",
-                [](wrapped_type & self, float const & positionX, float const & positionY, float const & positionZ)
+                [](wrapped_type & self)
                 {
-                    Qt3DRender::QCamera * camera = self.camera();
-                    if (camera)
-                    {
-                        self.resetCamera(camera, positionX, positionY, positionZ);
-                    }
-                },
-                py::arg("positionX") = 0.0f,
-                py::arg("positionY") = 0.0f,
-                py::arg("positionZ") = 10.0f)
+                    self.resetCamera();
+                })
             .def("cameraController", &wrapped_type::cameraController);
 
 #define DECL_QVECTOR3D_PROPERTY(NAME, GETTER, SETTER)          \


### PR DESCRIPTION
https://github.com/solvcon/modmesh/issues/70

In this PR:
* Now Ctrl+W/Arrow up is to move camera forward and Ctrl+S/Arrow down to backward. Q/E and Page Up/Down keys are removed
* Added items to View submenu to control camera translation and rotation
* Refactored resetCamera function
* Fixed the error when there are no subwindows open, but resetCamera is pressed

<img width="590" alt="Screenshot 2024-08-14 at 20 54 01" src="https://github.com/user-attachments/assets/fe1ed833-899f-40d9-b4db-c80125195192">

