### PR TITLE
[ci] upgrade Qt version to 6.8.1 LTS

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -142,10 +142,10 @@ jobs:
       uses: jurplel/install-qt-action@v4
       with:
         aqtversion: '==3.1.*'
-        version: '6.6.3'
+        version: '6.8.1'
         host: 'linux'
         target: 'desktop'
-        arch: 'gcc_64'
+        arch: 'linux_gcc_64'
         modules: 'qt3d'
         setup-python: 'false'
         cache: true
@@ -312,7 +312,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           aqtversion: '==3.1.*'
-          version: '6.6.3'
+          version: '6.8.1'
           host: 'mac'
           target: 'desktop'
           arch: 'clang_64'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -95,10 +95,10 @@ jobs:
       uses: jurplel/install-qt-action@v4
       with:
         aqtversion: '==3.1.*'
-        version: '6.6.3'
+        version: '6.8.1'
         host: 'linux'
         target: 'desktop'
-        arch: 'gcc_64'
+        arch: 'linux_gcc_64'
         modules: 'qt3d'
         setup-python: 'false'
         cache: true
@@ -221,7 +221,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           aqtversion: '==3.1.*'
-          version: '6.6.3'
+          version: '6.8.1'
           host: 'mac'
           target: 'desktop'
           arch: 'clang_64'


### PR DESCRIPTION
In this PR, we upgrade the Qt version to 6.8.1 LTS for Ubuntu and macOS, aligning all platforms to the latest LTS version.