### PR TITLE
Refactor to rename viewer to pilot

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -237,19 +237,19 @@ jobs:
         python3 -c "import modmesh; assert modmesh.HAS_VIEW == True"
         make pytest VERBOSE=1
 
-    - name: make viewer
+    - name: make pilot
       run: |
         rm -f build/*/Makefile
-        make viewer \
+        make pilot \
           VERBOSE=1 USE_CLANG_TIDY=OFF \
           BUILD_QT=ON \
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON"
 
-    - name: make run_viewer_pytest
+    - name: make run_pilot_pytest
       run: |
         export LD_LIBRARY_PATH=$(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
-        make run_viewer_pytest VERBOSE=0
+        make run_pilot_pytest VERBOSE=0
 
     # FIXME: turn off until all issues resolved
     - name: make cmake USE_SANITIZER=ON & make pytest
@@ -431,18 +431,18 @@ jobs:
           fi
           make pytest ${JOB_MAKE_ARGS}
 
-      - name: make viewer
+      - name: make pilot
         run: |
           rm -f build/*/Makefile
-          make viewer \
+          make pilot \
             VERBOSE=1 USE_CLANG_TIDY=OFF \
             BUILD_QT=ON \
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON"
 
-      - name: make run_viewer_pytest
+      - name: make run_pilot_pytest
         run: |
-          make run_viewer_pytest VERBOSE=1
+          make run_pilot_pytest VERBOSE=1
 
       # FIXME: turn off until all issues resolved
       - name: make cmake USE_SANITIZER=ON & make pytest
@@ -563,11 +563,11 @@ jobs:
             --config ${{ matrix.cmake_build_type }} `
             --target run_gtest
 
-      - name: cmake run_viewer_pytest
+      - name: cmake run_pilot_pytest
         run: |
           cmake --build ${{ github.workspace }}/build `
             --config ${{ matrix.cmake_build_type }} `
-            --target run_viewer_pytest
+            --target run_pilot_pytest
 
       - name: generate portable
         if: ${{ matrix.cmake_build_type == 'Release' }}
@@ -575,7 +575,7 @@ jobs:
           # Get the Python version installed and extract the major+minor version components
           $py_ver=$(python3 -V | awk '{print $2}')
           $py_main_ver=$(echo $py_ver | awk -F. '{print $1$2}')
-          $destination=".\modmesh-viewer-win64\modmesh-viewer-win64"
+          $destination=".\modmesh-pilot-win64\modmesh-pilot-win64"
           $py_exec="$destination\python.exe"
 
           # Create the destination directory
@@ -597,11 +597,11 @@ jobs:
           Invoke-WebRequest -Uri $get_pip_url -OutFile $get_pip_script
           & $py_exec $get_pip_script
 
-          # Install necessary packages for the viewer
+          # Install necessary packages for the pilot
           $qt_ver=$(qmake -query QT_VERSION)
           & $py_exec -m pip install numpy matplotlib PySide6==$qt_ver shiboken6-generator==$qt_ver
 
-          # Copy pyside6 and shiboken6 DLLs alongside the viewer executable
+          # Copy pyside6 and shiboken6 DLLs alongside the pilot executable
           $pyside6_path=$(& $py_exec -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))") 
           $shiboken6_path=$(& $py_exec -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
           copy "$pyside6_path\pyside6.abi3.dll" $destination
@@ -609,13 +609,13 @@ jobs:
           # Remove redundant Qt DLLs from PySide6
           Remove-Item -Path $pyside6_path\Qt*.dll
 
-          # Configure and build the viewer
+          # Configure and build the pilot
           cmake -Dpybind11_DIR="$(pybind11-config --cmakedir)" -S . -B build
-          cmake --build build --config Release --target viewer
+          cmake --build build --config Release --target pilot
 
-          # Deploy the Qt environment for the viewer executable and copy necessary files
-          Copy-Item -Path ".\build\cpp\binary\viewer\Release\viewer.exe" -Destination $destination
-          windeployqt --release "$destination\viewer.exe"
+          # Deploy the Qt environment for the pilot executable and copy necessary files
+          Copy-Item -Path ".\build\cpp\binary\viewer\Release\pilot.exe" -Destination $destination
+          windeployqt --release "$destination\pilot.exe"
           Copy-Item -Path ".\modmesh" -Destination $destination -Recurse
           # PUI is necessary
           Copy-Item -Path ".\thirdparty" -Destination $destination -Recurse
@@ -624,5 +624,5 @@ jobs:
         if: ${{ matrix.cmake_build_type == 'Release' }}
         uses: actions/upload-artifact@v4
         with:
-          name: modmesh-viewer-win64
-          path: modmesh-viewer-win64/
+          name: modmesh-pilot-win64
+          path: modmesh-pilot-win64/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -145,17 +145,17 @@ jobs:
     - name: make cinclude (check_include)
       run: make cinclude
 
-    - name: make viewer
+    - name: make pilot
       run: |
-        make viewer \
+        make pilot \
           ${JOB_MAKE_ARGS} \
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON"
 
-    - name: make run_viewer_pytest
+    - name: make run_pilot_pytest
       run: |
         export LD_LIBRARY_PATH=$(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
-        make run_viewer_pytest \
+        make run_pilot_pytest \
           ${JOB_MAKE_ARGS} \
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON"
@@ -278,28 +278,28 @@ jobs:
       - name: make cinclude (check_include)
         run: make cinclude
 
-      - name: make viewer USE_PYTEST_HELPER_BINDING=OFF
+      - name: make pilot USE_PYTEST_HELPER_BINDING=OFF
         run: |
-          make viewer \
+          make pilot \
             ${JOB_MAKE_ARGS} \
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON"
 
-      - name: make viewer USE_PYTEST_HELPER_BINDING=ON
+      - name: make pilot USE_PYTEST_HELPER_BINDING=ON
         run: |
           rm -f build/*/Makefile
-          make viewer \
+          make pilot \
             ${JOB_MAKE_ARGS} \
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON"
 
-      - name: make run_viewer_pytest
+      - name: make run_pilot_pytest
         run: |
           # PySide6 installed by pip will bundle with a prebuilt Qt,
           # this will cause duplicated symbol.
           # Solve this issue by removed PySide6 prebuilt Qt library
           rm -rf $(python3 -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))")/Qt/lib/*.framework
-          make run_viewer_pytest \
+          make run_pilot_pytest \
             ${JOB_MAKE_ARGS} \
             CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"

--- a/Makefile
+++ b/Makefile
@@ -118,16 +118,16 @@ pytest: buildext
 	env $(RUNENV) \
 		$(PYTEST) $(PYTEST_OPTS) tests/
 
-.PHONY: viewer
-viewer: cmake
+.PHONY: pilot
+pilot: cmake
 	cmake --build $(BUILD_PATH) --target $@ VERBOSE=$(VERBOSE) $(MAKE_PARALLEL)
 
 .PHONY: gtest
 gtest: cmake
 	cmake --build $(BUILD_PATH) --target run_gtest VERBOSE=$(VERBOSE) $(MAKE_PARALLEL)
 
-.PHONY: run_viewer_pytest
-run_viewer_pytest: viewer
+.PHONY: run_pilot_pytest
+run_pilot_pytest: pilot
 	cmake --build $(BUILD_PATH) --target $@ VERBOSE=$(VERBOSE)
 
 .PHONY: standalone_buffer_setup

--- a/cpp/binary/viewer/CMakeLists.txt
+++ b/cpp/binary/viewer/CMakeLists.txt
@@ -2,7 +2,7 @@
 # BSD-style license; see COPYING
 
 cmake_minimum_required(VERSION 3.16)
-project(viewer LANGUAGES CXX)
+project(pilot LANGUAGES CXX)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -10,7 +10,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(PROJECT_ROOT_DIR ${PROJECT_SOURCE_DIR}/../../../)
 
 if(NOT DEFINED INSTALL_VIEWERDIR)
-    set(INSTALL_VIEWERDIR "viewer")
+    set(INSTALL_VIEWERDIR "pilot")
 endif()
 
 set(CMAKE_AUTOMOC ON)
@@ -31,33 +31,33 @@ if(APPLE)
     set_source_files_properties(${app_icon_macos} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 
     qt_add_executable(
-        viewer
+        pilot
         MACOSX_BUNDLE
         viewer.cpp
         ${app_icon_macos}
     )
 else()
     qt_add_executable(
-        viewer
+        pilot
         viewer.cpp
     )
 endif()
 
 target_link_libraries(
-    viewer PUBLIC
+    pilot PUBLIC
     pybind11::embed
     modmesh_primary
 )
 if(WIN32)
     set_target_properties(
-        viewer
+        pilot
         PROPERTIES
         LINK_FLAGS_DEBUG "/SUBSYSTEM:CONSOLE" # open the console for debug mode
     )
 endif(WIN32)
 
 qt_add_resources(
-    viewer "app_icon"
+    pilot "app_icon"
     PREFIX "/"
     BASE ${PROJECT_ROOT_DIR}/resources/viewer
     FILES
@@ -65,32 +65,32 @@ qt_add_resources(
 )
 
 if(HIDE_SYMBOL)
-    set_target_properties(viewer PROPERTIES CXX_VISIBILITY_PRESET "hidden")
+    set_target_properties(pilot PROPERTIES CXX_VISIBILITY_PRESET "hidden")
 else()
-    set_target_properties(viewer PROPERTIES CXX_VISIBILITY_PRESET "default")
+    set_target_properties(pilot PROPERTIES CXX_VISIBILITY_PRESET "default")
 endif()
 
 target_compile_options(
-    viewer PRIVATE
+    pilot PRIVATE
     ${COMMON_COMPILER_OPTIONS}
 )
 
 if(CLANG_TIDY_EXE AND USE_CLANG_TIDY)
     set_target_properties(
-        viewer PROPERTIES
+        pilot PROPERTIES
         CXX_CLANG_TIDY "${DO_CLANG_TIDY}"
     )
 endif()
 
 # Hack: add a .clang-tidy file in the generated .rcc directory.
 # See https://gitlab.kitware.com/cmake/cmake/-/merge_requests/777
-file(WRITE "${viewer_BINARY_DIR}/.rcc/.clang-tidy" "---
+file(WRITE "${pilot_BINARY_DIR}/.rcc/.clang-tidy" "---
 Checks: '-*,llvm-twine-local'")
-file(WRITE "${viewer_BINARY_DIR}/viewer_autogen/.clang-tidy" "---
+file(WRITE "${pilot_BINARY_DIR}/viewer_autogen/.clang-tidy" "---
 Checks: '-bugprone-suspicious-include,llvm-twine-local'")
 
 set_target_properties(
-    viewer PROPERTIES
+    pilot PROPERTIES
     WIN32_EXECUTABLE TRUE
     MACOSX_BUNDLE TRUE
 )
@@ -101,16 +101,16 @@ if(APPLE)
     find_library(APPLE_FWK_METAL Metal REQUIRED)
 
     target_link_libraries(
-        viewer PUBLIC
+        pilot PUBLIC
         ${APPLE_FWK_FOUNDATION}
         ${APPLE_FWK_QUARTZ_CORE}
         ${APPLE_FWK_METAL}
     )
 endif()
 
-add_custom_target(run_viewer_pytest $<TARGET_FILE:viewer> --mode=pytest)
+add_custom_target(run_pilot_pytest $<TARGET_FILE:pilot> --mode=pytest)
 
-install(TARGETS viewer
+install(TARGETS pilot
     RUNTIME DESTINATION "${INSTALL_VIEWERDIR}"
     BUNDLE DESTINATION "${INSTALL_VIEWERDIR}"
     LIBRARY DESTINATION "${INSTALL_VIEWERDIR}"

--- a/cpp/modmesh/python/module.cpp
+++ b/cpp/modmesh/python/module.cpp
@@ -65,11 +65,13 @@ void initialize(pybind11::module_ mod)
 #endif
 
 #ifdef QT_CORE_LIB
-    mod.attr("HAS_VIEW") = true;
+    mod.attr("HAS_VIEW") = true; // backward compatibility
+    mod.attr("HAS_PILOT") = true;
     pybind11::module_ view_mod = mod.def_submodule("view", "view");
     initialize_view(view_mod);
 #else // QT_CORE_LIB
-    mod.attr("HAS_VIEW") = false;
+    mod.attr("HAS_VIEW") = false; // backward compatibility
+    mod.attr("HAS_PILOT") = false;
 #endif // QT_CORE_LIB
 }
 

--- a/modmesh/__init__.py
+++ b/modmesh/__init__.py
@@ -36,7 +36,7 @@ modmesh: the description of the package is intentionally left blank
 from . import core
 from .core import *  # noqa: F401, F403
 from . import apputil  # noqa: F401
-from . import view  # noqa: F401
+from . import pilot  # noqa: F401
 from . import spacetime  # noqa: F401
 from . import onedim  # noqa: F401
 from . import system  # noqa: F401

--- a/modmesh/app/bad_euler1d.py
+++ b/modmesh/app/bad_euler1d.py
@@ -32,13 +32,13 @@ from matplotlib.backends.backend_qtagg import (
     FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
 from matplotlib.figure import Figure
 
-from .. import view
+from .. import pilot
 from .. import spacetime as libst
 
 
 def load_app():
     cmd = "win, svr = mm.app.bad_euler1d.run(animate=True, interval=10)"
-    view.mgr.pycon.command = cmd
+    pilot.mgr.pycon.command = cmd
 
 
 class ApplicationWindow(QtWidgets.QMainWindow):

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -53,7 +53,7 @@ from PUI.PySide6.table import Table
 from PUI.PySide6.toolbar import ToolBar
 from PUI.PySide6.modal import Modal
 from ..onedim import euler1d
-from .. import view
+from .. import pilot
 
 
 @dataclass
@@ -677,8 +677,8 @@ class Euler1DApp():
         if sys.stdout is not None:
             sys.stdout.write(msg)
             sys.stdout.write('\n')
-        view.mgr.pycon.writeToHistory(msg)
-        view.mgr.pycon.writeToHistory('\n')
+        pilot.mgr.pycon.writeToHistory(msg)
+        pilot.mgr.pycon.writeToHistory('\n')
 
     def update_lines(self):
         """
@@ -833,8 +833,8 @@ def load_app():
     config_widget = QDockWidget("config")
     config_widget.setWidget(config_window.ui.ui)
 
-    view.mgr.mainWindow.addDockWidget(Qt.LeftDockWidgetArea, config_widget)
-    _subwin = view.mgr.addSubWindow(plotting_area.ui.ui)
+    pilot.mgr.mainWindow.addDockWidget(Qt.LeftDockWidgetArea, config_widget)
+    _subwin = pilot.mgr.addSubWindow(plotting_area.ui.ui)
     _subwin.showMaximized()
 
     config_window.redraw()

--- a/modmesh/app/linear_wave.py
+++ b/modmesh/app/linear_wave.py
@@ -32,13 +32,13 @@ from matplotlib.backends.backend_qtagg import (
     FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
 from matplotlib.figure import Figure
 
-from .. import view
+from .. import pilot
 from .. import spacetime as libst
 
 
 def load_app():
     cmd = "win, svr = mm.app.linear_wave.run_linear(animate=True, interval=10)"
-    view.mgr.pycon.command = cmd
+    pilot.mgr.pycon.command = cmd
 
 
 class ApplicationWindow(QtWidgets.QMainWindow):

--- a/modmesh/app/sample_mesh.py
+++ b/modmesh/app/sample_mesh.py
@@ -30,7 +30,7 @@ Show sample mesh
 """
 
 from .. import core
-from .. import view
+from .. import pilot
 from .. import apputil
 
 
@@ -43,9 +43,9 @@ w_tri.updateMesh(mh_tri)
 w_tri.showMark()
 print("tri nedge:", mh_tri.nedge)
 """
-    view.mgr.pycon.writeToHistory(cmd)
+    pilot.mgr.pycon.writeToHistory(cmd)
     if set_command:
-        view.mgr.pycon.command = cmd.strip()
+        pilot.mgr.pycon.command = cmd.strip()
 
 
 def help_tet(set_command=False):
@@ -57,9 +57,9 @@ w_tet.updateMesh(mh_tet)
 w_tet.showMark()
 print("tet nedge:", mh_tet.nedge)
 """
-    view.mgr.pycon.writeToHistory(cmd)
+    pilot.mgr.pycon.writeToHistory(cmd)
     if set_command:
-        view.mgr.pycon.command = cmd.strip()
+        pilot.mgr.pycon.command = cmd.strip()
 
 
 def help_2dmix(set_command=False):
@@ -71,9 +71,9 @@ w_2dmix.updateMesh(mh_2dmix)
 w_2dmix.showMark()
 print("2dmix nedge:", mh_2dmix.nedge)
 """
-    view.mgr.pycon.writeToHistory(cmd)
+    pilot.mgr.pycon.writeToHistory(cmd)
     if set_command:
-        view.mgr.pycon.command = cmd.strip()
+        pilot.mgr.pycon.command = cmd.strip()
 
 
 def help_3dmix(set_command=False):
@@ -85,9 +85,9 @@ w_3dmix.updateMesh(mh_3dmix)
 w_3dmix.showMark()
 print("3dmix nedge:", mh_3dmix.nedge)
 """
-    view.mgr.pycon.writeToHistory(cmd)
+    pilot.mgr.pycon.writeToHistory(cmd)
     if set_command:
-        view.mgr.pycon.command = cmd.strip()
+        pilot.mgr.pycon.command = cmd.strip()
 
 
 def help_solvcon(set_command=False):
@@ -99,9 +99,9 @@ w_solvcon.updateMesh(mh_solvcon)
 w_solvcon.showMark()
 print("solvcon nedge:", mh_solvcon.nedge)
 """
-    view.mgr.pycon.writeToHistory(cmd)
+    pilot.mgr.pycon.writeToHistory(cmd)
     if set_command:
-        view.mgr.pycon.command = cmd.strip()
+        pilot.mgr.pycon.command = cmd.strip()
 
 
 def help_other(set_command=False):
@@ -117,12 +117,12 @@ w_tri.position = (-10, -10, -20)
 w_tri.view_center = (0, 0, 0)
 
 # Outdated and may not work:
-# line = mm.view.RLine(-1, -1, -1, -2, -2, -2, 0, 128, 128)
+# line = mm.pilot.RLine(-1, -1, -1, -2, -2, -2, 0, 128, 128)
 # print(line)
 """
-    view.mgr.pycon.writeToHistory(cmd)
+    pilot.mgr.pycon.writeToHistory(cmd)
     if set_command:
-        view.mgr.pycon.command = cmd.strip()
+        pilot.mgr.pycon.command = cmd.strip()
 
 
 def help_gmsh_viewer(path, set_command=False):
@@ -133,9 +133,9 @@ mh_viewer = make_gmsh_viewer("{path}")
 w_mh_viewer.updateMesh(mh_viewer)
 w_mh_viewer.showMark()
 """
-    view.mgr.pycon.writeToHistory(cmd)
+    pilot.mgr.pycon.writeToHistory(cmd)
     if set_command:
-        view.mgr.pycon.command = cmd.strip()
+        pilot.mgr.pycon.command = cmd.strip()
 
 
 def help_plot3d_viewer(path, set_command=False):
@@ -146,9 +146,9 @@ mh_viewer = make_plot3d_viewer("{path}")
 w_mh_viewer.updateMesh(mh_viewer)
 w_mh_viewer.showMark()
 """
-    view.mgr.pycon.writeToHistory(cmd)
+    pilot.mgr.pycon.writeToHistory(cmd)
     if set_command:
-        view.mgr.pycon.command = cmd.strip()
+        pilot.mgr.pycon.command = cmd.strip()
 
 
 def help_bezier(set_command=False):
@@ -156,9 +156,9 @@ def help_bezier(set_command=False):
 # Open a sub window for some bezier curves:
 w = make_bezier()
 """
-    view.mgr.pycon.writeToHistory(cmd)
+    pilot.mgr.pycon.writeToHistory(cmd)
     if set_command:
-        view.mgr.pycon.command = cmd.strip()
+        pilot.mgr.pycon.command = cmd.strip()
 
 
 def make_gmsh_viewer(path):
@@ -392,7 +392,7 @@ def make_bezier():
         [Vector(0, 2, 0), Vector(1, 3, 0), Vector(3, 3, 0),
          Vector(4, 2, 0)])
     b3.sample(9)
-    wid = view.mgr.add3DWidget()
+    wid = pilot.mgr.add3DWidget()
     wid.updateWorld(w)
     wid.showMark()
     return wid
@@ -418,7 +418,7 @@ def load_app():
         'make_gmsh_viewer',
         'make_bezier',
         'make_plot3d_viewer',
-        ('add3DWidget', view.mgr.add3DWidget),
+        ('add3DWidget', pilot.mgr.add3DWidget),
     )
     for k in symbols:
         if isinstance(k, tuple):
@@ -427,9 +427,9 @@ def load_app():
             o = globals().get(k, None)
             if o is None:
                 o = locals().get(k, None)
-        view.mgr.pycon.writeToHistory(f"Adding symbol {k}\n")
+        pilot.mgr.pycon.writeToHistory(f"Adding symbol {k}\n")
         aenv.globals[k] = o
-    view.mgr.pycon.writeToHistory("""
+    pilot.mgr.pycon.writeToHistory("""
 # Use the functions for more examples:
 help_tri(set_command=False)  # or True
 help_tet(set_command=False)  # or True

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -85,7 +85,8 @@ __all__ = [  # noqa: F822
     'ProcessInfo',
     'METAL_BUILT',
     'metal_running',
-    'HAS_VIEW',
+    'HAS_VIEW',  # backward compatibility
+    'HAS_PILOT',
     'calc_bernstein_polynomial',
     'interpolate_bernstein',
     'Vector3dFp32',

--- a/modmesh/gui/naca.py
+++ b/modmesh/gui/naca.py
@@ -30,7 +30,7 @@ Show NACA airfoil shape
 """
 
 from modmesh import core
-from modmesh import view
+from modmesh import pilot
 from modmesh.pilot import airfoil
 
 
@@ -47,7 +47,7 @@ def runmain():
         sampler.draw_line()
     else:
         sampler.draw_cbc()
-    wid = view.mgr.add3DWidget()
+    wid = pilot.mgr.add3DWidget()
     wid.updateWorld(w)
     wid.showMark()
 

--- a/modmesh/gui/sample_mesh.py
+++ b/modmesh/gui/sample_mesh.py
@@ -33,7 +33,7 @@ import os
 
 import modmesh as mm
 from .. import core
-from .. import view
+from .. import pilot
 
 
 def mesh_triangle():
@@ -44,7 +44,7 @@ def mesh_triangle():
     mh.build_interior()
     mh.build_boundary()
     mh.build_ghost()
-    w_tri = view.mgr.add3DWidget()
+    w_tri = pilot.mgr.add3DWidget()
     w_tri.updateMesh(mh)
     w_tri.showMark()
     print("tri nedge:", mh.nedge)
@@ -58,7 +58,7 @@ def mesh_tetrahedron():
     mh.build_interior()
     mh.build_boundary()
     mh.build_ghost()
-    w_tet = view.mgr.add3DWidget()
+    w_tet = pilot.mgr.add3DWidget()
     w_tet.updateMesh(mh)
     w_tet.showMark()
     print("tet nedge:", mh.nedge)
@@ -168,7 +168,7 @@ def mesh_solvcon_2dtext():
     mh.build_boundary()
     mh.build_ghost()
     # Open a sub window for solvcon icon:
-    w_solvcon = view.mgr.add3DWidget()
+    w_solvcon = pilot.mgr.add3DWidget()
     w_solvcon.updateMesh(mh)
     w_solvcon.showMark()
     print("solvcon nedge:", mh.nedge)
@@ -199,10 +199,10 @@ def mesh_3dmix():
     mh.build_ghost()
 
     # Open a sub window for triangles and quadrilaterals:
-    w_3dmix = view.mgr.add3DWidget()
+    w_3dmix = pilot.mgr.add3DWidget()
     w_3dmix.updateMesh(mh)
     w_3dmix.showMark()
-    view.mgr.pycon.writeToHistory(f"3dmix nedge: {mh.nedge}\n")
+    pilot.mgr.pycon.writeToHistory(f"3dmix nedge: {mh.nedge}\n")
 
 
 def mesh_rectangle():
@@ -210,19 +210,19 @@ def mesh_rectangle():
     fn = os.path.abspath(fn)
     fn = os.path.join(fn, "tests", "data", "rectangle.msh")
     if not os.path.exists(fn):
-        view.mgr.pycon.writeToHistory(f"{fn} does not exist\n")
+        pilot.mgr.pycon.writeToHistory(f"{fn} does not exist\n")
         return
 
     with open(fn, 'rb') as fobj:
         data = fobj.read()
-    view.mgr.pycon.writeToHistory(f"gmsh mesh file {fn} is read\n")
+    pilot.mgr.pycon.writeToHistory(f"gmsh mesh file {fn} is read\n")
     gmsh = mm.Gmsh(data)
     mh = gmsh.to_block()
-    view.mgr.pycon.writeToHistory("StaticMesh object created from gmsh\n")
+    pilot.mgr.pycon.writeToHistory("StaticMesh object created from gmsh\n")
     # Open a sub window for triangles and quadrilaterals:
-    w = view.mgr.add3DWidget()
+    w = pilot.mgr.add3DWidget()
     w.updateMesh(mh)
     w.showMark()
-    view.mgr.pycon.writeToHistory(f"nedge: {mh.nedge}\n")
+    pilot.mgr.pycon.writeToHistory(f"nedge: {mh.nedge}\n")
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/pilot/__init__.py
+++ b/modmesh/pilot/__init__.py
@@ -29,10 +29,38 @@
 Drawing and visualization sub-system of modmesh.
 """
 
-from . import airfoil  # noqa: F401
+# The "pilot" sub-package houses all GUI related code and should not be
+# imported to the top-level "modmesh" namespace.
 
-__all__ = [
+from . import airfoil  # noqa: F401
+from . import _gui
+from ._gui import launch
+
+_from_impl = [  # noqa: F822
+    'R3DWidget',
+    'RLine',
+    'RPythonConsoleDockWidget',
+    'RManager',
+    'RCameraController',
+    'mgr',
+]
+
+__all__ = _from_impl + [  # noqa: F822
+    'launch',
     'airfoil',
 ]
+
+
+enable = _gui.enable
+
+
+def _load():
+    if enable:
+        for name in _from_impl:
+            globals()[name] = getattr(_gui, name)
+
+
+_load()
+del _load
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/pilot/_gui.py
+++ b/modmesh/pilot/_gui.py
@@ -26,7 +26,7 @@
 
 
 """
-Viewer
+Graphical-user interface code
 """
 
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
@@ -179,7 +179,7 @@ def populate_menu():
     )
 
 
-def launch(name="Modmesh Viewer", size=(1000, 600)):
+def launch(name="pilot", size=(1000, 600)):
     """
     The entry point of the pilot GUI application.
 

--- a/modmesh/system.py
+++ b/modmesh/system.py
@@ -37,7 +37,7 @@ import argparse
 import traceback
 
 import modmesh
-from . import view
+from . import pilot
 from . import apputil
 
 
@@ -63,10 +63,10 @@ class ModmeshArgumentParser(argparse.ArgumentParser):
 
 
 def _parse_command_line(argv):
-    parser = ModmeshArgumentParser(description="Viewer")
+    parser = ModmeshArgumentParser(description="Pilot")
     parser.add_argument('--mode', dest='mode', action='store',
-                        default='viewer',
-                        choices=['viewer', 'python', 'pytest'],
+                        default='pilot',
+                        choices=['pilot', 'python', 'pytest'],
                         help='mode selection (default = %(default)s)')
     args = parser.parse_args(argv[1:])
     if parser.exited:
@@ -76,9 +76,9 @@ def _parse_command_line(argv):
     return args
 
 
-def _run_viewer(argv=None):
-    """Run the viewer application."""
-    return view.launch()
+def _run_pilot(argv=None):
+    """Run the pilot application."""
+    return pilot.launch()
 
 
 def _run_pytest():
@@ -102,8 +102,9 @@ def enter_main(argv):
     ret = 0
     if args.exit:
         ret = args.exit[0]
-    elif 'viewer' == args.mode:
-        ret = _run_viewer(argv)
+    elif 'pilot' == args.mode or 'viewer' == args.mode:
+        # 'viewer' is for backward compatibility
+        ret = _run_pilot(argv)
     elif 'pytest' == args.mode:
         ret = _run_pytest()
     elif 'python' == args.mode:

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -398,7 +398,7 @@ class CommandLineInfoTC(unittest.TestCase):
         self.cmdline = modmesh.ProcessInfo.instance.command_line
 
     def test_populated(self):
-        if "viewer" in modmesh.clinfo.executable_basename:
+        if "pilot" in modmesh.clinfo.executable_basename:
             self.assertTrue(self.cmdline.populated)
             self.assertNotEqual(len(self.cmdline.populated_argv), 0)
         else:

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -31,9 +31,9 @@ import os
 
 import modmesh
 try:
-    from modmesh import view
+    from modmesh import pilot
 except ImportError:
-    view = None
+    pilot = None
 try:
     import PUI.PySide6
 except ImportError:
@@ -46,11 +46,11 @@ except ImportError:
 GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
 
 
-@unittest.skipUnless(modmesh.HAS_VIEW, "Qt view is not built")
+@unittest.skipUnless(modmesh.HAS_PILOT, "Qt pilot is not built")
 class ViewTC(unittest.TestCase):
 
     def test_import(self):
-        self.assertTrue(hasattr(modmesh.view, "mgr"))
+        self.assertTrue(hasattr(modmesh.pilot, "mgr"))
         self.assertTrue(hasattr(PUI.PySide6, "PUINode"))
         self.assertTrue(hasattr(PUI.PySide6, "PUIView"))
         self.assertEqual(PUI.PySide6.PUI_BACKEND, "PySide6",
@@ -58,9 +58,9 @@ class ViewTC(unittest.TestCase):
 
     @unittest.skip("headless testing is not ready")
     def test_pycon(self):
-        self.assertTrue(view.mgr.pycon.python_redirect)
-        view.mgr.pycon.python_redirect = False
-        self.assertFalse(view.mgr.pycon.python_redirect)
+        self.assertTrue(pilot.mgr.pycon.python_redirect)
+        pilot.mgr.pycon.python_redirect = False
+        self.assertFalse(pilot.mgr.pycon.python_redirect)
 
 
 class ViewCameraTB:
@@ -68,7 +68,7 @@ class ViewCameraTB:
 
     @classmethod
     def setUpClass(cls):
-        widget = view.RManager.instance.setUp().add3DWidget()
+        widget = pilot.RManager.instance.setUp().add3DWidget()
 
         if cls.camera_type is not None:
             widget.setCameraType(cls.camera_type)


### PR DESCRIPTION
Rename the Python module `modmesh.view` to package `modmesh.pilot`.  `modmesh.pilot` will host all code related to GUI and visualization.

Also rename the GUI executable from `viewer` to `pilot`.