### PR TITLE
Enhance the output format for the function CallProfiler::print_statistics in the profiler

### DIFF
--- a/cpp/modmesh/toggle/profile.cpp
+++ b/cpp/modmesh/toggle/profile.cpp
@@ -36,7 +36,7 @@ std::string TimeRegistry::detailed_report() const
     std::ostringstream ostm;
     /// Header
     ostm
-        << std::setw(40) << total_call_count()
+        << std::setw(79) << total_call_count()
         << " function calls in " << total_time()
         << " seconds" << std::endl;
     ostm
@@ -50,6 +50,7 @@ std::string TimeRegistry::detailed_report() const
         << std::endl;
 
     /// Body
+    ostm << std::fixed << std::setprecision(6);
     for (auto it = m_entry.begin(); it != m_entry.end(); ++it)
     {
         ostm


### PR DESCRIPTION
I improved the function call output format for Issue #421, transformed function call statistics from plain text to a structured table format.

To draw the divider for the table conveniently, I rounded the output numbers for Total Time (s), Per Call (s), Cumulative Time (s), and Per Call (s) to six decimal places.

The origin table show as below:
```
                                        7 function calls in 2.40007 seconds

                           Function Name               Call Count           Total Time (s)             Per Call (s)      Cumulative Time (s)             Per Call (s)
                                     bar                        4                  2.00004                 0.500009                  2.00004                 0.500009
                                     baz                        1                 0.800013                 0.800013                 0.200003                 0.200003
                                     foo                        2                  1.20004                 0.600022                 0.200027                 0.100014
```

And I transformed the table into:
```
                                                 7 function calls in 2.40002 seconds

---------------------------------------------------------------------------------------------------------------------------------------
|    Function Name    |    Call Count    |    Total Time (s)    |    Per Call (s)    |    Cumulative Time (s)    |    Per Call (s)    |
---------------------------------------------------------------------------------------------------------------------------------------
|        bar          |        4         |       2.000012       |      0.500003      |          2.000012         |      0.500003      |
|        baz          |        1         |       0.800010       |      0.800010      |          0.200006         |      0.200006      |
|        foo          |        2         |       1.200014       |      0.600007      |          0.200007         |      0.100003      |
---------------------------------------------------------------------------------------------------------------------------------------
```