### PR TITLE
Fix the construction of SimpleArray from slicing ndarray

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -32,6 +32,8 @@
 
 #include <limits>
 #include <stdexcept>
+#include <functional>
+#include <numeric>
 
 #if defined(_MSC_VER)
 #include <BaseTsd.h>
@@ -304,6 +306,65 @@ public:
                 throw std::runtime_error(Formatter() << "SimpleArray: shape byte count " << nbytes
                                                      << " differs from buffer " << buffer->nbytes());
             }
+        }
+    }
+
+    explicit SimpleArray(small_vector<size_t> const & shape,
+                         small_vector<size_t> const & stride,
+                         std::shared_ptr<buffer_type> const & buffer,
+                         bool is_c_contiguous = true,
+                         bool is_f_contiguous = false)
+        : SimpleArray(buffer)
+    {
+        if (buffer)
+        {
+            if (shape.size() != stride.size())
+            {
+                throw std::runtime_error("SimpleArray: shape and stride size mismatch");
+            }
+
+            if (is_c_contiguous)
+            {
+                if (stride[stride.size() - 1] != 1)
+                {
+                    throw std::runtime_error("SimpleArray: C contiguous stride must end with 1");
+                }
+                for (size_t it = 0; it < shape.size() - 1; ++it)
+                {
+                    if (stride[it] != shape[it + 1] * stride[it + 1])
+                    {
+                        throw std::runtime_error("SimpleArray: C contiguous stride must match shape");
+                    }
+                }
+            }
+            if (is_f_contiguous)
+            {
+                if (stride[0] != 1)
+                {
+                    throw std::runtime_error("SimpleArray: Fortran contiguous stride must start with 1");
+                }
+                for (size_t it = 0; it < shape.size() - 1; ++it)
+                {
+                    if (stride[it + 1] != shape[it] * stride[it])
+                    {
+                        throw std::runtime_error("SimpleArray: Fortran contiguous stride must match shape");
+                    }
+                }
+            }
+
+            const size_t nbytes = ITEMSIZE *
+                                  std::accumulate(shape.begin(),
+                                                  shape.end(),
+                                                  static_cast<size_t>(1),
+                                                  std::multiplies<size_t>());
+            if (nbytes != buffer->nbytes())
+            {
+                throw std::runtime_error(Formatter() << "SimpleArray: shape byte count " << nbytes
+                                                     << " differs from buffer " << buffer->nbytes());
+            }
+
+            m_shape = shape;
+            m_stride = stride;
         }
     }
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -450,6 +450,27 @@ class SimpleArrayBasicTC(unittest.TestCase):
         sarr.ndarray.fill(100)
         self.assertTrue((ndarr == 100).all())
 
+    def test_SimpleArray_from_ndarray_slice(self):
+        ndarr = np.arange(1000, dtype='float64').reshape((10, 10, 10))
+        parr = ndarr[1:7:3, 6:2:-1, 3:9]
+        sarr = modmesh.SimpleArrayFloat64(array=ndarr[1:7:3, 6:2:-1, 3:9])
+
+        for i in range(2):
+            for j in range(4):
+                for k in range(6):
+                    self.assertEqual(parr[i, j, k], sarr[i, j, k])
+
+    def test_SimpleArray_from_ndarray_transpose(self):
+        ndarr = np.arange(350, dtype='float64').reshape((5, 7, 10))
+        # The following array is F contiguous.
+        parr = ndarr[2:4].T
+        sarr = modmesh.SimpleArrayFloat64(array=ndarr[2:4].T)
+
+        for i in range(10):
+            for j in range(7):
+                for k in range(2):
+                    self.assertEqual(parr[i, j, k], sarr[i, j, k])
+
     def test_SimpleArray_broadcast_ellipsis_shape(self):
         sarr = modmesh.SimpleArrayFloat64((2, 3, 4))
         ndarr = np.arange(2 * 3 * 4, dtype='float64').reshape((2, 3, 4))


### PR DESCRIPTION
In this pull request, I fix the issue #432 by passing the stride vector to SimpleArray.