### PR TITLE
Allow `modmesh.World` to keep vertices

### DIFF
--- a/cpp/modmesh/buffer/BufferExpander.hpp
+++ b/cpp/modmesh/buffer/BufferExpander.hpp
@@ -115,6 +115,25 @@ public:
         m_end = m_begin + length;
     }
 
+    /**
+     * Push up the size by amount.
+     * @param amount
+     *  Number of bytes to push up.
+     */
+    void push_size(size_type amount)
+    {
+        if (size() + amount > capacity())
+        {
+            throw std::out_of_range(
+                Formatter()
+                << name() << ": "
+                << "size() " << size() << " + "
+                << "amount " << amount << " > "
+                << "capacity() " << capacity());
+        }
+        m_end += amount;
+    }
+
     std::shared_ptr<ConcreteBuffer> copy_concrete(size_type cap = 0) const;
     std::shared_ptr<ConcreteBuffer> const & as_concrete(size_type cap = 0);
     bool is_concrete() const { return bool(m_concrete_buffer); }

--- a/cpp/modmesh/buffer/SimpleCollector.hpp
+++ b/cpp/modmesh/buffer/SimpleCollector.hpp
@@ -115,6 +115,20 @@ public:
         return SimpleArray<T>(expander().as_concrete());
     }
 
+    void push_back(value_type const & value)
+    {
+        size_t const it = size();
+        push_size();
+        (*this)[it] = value;
+    }
+
+    void push_back(value_type && value)
+    {
+        size_t const it = size();
+        push_size();
+        (*this)[it] = value;
+    }
+
     /* Backdoor */
     value_type const & data(size_t it) const { return data()[it]; }
     value_type & data(size_t it) { return data()[it]; }
@@ -131,6 +145,27 @@ private:
         if (it >= size())
         {
             throw std::out_of_range(Formatter() << "SimpleCollector: index " << it << " is out of bounds with size " << size());
+        }
+    }
+
+    /**
+     * Push up the size of the underneath expander by one ITEMSIZE.
+     */
+    void push_size()
+    {
+        if (capacity() == 0)
+        {
+            reserve(1);
+            m_expander->push_size(ITEMSIZE);
+        }
+        else if (size() == capacity())
+        {
+            reserve(size() * 2);
+            m_expander->push_size(ITEMSIZE);
+        }
+        else
+        {
+            // do nothing
         }
     }
 

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -233,6 +233,10 @@ WrapSimpleCollector<T>::WrapSimpleCollector(pybind11::module & mod, char const *
             "__setitem__",
             [](wrapped_type & self, size_t key, value_type val)
             { self.at(key) = val; })
+        .def(
+            "push_back",
+            [](wrapped_type & self, value_type value)
+            { self.push_back(value); })
         .def_timed("as_array", &wrapped_type::as_array)
         //
         ;

--- a/cpp/modmesh/universe/World.hpp
+++ b/cpp/modmesh/universe/World.hpp
@@ -56,7 +56,9 @@ public:
 
     using real_type = T;
     using value_type = T;
+    using size_type = typename NumberBase<int32_t, T>::size_type;
     using vector_type = Vector3d<T>;
+    using vertex_type = vector_type;
     using edge_type = Edge3d<T>;
     using bezier_type = Bezier3d<T>;
 
@@ -74,6 +76,25 @@ public:
     World & operator=(World const &) = delete;
     World & operator=(World &&) = delete;
     ~World() = default;
+
+    void add_vertex(vertex_type const & vertex);
+    void add_vertex(value_type x, value_type y, value_type z)
+    {
+        add_vertex(vertex_type(x, y, z));
+    }
+    size_t nvertex() const { return m_vertices.size(); }
+    vertex_type const & vertex(size_t i) const { return m_vertices[i]; }
+    vertex_type & vertex(size_t i) { return m_vertices[i]; }
+    vertex_type const & vertex_at(size_t i) const
+    {
+        check_size(i, m_vertices.size(), "vertex");
+        return m_vertices[i];
+    }
+    vertex_type & vertex_at(size_t i)
+    {
+        check_size(i, m_vertices.size(), "vertex");
+        return m_vertices[i];
+    }
 
     void add_edge(edge_type const & edge);
     void add_edge(value_type x0, value_type y0, value_type z0, value_type x1, value_type y1, value_type z1)
@@ -119,10 +140,17 @@ private:
         }
     }
 
+    SimpleCollector<vertex_type> m_vertices;
     std::deque<Edge3d<T>> m_edges;
     std::deque<Bezier3d<T>> m_beziers;
 
 }; /* end class World */
+
+template <typename T>
+void World<T>::add_vertex(vertex_type const & vertex)
+{
+    m_vertices.push_back(vertex);
+}
 
 template <typename T>
 void World<T>::add_edge(edge_type const & edge)

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -304,6 +304,7 @@ public:
 
     using value_type = typename wrapped_type::value_type;
     using vector_type = typename wrapped_type::vector_type;
+    using vertex_type = typename wrapped_type::vertex_type;
     using edge_type = typename wrapped_type::edge_type;
     using bezier_type = typename wrapped_type::bezier_type;
 
@@ -331,6 +332,34 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
 
     // Bezier curves
     (*this)
+        .def(
+            "add_vertex",
+            [](wrapped_type & self, vertex_type const & vertex) -> auto &
+            {
+                self.add_vertex(vertex);
+                return self.vertex_at(self.nvertex() - 1);
+            },
+            py::arg("vertex"),
+            py::return_value_policy::reference_internal)
+        .def(
+            "add_vertex",
+            [](wrapped_type & self, value_type x, value_type y, value_type z) -> auto &
+            {
+                self.add_vertex(x, y, z);
+                return self.vertex_at(self.nvertex() - 1);
+            },
+            py::arg("x"),
+            py::arg("y"),
+            py::arg("z"),
+            py::return_value_policy::reference_internal)
+        .def_property_readonly("nvertex", &wrapped_type::nvertex)
+        .def(
+            "vertex",
+            [](wrapped_type & self, size_t i) -> auto &
+            {
+                return self.vertex_at(i);
+            },
+            py::return_value_policy::reference_internal)
         .def(
             "add_edge",
             [](wrapped_type & self, edge_type const & edge) -> auto &

--- a/modmesh/testing.py
+++ b/modmesh/testing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
+# Copyright (c) 2023, Yung-Yu Chen <yyc@solvcon.net>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -24,26 +24,14 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-
-"""
-modmesh: the description of the package is intentionally left blank
-"""
+import numpy as np
 
 
-# Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
+class TestBase:
 
-
-from . import core
-from .core import *  # noqa: F401, F403
-from . import apputil  # noqa: F401
-from . import spacetime  # noqa: F401
-from . import onedim  # noqa: F401
-from . import system  # noqa: F401
-from . import testing  # noqa: F401
-from . import toggle  # noqa: F401
-
-
-clinfo = core.ProcessInfo.instance.command_line
-
+    def assert_allclose(self, *args, **kw):
+        if 'rtol' not in kw:
+            kw['rtol'] = 1.e-12
+        return np.testing.assert_allclose(*args, **kw)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1069,4 +1069,35 @@ class SimpleCollectorTC(unittest.TestCase):
             ct[it] = it + 10
         self.assertEqual(list(it + 10 for it in range(6)), list(ct))
 
+    def test_push_back(self):
+        # Starting from 0.
+        ct = modmesh.SimpleCollectorFloat64()
+        self.assertEqual(0, ct.capacity)
+        self.assertEqual(0, len(ct))
+
+        ct.push_back(3.14159)
+        self.assertEqual(1, ct.capacity)
+        self.assertEqual(1, len(ct))
+        self.assertEqual(ct[0], 3.14159)
+
+        ct.push_back(3.14159 * 2)
+        self.assertEqual(2, ct.capacity)
+        self.assertEqual(2, len(ct))
+        self.assertEqual(ct[1], 3.14159 * 2)
+
+        ct.push_back(3.14159 * 3)
+        self.assertEqual(4, ct.capacity)
+        self.assertEqual(3, len(ct))
+        self.assertEqual(ct[2], 3.14159 * 3)
+
+        # Starting from non-zero and not power of 2.
+        ct = modmesh.SimpleCollectorFloat64(10)
+        self.assertEqual(10, ct.capacity)
+        self.assertEqual(10, len(ct))
+
+        ct.push_back(3.14159 * 4)
+        self.assertEqual(20, ct.capacity)  # double capacity but not power of 2
+        self.assertEqual(11, len(ct))
+        self.assertEqual(ct[10], 3.14159 * 4)
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -31,7 +31,17 @@ import numpy as np
 import modmesh as mm
 
 
-class ComplexTC(unittest.TestCase):
+class ComplexTC(unittest.TestCase, mm.testing.TestBase):
+
+    def assert_allclose32(self, *args, **kw):
+        if 'rtol' not in kw:
+            kw['rtol'] = 1.e-7
+        return super().assert_allclose(*args, **kw)
+
+    def assert_allclose64(self, *args, **kw):
+        if 'rtol' not in kw:
+            kw['rtol'] = 1.e-15
+        return super().assert_allclose(*args, **kw)
 
     def setUp(self):
         self.real1_32 = np.float32(0.7)
@@ -46,23 +56,23 @@ class ComplexTC(unittest.TestCase):
 
     def test_construct_float32_default(self):
         cplx = mm.ComplexFloat32()
-        self.assertAlmostEqual(cplx.real, 0.0)
-        self.assertAlmostEqual(cplx.imag, 0.0)
+        self.assert_allclose32(cplx.real, 0.0)
+        self.assert_allclose32(cplx.imag, 0.0)
 
     def test_construct_float64_default(self):
         cplx = mm.ComplexFloat64()
-        self.assertAlmostEqual(cplx.real, 0.0)
-        self.assertAlmostEqual(cplx.imag, 0.0)
+        self.assert_allclose64(cplx.real, 0.0)
+        self.assert_allclose64(cplx.imag, 0.0)
 
     def test_construct_float32_random(self):
         cplx = mm.ComplexFloat32(self.real1_32, self.imag1_32)
-        self.assertAlmostEqual(cplx.real, self.real1_32)
-        self.assertAlmostEqual(cplx.imag, self.imag1_32)
+        self.assert_allclose32(cplx.real, self.real1_32)
+        self.assert_allclose32(cplx.imag, self.imag1_32)
 
     def test_construct_float64_random(self):
         cplx = mm.ComplexFloat64(self.real1_64, self.imag1_64)
-        self.assertAlmostEqual(cplx.real, self.real1_64)
-        self.assertAlmostEqual(cplx.imag, self.imag1_64)
+        self.assert_allclose64(cplx.real, self.real1_64)
+        self.assert_allclose64(cplx.imag, self.imag1_64)
 
     def test_operator_add_float32(self):
         cplx1 = mm.ComplexFloat32(self.real1_32, self.imag1_32)
@@ -73,8 +83,8 @@ class ComplexTC(unittest.TestCase):
         expected_real = self.real1_32 + self.real2_32
         expected_imag = self.imag1_32 + self.imag2_32
 
-        self.assertAlmostEqual(result.real, expected_real)
-        self.assertAlmostEqual(result.imag, expected_imag)
+        self.assert_allclose32(result.real, expected_real)
+        self.assert_allclose32(result.imag, expected_imag)
 
     def test_operator_add_float64(self):
         cplx1 = mm.ComplexFloat64(self.real1_64, self.imag1_64)
@@ -85,8 +95,8 @@ class ComplexTC(unittest.TestCase):
         expected_real = self.real1_64 + self.real2_64
         expected_imag = self.imag1_64 + self.imag2_64
 
-        self.assertAlmostEqual(result.real, expected_real)
-        self.assertAlmostEqual(result.imag, expected_imag)
+        self.assert_allclose64(result.real, expected_real)
+        self.assert_allclose64(result.imag, expected_imag)
 
     def test_operator_sub_float32(self):
         cplx1 = mm.ComplexFloat32(self.real1_32, self.imag1_32)
@@ -97,8 +107,8 @@ class ComplexTC(unittest.TestCase):
         expected_real = self.real1_32 - self.real2_32
         expected_imag = self.imag1_32 - self.imag2_32
 
-        self.assertAlmostEqual(result.real, expected_real)
-        self.assertAlmostEqual(result.imag, expected_imag)
+        self.assert_allclose32(result.real, expected_real)
+        self.assert_allclose32(result.imag, expected_imag)
 
     def test_operator_sub_float64(self):
         cplx1 = mm.ComplexFloat64(self.real1_64, self.imag1_64)
@@ -109,8 +119,8 @@ class ComplexTC(unittest.TestCase):
         expected_real = self.real1_64 - self.real2_64
         expected_imag = self.imag1_64 - self.imag2_64
 
-        self.assertAlmostEqual(result.real, expected_real)
-        self.assertAlmostEqual(result.imag, expected_imag)
+        self.assert_allclose64(result.real, expected_real)
+        self.assert_allclose64(result.imag, expected_imag)
 
     def test_operator_mul_float32(self):
         cplx1 = mm.ComplexFloat32(self.real1_32, self.imag1_32)
@@ -123,8 +133,8 @@ class ComplexTC(unittest.TestCase):
         expected_imag = (self.real1_32 * self.imag2_32
                          + self.imag1_32 * self.real2_32)
 
-        self.assertAlmostEqual(result.real, expected_real)
-        self.assertAlmostEqual(result.imag, expected_imag)
+        self.assert_allclose32(result.real, expected_real)
+        self.assert_allclose32(result.imag, expected_imag)
 
     def test_operator_mul_float64(self):
         cplx1 = mm.ComplexFloat64(self.real1_64, self.imag1_64)
@@ -137,8 +147,8 @@ class ComplexTC(unittest.TestCase):
         expected_imag = (self.real1_64 * self.imag2_64
                          + self.imag1_64 * self.real2_64)
 
-        self.assertAlmostEqual(result.real, expected_real)
-        self.assertAlmostEqual(result.imag, expected_imag)
+        self.assert_allclose64(result.real, expected_real)
+        self.assert_allclose64(result.imag, expected_imag)
 
     def test_operator_div_float32_scalar(self):
         cplx = mm.ComplexFloat32(self.real1_32, self.imag1_32)
@@ -150,8 +160,8 @@ class ComplexTC(unittest.TestCase):
         expected_real = self.real1_32 / divisor
         expected_imag = self.imag1_32 / divisor
 
-        self.assertAlmostEqual(result.real, expected_real)
-        self.assertAlmostEqual(result.imag, expected_imag)
+        self.assert_allclose32(result.real, expected_real)
+        self.assert_allclose32(result.imag, expected_imag)
 
     def test_operator_div_float64_scalar(self):
         cplx = mm.ComplexFloat64(self.real1_64, self.imag1_64)
@@ -162,8 +172,8 @@ class ComplexTC(unittest.TestCase):
         expected_real = self.real1_64 / divisor
         expected_imag = self.imag1_64 / divisor
 
-        self.assertAlmostEqual(result.real, expected_real)
-        self.assertAlmostEqual(result.imag, expected_imag)
+        self.assert_allclose64(result.real, expected_real)
+        self.assert_allclose64(result.imag, expected_imag)
 
     def test_norm_float32(self):
         cplx = mm.ComplexFloat32(self.real1_32, self.imag1_32)
@@ -172,7 +182,7 @@ class ComplexTC(unittest.TestCase):
 
         expected_val = self.real1_32 ** 2 + self.imag1_32 ** 2
 
-        self.assertAlmostEqual(result, expected_val)
+        self.assert_allclose32(result, expected_val)
 
     def test_norm_float64(self):
         cplx = mm.ComplexFloat64(self.real1_64, self.imag1_64)
@@ -181,4 +191,4 @@ class ComplexTC(unittest.TestCase):
 
         expected_val = self.real1_64 ** 2 + self.imag1_64 ** 2
 
-        self.assertAlmostEqual(result, expected_val)
+        self.assert_allclose64(result, expected_val)

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -27,17 +27,8 @@
 
 import unittest
 
-import numpy as np
-
 import modmesh
-
-
-class ModMeshTB:
-
-    def assert_allclose(self, *args, **kw):
-        if 'rtol' not in kw:
-            kw['rtol'] = 1.e-12
-        return np.testing.assert_allclose(*args, **kw)
+from modmesh.testing import TestBase as ModMeshTB
 
 
 class BernsteinTB(ModMeshTB):

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -429,6 +429,38 @@ class WorldTB(ModMeshTB):
         # Confirm we worked on the internal instead of copy
         self.assertEqual(w.bezier(0).nlocus, 5)
 
+    def test_vertex(self):
+        Vector = self.vkls
+        World = self.wkls
+
+        w = World()
+
+        # Empty
+        self.assertEqual(w.nvertex, 0)
+        with self.assertRaisesRegex(
+                IndexError, "World: \\(vertex\\) i 0 >= size 0"):
+            w.vertex(0)
+
+        # Add a vertex by object
+        v = w.add_vertex(Vector(0, 1, 2))
+        self.assertEqual(list(v), [0, 1, 2])
+        self.assertEqual(list(w.vertex(0)), [0, 1, 2])
+        self.assertEqual(v, w.vertex(0))
+        self.assertEqual(w.nvertex, 1)
+        with self.assertRaisesRegex(
+                IndexError, "World: \\(vertex\\) i 1 >= size 1"):
+            w.vertex(1)
+
+        # Add a vertex by coordinate
+        v = w.add_vertex(3.1415, 3.1416, 3.1417)
+        self.assert_allclose(list(v), [3.1415, 3.1416, 3.1417])
+        self.assert_allclose(list(w.vertex(1)), [3.1415, 3.1416, 3.1417])
+        self.assertEqual(v, w.vertex(1))
+        self.assertEqual(w.nvertex, 2)
+        with self.assertRaisesRegex(
+                IndexError, "World: \\(vertex\\) i 2 >= size 2"):
+            w.vertex(2)
+
 
 class WorldFp32TC(WorldTB, unittest.TestCase):
 


### PR DESCRIPTION
For `modmesh.World`:

* Implement `vertex()`, `add_vertex()`, `nvertex` on `World`.
* Use `SimpleCollector` to implement the vertex container in `World`.
* Add `push_back` to `SimpleCollector`.

To improve the relevant testing:

* Create `modmesh.testing.TestBase` to house common code for testing.