### PR TITLE
Add the base class `PilotFeature` in the module `modmesh.pilot._gui_common`

### DIFF
--- a/modmesh/__init__.py
+++ b/modmesh/__init__.py
@@ -36,7 +36,6 @@ modmesh: the description of the package is intentionally left blank
 from . import core
 from .core import *  # noqa: F401, F403
 from . import apputil  # noqa: F401
-from . import pilot  # noqa: F401
 from . import spacetime  # noqa: F401
 from . import onedim  # noqa: F401
 from . import system  # noqa: F401

--- a/modmesh/pilot/__init__.py
+++ b/modmesh/pilot/__init__.py
@@ -42,11 +42,12 @@ from ._pilot_core import (  # noqa: F401
     RManager,
     RCameraController,
 )
-from ._gui import (  # noqa: F401
-    controller,
-    launch,
-)
-from . import airfoil  # noqa: F401
+if enable:
+    from ._gui import (  # noqa: F401
+        controller,
+        launch,
+    )
+    from . import airfoil  # noqa: F401
 
 # NOTE: intentionally omit __all__ for now
 

--- a/modmesh/pilot/_gui_common.py
+++ b/modmesh/pilot/_gui_common.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2025, Yung-Yu Chen <yyc@solvcon.net>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+from . import _pilot_core as _pcore
+from PySide6 import QtCore, QtGui
+
+
+class PilotFeature(QtCore.QObject):
+    """
+    Base class to house common GUI code for prototyping pilot features.
+
+    :ivar _mgr:
+        The modmesh pilot application manager implemented with Qt in C++.
+    :itype mgr: modmesh.pilot.RManager
+    """
+
+    def __init__(self, *args, **kw):
+        """
+        :param mgr:
+            The modmesh pilot application manager implemented with Qt in C++.
+        :type mgr: modmesh.pilot.RManager
+        """
+        self._mgr = kw.pop('mgr')
+        if not isinstance(self._mgr, _pcore.RManager):
+            raise TypeError(
+                "'mgr' must be an instance of 'modmesh.pilot.RManager'")
+        super(PilotFeature, self).__init__(*args, **kw)
+
+    @property
+    def _pycon(self):
+        """
+        :rtype: modmesh.pilot.RPythonConsoleDockWidget
+        """
+        return self._mgr.pycon
+
+    @property
+    def _mainWindow(self):
+        """
+        :rtype: PySide6.QtWidget.QMainWindow
+        """
+        return self._mgr.mainWindow
+
+    def _add_menu_item(self, menu, text, tip, func):
+        """
+        Add an item to the corresponding menu.
+
+        :param menu: The menu to add the item to.
+        :type menu: PySide6.QtWidget.QMenu
+        :param text: Menu description string.
+        :param tip: Menu tip string.
+        :param func: Python callable.
+
+        :return: None
+        """
+        act = QtGui.QAction(text, self._mainWindow)
+        act.setStatusTip(tip)
+        act.triggered.connect(func)
+        menu.addAction(act)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/pilot/_mesh.py
+++ b/modmesh/pilot/_mesh.py
@@ -31,9 +31,10 @@ Show meshes.
 
 import os
 
-from PySide6 import QtCore, QtWidgets, QtGui
+from PySide6 import QtCore, QtWidgets
 
 from .. import core
+from ._gui_common import PilotFeature
 
 __all__ = [  # noqa: F822
     'SampleMesh',
@@ -41,77 +42,53 @@ __all__ = [  # noqa: F822
 ]
 
 
-def _add_menu_item(mainWindow, menu, text, tip, func):
-    act = QtGui.QAction(text, mainWindow)
-    act.setStatusTip(tip)
-    act.triggered.connect(func)
-    menu.addAction(act)
-
-
-class SampleMesh(object):
+class SampleMesh(PilotFeature):
     """
     Create sample mesh windows.
     """
 
-    def __init__(self, mgr):
-        self._mgr = mgr
-
-    @property
-    def _pycon(self):
-        return self._mgr.pycon
-
     def populate_menu(self):
-        _add_menu_item(
-            mainWindow=self._mgr.mainWindow,
+        self._add_menu_item(
             menu=self._mgr.meshMenu,
             text="Sample: mesh of a triangle (2D)",
             tip="Create a very simple sample mesh of a triangle",
             func=self.mesh_triangle,
         )
 
-        _add_menu_item(
-            mainWindow=self._mgr.mainWindow,
+        self._add_menu_item(
             menu=self._mgr.meshMenu,
             text="Sample: mesh of a tetrahedron (3D)",
             tip="Create a very simple sample mesh of a tetrahedron",
             func=self.mesh_tetrahedron,
         )
 
-        _add_menu_item(
-            mainWindow=self._mgr.mainWindow,
+        self._add_menu_item(
             menu=self._mgr.meshMenu,
             text="Sample: mesh of \"solvcon\" text in 2D",
             tip="Create a sample mesh drawing a text string of \"solvcon\"",
             func=self.mesh_solvcon_2dtext,
         )
 
-        _add_menu_item(
-            mainWindow=self._mgr.mainWindow,
+        self._add_menu_item(
             menu=self._mgr.meshMenu,
             text="Sample: small 2D mesh of mixed elements",
             tip="Create a small sample mesh of mixed elements in 2D",
             func=self.mesh_2dmix_small,
         )
 
-        _add_menu_item(
-            mainWindow=self._mgr.mainWindow,
+        self._add_menu_item(
             menu=self._mgr.meshMenu,
             text="Sample: larger 2D mesh of mixed elements",
             tip="Create a larger simple sample mesh of mixed elements in 2D",
             func=self.mesh_2dmix_large,
         )
 
-        _add_menu_item(
-            mainWindow=self._mgr.mainWindow,
+        self._add_menu_item(
             menu=self._mgr.meshMenu,
             text="Sample: 3D mesh of mixed elements",
             tip="Create a very simple sample mesh of mixed elements in 3D",
             func=self.mesh_3dmix,
         )
-
-    @property
-    def mainWindow(self):
-        return self._mgr.mainWindow
 
     def mesh_triangle(self):
         mh = core.StaticMesh(ndim=2, nnode=4, nface=0, ncell=3)
@@ -339,9 +316,8 @@ class SampleMesh(object):
         self._mgr.pycon.writeToHistory(f"3dmix nedge: {mh.nedge}\n")
 
 
-class GmshFileDialog(QtCore.QObject):
+class GmshFileDialog(PilotFeature):
     def __init__(self, *args, **kw):
-        self._mgr = kw.pop('mgr')
         super(GmshFileDialog, self).__init__(*args, **kw)
         self._diag = QtWidgets.QFileDialog()
         self._diag.setFileMode(QtWidgets.QFileDialog.ExistingFile)
@@ -352,8 +328,7 @@ class GmshFileDialog(QtCore.QObject):
         self._diag.open(self, QtCore.SLOT('on_finished()'))
 
     def populate_menu(self):
-        _add_menu_item(
-            mainWindow=self._mgr.mainWindow,
+        self._add_menu_item(
             menu=self._mgr.fileMenu,
             text="Open Gmsh file",
             tip="Open Gmsh file",
@@ -407,9 +382,5 @@ class GmshFileDialog(QtCore.QObject):
         w.updateMesh(mh)
         w.showMark()
         self._pycon.writeToHistory(f"nedge: {mh.nedge}\n")
-
-    @property
-    def _pycon(self):
-        return self._mgr.pycon
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/pilot/airfoil/__init__.py
+++ b/modmesh/pilot/airfoil/__init__.py
@@ -30,7 +30,11 @@ Airfoil shape
 """
 
 from ._naca import Naca4, Naca4Sampler
-from ._airfoil_gui import Naca4Airfoil
+from .. import _pilot_core as _pcore
+if _pcore.enable:
+    from ._airfoil_gui import Naca4Airfoil
+else:
+    Naca4Airfoil = None
 
 __all__ = [
     'Naca4',

--- a/modmesh/pilot/airfoil/_airfoil_gui.py
+++ b/modmesh/pilot/airfoil/_airfoil_gui.py
@@ -31,35 +31,17 @@ GUI for NACA airfoil shape
 
 from ... import core
 
-from .. import _pilot_core as _pcore
+from .._gui_common import PilotFeature
 from . import _naca
 
-if _pcore.enable:
-    from PySide6 import QtGui
 
-
-def _add_menu_item(mainWindow, menu, text, tip, func):
-    act = QtGui.QAction(text, mainWindow)
-    act.setStatusTip(tip)
-    act.triggered.connect(func)
-    menu.addAction(act)
-
-
-class Naca4Airfoil(object):
+class Naca4Airfoil(PilotFeature):
     """
     Provide pilot GUI control for the NACA 4-digit airfoil shape.
     """
 
-    def __init__(self, mgr):
-        self._mgr = mgr
-
-    @property
-    def _pycon(self):
-        return self._mgr.pycon
-
     def populate_menu(self):
-        _add_menu_item(
-            mainWindow=self._mgr.mainWindow,
+        self._add_menu_item(
             menu=self._mgr.meshMenu,
             text="Sample: NACA 4-digit",
             tip="Draw a NACA 4-digit airfoil",
@@ -80,7 +62,7 @@ class Naca4Airfoil(object):
             sampler.draw_line()
         else:
             sampler.draw_cbc()
-        wid = _pcore.mgr.add3DWidget()
+        wid = self._mgr.add3DWidget()
         wid.updateWorld(w)
         wid.showMark()
 

--- a/modmesh/system.py
+++ b/modmesh/system.py
@@ -37,7 +37,6 @@ import argparse
 import traceback
 
 import modmesh
-from . import pilot
 from . import apputil
 
 
@@ -78,6 +77,10 @@ def _parse_command_line(argv):
 
 def _run_pilot(argv=None):
     """Run the pilot application."""
+    # The local importing pilot delays loading GUI/Qt code. GUI/Qt may be
+    # unavailable in some execution modes and the module modmesh.pilot and
+    # PySide6 should not be imported at module level.
+    from . import pilot
     return pilot.launch()
 
 

--- a/tests/test_pilot_airfoil.py
+++ b/tests/test_pilot_airfoil.py
@@ -28,7 +28,7 @@
 import unittest
 
 import modmesh as mm
-from modmesh.pilot import airfoil
+from modmesh.pilot.airfoil import _naca
 
 
 class Naca4TC(unittest.TestCase):
@@ -39,21 +39,21 @@ class Naca4TC(unittest.TestCase):
             points = naca4.calc_points(11)
             self.assertEqual((23, 2), points.shape)
 
-        _check_size(airfoil.Naca4(number='0012', open_trailing_edge=False,
-                                  cosine_spacing=False))
-        _check_size(airfoil.Naca4(number='0012', open_trailing_edge=True,
-                                  cosine_spacing=False))
-        _check_size(airfoil.Naca4(number='0012', open_trailing_edge=True,
-                                  cosine_spacing=False))
-        _check_size(airfoil.Naca4(number='0012', open_trailing_edge=True,
-                                  cosine_spacing=True))
+        _check_size(_naca.Naca4(number='0012', open_trailing_edge=False,
+                                cosine_spacing=False))
+        _check_size(_naca.Naca4(number='0012', open_trailing_edge=True,
+                                cosine_spacing=False))
+        _check_size(_naca.Naca4(number='0012', open_trailing_edge=True,
+                                cosine_spacing=False))
+        _check_size(_naca.Naca4(number='0012', open_trailing_edge=True,
+                                cosine_spacing=True))
 
 
 class Naca4SamplerTC(unittest.TestCase):
     def test_construction(self):
         w = mm.WorldFp64()
-        naca4 = airfoil.Naca4(number='0012', open_trailing_edge=False,
-                              cosine_spacing=False)
-        airfoil.Naca4Sampler(w, naca4)
+        naca4 = _naca.Naca4(number='0012', open_trailing_edge=False,
+                            cosine_spacing=False)
+        _naca.Naca4Sampler(w, naca4)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
The base class `PilotFeature` represents a house for a feature that is being prototyped in pilot.  It serves the following derived classes: `SampleMesh`, `GmshFileDialog`, `Naca4Airfoil`.

Do not import `pilot` from `modmesh` namespace automaticfally. Use local import for code in `modmesh.system`.