### PR TITLE
Draw vertices as points using Qt3D

### DIFF
--- a/cpp/modmesh/pilot/R3DWidget.cpp
+++ b/cpp/modmesh/pilot/R3DWidget.cpp
@@ -79,12 +79,13 @@ void R3DWidget::updateWorld(std::shared_ptr<WorldFp64> const & world)
 {
     for (Qt3DCore::QNode * child : m_scene->childNodes())
     {
-        if (typeid(*child) == typeid(RWorld))
+        if ((typeid(*child) == typeid(RLines)) || (typeid(*child) == typeid(RVertices)))
         {
             child->deleteLater();
         }
     }
-    new RWorld(world, m_scene);
+    new RVertices(world, m_scene);
+    new RLines(world, m_scene);
 }
 
 void R3DWidget::closeAndDestroy()

--- a/cpp/modmesh/pilot/RWorld.hpp
+++ b/cpp/modmesh/pilot/RWorld.hpp
@@ -50,33 +50,41 @@
 namespace modmesh
 {
 
-/**
- * Make a world viewable.
- */
-class RWorld
+class RVertices
     : public Qt3DCore::QEntity
 {
+    Q_OBJECT
 
 public:
 
-    RWorld(std::shared_ptr<WorldFp64> const & world, Qt3DCore::QNode * parent = nullptr);
-
-    void set_world(std::shared_ptr<WorldFp64> const & world) { m_world = world; }
-    bool has_world() const { return bool(m_world); }
-    WorldFp64 const & world() const { return *m_world; }
-    WorldFp64 & world() { return *m_world; }
-
-    void update_geometry();
+    RVertices(std::shared_ptr<WorldFp64> const & world, Qt3DCore::QNode * parent = nullptr);
 
 private:
-
-    std::shared_ptr<WorldFp64> m_world;
 
     Qt3DCore::QGeometry * m_geometry = nullptr;
     Qt3DRender::QGeometryRenderer * m_renderer = nullptr;
     Qt3DRender::QMaterial * m_material = nullptr;
 
-}; /* end class R3DWorld */
+}; /* end class RVertices */
+
+class RLines
+    : public Qt3DCore::QEntity
+{
+    Q_OBJECT
+
+public:
+
+    RLines(std::shared_ptr<WorldFp64> const & world, Qt3DCore::QNode * parent = nullptr);
+
+    void update();
+
+private:
+
+    Qt3DCore::QGeometry * m_geometry = nullptr;
+    Qt3DRender::QGeometryRenderer * m_renderer = nullptr;
+    Qt3DRender::QMaterial * m_material = nullptr;
+
+}; /* end class RLines */
 
 } /* end namespace modmesh */
 

--- a/modmesh/pilot/_gui.py
+++ b/modmesh/pilot/_gui.py
@@ -69,6 +69,7 @@ class _Controller(metaclass=_Singleton):
         self._rmgr = None
         self.gmsh_dialog = None
         self.sample_mesh = None
+        self.recdom = None
         self.naca4airfoil = None
         self.eulerone = None
 
@@ -82,6 +83,7 @@ class _Controller(metaclass=_Singleton):
         self._rmgr.resize(w=size[0], h=size[1])
         self.gmsh_dialog = _mesh.GmshFileDialog(mgr=self._rmgr)
         self.sample_mesh = _mesh.SampleMesh(mgr=self._rmgr)
+        self.recdom = _mesh.RectangularDomain(mgr=self._rmgr)
         self.naca4airfoil = airfoil.Naca4Airfoil(mgr=self._rmgr)
         self.eulerone = _euler1d.Euler1DApp(mgr=self._rmgr)
         self.populate_menu()
@@ -106,6 +108,7 @@ class _Controller(metaclass=_Singleton):
         self.gmsh_dialog.populate_menu()
         self.sample_mesh.populate_menu()
         self.naca4airfoil.populate_menu()
+        self.recdom.populate_menu()
         self.eulerone.populate_menu()
 
         if sys.platform != 'darwin':

--- a/modmesh/pilot/_mesh.py
+++ b/modmesh/pilot/_mesh.py
@@ -383,4 +383,61 @@ class GmshFileDialog(PilotFeature):
         w.showMark()
         self._pycon.writeToHistory(f"nedge: {mh.nedge}\n")
 
+
+class RectangularDomain(PilotFeature):
+    """
+    Placeholder for prototyping code for generating triangular mesh in a
+    rectangular domain.
+    """
+    def __init__(self, *args, **kw) -> None:
+        super().__init__(*args, **kw)
+        self.world: core.WorldFp64 = None
+        self.mesh: core.StaticMesh = None
+
+    def populate_menu(self):
+        self._add_menu_item(
+            menu=self._mgr.meshMenu,
+            text="Create triangle mesh in rectangular domain",
+            tip="Create triangle mesh in rectangular domain",
+            func=self.run,
+        )
+
+    def setup(self):
+        pass
+
+    def _create_mesh(self) -> core.StaticMesh:
+        HEX = core.StaticMesh.HEXAHEDRON
+        TET = core.StaticMesh.TETRAHEDRON
+        PSM = core.StaticMesh.PRISM
+        PYR = core.StaticMesh.PYRAMID
+
+        mh = core.StaticMesh(ndim=3, nnode=11, nface=0, ncell=4)
+        mh.ndcrd.ndarray[:, :] = [
+            (0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0),
+            (0, 0, 1), (1, 0, 1), (1, 1, 1), (0, 1, 1),
+            (0.5, 1.5, 0.5),
+            (1.5, 1, 0.5), (1.5, 0, 0.5),
+        ]
+        mh.cltpn.ndarray[:] = [
+            HEX, PYR, TET, PSM,
+        ]
+        mh.clnds.ndarray[:, :9] = [
+            (8, 0, 1, 2, 3, 4, 5, 6, 7), (5, 2, 3, 7, 6, 8, -1, -1, -1),
+            (4, 2, 6, 9, 8, -1, -1, -1, -1), (6, 2, 6, 9, 1, 5, 10, -1, -1),
+        ]
+        mh.build_interior()
+        mh.build_boundary()
+        mh.build_ghost()
+
+        return mh
+
+    def run(self):
+        mh = self._create_mesh()
+
+        # Open a sub window for triangles and quadrilaterals:
+        w_3dmix = self._mgr.add3DWidget()
+        w_3dmix.updateMesh(mh)
+        w_3dmix.showMark()
+        self._mgr.pycon.writeToHistory(f"3dmix nedge: {mh.nedge}\n")
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/pilot/_mesh.py
+++ b/modmesh/pilot/_mesh.py
@@ -441,6 +441,8 @@ class RectangularDomain(PilotFeature):
 
     def _create_world(self) -> core.WorldFp64:
         w = core.WorldFp64()
+        for pt in self.points:
+            w.add_vertex(pt[0], pt[1], 0.0)
         for ed in self.edges:
             p0 = self.points[ed[0]]
             p1 = self.points[ed[1]]


### PR DESCRIPTION
Split `RWorld` into `RVertices` and `RLines` to draw both lines and vertices in the Qt3D scene.

This is preparatory work for prototyping Delaunay triangulation for 2D mesh generation.  I need more GUI enhancements to help study the prototype.