### PR TITLE
Camera Controller: expose complete API to python

### DIFF
--- a/cpp/modmesh/view/R3DWidget.cpp
+++ b/cpp/modmesh/view/R3DWidget.cpp
@@ -41,7 +41,8 @@ R3DWidget::R3DWidget(Qt3DExtras::Qt3DWindow * window, RScene * scene, QWidget * 
 {
     m_view->setRootEntity(m_scene);
 
-    resetCamera();
+    cameraController()->setCamera(m_view->camera());
+    cameraController()->reset();
 
     if (Toggle::instance().fixed().get_show_axis())
     {
@@ -97,23 +98,6 @@ void R3DWidget::resizeEvent(QResizeEvent * event)
     QWidget::resizeEvent(event);
     m_view->resize(event->size());
     m_container->resize(event->size());
-}
-
-void R3DWidget::resetCamera() const
-{
-    Qt3DRender::QCamera * camera = m_view->camera();
-
-    // Set up the camera.
-    camera->lens()->setPerspectiveProjection(45.0f, 16.0f / 9.0f, 0.1f, 1000.0f);
-    camera->setPosition(QVector3D(0.0f, 0.0f, 10.0f));
-    camera->setViewCenter(QVector3D(0.0f, 0.0f, 0.0f));
-    camera->setUpVector(QVector3D(0.f, 1.f, 0.f));
-
-    // Set up the camera control.
-    auto * control = m_scene->controller();
-    control->setCamera(camera);
-    control->setLinearSpeed(50.0f);
-    control->setLookSpeed(180.0f);
 }
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/view/R3DWidget.hpp
+++ b/cpp/modmesh/view/R3DWidget.hpp
@@ -59,7 +59,8 @@ public:
     CameraController * controller() const { return m_controller; }
     Qt3DExtras::QAbstractCameraController * qtController() const { return m_controller->asQtCameraController(); }
 
-    void setCameraController(CameraController * controller) {
+    void setCameraController(CameraController * controller)
+    {
         qtController()->deleteLater();
         m_controller = controller;
     }
@@ -70,7 +71,7 @@ public:
 
 private:
 
-    CameraController* m_controller;
+    CameraController * m_controller;
 
 }; /* end class RScene */
 

--- a/cpp/modmesh/view/R3DWidget.hpp
+++ b/cpp/modmesh/view/R3DWidget.hpp
@@ -46,7 +46,8 @@
 namespace modmesh
 {
 
-class RScene : public Qt3DCore::QEntity
+class RScene
+    : public Qt3DCore::QEntity
 {
 public:
 
@@ -57,11 +58,10 @@ public:
     }
 
     CameraController * controller() const { return m_controller; }
-    Qt3DExtras::QAbstractCameraController * qtController() const { return m_controller->asQtCameraController(); }
 
     void setCameraController(CameraController * controller)
     {
-        qtController()->deleteLater();
+        m_controller->deleteLater();
         m_controller = controller;
     }
 
@@ -97,7 +97,6 @@ public:
     Qt3DRender::QCamera * camera() { return m_view->camera(); }
 
     CameraController * cameraController() const { return m_scene->controller(); }
-    Qt3DExtras::QAbstractCameraController * qtCameraController() const { return m_scene->qtController(); }
 
     QPixmap grabPixmap() const { return m_view->screen()->grabWindow(m_view->winId()); }
 

--- a/cpp/modmesh/view/R3DWidget.hpp
+++ b/cpp/modmesh/view/R3DWidget.hpp
@@ -46,24 +46,21 @@
 namespace modmesh
 {
 
-class RScene
-    : public Qt3DCore::QEntity
+class RScene : public Qt3DCore::QEntity
 {
-
 public:
 
-    explicit RScene(Qt3DCore::QNode * parent = nullptr)
-        : Qt3DCore::QEntity(parent)
-        , m_controller(new ROrbitCameraController(this))
+    explicit RScene(QNode * parent = nullptr)
+        : QEntity(parent)
     {
+        m_controller = new ROrbitCameraController(this);
     }
 
-    Qt3DExtras::QAbstractCameraController const * controller() const { return m_controller; }
-    Qt3DExtras::QAbstractCameraController * controller() { return m_controller; }
+    CameraController * controller() const { return m_controller; }
+    Qt3DExtras::QAbstractCameraController * qtController() const { return m_controller->asQtCameraController(); }
 
-    void setCameraController(Qt3DExtras::QAbstractCameraController * controller)
-    {
-        m_controller->deleteLater();
+    void setCameraController(CameraController * controller) {
+        qtController()->deleteLater();
         m_controller = controller;
     }
 
@@ -73,7 +70,7 @@ public:
 
 private:
 
-    Qt3DExtras::QAbstractCameraController * m_controller = nullptr;
+    CameraController* m_controller;
 
 }; /* end class RScene */
 
@@ -97,8 +94,9 @@ public:
     Qt3DExtras::Qt3DWindow * view() { return m_view; }
     RScene * scene() { return m_scene; }
     Qt3DRender::QCamera * camera() { return m_view->camera(); }
-    Qt3DExtras::QAbstractCameraController * qtCameraController() { return m_scene->controller(); }
-    CameraController * cameraController() { return dynamic_cast<CameraController *>(m_scene->controller()); }
+
+    CameraController * cameraController() const { return m_scene->controller(); }
+    Qt3DExtras::QAbstractCameraController * qtCameraController() const { return m_scene->qtController(); }
 
     QPixmap grabPixmap() const { return m_view->screen()->grabWindow(m_view->winId()); }
 

--- a/cpp/modmesh/view/R3DWidget.hpp
+++ b/cpp/modmesh/view/R3DWidget.hpp
@@ -57,9 +57,9 @@ public:
         m_controller = new ROrbitCameraController(this);
     }
 
-    CameraController * controller() const { return m_controller; }
+    RCameraController * controller() const { return m_controller; }
 
-    void setCameraController(CameraController * controller)
+    void setCameraController(RCameraController * controller)
     {
         m_controller->deleteLater();
         m_controller = controller;
@@ -71,7 +71,7 @@ public:
 
 private:
 
-    CameraController * m_controller;
+    RCameraController * m_controller;
 
 }; /* end class RScene */
 
@@ -96,7 +96,7 @@ public:
     RScene * scene() { return m_scene; }
     Qt3DRender::QCamera * camera() { return m_view->camera(); }
 
-    CameraController * cameraController() const { return m_scene->controller(); }
+    RCameraController * cameraController() const { return m_scene->controller(); }
 
     QPixmap grabPixmap() const { return m_view->screen()->grabWindow(m_view->winId()); }
 

--- a/cpp/modmesh/view/R3DWidget.hpp
+++ b/cpp/modmesh/view/R3DWidget.hpp
@@ -100,8 +100,6 @@ public:
     Qt3DExtras::QAbstractCameraController * qtCameraController() { return m_scene->controller(); }
     CameraController * cameraController() { return dynamic_cast<CameraController *>(m_scene->controller()); }
 
-    void resetCamera() const;
-
     QPixmap grabPixmap() const { return m_view->screen()->grabWindow(m_view->winId()); }
 
     void showMark();

--- a/cpp/modmesh/view/RCameraController.cpp
+++ b/cpp/modmesh/view/RCameraController.cpp
@@ -214,7 +214,10 @@ void RCameraInputListener::initKeyboardListeners() const
 
 void CameraController::reset()
 {
-    camera()->lens()->setPerspectiveProjection(45.0f, camera()->lens()->aspectRatio(), 0.1f, 1000.0f);
+    constexpr float fov_deg = 45.0f;
+    constexpr float nearPlane = 0.1f;
+    constexpr float farPlane = 1000.0f;
+    camera()->lens()->setPerspectiveProjection(fov_deg, camera()->lens()->aspectRatio(), nearPlane, farPlane);
 
     setPosition(m_default_position);
     setViewCenter(m_default_view_center);
@@ -225,17 +228,17 @@ void CameraController::reset()
 }
 
 RFirstPersonCameraController::RFirstPersonCameraController(QNode * parent)
-    : QFirstPersonCameraController(parent)
+    : CameraController(parent)
 {
     auto callback = [this](const CameraInputState & state, const float dt)
     {
-        updateCameraPosition(state, dt);
+        moveCamera(state, dt);
     };
 
     m_listener = new RCameraInputListener(keyboardDevice(), mouseDevice(), callback, this);
 }
 
-void RFirstPersonCameraController::updateCameraPosition(const CameraInputState & input, const float dt)
+void RFirstPersonCameraController::moveCamera(const CameraInputState & input, const float dt)
 {
     constexpr auto positiveY = QVector3D(0.f, 1.f, 0.f);
 
@@ -256,17 +259,17 @@ void RFirstPersonCameraController::updateCameraPosition(const CameraInputState &
 }
 
 ROrbitCameraController::ROrbitCameraController(QNode * parent)
-    : QOrbitCameraController(parent)
+    : CameraController(parent)
 {
     auto callback = [this](const CameraInputState & state, const float dt)
     {
-        updateCameraPosition(state, dt);
+        moveCamera(state, dt);
     };
 
     m_listener = new RCameraInputListener(keyboardDevice(), mouseDevice(), callback, this);
 }
 
-void ROrbitCameraController::updateCameraPosition(const CameraInputState & input, const float dt)
+void ROrbitCameraController::moveCamera(const CameraInputState & input, const float dt)
 {
     if (camera() == nullptr)
         return;
@@ -317,7 +320,9 @@ void ROrbitCameraController::updateCameraPosition(const CameraInputState & input
 
 void ROrbitCameraController::zoom(const float zoomValue) const
 {
-    const float limitSquared = zoomInLimit() * zoomInLimit();
+    constexpr float zoomInLimit = 2.0f; // Default Qt zoomInLimit value
+
+    const float limitSquared = zoomInLimit * zoomInLimit;
     const float distanceSquared = zoomDistanceSquared(camera()->position(), camera()->viewCenter());
 
     const float z = distanceSquared > limitSquared ? zoomValue : -0.5f;

--- a/cpp/modmesh/view/RCameraController.cpp
+++ b/cpp/modmesh/view/RCameraController.cpp
@@ -216,12 +216,12 @@ void CameraController::reset()
 {
     camera()->lens()->setPerspectiveProjection(45.0f, 16.0f / 9.0f, 0.1f, 1000.0f);
 
-    setPosition(QVector3D(0.0f, 0.0f, 10.0f));
-    setViewCenter(QVector3D(0.0f, 0.0f, 0.0f));
-    setUpVector(QVector3D(0.f, 1.f, 0.f));
+    setPosition(m_default_position);
+    setViewCenter(m_default_view_center);
+    setUpVector(m_default_up_vector);
 
-    setLinearSpeed(50.0f);
-    setLookSpeed(180.0f);
+    setLinearSpeed(m_default_linear_speed);
+    setLookSpeed(m_default_look_speed);
 }
 
 RFirstPersonCameraController::RFirstPersonCameraController(QNode * parent)

--- a/cpp/modmesh/view/RCameraController.cpp
+++ b/cpp/modmesh/view/RCameraController.cpp
@@ -214,7 +214,7 @@ void RCameraInputListener::initKeyboardListeners() const
 
 void CameraController::reset()
 {
-    camera()->lens()->setPerspectiveProjection(45.0f, 16.0f / 9.0f, 0.1f, 1000.0f);
+    camera()->lens()->setPerspectiveProjection(45.0f, camera()->lens()->aspectRatio(), 0.1f, 1000.0f);
 
     setPosition(m_default_position);
     setViewCenter(m_default_view_center);

--- a/cpp/modmesh/view/RCameraController.cpp
+++ b/cpp/modmesh/view/RCameraController.cpp
@@ -212,6 +212,18 @@ void RCameraInputListener::initKeyboardListeners() const
     m_ty_axis->addInput(m_keyboard_ty_neg_input);
 }
 
+void CameraController::reset()
+{
+    camera()->lens()->setPerspectiveProjection(45.0f, 16.0f / 9.0f, 0.1f, 1000.0f);
+
+    setPosition(QVector3D(0.0f, 0.0f, 10.0f));
+    setViewCenter(QVector3D(0.0f, 0.0f, 0.0f));
+    setUpVector(QVector3D(0.f, 1.f, 0.f));
+
+    setLinearSpeed(50.0f);
+    setLookSpeed(180.0f);
+}
+
 RFirstPersonCameraController::RFirstPersonCameraController(QNode * parent)
     : QFirstPersonCameraController(parent)
 {

--- a/cpp/modmesh/view/RCameraController.cpp
+++ b/cpp/modmesh/view/RCameraController.cpp
@@ -212,7 +212,7 @@ void RCameraInputListener::initKeyboardListeners() const
     m_ty_axis->addInput(m_keyboard_ty_neg_input);
 }
 
-void CameraController::reset()
+void RCameraController::reset()
 {
     constexpr float fov_deg = 45.0f;
     constexpr float nearPlane = 0.1f;
@@ -228,7 +228,7 @@ void CameraController::reset()
 }
 
 RFirstPersonCameraController::RFirstPersonCameraController(QNode * parent)
-    : CameraController(parent)
+    : RCameraController(parent)
 {
     auto callback = [this](const CameraInputState & state, const float dt)
     {
@@ -259,7 +259,7 @@ void RFirstPersonCameraController::moveCamera(const CameraInputState & input, co
 }
 
 ROrbitCameraController::ROrbitCameraController(QNode * parent)
-    : CameraController(parent)
+    : RCameraController(parent)
 {
     auto callback = [this](const CameraInputState & state, const float dt)
     {

--- a/cpp/modmesh/view/RCameraController.hpp
+++ b/cpp/modmesh/view/RCameraController.hpp
@@ -135,21 +135,29 @@ public:
 
     virtual void updateCameraPosition(const CameraInputState & state, float dt) = 0;
 
-    virtual Qt3DRender::QCamera * getCamera() = 0;
+    virtual Qt3DRender::QCamera * camera() const = 0;
+    virtual void setCamera(Qt3DRender::QCamera * camera) = 0;
 
-    virtual float getLinearSpeed() = 0;
+    virtual float linearSpeed() const = 0;
+    virtual void setLinearSpeed(float value) = 0;
 
-    virtual float getLookSpeed() = 0;
+    virtual float lookSpeed() const = 0;
+    virtual void setLookSpeed(float value) = 0;
 
     virtual CameraControllerType getType() = 0;
 
-    QVector3D position() { return getCamera()->position(); }
+    QVector3D position() const { return camera()->position(); }
+    void setPosition(const QVector3D & value) const { camera()->setPosition(value); }
 
-    QVector3D viewVector() { return getCamera()->viewVector(); }
+    QVector3D viewVector() const { return camera()->viewVector(); }
 
-    QVector3D viewCenter() { return getCamera()->viewCenter(); }
+    QVector3D viewCenter() const { return camera()->viewCenter(); }
+    void setViewCenter(const QVector3D & value) const { camera()->setViewCenter(value); }
 
-    QVector3D upVector() { return getCamera()->upVector(); }
+    QVector3D upVector() const { return camera()->upVector(); }
+    void setUpVector(const QVector3D & value) const { camera()->setUpVector(value); }
+
+    void reset();
 
 protected:
     RCameraInputListener * m_listener = nullptr;
@@ -169,9 +177,14 @@ class RFirstPersonCameraController : public Qt3DExtras::QFirstPersonCameraContro
 public:
     explicit RFirstPersonCameraController(QNode * parent = nullptr);
 
-    Qt3DRender::QCamera * getCamera() override { return camera(); }
-    float getLinearSpeed() override { return linearSpeed(); }
-    float getLookSpeed() override { return lookSpeed(); }
+    Qt3DRender::QCamera * camera() const override { return QFirstPersonCameraController::camera(); }
+    void setCamera(Qt3DRender::QCamera * camera) override { QFirstPersonCameraController::setCamera(camera); }
+
+    float linearSpeed() const override { return QFirstPersonCameraController::linearSpeed(); }
+    void setLinearSpeed(float value) override { QFirstPersonCameraController::setLinearSpeed(value); }
+
+    float lookSpeed() const override { return QFirstPersonCameraController::lookSpeed(); }
+    void setLookSpeed(float value) override { QFirstPersonCameraController::setLookSpeed(value); }
 
 private:
     static constexpr auto lookSpeedFactorOnShiftPressed = 0.2f;
@@ -191,9 +204,14 @@ class ROrbitCameraController : public Qt3DExtras::QOrbitCameraController
 public:
     explicit ROrbitCameraController(QNode * parent = nullptr);
 
-    Qt3DRender::QCamera * getCamera() override { return camera(); }
-    float getLinearSpeed() override { return linearSpeed(); }
-    float getLookSpeed() override { return lookSpeed(); }
+    Qt3DRender::QCamera * camera() const override { return QOrbitCameraController::camera(); }
+    void setCamera(Qt3DRender::QCamera * camera) override { QOrbitCameraController::setCamera(camera); }
+
+    float linearSpeed() const override { return QOrbitCameraController::linearSpeed(); }
+    void setLinearSpeed(float value) override { QOrbitCameraController::setLinearSpeed(value); }
+
+    float lookSpeed() const override { return QOrbitCameraController::lookSpeed(); }
+    void setLookSpeed(float value) override { QOrbitCameraController::setLookSpeed(value); }
 
 private:
     void moveCamera(const InputState & state, float dt) override {}

--- a/cpp/modmesh/view/RCameraController.hpp
+++ b/cpp/modmesh/view/RCameraController.hpp
@@ -159,10 +159,19 @@ public:
 
     void reset();
 
+    QVector3D defaultPosition() const { return m_default_position; }
     void setDefaultPosition(QVector3D value) { m_default_position = value; }
+
+    QVector3D defaultViewCenter() const { return m_default_view_center; }
     void setDefaultViewCenter(QVector3D value) { m_default_view_center = value; }
+
+    QVector3D defaultUpVector() const { return m_default_up_vector; }
     void setDefaultUpVector(QVector3D value) { m_default_up_vector = value; }
+
+    float defaultLinearSpeed() const { return m_default_linear_speed; }
     void setDefaultLinearSpeed(float value) { m_default_linear_speed = value; }
+
+    float defaultLookSpeed() const { return m_default_look_speed; }
     void setDefaultLookSpeed(float value) { m_default_look_speed = value; }
 
     Qt3DExtras::QAbstractCameraController * asQtCameraController()

--- a/cpp/modmesh/view/RCameraController.hpp
+++ b/cpp/modmesh/view/RCameraController.hpp
@@ -126,18 +126,20 @@ private:
     Qt3DInput::QButtonAxisInput * m_keyboard_tz_neg_input;
 }; /* end class RCameraInputListener */
 
-class CameraController : public Qt3DExtras::QAbstractCameraController
+class RCameraController : public Qt3DExtras::QAbstractCameraController
 {
     Q_OBJECT
 
 public:
-    explicit CameraController(Qt3DCore::QNode * parent = nullptr)
+    explicit RCameraController(Qt3DCore::QNode * parent = nullptr)
         : QAbstractCameraController(parent)
     {
     }
 
-    // Do nothing in QAbstractCameraController's moveCamera
-    void moveCamera(const InputState & state, float dt) override {}
+    void moveCamera(const InputState & state, float dt) override
+    {
+        // Do nothing in QAbstractCameraController's moveCamera
+    }
 
     virtual void moveCamera(const CameraInputState & state, float dt) = 0;
 
@@ -191,7 +193,7 @@ private:
     float m_default_look_speed = 180.0f;
 }; /* end class CameraController */
 
-class RFirstPersonCameraController : public CameraController
+class RFirstPersonCameraController : public RCameraController
 {
     Q_OBJECT
 
@@ -206,7 +208,7 @@ private:
     CameraControllerType getType() override { return CameraControllerType::FirstPerson; }
 }; /* end class RFirstPersonCameraController */
 
-class ROrbitCameraController : public CameraController
+class ROrbitCameraController : public RCameraController
 {
     Q_OBJECT
 

--- a/cpp/modmesh/view/RCameraController.hpp
+++ b/cpp/modmesh/view/RCameraController.hpp
@@ -165,15 +165,15 @@ public:
     void setDefaultLinearSpeed(float value) { m_default_linear_speed = value; }
     void setDefaultLookSpeed(float value) { m_default_look_speed = value; }
 
-protected:
-    RCameraInputListener * m_listener = nullptr;
-
-private:
     Qt3DExtras::QAbstractCameraController * asQtCameraController()
     {
         return dynamic_cast<Qt3DExtras::QAbstractCameraController *>(this);
     }
 
+protected:
+    RCameraInputListener * m_listener = nullptr;
+
+private:
     QVector3D m_default_position = QVector3D(0.0f, 0.0f, 10.0f);
     QVector3D m_default_view_center = QVector3D(0.0f, 0.0f, 0.0f);
     QVector3D m_default_up_vector = QVector3D(0.0f, 1.0f, 0.0f);

--- a/cpp/modmesh/view/RCameraController.hpp
+++ b/cpp/modmesh/view/RCameraController.hpp
@@ -159,6 +159,12 @@ public:
 
     void reset();
 
+    void setDefaultPosition(QVector3D value) { m_default_position = value; }
+    void setDefaultViewCenter(QVector3D value) { m_default_view_center = value; }
+    void setDefaultUpVector(QVector3D value) { m_default_up_vector = value; }
+    void setDefaultLinearSpeed(float value) { m_default_linear_speed = value; }
+    void setDefaultLookSpeed(float value) { m_default_look_speed = value; }
+
 protected:
     RCameraInputListener * m_listener = nullptr;
 
@@ -167,6 +173,12 @@ private:
     {
         return dynamic_cast<Qt3DExtras::QAbstractCameraController *>(this);
     }
+
+    QVector3D m_default_position = QVector3D(0.0f, 0.0f, 10.0f);
+    QVector3D m_default_view_center = QVector3D(0.0f, 0.0f, 0.0f);
+    QVector3D m_default_up_vector = QVector3D(0.0f, 1.0f, 0.0f);
+    float m_default_linear_speed = 50.0f;
+    float m_default_look_speed = 180.0f;
 }; /* end class CameraController */
 
 class RFirstPersonCameraController : public Qt3DExtras::QFirstPersonCameraController

--- a/cpp/modmesh/view/RManager.cpp
+++ b/cpp/modmesh/view/RManager.cpp
@@ -379,7 +379,7 @@ std::function<void()> RManager::createCameraMovementItemHandler(const std::funct
             }
         }
 
-        viewer->cameraController()->updateCameraPosition(input, 0.01);
+        viewer->cameraController()->moveCamera(input, 0.01);
     };
 }
 

--- a/cpp/modmesh/view/RManager.cpp
+++ b/cpp/modmesh/view/RManager.cpp
@@ -267,7 +267,7 @@ void RManager::setUpCameraMovementMenuItems() const
             if (viewer == nullptr || viewer->camera() == nullptr)
                 return;
 
-            viewer->resetCamera();
+            viewer->cameraController()->reset();
         });
 
     auto * move_camera_up = new RAction(

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -196,12 +196,6 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapR3DWidget
                     }
                 },
                 py::arg("name"))
-            .def(
-                "resetCamera",
-                [](wrapped_type & self)
-                {
-                    self.resetCamera();
-                })
             .def("cameraController", &wrapped_type::cameraController);
 
 #define DECL_QVECTOR3D_PROPERTY(NAME, GETTER, SETTER)          \
@@ -449,6 +443,10 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRCameraController
 
         (*this)
             .def(
+                "reset",
+                [](wrapped_type & self)
+                { self.reset(); })
+            .def(
                 "updateCameraPosition",
                 [](
                     wrapped_type & self,
@@ -497,13 +495,36 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRCameraController
                     return py::make_tuple(position.x(), position.y(), position.z());
                 })
             .def(
+                "setPosition",
+                [](wrapped_type & self, float x, float y, float z)
+                {
+                    self.setPosition(QVector3D(x, y, z));
+                },
+                py::arg("x"),
+                py::arg("y"),
+                py::arg("z"))
+            .def(
                 "linearSpeed",
                 [](wrapped_base_type & self)
-                { return self.getLinearSpeed(); })
+                { return self.linearSpeed(); })
+            .def(
+                "setLinearSpeed",
+                [](wrapped_base_type & self, float value)
+                {
+                    self.setLinearSpeed(value);
+                },
+                py::arg("value"))
             .def(
                 "lookSpeed",
                 [](wrapped_base_type & self)
-                { return self.getLookSpeed(); })
+                { return self.lookSpeed(); })
+            .def(
+                "setLookSpeed",
+                [](wrapped_base_type & self, float value)
+                {
+                    self.setLookSpeed(value);
+                },
+                py::arg("value"))
             .def(
                 "viewCenter",
                 [](wrapped_base_type & self)
@@ -511,6 +532,15 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRCameraController
                     const auto center = self.viewCenter();
                     return py::make_tuple(center.x(), center.y(), center.z());
                 })
+            .def(
+                "setViewCenter",
+                [](wrapped_type & self, float x, float y, float z)
+                {
+                    self.setViewCenter(QVector3D(x, y, z));
+                },
+                py::arg("x"),
+                py::arg("y"),
+                py::arg("z"))
             .def(
                 "viewVector",
                 [](wrapped_base_type & self)
@@ -524,7 +554,16 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRCameraController
                 {
                     const auto vector = self.upVector();
                     return py::make_tuple(vector.x(), vector.y(), vector.z());
-                });
+                })
+            .def(
+                "setUpVector",
+                [](wrapped_type & self, float x, float y, float z)
+                {
+                    self.setUpVector(QVector3D(x, y, z));
+                },
+                py::arg("x"),
+                py::arg("y"),
+                py::arg("z"));
     }
 };
 

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -405,7 +405,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRManager
 }; /* end class WrapRManager */
 
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRCameraController
-    : public WrapBase<WrapRCameraController, CameraController>
+    : public WrapBase<WrapRCameraController, RCameraController>
 {
 
     friend root_base_type;

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -448,7 +448,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRCameraController
                     input.shiftKeyActive = shift_key;
 
                     constexpr float dt = 1.0f;
-                    self.updateCameraPosition(input, dt);
+                    self.moveCamera(input, dt);
                 },
 
                 py::arg("x") = 0.f,
@@ -468,7 +468,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRCameraController
                     return py::make_tuple(vector.x(), vector.y(), vector.z());
                 });
 
-#define DECL_QVECTOR3D_PROPERTY(NAME, GETTER, SETTER)          \
+#define MM_DECL_QVECTOR3D_PROPERTY(NAME, GETTER, SETTER)       \
     .def_property(                                             \
         #NAME,                                                 \
         [](wrapped_type & self)                                \
@@ -486,37 +486,37 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRCameraController
 
         (*this)
             // clang-format off
-                    DECL_QVECTOR3D_PROPERTY(position, position, setPosition)
-                    DECL_QVECTOR3D_PROPERTY(up_vector, upVector, setUpVector)
-                    DECL_QVECTOR3D_PROPERTY(view_center, viewCenter, setViewCenter)
-                    DECL_QVECTOR3D_PROPERTY(default_position, defaultPosition, setDefaultPosition)
-                    DECL_QVECTOR3D_PROPERTY(default_view_center, defaultViewCenter, setDefaultViewCenter)
-                    DECL_QVECTOR3D_PROPERTY(default_up_vector, defaultUpVector, setDefaultUpVector)
+                    MM_DECL_QVECTOR3D_PROPERTY(position, position, setPosition)
+                    MM_DECL_QVECTOR3D_PROPERTY(up_vector, upVector, setUpVector)
+                    MM_DECL_QVECTOR3D_PROPERTY(view_center, viewCenter, setViewCenter)
+                    MM_DECL_QVECTOR3D_PROPERTY(default_position, defaultPosition, setDefaultPosition)
+                    MM_DECL_QVECTOR3D_PROPERTY(default_view_center, defaultViewCenter, setDefaultViewCenter)
+                    MM_DECL_QVECTOR3D_PROPERTY(default_up_vector, defaultUpVector, setDefaultUpVector)
             // clang-format on
             ;
-#undef DECL_QVECTOR3D_PROPERTY
+#undef MM_DECL_QVECTOR3D_PROPERTY
 
-#define DECL_FLOAT_PROPERTY(NAME, GETTER, SETTER) \
-    .def_property(                                \
-        #NAME,                                    \
-        [](wrapped_type & self)                   \
-        {                                         \
-            return self.GETTER();                 \
-        },                                        \
-        [](wrapped_type & self, float v)          \
-        {                                         \
-            self.SETTER(v);                       \
+#define MM_DECL_FLOAT_PROPERTY(NAME, GETTER, SETTER) \
+    .def_property(                                   \
+        #NAME,                                       \
+        [](wrapped_type & self)                      \
+        {                                            \
+            return self.GETTER();                    \
+        },                                           \
+        [](wrapped_type & self, float v)             \
+        {                                            \
+            self.SETTER(v);                          \
         })
 
         (*this)
             // clang-format off
-                DECL_FLOAT_PROPERTY(linear_speed, linearSpeed, setLinearSpeed)
-                DECL_FLOAT_PROPERTY(look_speed, lookSpeed, setLookSpeed)
-                DECL_FLOAT_PROPERTY(default_linear_speed, defaultLinearSpeed, setDefaultLinearSpeed)
-                DECL_FLOAT_PROPERTY(default_look_speed, defaultLookSpeed, setDefaultLookSpeed)
+                MM_DECL_FLOAT_PROPERTY(linear_speed, linearSpeed, setLinearSpeed)
+                MM_DECL_FLOAT_PROPERTY(look_speed, lookSpeed, setLookSpeed)
+                MM_DECL_FLOAT_PROPERTY(default_linear_speed, defaultLinearSpeed, setDefaultLinearSpeed)
+                MM_DECL_FLOAT_PROPERTY(default_look_speed, defaultLookSpeed, setDefaultLookSpeed)
             // clang-format on
             ;
-#undef DECL_FLOAT_PROPERTY
+#undef MM_DECL_FLOAT_PROPERTY
     }
 };
 

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -196,33 +196,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapR3DWidget
                     }
                 },
                 py::arg("name"))
-            .def("cameraController", &wrapped_type::cameraController);
-
-#define DECL_QVECTOR3D_PROPERTY(NAME, GETTER, SETTER)          \
-    .def_property(                                             \
-        #NAME,                                                 \
-        [](wrapped_type & self)                                \
-        {                                                      \
-            QVector3D const v = self.camera()->GETTER();       \
-            return py::make_tuple(v.x(), v.y(), v.z());        \
-        },                                                     \
-        [](wrapped_type & self, std::vector<double> const & v) \
-        {                                                      \
-            double const x = v.at(0);                          \
-            double const y = v.at(1);                          \
-            double const z = v.at(2);                          \
-            self.camera()->SETTER(QVector3D(x, y, z));         \
-        })
-
-        (*this)
-            // clang-format off
-            DECL_QVECTOR3D_PROPERTY(position, position, setPosition)
-            DECL_QVECTOR3D_PROPERTY(up_vector, upVector, setUpVector)
-            DECL_QVECTOR3D_PROPERTY(view_center, viewCenter, setViewCenter)
-            // clang-format on
-            ;
-
-#undef DECL_QVECTOR3D_PROPERTY
+            .def_property_readonly("camera", &wrapped_type::cameraController);
     }
 
 }; /* end class WrapR3DWidget */
@@ -447,7 +421,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRCameraController
                 [](wrapped_type & self)
                 { self.reset(); })
             .def(
-                "updateCameraPosition",
+                "move",
                 [](
                     wrapped_type & self,
                     float x,
@@ -458,8 +432,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRCameraController
                     bool left_mouse_button,
                     bool right_mouse_button,
                     bool alt_key,
-                    bool shift_key,
-                    float dt)
+                    bool shift_key)
                 {
                     CameraInputState input{};
                     input.txAxisValue = x;
@@ -474,6 +447,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRCameraController
                     input.altKeyActive = alt_key;
                     input.shiftKeyActive = shift_key;
 
+                    constexpr float dt = 1.0f;
                     self.updateCameraPosition(input, dt);
                 },
 
@@ -485,126 +459,64 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRCameraController
                 py::arg("left_mouse_button") = false,
                 py::arg("right_mouse_button") = false,
                 py::arg("alt_key") = false,
-                py::arg("shift_key") = false,
-                py::arg("dt"))
-            .def(
-                "position",
-                [](wrapped_type & self)
-                {
-                    const auto position = self.position();
-                    return py::make_tuple(position.x(), position.y(), position.z());
-                })
-            .def(
-                "setPosition",
-                [](wrapped_type & self, float x, float y, float z)
-                {
-                    self.setPosition(QVector3D(x, y, z));
-                },
-                py::arg("x"),
-                py::arg("y"),
-                py::arg("z"))
-            .def(
-                "linearSpeed",
-                [](wrapped_base_type & self)
-                { return self.linearSpeed(); })
-            .def(
-                "setLinearSpeed",
-                [](wrapped_base_type & self, float value)
-                {
-                    self.setLinearSpeed(value);
-                },
-                py::arg("value"))
-            .def(
-                "lookSpeed",
-                [](wrapped_base_type & self)
-                { return self.lookSpeed(); })
-            .def(
-                "setLookSpeed",
-                [](wrapped_base_type & self, float value)
-                {
-                    self.setLookSpeed(value);
-                },
-                py::arg("value"))
-            .def(
-                "viewCenter",
-                [](wrapped_base_type & self)
-                {
-                    const auto center = self.viewCenter();
-                    return py::make_tuple(center.x(), center.y(), center.z());
-                })
-            .def(
-                "setViewCenter",
-                [](wrapped_type & self, float x, float y, float z)
-                {
-                    self.setViewCenter(QVector3D(x, y, z));
-                },
-                py::arg("x"),
-                py::arg("y"),
-                py::arg("z"))
-            .def(
-                "viewVector",
+                py::arg("shift_key") = false)
+            .def_property_readonly(
+                "view_vector",
                 [](wrapped_base_type & self)
                 {
                     const auto vector = self.viewVector();
                     return py::make_tuple(vector.x(), vector.y(), vector.z());
-                })
-            .def(
-                "upVector",
-                [](wrapped_base_type & self)
-                {
-                    const auto vector = self.upVector();
-                    return py::make_tuple(vector.x(), vector.y(), vector.z());
-                })
-            .def(
-                "setUpVector",
-                [](wrapped_type & self, float x, float y, float z)
-                {
-                    self.setUpVector(QVector3D(x, y, z));
-                },
-                py::arg("x"),
-                py::arg("y"),
-                py::arg("z"))
-            .def(
-                "setDefaultPosition",
-                [](wrapped_type & self, float x, float y, float z)
-                {
-                    self.setDefaultPosition(QVector3D(x, y, z));
-                },
-                py::arg("x"),
-                py::arg("y"),
-                py::arg("z"))
-            .def(
-                "setDefaultViewCenter",
-                [](wrapped_type & self, float x, float y, float z)
-                {
-                    self.setDefaultViewCenter(QVector3D(x, y, z));
-                },
-                py::arg("x"),
-                py::arg("y"),
-                py::arg("z"))
-            .def(
-                "setDefaultUpVector",
-                [](wrapped_type & self, float x, float y, float z)
-                {
-                    self.setDefaultUpVector(QVector3D(x, y, z));
-                },
-                py::arg("x"),
-                py::arg("y"),
-                py::arg("z"))
-            .def(
-                "setDefaultLinearSpeed",
-                [](wrapped_base_type & self, float value)
-                {
-                    self.setDefaultLinearSpeed(value);
-                },
-                py::arg("value"))
-            .def(
-                "setDefaultLookSpeed",
-                [](wrapped_base_type & self, float value)
-                {
-                    self.setDefaultLookSpeed(value);
-                },
-                py::arg("value"));
+                });
+
+#define DECL_QVECTOR3D_PROPERTY(NAME, GETTER, SETTER)          \
+    .def_property(                                             \
+        #NAME,                                                 \
+        [](wrapped_type & self)                                \
+        {                                                      \
+            QVector3D const v = self.GETTER();                 \
+            return py::make_tuple(v.x(), v.y(), v.z());        \
+        },                                                     \
+        [](wrapped_type & self, std::vector<double> const & v) \
+        {                                                      \
+            double const x = v.at(0);                          \
+            double const y = v.at(1);                          \
+            double const z = v.at(2);                          \
+            self.SETTER(QVector3D(x, y, z));                   \
+        })
+
+        (*this)
+            // clang-format off
+                    DECL_QVECTOR3D_PROPERTY(position, position, setPosition)
+                    DECL_QVECTOR3D_PROPERTY(up_vector, upVector, setUpVector)
+                    DECL_QVECTOR3D_PROPERTY(view_center, viewCenter, setViewCenter)
+                    DECL_QVECTOR3D_PROPERTY(default_position, defaultPosition, setDefaultPosition)
+                    DECL_QVECTOR3D_PROPERTY(default_view_center, defaultViewCenter, setDefaultViewCenter)
+                    DECL_QVECTOR3D_PROPERTY(default_up_vector, defaultUpVector, setDefaultUpVector)
+            // clang-format on
+            ;
+#undef DECL_QVECTOR3D_PROPERTY
+
+#define DECL_FLOAT_PROPERTY(NAME, GETTER, SETTER) \
+    .def_property(                                \
+        #NAME,                                    \
+        [](wrapped_type & self)                   \
+        {                                         \
+            return self.GETTER();                 \
+        },                                        \
+        [](wrapped_type & self, float v)          \
+        {                                         \
+            self.SETTER(v);                       \
+        })
+
+        (*this)
+            // clang-format off
+                DECL_FLOAT_PROPERTY(linear_speed, linearSpeed, setLinearSpeed)
+                DECL_FLOAT_PROPERTY(look_speed, lookSpeed, setLookSpeed)
+                DECL_FLOAT_PROPERTY(default_linear_speed, defaultLinearSpeed, setDefaultLinearSpeed)
+                DECL_FLOAT_PROPERTY(default_look_speed, defaultLookSpeed, setDefaultLookSpeed)
+            // clang-format on
+            ;
+#undef DECL_FLOAT_PROPERTY
     }
 };
 

--- a/cpp/modmesh/view/wrap_view.cpp
+++ b/cpp/modmesh/view/wrap_view.cpp
@@ -563,7 +563,48 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRCameraController
                 },
                 py::arg("x"),
                 py::arg("y"),
-                py::arg("z"));
+                py::arg("z"))
+            .def(
+                "setDefaultPosition",
+                [](wrapped_type & self, float x, float y, float z)
+                {
+                    self.setDefaultPosition(QVector3D(x, y, z));
+                },
+                py::arg("x"),
+                py::arg("y"),
+                py::arg("z"))
+            .def(
+                "setDefaultViewCenter",
+                [](wrapped_type & self, float x, float y, float z)
+                {
+                    self.setDefaultViewCenter(QVector3D(x, y, z));
+                },
+                py::arg("x"),
+                py::arg("y"),
+                py::arg("z"))
+            .def(
+                "setDefaultUpVector",
+                [](wrapped_type & self, float x, float y, float z)
+                {
+                    self.setDefaultUpVector(QVector3D(x, y, z));
+                },
+                py::arg("x"),
+                py::arg("y"),
+                py::arg("z"))
+            .def(
+                "setDefaultLinearSpeed",
+                [](wrapped_base_type & self, float value)
+                {
+                    self.setDefaultLinearSpeed(value);
+                },
+                py::arg("value"))
+            .def(
+                "setDefaultLookSpeed",
+                [](wrapped_base_type & self, float value)
+                {
+                    self.setDefaultLookSpeed(value);
+                },
+                py::arg("value"));
     }
 };
 

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -30,6 +30,7 @@ import numpy as np
 import os
 
 import modmesh
+
 try:
     from modmesh import view
 except ImportError:
@@ -75,13 +76,24 @@ class ViewCameraTB:
         cls.controller = widget.cameraController()
 
         cls.move = cls.controller.updateCameraPosition
+        cls.resetCamera = cls.controller.reset
 
         cls.pos = cls.controller.position
+        cls.set_pos = cls.controller.setPosition
+
         cls.look_speed = cls.controller.lookSpeed
+        cls.set_look_speed = cls.controller.setLookSpeed
+
         cls.linear_speed = cls.controller.linearSpeed
+        cls.set_linear_speed = cls.controller.setLinearSpeed
+
         cls.view_vector = cls.controller.viewVector
+
         cls.view_center = cls.controller.viewCenter
+        cls.set_view_center = cls.controller.setViewCenter
+
         cls.up_vector = cls.controller.upVector
+        cls.set_up_vector = cls.controller.setUpVector
 
     @classmethod
     def tearDownClass(cls):
@@ -112,11 +124,36 @@ class ViewCameraTB:
 
 
 @unittest.skipIf(GITHUB_ACTIONS, "GUI is not available in GitHub Actions")
+class ViewCommonCameraTC(ViewCameraTB, unittest.TestCase):
+    camera_type = "fps"  # no difference when use orbit camera
+
+    def setUp(self):
+        self.resetCamera()
+
+    def test_value_get_set(self):
+        self.set_linear_speed(123.0)
+        self.assertEqual(self.linear_speed(), 123.0)
+
+        self.set_look_speed(456.0)
+        self.assertEqual(self.look_speed(), 456.0)
+
+    def test_vector_get_set(self):
+        self.set_pos(x=1, y=2, z=3)
+        self.assertEqual(self.pos(), (1, 2, 3))
+
+        self.set_view_center(x=4, y=5, z=6)
+        self.assertEqual(self.view_center(), (4, 5, 6))
+
+        self.set_up_vector(x=7, y=8, z=9)
+        self.assertEqual(self.up_vector(), (7, 8, 9))
+
+
+@unittest.skipIf(GITHUB_ACTIONS, "GUI is not available in GitHub Actions")
 class ViewFPSCameraTC(ViewCameraTB, unittest.TestCase):
     camera_type = "fps"
 
     def setUp(self):
-        self.widget.resetCamera()
+        self.resetCamera()
 
     def test_reset(self):
         dt = 0.01
@@ -133,7 +170,7 @@ class ViewFPSCameraTC(ViewCameraTB, unittest.TestCase):
         self.assertNotEqual(self.view_center(), initial_view_center)
         self.assertNotEqual(self.up_vector(), initial_up_vector)
 
-        self.widget.resetCamera()
+        self.resetCamera()
 
         self.assertEqual(self.pos(), initial_pos)
         self.assertEqual(self.view_vector(), initial_view_vector)
@@ -212,7 +249,7 @@ class ViewOrbitCameraTC(ViewCameraTB, unittest.TestCase):
     camera_type = "orbit"
 
     def setUp(self):
-        self.widget.resetCamera()
+        self.resetCamera()
 
     def test_reset(self):
         dt = 0.01
@@ -229,7 +266,7 @@ class ViewOrbitCameraTC(ViewCameraTB, unittest.TestCase):
         self.assertNotEqual(self.view_center(), initial_view_center)
         self.assertNotEqual(self.up_vector(), initial_up_vector)
 
-        self.widget.resetCamera()
+        self.resetCamera()
 
         self.assertEqual(self.pos(), initial_pos)
         self.assertEqual(self.view_vector(), initial_view_vector)

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -95,6 +95,12 @@ class ViewCameraTB:
         cls.up_vector = cls.controller.upVector
         cls.set_up_vector = cls.controller.setUpVector
 
+        cls.set_default_pos = cls.controller.setDefaultPosition
+        cls.set_default_view_center = cls.controller.setDefaultViewCenter
+        cls.set_default_up_vector = cls.controller.setDefaultUpVector
+        cls.set_default_linear_speed = cls.controller.setDefaultLinearSpeed
+        cls.set_default_look_speed = cls.controller.setDefaultLookSpeed
+
     @classmethod
     def tearDownClass(cls):
         cls.widget.close_and_destroy()
@@ -146,6 +152,21 @@ class ViewCommonCameraTC(ViewCameraTB, unittest.TestCase):
 
         self.set_up_vector(x=7, y=8, z=9)
         self.assertEqual(self.up_vector(), (7, 8, 9))
+
+    def test_default_values(self):
+        self.set_default_pos(x=1, y=2, z=3)
+        self.set_default_view_center(x=4, y=5, z=6)
+        self.set_default_up_vector(x=7, y=8, z=9)
+        self.set_default_linear_speed(123.0)
+        self.set_default_look_speed(456.0)
+
+        self.resetCamera()
+
+        self.assertEqual(self.pos(), (1, 2, 3))
+        self.assertEqual(self.view_center(), (4, 5, 6))
+        self.assertEqual(self.up_vector(), (7, 8, 9))
+        self.assertEqual(self.linear_speed(), 123.0)
+        self.assertEqual(self.look_speed(), 456.0)
 
 
 @unittest.skipIf(GITHUB_ACTIONS, "GUI is not available in GitHub Actions")

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -30,7 +30,6 @@ import numpy as np
 import os
 
 import modmesh
-
 try:
     from modmesh import view
 except ImportError:
@@ -70,7 +69,9 @@ class ViewCameraTB:
     @classmethod
     def setUpClass(cls):
         widget = view.RManager.instance.setUp().add3DWidget()
-        widget.setCameraType(cls.camera_type)
+
+        if cls.camera_type is not None:
+            widget.setCameraType(cls.camera_type)
 
         cls.widget = widget
         cls.camera = widget.camera
@@ -105,47 +106,51 @@ class ViewCameraTB:
 
 @unittest.skipIf(GITHUB_ACTIONS, "GUI is not available in GitHub Actions")
 class ViewCommonCameraTC(ViewCameraTB, unittest.TestCase):
-    camera_type = "fps"  # no difference when use orbit camera
-
-    def setUp(self):
-        self.camera.reset()
-
     def test_value_get_set(self):
         c = self.camera
 
-        c.linear_speed = 123.0
-        self.assertEqual(c.linear_speed, 123.0)
+        for camera_type in ["fps", "orbit"]:
+            self.widget.setCameraType(camera_type)
 
-        c.look_speed = 456.0
-        self.assertEqual(c.look_speed, 456.0)
+            c.linear_speed = 123.0
+            self.assertEqual(c.linear_speed, 123.0)
+
+            c.look_speed = 456.0
+            self.assertEqual(c.look_speed, 456.0)
 
     def test_vector_get_set(self):
         c = self.camera
 
-        c.position = (1, 2, 3)
-        c.view_center = (4, 5, 6)
-        c.up_vector = (7, 8, 9)
+        for camera_type in ["fps", "orbit"]:
+            self.widget.setCameraType(camera_type)
 
-        self.assertEqual(c.position, (1, 2, 3))
-        self.assertEqual(c.view_center, (4, 5, 6))
-        self.assertEqual(c.up_vector, (7, 8, 9))
+            c.position = (1, 2, 3)
+            c.view_center = (4, 5, 6)
+            c.up_vector = (7, 8, 9)
+
+            self.assertEqual(c.position, (1, 2, 3))
+            self.assertEqual(c.view_center, (4, 5, 6))
+            self.assertEqual(c.up_vector, (7, 8, 9))
 
     def test_default_values(self):
         c = self.camera
 
-        c.default_position = (1, 2, 3)
-        c.default_view_center = (4, 5, 6)
-        c.default_up_vector = (7, 8, 9)
-        c.default_linear_speed = 123.0
-        c.default_look_speed = 456.0
+        for camera_type in ["fps", "orbit"]:
+            self.widget.setCameraType(camera_type)
 
-        c.reset()
+            c.default_position = (1, 2, 3)
+            c.default_view_center = (4, 5, 6)
+            c.default_up_vector = (7, 8, 9)
+            c.default_linear_speed = 123.0
+            c.default_look_speed = 456.0
 
-        self.assertEqual(c.position, (1, 2, 3))
-        self.assertEqual(c.view_center, (4, 5, 6))
-        self.assertEqual(c.up_vector, (7, 8, 9))
-        self.assertEqual(c.linear_speed, 123.0)
-        self.assertEqual(c.look_speed, 456.0)
+            c.reset()
+
+            self.assertEqual(c.position, (1, 2, 3))
+            self.assertEqual(c.view_center, (4, 5, 6))
+            self.assertEqual(c.up_vector, (7, 8, 9))
+            self.assertEqual(c.linear_speed, 123.0)
+            self.assertEqual(c.look_speed, 456.0)
 
 
 @unittest.skipIf(GITHUB_ACTIONS, "GUI is not available in GitHub Actions")


### PR DESCRIPTION
In this PR:
* New props added to camera controller to control it's reset behaviour: defaultPosition, defaultUpVector, defaultViewCenter, defaultLookSpeed, defaultLinearSpeed
* All these props are exposed to python
* Camera controller python API was rewritten to use `def_property` using macros. Tests also were updated
* Minor issue was fixed: When reset camera, aspect ratio was incorrect
