### PR TITLE
Fix macos-14 pip install failure for pyside6 6.6.3 for Python 3.13

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -324,12 +324,19 @@ jobs:
         run: |
           echo "which python3: $(which python3)"
           ls -al $(which python3)
-          if [ "${{ matrix.os }}" == "macos-13" ] || [ "${{ matrix.os }}" == "macos-14" ] ; then
+          if [ "${{ matrix.os }}" == "macos-13" ] ; then
             # suppress the warning of pip because brew forces PEP668 since python3.12
             python3 -m pip -v install --upgrade setuptools  --break-system-packages
             python3 -m pip -v install --upgrade pip  --break-system-packages
             python3 -m pip -v install --upgrade numpy pytest flake8 jsonschema  --break-system-packages
             python3 -m pip -v install --upgrade pyside6==$(qmake -query QT_VERSION)  --break-system-packages
+          elif [ "${{ matrix.os }}" == "macos-14" ] ; then
+            python3 -m pip -v install --upgrade setuptools
+            python3 -m pip -v install --upgrade pip
+            python3 -m pip -v install --upgrade numpy pytest flake8 jsonschema
+            # For now (2024/10/22), pyside6 6.6.3 does not support Python 3.13.
+            # Use --ignore-requires-python to force installation.
+            python3 -m pip -v install --upgrade pyside6==$(qmake -query QT_VERSION)  --break-system-packages --ignore-requires-python
           else
             python3 -m pip -v install --upgrade setuptools
             python3 -m pip -v install --upgrade pip


### PR DESCRIPTION
On macos-14, pip cannot find a good binary of pyside6 6.6.3 for Python 3.13.  The [failing CI log](https://github.com/solvcon/modmesh/actions/runs/11445576647/job/31870334328#step:6:129) shows:

```
ERROR: Could not find a version that satisfies the requirement pyside6==6.6.3 (from versions: none)
  Link requires a different Python (3.13.0 not in: '<3.13,>=3.8'): https://files.pythonhosted.org/packages/1e/b9/7bb4afc8b5bfc3fbbbeb1e6b66ac306faa5b7f2694450313a33970b735f8/PySide6-6.6.1-cp38-abi3-macosx_11_0_universal2.whl (from https://pypi.org/simple/pyside6/) (requires-python:<3.13,>=3.8)
  Link requires a different Python (3.13.0 not in: '<3.13,>=3.8'): https://files.pythonhosted.org/packages/c3/0e/2cabb4d5c248ec1bda69545d7c762b3a2866b39ce7c41be4a8404993a641/PySide6-6.6.2-cp38-abi3-macosx_11_0_universal2.whl (from https://pypi.org/simple/pyside6/) (requires-python:<3.13,>=3.8)
  Link requires a different Python (3.13.0 not in: '<3.13,>=3.8'): https://files.pythonhosted.org/packages/69/05/d952e68097ede1f66ef6b8d19c4807fe4887a13c771725ca31de2b20daae/PySide6-6.6.3-cp38-abi3-macosx_11_0_universal2.whl (from https://pypi.org/simple/pyside6/) (requires-python:<3.13,>=3.8)
  Link requires a different Python (3.13.0 not in: '<3.13,>=3.8'): https://files.pythonhosted.org/packages/ba/9a/3483d05305701ba810192572cee5977ff884c033a1b8f96ab9582d81ccd4/PySide6-6.6.3.1-cp38-abi3-macosx_11_0_universal2.whl (from https://pypi.org/simple/pyside6/) (requires-python:<3.13,>=3.8)
  Link requires a different Python (3.13.0 not in: '<3.13,>=3.9'): https://files.pythonhosted.org/packages/1e/a4/8fd2f8f1d34db1f44a99d4f994e9f81498960161547319b7ce6258acd6bd/PySide6-6.7.0-cp39-abi3-macosx_11_0_universal2.whl (from https://pypi.org/simple/pyside6/) (requires-python:<3.13,>=3.9)
  Link requires a different Python (3.13.0 not in: '<3.13,>=3.9'): https://files.pythonhosted.org/packages/73/d3/bf6978b24986c6d7423bddd5386ae2c0c59be95af4744451b5e4b7308afd/PySide6-6.7.1-cp39-abi3-macosx_11_0_universal2.whl (from https://pypi.org/simple/pyside6/) (requires-python:<3.13,>=3.9)
  Link requires a different Python (3.13.0 not in: '<3.13,>=3.9'): https://files.pythonhosted.org/packages/df/57/69b9104f6a30a7f2c0ed78c425304ab964e9b10907b5e1d9d744dd1f714e/PySide6-6.7.2-cp39-abi3-macosx_11_0_universal2.whl (from https://pypi.org/simple/pyside6/) (requires-python:<3.13,>=3.9)
  Link requires a different Python (3.13.0 not in: '<3.13,>=3.9'): https://files.pythonhosted.org/packages/d4/34/86b0fd9b5ce8eee35bd1311a620e8cdfd56d0ca36edca314a6189336682d/PySide6-6.7.3-cp39-abi3-macosx_11_0_universal2.whl (from https://pypi.org/simple/pyside6/) (requires-python:<3.13,>=3.9)
  Link requires a different Python (3.13.0 not in: '<3.13,>=3.9'): https://files.pythonhosted.org/packages/23/4a/bfad04cea602e28d5f43d752291cd539b6e64c82d15dfe7301a4fee9def6/PySide6-6.8.0-cp39-abi3-macosx_12_0_universal2.whl (from https://pypi.org/simple/pyside6/) (requires-python:<3.13,>=3.9)
  Link requires a different Python (3.13.0 not in: '<3.13,>=3.9'): https://files.pythonhosted.org/packages/cb/2d/09a3215a48680fa76d1d74aea28e006f88fe3be992f4dea556f79e6e0c6e/PySide6-6.8.0.1-cp39-abi3-macosx_12_0_universal2.whl (from https://pypi.org/simple/pyside6/) (requires-python:<3.13,>=3.9)
ERROR: No matching distribution found for pyside6==6.6.3
```

I am working it around by using `pip install --ignore-requires-python`.