### PR TITLE
Fix freeing non-allocated memory when copy shape_type

### DIFF
--- a/cpp/modmesh/buffer/small_vector.hpp
+++ b/cpp/modmesh/buffer/small_vector.hpp
@@ -141,7 +141,7 @@ public:
             }
             else
             {
-                if (m_capacity < other.m_size)
+                if (m_capacity < other.m_size && m_head != m_data.data())
                 {
                     delete[] m_head;
                     m_head = nullptr;


### PR DESCRIPTION
This PR fixed the bug described in Issue #437.

## Bug Description

Memory crash happened when constructing a `SimpleArray` from `np.ndarray`. This was due to freeing the memory of non-allocated memory in the copy assignment operator of `shape_type` aka. `small_vector<size_t>`.

**This bug only happens when the size of the shape of the source `np.ndarray` is larger then 3**

### Bug Backtrace

```
In File <cpp/modmesh/buffer/small_vector.hpp> line 146: delete[] m_head;
In File <cpp/modmesh/buffer/SimpleArray.hpp> line 351: m_shape = shape;
In File <cpp/modmesh/buffer/SimpleArray.hpp> line 317: SimpleArray(shape, stride, buffer)
In File <cpp/modmesh/buffer/pymod/wrap_SimpleArray.hpp> line 94: return wrapped_type(shape, stride, buffer, is_c_contiguous, is_f_contiguous);
```

### Solution

The delete statement where the error happens are intended to remove the allocated buffer when the source vector has larger capacity than the target vector. However when deleting the array, it wasn't check whether the buffer was allocated or not. Therefore, this PR adds this check. Also I went through all the constructors and assignment operators of `small_vector` and confirmed that this issue doesn't happen in other place.