### PR TITLE
Fix the issue that freezes `SimpleCollector::push_back` from 2 -> 3

### DIFF
--- a/cpp/modmesh/buffer/SimpleCollector.hpp
+++ b/cpp/modmesh/buffer/SimpleCollector.hpp
@@ -156,17 +156,16 @@ private:
         if (capacity() == 0)
         {
             reserve(1);
-            m_expander->push_size(ITEMSIZE);
         }
         else if (size() == capacity())
         {
             reserve(size() * 2);
-            m_expander->push_size(ITEMSIZE);
         }
         else
         {
             // do nothing
         }
+        m_expander->push_size(ITEMSIZE);
     }
 
     std::shared_ptr<expander_type> m_expander;

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1090,6 +1090,11 @@ class SimpleCollectorTC(unittest.TestCase):
         self.assertEqual(3, len(ct))
         self.assertEqual(ct[2], 3.14159 * 3)
 
+        for it in range(10):
+            ct.push_back(3.14159 * (3 + it + 1))
+            self.assertEqual(3 + it + 1, len(ct))
+            self.assertEqual(ct[3 + it], 3.14159 * (3 + it + 1))
+
         # Starting from non-zero and not power of 2.
         ct = modmesh.SimpleCollectorFloat64(10)
         self.assertEqual(10, ct.capacity)

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -452,6 +452,11 @@ class WorldTB(ModMeshTB):
                 IndexError, "World: \\(vertex\\) i 2 >= size 2"):
             w.vertex(2)
 
+        # Add many vertices
+        for it in range(10):
+            w.add_vertex(3.1415 + it, 3.1416 + it, 3.1417 + it)
+            self.assertEqual(w.nvertex, 2 + it + 1)
+
 
 class WorldFp32TC(WorldTB, unittest.TestCase):
 


### PR DESCRIPTION
A logical bug in `SimpleCollector::push_back` prevents the size from increasing from 2 to 3.

The bug was introduced with the initial implementation in PR #465 .