### PR TITLE
Implement `sort`, `argsort` and `take_along_axis` for one dimensional `SimpleArray`

### DIFF
--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -154,6 +154,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                                    { return pybind11::cast(SimpleArrayPlex(arr)); })
             .wrap_modifiers()
             .wrap_calculators()
+            .wrap_sort()
             // ATTENTION: always keep the same interface between WrapSimpleArrayPlex and WrapSimpleArray
             ;
     }
@@ -185,6 +186,25 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def("max", &wrapped_type::max)
             .def("sum", &wrapped_type::sum)
             .def("abs", &wrapped_type::abs)
+            //
+            ;
+
+        return *this;
+    }
+
+    wrapper_type & wrap_sort()
+    {
+        namespace py = pybind11; // NOLINT(misc-unused-alias-decls)
+
+        (*this)
+            .def("sort", &wrapped_type::sort)
+            .def(
+                "argsort",
+                [](wrapped_type & self)
+                { return pybind11::cast(self.argsort()); })
+            .def("take_along_axis",
+                 [](wrapped_type & self, py::object const & indices)
+                 { return pybind11::cast(self.take_along_axis(indices.cast<SimpleArrayUint64>())); })
             //
             ;
 


### PR DESCRIPTION
# Description

Basic sorting functions, `sort` and `argsort`, requested in issue #435 are implemented in this PR. 

## Current Stage

### `SimpleArray::sort`

This C++ function is the inplace sorting function for `SimpleArray`. It currently supports only 1 dimensional array. 
It basically just wrap the `std::sort` from C++ STL with dimension check.

### `SimpleArray::argsort`

This is the function that returns an array in which the indices are stored in the order that the array is sorted. 
For example, if the array is `arr = [1, 9, 7, 3, 5]`, the returned array will be `[0, 3, 4, 2, 1]` indicating that `arr[0]->arr[3]->arr[4]->arr[2]->arr[1]` is the sorted order of `arr`.

### `SimpleArray::take_along_axis`

This function is to apply the result that returned by `argsort` of another `SimpleArray` to make it sorted based on another array.
A concrete example is shown below.

```c++
constexpr size_t N = 10;
SimpleArray<uint64_t> array(N);
SimpleArray<uint64_t> other(N);

// ... add data to arrays

other.take_along_axis(array.argsort());
```

## Current Problem

- [ ] How to implement a wrapped python function returns `Option[SimpleArray]` in C++. as the prototype of `sort` are intended to be the following as mentioned in issue #435?
  ```python
  sarr = SimpleArrayUint32()
  assert(sarr.sort(inplace=True) is None)
  assert(sarr.sort(inplace=False).shape == sarr.shape)
  ```
- [x] How should the python prototype of `argsort` be like?
- [ ] How should the python prototype of `TimeSeriesDataFrame.reorder` be like?