### PR TITLE
Make point and segment containers available in `World`

### DIFF
--- a/cpp/modmesh/pilot/RWorld.cpp
+++ b/cpp/modmesh/pilot/RWorld.cpp
@@ -159,14 +159,14 @@ RLines::RLines(std::shared_ptr<WorldFp64> const & world, Qt3DCore::QNode * paren
                 size_t ipt = 0;
                 for (size_t i = 0; i < world->nsegment(); ++i)
                 {
-                    Segment3dFp64 const & e = world->segment(i);
-                    sarr(ipt, 0) = e.v0()[0];
-                    sarr(ipt, 1) = e.v0()[1];
-                    sarr(ipt, 2) = e.v0()[2];
+                    Segment3dFp64 const & s = world->segment(i);
+                    sarr(ipt, 0) = s.p0()[0];
+                    sarr(ipt, 1) = s.p0()[1];
+                    sarr(ipt, 2) = s.p0()[2];
                     ++ipt;
-                    sarr(ipt, 0) = e.v1()[0];
-                    sarr(ipt, 1) = e.v1()[1];
-                    sarr(ipt, 2) = e.v1()[2];
+                    sarr(ipt, 0) = s.p1()[0];
+                    sarr(ipt, 1) = s.p1()[1];
+                    sarr(ipt, 2) = s.p1()[2];
                     ++ipt;
                 }
                 for (size_t i = 0; i < world->nbezier(); ++i)

--- a/cpp/modmesh/pilot/RWorld.cpp
+++ b/cpp/modmesh/pilot/RWorld.cpp
@@ -42,7 +42,7 @@ RVertices::RVertices(std::shared_ptr<WorldFp64> const & world, Qt3DCore::QNode *
     , m_renderer(new Qt3DRender::QGeometryRenderer())
     , m_material(new Qt3DExtras::QDiffuseSpecularMaterial())
 {
-    size_t const npoint = world->nvertex();
+    size_t const npoint = world->npoint();
 
     if (npoint > 0)
     {
@@ -60,9 +60,9 @@ RVertices::RVertices(std::shared_ptr<WorldFp64> const & world, Qt3DCore::QNode *
                 QByteArray barray;
                 barray.resize(npoint * 3 * sizeof(float));
                 SimpleArray<float> sarr = makeSimpleArray<float>(barray, small_vector<size_t>{npoint, 3}, /*view*/ true);
-                for (size_t i = 0; i < world->nvertex(); ++i)
+                for (size_t i = 0; i < world->npoint(); ++i)
                 {
-                    Point3dFp64 const & v = world->vertex(i);
+                    Point3dFp64 const & v = world->point(i);
                     sarr(i, 0) = v[0];
                     sarr(i, 1) = v[1];
                     sarr(i, 2) = v[2];
@@ -88,7 +88,7 @@ RVertices::RVertices(std::shared_ptr<WorldFp64> const & world, Qt3DCore::QNode *
                 QByteArray barray;
                 barray.resize(npoint * sizeof(uint32_t));
                 SimpleArray<uint32_t> sarr = makeSimpleArray<uint32_t>(barray, small_vector<size_t>{npoint}, /*view*/ true);
-                for (size_t i = 0; i < world->nvertex(); ++i)
+                for (size_t i = 0; i < world->npoint(); ++i)
                 {
                     sarr(i) = i;
                 }

--- a/cpp/modmesh/universe/World.hpp
+++ b/cpp/modmesh/universe/World.hpp
@@ -54,12 +54,10 @@ private:
 
 public:
 
-    // TODO: rename vertex as point
     using real_type = T;
     using value_type = T;
     using size_type = typename NumberBase<int32_t, T>::size_type;
-    using vector_type = Point3d<T>;
-    using vertex_type = vector_type;
+    using point_type = Point3d<T>;
     using segment_type = Segment3d<T>;
     using bezier_type = Bezier3d<T>;
 
@@ -73,7 +71,7 @@ public:
     }
 
     explicit World(ctor_passkey const &)
-        : m_vertices(point_pad_type::construct(/* ndim */ 3))
+        : m_points(point_pad_type::construct(/* ndim */ 3))
         , m_segments(segment_pad_type::construct(/* ndim */ 3))
     {
     }
@@ -85,20 +83,26 @@ public:
     World & operator=(World &&) = delete;
     ~World() = default;
 
-    void add_vertex(vertex_type const & vertex);
-    void add_vertex(value_type x, value_type y, value_type z)
+    void add_point(point_type const & vertex)
     {
-        add_vertex(vertex_type(x, y, z));
+        m_points->append(vertex);
     }
-    size_t nvertex() const { return m_vertices->size(); }
-    vertex_type vertex(size_t i) const { return m_vertices->get(i); }
-    vertex_type vertex_at(size_t i) const
+    void add_point(value_type x, value_type y, value_type z)
     {
-        check_size(i, m_vertices->size(), "vertex");
-        return m_vertices->get(i);
+        add_point(point_type(x, y, z));
+    }
+    size_t npoint() const { return m_points->size(); }
+    point_type point(size_t i) const { return m_points->get(i); }
+    point_type point_at(size_t i) const
+    {
+        check_size(i, m_points->size(), "point");
+        return m_points->get(i);
     }
 
-    void add_segment(segment_type const & segment);
+    void add_segment(segment_type const & segment)
+    {
+        m_segments->append(segment);
+    }
     void add_segment(value_type x0, value_type y0, value_type z0, value_type x1, value_type y1, value_type z1)
     {
         add_segment(segment_type(x0, y0, z0, x1, y1, z1));
@@ -107,11 +111,14 @@ public:
     segment_type segment(size_t i) const { return m_segments->get(i); }
     segment_type segment_at(size_t i) const
     {
-        check_size(i, m_segments->size(), "edge");
+        check_size(i, m_segments->size(), "segment");
         return m_segments->get(i);
     }
 
-    void add_bezier(std::vector<vector_type> const & controls);
+    void add_bezier(std::vector<point_type> const & controls)
+    {
+        m_beziers.emplace_back(controls);
+    }
     size_t nbezier() const { return m_beziers.size(); }
     bezier_type const & bezier(size_t i) const { return m_beziers[i]; }
     bezier_type & bezier(size_t i) { return m_beziers[i]; }
@@ -136,34 +143,11 @@ private:
         }
     }
 
-#if 1
-    std::shared_ptr<point_pad_type> m_vertices;
+    std::shared_ptr<point_pad_type> m_points;
     std::shared_ptr<segment_pad_type> m_segments;
-#else
-    SimpleCollector<vertex_type> m_vertices;
-    std::deque<Segment3d<T>> m_segments;
-#endif
     std::deque<Bezier3d<T>> m_beziers;
 
 }; /* end class World */
-
-template <typename T>
-void World<T>::add_vertex(vertex_type const & vertex)
-{
-    m_vertices->append(vertex);
-}
-
-template <typename T>
-void World<T>::add_segment(segment_type const & segment)
-{
-    m_segments->append(segment);
-}
-
-template <typename T>
-void World<T>::add_bezier(std::vector<vector_type> const & controls)
-{
-    m_beziers.emplace_back(controls);
-}
 
 using WorldFp32 = World<float>;
 using WorldFp64 = World<double>;

--- a/cpp/modmesh/universe/World.hpp
+++ b/cpp/modmesh/universe/World.hpp
@@ -98,6 +98,7 @@ public:
         check_size(i, m_points->size(), "point");
         return m_points->get(i);
     }
+    std::shared_ptr<point_pad_type> points() { return m_points; }
 
     void add_segment(segment_type const & segment)
     {
@@ -114,6 +115,7 @@ public:
         check_size(i, m_segments->size(), "segment");
         return m_segments->get(i);
     }
+    std::shared_ptr<segment_pad_type> segments() { return m_segments; }
 
     void add_bezier(std::vector<point_type> const & controls)
     {

--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -598,14 +598,7 @@ public:
         : m_p0(point_pad_type::construct(x0, y0, clone))
         , m_p1(point_pad_type::construct(x1, y1, clone))
     {
-        if (m_p0->size() != m_p1->size())
-        {
-            throw std::invalid_argument(
-                Formatter()
-                << "SegmentPad::SegmentPad: "
-                << "m_p0->size() " << m_p0->size() << " m_p1->size() " << m_p1->size()
-                << " are not the same");
-        }
+        check_constructor_point_size(*m_p0, *m_p1);
     }
 
     SegmentPad(
@@ -620,14 +613,7 @@ public:
         : m_p0(point_pad_type::construct(x0, y0, z0, clone))
         , m_p1(point_pad_type::construct(x1, y1, z1, clone))
     {
-        if (m_p0->size() != m_p1->size())
-        {
-            throw std::invalid_argument(
-                Formatter()
-                << "SegmentPad::SegmentPad: "
-                << "m_p0->size() " << m_p0->size() << " m_p1->size() " << m_p1->size()
-                << " are not the same");
-        }
+        check_constructor_point_size(*m_p0, *m_p1);
     }
 
     SegmentPad() = delete;
@@ -852,6 +838,18 @@ public:
     }
 
 private:
+
+    void check_constructor_point_size(point_pad_type const & p0, point_pad_type const & p1)
+    {
+        if (m_p0->size() != m_p1->size())
+        {
+            throw std::invalid_argument(
+                Formatter()
+                << "SegmentPad::SegmentPad: "
+                << "p0.size() " << p0.size() << " p1.size() " << p1.size()
+                << " are not the same");
+        }
+    }
 
     std::shared_ptr<point_pad_type> m_p0;
     std::shared_ptr<point_pad_type> m_p1;

--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -425,6 +425,25 @@ private:
 using PointPadFp32 = PointPad<float>;
 using PointPadFp64 = PointPad<double>;
 
+namespace detail
+{
+
+template <typename T>
+struct Segment3dNamed
+{
+    T x0, y0, z0, x1, y1, z1;
+}; /* end struct Segment3dNamed */
+
+template <typename T>
+union Segment3dData
+{
+    Point3d<T> p[2];
+    T v[6];
+    Segment3dNamed<T> f;
+}; /* end union Segment3dData */
+
+} /* end namespace detail */
+
 /**
  * Segment in three-dimensional space.
  *
@@ -441,12 +460,12 @@ public:
     using value_type = typename point_type::value_type;
 
     Segment3d(point_type const & v0, point_type const & v1)
-        : m_vec{v0, v1}
+        : m_data{v0, v1}
     {
     }
 
     Segment3d(value_type x0, value_type y0, value_type z0, value_type x1, value_type y1, value_type z1)
-        : m_vec{point_type{x0, y0, z0}, point_type{x1, y1, z1}}
+        : m_data{point_type{x0, y0, z0}, point_type{x1, y1, z1}}
     {
     }
 
@@ -457,50 +476,49 @@ public:
     Segment3d & operator=(Segment3d &&) = default;
     ~Segment3d() = default;
 
-    // TODO: rename v0, v1 to p0, p1
-    point_type const & v0() const { return m_vec[0]; }
-    point_type & v0() { return m_vec[0]; }
-    void set_v0(point_type const & v) { m_vec[0] = v; }
-    point_type const & v1() const { return m_vec[1]; }
-    point_type & v1() { return m_vec[1]; }
-    void set_v1(point_type const & v) { m_vec[1] = v; }
+    point_type const & p0() const { return m_data.p[0]; }
+    point_type & p0() { return m_data.p[0]; }
+    void set_p0(point_type const & v) { m_data.p[0] = v; }
+    point_type const & p1() const { return m_data.p[1]; }
+    point_type & p1() { return m_data.p[1]; }
+    void set_p1(point_type const & v) { m_data.p[1] = v; }
 
-    value_type x0() const { return m_vec[0].x(); }
-    value_type & x0() { return m_vec[0].x(); }
-    void set_x0(value_type v) { m_vec[0].set_x(v); }
+    value_type x0() const { return m_data.p[0].x(); }
+    value_type & x0() { return m_data.p[0].x(); }
+    void set_x0(value_type v) { m_data.p[0].set_x(v); }
 
-    value_type y0() const { return m_vec[0].y(); }
-    value_type & y0() { return m_vec[0].y(); }
-    void set_y0(value_type v) { m_vec[0].set_y(v); }
+    value_type y0() const { return m_data.p[0].y(); }
+    value_type & y0() { return m_data.p[0].y(); }
+    void set_y0(value_type v) { m_data.p[0].set_y(v); }
 
-    value_type z0() const { return m_vec[0].z(); }
-    value_type & z0() { return m_vec[0].z(); }
-    void set_z0(value_type v) { m_vec[0].set_z(v); }
+    value_type z0() const { return m_data.p[0].z(); }
+    value_type & z0() { return m_data.p[0].z(); }
+    void set_z0(value_type v) { m_data.p[0].set_z(v); }
 
-    value_type x1() const { return m_vec[1].x(); }
-    value_type & x1() { return m_vec[1].x(); }
-    void set_x1(value_type v) { m_vec[1].set_x(v); }
+    value_type x1() const { return m_data.p[1].x(); }
+    value_type & x1() { return m_data.p[1].x(); }
+    void set_x1(value_type v) { m_data.p[1].set_x(v); }
 
-    value_type y1() const { return m_vec[1].y(); }
-    value_type & y1() { return m_vec[1].y(); }
-    void set_y1(value_type v) { m_vec[1].set_y(v); }
+    value_type y1() const { return m_data.p[1].y(); }
+    value_type & y1() { return m_data.p[1].y(); }
+    void set_y1(value_type v) { m_data.p[1].set_y(v); }
 
-    value_type z1() const { return m_vec[1].z(); }
-    value_type & z1() { return m_vec[1].z(); }
-    void set_z1(value_type v) { m_vec[1].set_z(v); }
+    value_type z1() const { return m_data.p[1].z(); }
+    value_type & z1() { return m_data.p[1].z(); }
+    void set_z1(value_type v) { m_data.p[1].set_z(v); }
 
-    point_type const & operator[](size_t i) const { return m_vec[i]; }
-    point_type & operator[](size_t i) { return m_vec[i]; }
+    point_type const & operator[](size_t i) const { return m_data.p[i]; }
+    point_type & operator[](size_t i) { return m_data.p[i]; }
 
     point_type const & at(size_t i) const
     {
         check_size(i, 2);
-        return m_vec[i];
+        return m_data.p[i];
     }
     point_type & at(size_t i)
     {
         check_size(i, 2);
-        return m_vec[i];
+        return m_data.p[i];
     }
 
     size_t size() const { return 2; }
@@ -515,8 +533,7 @@ private:
         }
     }
 
-    // TODO: rename to m_p0, m_p1 and union
-    point_type m_vec[2];
+    detail::Segment3dData<T> m_data;
 
 }; /* end class Segment3d */
 

--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -264,6 +264,16 @@ public:
 
     ~PointPad() = default;
 
+    void append(point_type const & point)
+    {
+        m_x.push_back(point.x());
+        m_y.push_back(point.y());
+        if (m_ndim == 3)
+        {
+            m_z.push_back(point.z());
+        }
+    }
+
     void append(T x, T y)
     {
         if (m_ndim != 2)
@@ -627,6 +637,12 @@ public:
     SegmentPad & operator=(SegmentPad &&) = delete;
 
     ~SegmentPad() = default;
+
+    void append(segment_type const & s)
+    {
+        m_p0->append(s.x0(), s.y0(), s.z0());
+        m_p1->append(s.x1(), s.y1(), s.z1());
+    }
 
     void append(T x0, T y0, T x1, T y1)
     {

--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -159,7 +159,14 @@ using Point3dFp64 = Point3d<double>;
 template <typename T>
 class PointPad
     : public NumberBase<int32_t, T>
+    , public std::enable_shared_from_this<PointPad<T>>
 {
+
+private:
+
+    struct ctor_passkey
+    {
+    };
 
 public:
 
@@ -167,9 +174,13 @@ public:
     using value_type = T;
     using point_type = Point3d<T>;
 
-    PointPad() = delete;
+    template <typename... Args>
+    static std::shared_ptr<PointPad<T>> construct(Args &&... args)
+    {
+        return std::make_shared<PointPad<T>>(std::forward<Args>(args)..., ctor_passkey());
+    }
 
-    PointPad(uint8_t ndim)
+    PointPad(uint8_t ndim, ctor_passkey const &)
         : m_ndim(ndim)
     {
         if (ndim > 3)
@@ -188,7 +199,7 @@ public:
         }
     }
 
-    PointPad(uint8_t ndim, size_t nelem)
+    PointPad(uint8_t ndim, size_t nelem, ctor_passkey const &)
         : m_ndim(ndim)
         , m_x(nelem)
         , m_y(nelem)
@@ -214,7 +225,7 @@ public:
         }
     }
 
-    PointPad(SimpleArray<T> & x, SimpleArray<T> & y, bool clone)
+    PointPad(SimpleArray<T> & x, SimpleArray<T> & y, bool clone, ctor_passkey const &)
         : m_ndim(2)
         , m_x(x, clone)
         , m_y(y, clone)
@@ -229,7 +240,7 @@ public:
         }
     }
 
-    PointPad(SimpleArray<T> & x, SimpleArray<T> & y, SimpleArray<T> & z, bool clone)
+    PointPad(SimpleArray<T> & x, SimpleArray<T> & y, SimpleArray<T> & z, bool clone, ctor_passkey const &)
         : m_ndim(3)
         , m_x(x, clone)
         , m_y(y, clone)
@@ -245,10 +256,11 @@ public:
         }
     }
 
-    PointPad(PointPad const &) = default;
-    PointPad(PointPad &&) = default;
-    PointPad & operator=(PointPad const &) = default;
-    PointPad & operator=(PointPad &&) = default;
+    PointPad() = delete;
+    PointPad(PointPad const &) = delete;
+    PointPad(PointPad &&) = delete;
+    PointPad & operator=(PointPad const &) = delete;
+    PointPad & operator=(PointPad &&) = delete;
 
     ~PointPad() = default;
 

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -283,8 +283,8 @@ WrapSegment3d<T>::WrapSegment3d(pybind11::module & mod, const char * pyname, con
 
     (*this)
         .def(py::init<point_type const &, point_type const &>(),
-             py::arg("v0"),
-             py::arg("v1"))
+             py::arg("p0"),
+             py::arg("p1"))
         .def(py::init<value_type, value_type, value_type, value_type, value_type, value_type>(),
              py::arg("x0"),
              py::arg("y0"),
@@ -327,8 +327,8 @@ WrapSegment3d<T>::WrapSegment3d(pybind11::module & mod, const char * pyname, con
         { self.NAME() = v; })
     // clang-format off
     (*this)
-        DECL_WRAP(v0)
-        DECL_WRAP(v1)
+        DECL_WRAP(p0)
+        DECL_WRAP(p1)
         ;
 #undef DECL_WRAP
     // clang-format on

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -632,8 +632,7 @@ public:
     using wrapped_type = typename base_type::wrapped_type;
 
     using value_type = typename wrapped_type::value_type;
-    using vector_type = typename wrapped_type::vector_type;
-    using vertex_type = typename wrapped_type::vertex_type;
+    using point_type = typename wrapped_type::point_type;
     using segment_type = typename wrapped_type::segment_type;
     using bezier_type = typename wrapped_type::bezier_type;
 
@@ -662,29 +661,29 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
     // Bezier curves
     (*this)
         .def(
-            "add_vertex",
-            [](wrapped_type & self, vertex_type const & vertex)
+            "add_point",
+            [](wrapped_type & self, point_type const & point)
             {
-                self.add_vertex(vertex);
-                return self.vertex_at(self.nvertex() - 1);
+                self.add_point(point);
+                return self.point_at(self.npoint() - 1);
             },
-            py::arg("vertex"))
+            py::arg("point"))
         .def(
-            "add_vertex",
+            "add_point",
             [](wrapped_type & self, value_type x, value_type y, value_type z)
             {
-                self.add_vertex(x, y, z);
-                return self.vertex_at(self.nvertex() - 1);
+                self.add_point(x, y, z);
+                return self.point_at(self.npoint() - 1);
             },
             py::arg("x"),
             py::arg("y"),
             py::arg("z"))
-        .def_property_readonly("nvertex", &wrapped_type::nvertex)
+        .def_property_readonly("npoint", &wrapped_type::npoint)
         .def(
-            "vertex",
+            "point",
             [](wrapped_type & self, size_t i)
             {
-                return self.vertex_at(i);
+                return self.point_at(i);
             })
         .def(
             "add_segment",
@@ -709,14 +708,14 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
             py::arg("z1"))
         .def_property_readonly("nsegment", &wrapped_type::nsegment)
         .def(
-            "edge",
+            "segment",
             [](wrapped_type & self, size_t i)
             {
                 return self.segment_at(i);
             })
         .def(
             "add_bezier",
-            [](wrapped_type & self, std::vector<typename wrapped_type::vector_type> const & controls) -> auto &
+            [](wrapped_type & self, std::vector<typename wrapped_type::point_type> const & controls) -> auto &
             {
                 self.add_bezier(controls);
                 return self.bezier_at(self.nbezier() - 1);

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -679,12 +679,8 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
             py::arg("y"),
             py::arg("z"))
         .def_property_readonly("npoint", &wrapped_type::npoint)
-        .def(
-            "point",
-            [](wrapped_type & self, size_t i)
-            {
-                return self.point_at(i);
-            })
+        .def("point", &wrapped_type::point_at)
+        .def_property_readonly("points", &wrapped_type::points)
         .def(
             "add_segment",
             [](wrapped_type & self, segment_type const & edge)
@@ -692,7 +688,7 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
                 self.add_segment(edge);
                 return self.segment_at(self.nsegment() - 1);
             },
-            py::arg("edge"))
+            py::arg("segment"))
         .def(
             "add_segment",
             [](wrapped_type & self, value_type x0, value_type y0, value_type z0, value_type x1, value_type y1, value_type z1)
@@ -707,12 +703,8 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
             py::arg("y1"),
             py::arg("z1"))
         .def_property_readonly("nsegment", &wrapped_type::nsegment)
-        .def(
-            "segment",
-            [](wrapped_type & self, size_t i)
-            {
-                return self.segment_at(i);
-            })
+        .def("segment", &wrapped_type::segment_at)
+        .def_property_readonly("segments", &wrapped_type::segments)
         .def(
             "add_bezier",
             [](wrapped_type & self, std::vector<typename wrapped_type::point_type> const & controls) -> auto &

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -118,12 +118,12 @@ WrapPoint3d<T>::WrapPoint3d(pybind11::module & mod, const char * pyname, const c
 
 template <typename T>
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapPointPad
-    : public WrapBase<WrapPointPad<T>, PointPad<T>>
+    : public WrapBase<WrapPointPad<T>, PointPad<T>, std::shared_ptr<PointPad<T>>>
 {
 
 public:
 
-    using base_type = WrapBase<WrapPointPad<T>, PointPad<T>>;
+    using base_type = WrapBase<WrapPointPad<T>, PointPad<T>, std::shared_ptr<PointPad<T>>>;
     using wrapped_type = typename base_type::wrapped_type;
 
     using value_type = typename base_type::wrapped_type::value_type;
@@ -145,17 +145,32 @@ WrapPointPad<T>::WrapPointPad(pybind11::module & mod, const char * pyname, const
 
     // Constructors
     (*this)
-        .def(py::init<uint8_t>(), py::arg("ndim"))
-        .def_timed(py::init<uint8_t, size_t>(), py::arg("ndim"), py::arg("nelem"))
-        .def_timed(py::init<SimpleArray<T> &, SimpleArray<T> &, bool>(),
-                   py::arg("x"),
-                   py::arg("y"),
-                   py::arg("clone"))
-        .def_timed(py::init<SimpleArray<T> &, SimpleArray<T> &, SimpleArray<T> &, bool>(),
-                   py::arg("x"),
-                   py::arg("y"),
-                   py::arg("z"),
-                   py::arg("clone"))
+        .def(
+            py::init(
+                [](uint8_t ndim)
+                { return wrapped_type::construct(ndim); }),
+            py::arg("ndim"))
+        .def(
+            py::init(
+                [](uint8_t ndim, size_t nelem)
+                { return wrapped_type::construct(ndim, nelem); }),
+            py::arg("ndim"),
+            py::arg("nelem"))
+        .def(
+            py::init(
+                [](SimpleArray<T> & x, SimpleArray<T> & y, bool clone)
+                { return wrapped_type::construct(x, y, clone); }),
+            py::arg("x"),
+            py::arg("y"),
+            py::arg("clone"))
+        .def(
+            py::init(
+                [](SimpleArray<T> & x, SimpleArray<T> & y, SimpleArray<T> & z, bool clone)
+                { return wrapped_type::construct(x, y, z, clone); }),
+            py::arg("x"),
+            py::arg("y"),
+            py::arg("z"),
+            py::arg("clone"))
         //
         ;
 

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -663,44 +663,40 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
     (*this)
         .def(
             "add_vertex",
-            [](wrapped_type & self, vertex_type const & vertex) -> auto &
+            [](wrapped_type & self, vertex_type const & vertex)
             {
                 self.add_vertex(vertex);
                 return self.vertex_at(self.nvertex() - 1);
             },
-            py::arg("vertex"),
-            py::return_value_policy::reference_internal)
+            py::arg("vertex"))
         .def(
             "add_vertex",
-            [](wrapped_type & self, value_type x, value_type y, value_type z) -> auto &
+            [](wrapped_type & self, value_type x, value_type y, value_type z)
             {
                 self.add_vertex(x, y, z);
                 return self.vertex_at(self.nvertex() - 1);
             },
             py::arg("x"),
             py::arg("y"),
-            py::arg("z"),
-            py::return_value_policy::reference_internal)
+            py::arg("z"))
         .def_property_readonly("nvertex", &wrapped_type::nvertex)
         .def(
             "vertex",
-            [](wrapped_type & self, size_t i) -> auto &
+            [](wrapped_type & self, size_t i)
             {
                 return self.vertex_at(i);
-            },
-            py::return_value_policy::reference_internal)
+            })
         .def(
             "add_segment",
-            [](wrapped_type & self, segment_type const & edge) -> auto &
+            [](wrapped_type & self, segment_type const & edge)
             {
                 self.add_segment(edge);
                 return self.segment_at(self.nsegment() - 1);
             },
-            py::arg("edge"),
-            py::return_value_policy::reference_internal)
+            py::arg("edge"))
         .def(
             "add_segment",
-            [](wrapped_type & self, value_type x0, value_type y0, value_type z0, value_type x1, value_type y1, value_type z1) -> auto &
+            [](wrapped_type & self, value_type x0, value_type y0, value_type z0, value_type x1, value_type y1, value_type z1)
             {
                 self.add_segment(x0, y0, z0, x1, y1, z1);
                 return self.segment_at(self.nsegment() - 1);
@@ -710,16 +706,14 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
             py::arg("z0"),
             py::arg("x1"),
             py::arg("y1"),
-            py::arg("z1"),
-            py::return_value_policy::reference_internal)
+            py::arg("z1"))
         .def_property_readonly("nsegment", &wrapped_type::nsegment)
         .def(
             "edge",
-            [](wrapped_type & self, size_t i) -> auto &
+            [](wrapped_type & self, size_t i)
             {
                 return self.segment_at(i);
-            },
-            py::return_value_policy::reference_internal)
+            })
         .def(
             "add_bezier",
             [](wrapped_type & self, std::vector<typename wrapped_type::vector_type> const & controls) -> auto &

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -134,8 +134,7 @@ public:
 protected:
 
     WrapPointPad(pybind11::module & mod, char const * pyname, char const * pydoc);
-};
-/* end class WrapPointPad */
+}; /* end class WrapPointPad */
 
 template <typename T>
 WrapPointPad<T>::WrapPointPad(pybind11::module & mod, const char * pyname, const char * pydoc)
@@ -351,6 +350,183 @@ WrapSegment3d<T>::WrapSegment3d(pybind11::module & mod, const char * pyname, con
        DECL_WRAP(y1)
        DECL_WRAP(z1)
        ;
+#undef DECL_WRAP
+    // clang-format on
+}
+
+template <typename T>
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSegmentPad
+    : public WrapBase<WrapSegmentPad<T>, SegmentPad<T>, std::shared_ptr<SegmentPad<T>>>
+{
+
+public:
+
+    using base_type = WrapBase<WrapSegmentPad<T>, SegmentPad<T>, std::shared_ptr<SegmentPad<T>>>;
+    using wrapped_type = typename base_type::wrapped_type;
+
+    using value_type = typename base_type::wrapped_type::value_type;
+    using point_type = typename base_type::wrapped_type::point_type;
+    using segment_type = typename base_type::wrapped_type::segment_type;
+    using point_pad_type = typename base_type::wrapped_type::point_pad_type;
+
+    friend typename base_type::root_base_type;
+
+protected:
+
+    WrapSegmentPad(pybind11::module & mod, char const * pyname, char const * pydoc);
+}; /* end class WrapSegmentPad */
+
+template <typename T>
+WrapSegmentPad<T>::WrapSegmentPad(pybind11::module & mod, const char * pyname, const char * pydoc)
+    : base_type(mod, pyname, pydoc)
+{
+    namespace py = pybind11;
+
+    // Constructors
+    (*this)
+        .def(
+            py::init(
+                [](uint8_t ndim)
+                { return wrapped_type::construct(ndim); }),
+            py::arg("ndim"))
+        .def(
+            py::init(
+                [](uint8_t ndim, size_t nelem)
+                { return wrapped_type::construct(ndim, nelem); }),
+            py::arg("ndim"),
+            py::arg("nelem"))
+        .def(
+            py::init(
+                [](
+                    SimpleArray<T> & x0,
+                    SimpleArray<T> & y0,
+                    SimpleArray<T> & x1,
+                    SimpleArray<T> & y1,
+                    bool clone)
+                { return wrapped_type::construct(x0, y0, x1, y1, clone); }),
+            py::arg("x0"),
+            py::arg("y0"),
+            py::arg("x1"),
+            py::arg("y1"),
+            py::arg("clone"))
+        .def(
+            py::init(
+                [](
+                    SimpleArray<T> & x0,
+                    SimpleArray<T> & y0,
+                    SimpleArray<T> & z0,
+                    SimpleArray<T> & x1,
+                    SimpleArray<T> & y1,
+                    SimpleArray<T> & z1,
+                    bool clone)
+                { return wrapped_type::construct(x0, y0, z0, x1, y1, z1, clone); }),
+            py::arg("x0"),
+            py::arg("y0"),
+            py::arg("z0"),
+            py::arg("x1"),
+            py::arg("y1"),
+            py::arg("z1"),
+            py::arg("clone"))
+        //
+        ;
+
+    (*this)
+        .def_property_readonly("ndim", &wrapped_type::ndim)
+        .def(
+            "append",
+            [](wrapped_type & self, value_type x0, value_type y0, value_type x1, value_type y1)
+            {
+                self.append(x0, y0, x1, y1);
+            },
+            py::arg("x0"),
+            py::arg("y0"),
+            py::arg("x1"),
+            py::arg("y1"))
+        .def(
+            "append",
+            [](wrapped_type & self, value_type x0, value_type y0, value_type z0, value_type x1, value_type y1, value_type z1)
+            {
+                self.append(x0, y0, z0, x1, y1, z1);
+            },
+            py::arg("x0"),
+            py::arg("y0"),
+            py::arg("z0"),
+            py::arg("x1"),
+            py::arg("y1"),
+            py::arg("z1"))
+        .def_timed("pack_array", &wrapped_type::pack_array)
+        .def_timed("expand", &wrapped_type::expand, py::arg("length"))
+        .def("__len__", &wrapped_type::size)
+        .def("__getitem__",
+             [](wrapped_type const & self, size_t it)
+             {
+                 return self.get_at(it);
+             })
+        .def("get_at",
+             [](wrapped_type const & self, size_t it)
+             {
+                 return self.get_at(it);
+             })
+        .def("set_at",
+             [](wrapped_type & self, size_t it, segment_type const & s)
+             {
+                 self.set_at(it, s);
+             })
+        .def("set_at",
+             [](wrapped_type & self, size_t it, point_type const & p0, point_type const & p1)
+             {
+                 self.set_at(it, p0, p1);
+             })
+        .def("set_at",
+             [](wrapped_type & self, size_t it, value_type x0, value_type y0, value_type x1, value_type y1)
+             {
+                 self.set_at(it, x0, y0, x1, y1);
+             })
+        .def("set_at",
+             [](wrapped_type & self, size_t it, value_type x0, value_type y0, value_type z0, value_type x1, value_type y1, value_type z1)
+             {
+                 self.set_at(it, x0, y0, z0, x1, y1, z1);
+             })
+        //
+        ;
+
+    // x, y, z, point element accessors.
+#define DECL_WRAP(NAME)                         \
+    .def(                                       \
+        #NAME,                                  \
+        [](wrapped_type const & self, size_t i) \
+        { return self.NAME(i); })
+    // clang-format off
+    (*this)
+        DECL_WRAP(x0_at)
+        DECL_WRAP(y0_at)
+        DECL_WRAP(z0_at)
+        DECL_WRAP(x1_at)
+        DECL_WRAP(y1_at)
+        DECL_WRAP(z1_at)
+        DECL_WRAP(p0_at)
+        DECL_WRAP(p1_at)
+        ;
+#undef DECL_WRAP
+    // clang-format on
+
+    // x, y, z, point array/batch accessors.
+#define DECL_WRAP(NAME)         \
+    .def_property_readonly(     \
+        #NAME,                  \
+        [](wrapped_type & self) \
+        { return self.NAME(); })
+    // clang-format off
+    (*this)
+        DECL_WRAP(x0)
+        DECL_WRAP(y0)
+        DECL_WRAP(z0)
+        DECL_WRAP(x1)
+        DECL_WRAP(y1)
+        DECL_WRAP(z1)
+        DECL_WRAP(p0)
+        DECL_WRAP(p1)
+        ;
 #undef DECL_WRAP
     // clang-format on
 }
@@ -573,6 +749,8 @@ void wrap_World(pybind11::module & mod)
     WrapPointPad<double>::commit(mod, "PointPadFp64", "PointPadFp64");
     WrapSegment3d<float>::commit(mod, "Segment3dFp32", "Segment3dFp32");
     WrapSegment3d<double>::commit(mod, "Segment3dFp64", "Segment3dFp64");
+    WrapSegmentPad<float>::commit(mod, "SegmentPadFp32", "SegmentPadFp32");
+    WrapSegmentPad<double>::commit(mod, "SegmentPadFp64", "SegmentPadFp64");
     WrapBezier3d<float>::commit(mod, "Bezier3dFp32", "Bezier3dFp32");
     WrapBezier3d<double>::commit(mod, "Bezier3dFp64", "Bezier3dFp64");
     WrapWorld<float>::commit(mod, "WorldFp32", "WorldFp32");

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -100,6 +100,8 @@ __all__ = [  # noqa: F822
     'Bezier3dFp64',
     'PointPadFp32',
     'PointPadFp64',
+    'SegmentPadFp32',
+    'SegmentPadFp64',
     'WorldFp32',
     'WorldFp64',
     'testhelper'

--- a/modmesh/pilot/_mesh.py
+++ b/modmesh/pilot/_mesh.py
@@ -442,7 +442,7 @@ class RectangularDomain(PilotFeature):
     def _create_world(self) -> core.WorldFp64:
         w = core.WorldFp64()
         for pt in self.points:
-            w.add_vertex(pt[0], pt[1], 0.0)
+            w.add_point(pt[0], pt[1], 0.0)
         for ed in self.edges:
             p0 = self.points[ed[0]]
             p1 = self.points[ed[1]]

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -617,6 +617,305 @@ class PointPadFp64TC(PointPadTB, unittest.TestCase):
         return super().assert_allclose(*args, **kw)
 
 
+class SegmentPadTB(ModMeshTB):
+
+    def test_ndim(self):
+        sp2d = self.skls(ndim=2)
+        self.assertEqual(sp2d.ndim, 2)
+        sp3d = self.skls(ndim=3)
+        self.assertEqual(sp3d.ndim, 3)
+
+        with self.assertRaisesRegex(
+                ValueError, "PointPad::PointPad: ndim = 0 < 2"):
+            self.skls(ndim=0)
+        with self.assertRaisesRegex(
+                ValueError, "PointPad::PointPad: ndim = 0 < 2"):
+            self.skls(ndim=0, nelem=2)
+        with self.assertRaisesRegex(
+                ValueError, "PointPad::PointPad: ndim = 1 < 2"):
+            self.skls(ndim=1)
+        with self.assertRaisesRegex(
+                ValueError, "PointPad::PointPad: ndim = 1 < 2"):
+            self.skls(ndim=1, nelem=3)
+        with self.assertRaisesRegex(
+                ValueError, "PointPad::PointPad: ndim = 4 > 3"):
+            self.skls(ndim=4)
+        with self.assertRaisesRegex(
+                ValueError, "PointPad::PointPad: ndim = 4 > 3"):
+            self.skls(ndim=4, nelem=5)
+
+    def test_construct_2d(self):
+        x0arr = self.akls(array=np.array([1, 2, 3], dtype=self.dtype))
+        y0arr = self.akls(array=np.array([4, 5, 6], dtype=self.dtype))
+        x1arr = self.akls(array=np.array([-1, -2, -3], dtype=self.dtype))
+        y1arr = self.akls(array=np.array([-4, -5, -6], dtype=self.dtype))
+        sp = self.skls(x0=x0arr, y0=y0arr, x1=x1arr, y1=y1arr, clone=False)
+        self.assertEqual(sp.ndim, 2)
+        self.assert_allclose(sp.x0, [1, 2, 3])
+        self.assert_allclose(sp.y0, [4, 5, 6])
+        self.assert_allclose(sp.x1, [-1, -2, -3])
+        self.assert_allclose(sp.y1, [-4, -5, -6])
+        self.assertEqual(len(sp.z0), 0)
+        self.assertEqual(len(sp.z1), 0)
+
+        # Test zero-copy writing
+        sp.x0[1] = 200.2
+        sp.y0[0] = -700.3
+        sp.x1[1] = -200.2
+        sp.y1[0] = 700.3
+        self.assert_allclose(list(sp[0]), [[1, -700.3, 0], [-1, 700.3, 0]])
+        self.assert_allclose(list(sp[1]), [[200.2, 5, 0], [-200.2, -5, 0]])
+        self.assert_allclose(list(sp[2]), [[3, 6, 0], [-3, -6, 0]])
+
+        sp2 = self.skls(ndim=2, nelem=3)
+        for i in range(len(sp)):
+            sp2.set_at(i, sp.get_at(i).x0, sp.get_at(i).y0,
+                       sp.get_at(i).x1, sp.get_at(i).y1)
+        self.assert_allclose(sp2.x0, [1, 200.2, 3])
+        self.assert_allclose(sp2.y0, [-700.3, 5, 6])
+        self.assert_allclose(sp2.x1, [-1, -200.2, -3])
+        self.assert_allclose(sp2.y1, [700.3, -5, -6])
+        self.assertEqual(len(sp2.z0), 0)
+        self.assertEqual(len(sp2.z1), 0)
+
+        packed = sp2.pack_array().ndarray
+        self.assertEqual(packed.shape, (3, 4))
+        self.assert_allclose(list(packed[0]), (1, -700.3, -1, 700.3))
+        self.assert_allclose(list(packed[1]), (200.2, 5, -200.2, -5))
+        self.assert_allclose(list(packed[2]), (3, 6, -3, -6))
+
+    def test_construct_3d(self):
+        x0arr = self.akls(array=np.array([1, 2, 3], dtype=self.dtype))
+        y0arr = self.akls(array=np.array([4, 5, 6], dtype=self.dtype))
+        z0arr = self.akls(array=np.array([7, 8, 9], dtype=self.dtype))
+        x1arr = self.akls(array=np.array([-1, -2, -3], dtype=self.dtype))
+        y1arr = self.akls(array=np.array([-4, -5, -6], dtype=self.dtype))
+        z1arr = self.akls(array=np.array([-7, -8, -9], dtype=self.dtype))
+        sp = self.skls(x0=x0arr, y0=y0arr, z0=z0arr,
+                       x1=x1arr, y1=y1arr, z1=z1arr, clone=False)
+        self.assertEqual(sp.ndim, 3)
+        self.assert_allclose(sp.x0, [1, 2, 3])
+        self.assert_allclose(sp.y0, [4, 5, 6])
+        self.assert_allclose(sp.z0, [7, 8, 9])
+        self.assert_allclose(sp.x1, [-1, -2, -3])
+        self.assert_allclose(sp.y1, [-4, -5, -6])
+        self.assert_allclose(sp.z1, [-7, -8, -9])
+
+        with self.assertRaisesRegex(
+                IndexError,
+                "SimpleCollector: index 3 is out of bounds with size 3"):
+            sp.x0_at(3)
+        with self.assertRaisesRegex(
+                IndexError,
+                "SimpleCollector: index 3 is out of bounds with size 3"):
+            sp.y1_at(3)
+        with self.assertRaisesRegex(
+                IndexError,
+                "SimpleCollector: index 3 is out of bounds with size 3"):
+            sp.z0_at(3)
+        with self.assertRaisesRegex(
+                IndexError,
+                "SimpleCollector: index 3 is out of bounds with size 3"):
+            sp.p0_at(3)
+        with self.assertRaisesRegex(
+                IndexError,
+                "SimpleCollector: index 3 is out of bounds with size 3"):
+            sp.get_at(3)
+        with self.assertRaisesRegex(
+                IndexError,
+                "SimpleCollector: index 3 is out of bounds with size 3"):
+            sp.set_at(3, self.gkls(0, 0, 0, 0, 0, 0))
+
+        # Test zero-copy writing
+        sp.x0[1] = 200.2
+        sp.y0[0] = -700.3
+        sp.z0[2] = 213.9
+        sp.x1[1] = -200.2
+        sp.y1[0] = 700.3
+        sp.z1[2] = -213.9
+        self.assert_allclose(list(sp[0]), [[1, -700.3, 7], [-1, 700.3, -7]])
+        self.assert_allclose(list(sp[1]), [[200.2, 5, 8], [-200.2, -5, -8]])
+        self.assert_allclose(list(sp[2]), [[3, 6, 213.9], [-3, -6, -213.9]])
+
+        sp2 = self.skls(ndim=3, nelem=3)
+        for i in range(len(sp)):
+            sp2.set_at(i, sp.get_at(i).x0, sp.get_at(i).y0, sp.get_at(i).z0,
+                       sp.get_at(i).x1, sp.get_at(i).y1, sp.get_at(i).z1)
+        self.assert_allclose(sp2.x0, [1, 200.2, 3])
+        self.assert_allclose(sp2.y0, [-700.3, 5, 6])
+        self.assert_allclose(sp2.z0, [7, 8, 213.9])
+        self.assert_allclose(sp2.x1, [-1, -200.2, -3])
+        self.assert_allclose(sp2.y1, [700.3, -5, -6])
+        self.assert_allclose(sp2.z1, [-7, -8, -213.9])
+
+        packed = sp2.pack_array().ndarray
+        self.assertEqual(packed.shape, (3, 6))
+        self.assert_allclose(list(packed[0]), (1, -700.3, 7, -1, 700.3, -7))
+        self.assert_allclose(list(packed[1]), (200.2, 5, 8, -200.2, -5, -8))
+        self.assert_allclose(list(packed[2]), (3, 6, 213.9, -3, -6, -213.9))
+
+    def test_append_2d(self):
+        sp = self.skls(ndim=2)
+        self.assertEqual(sp.ndim, 2)
+        self.assertEqual(len(sp), 0)
+        sp.append(1.1, 2.2, 7.1, 8.2)
+        self.assertEqual(len(sp), 1)
+        self.assert_allclose(sp.x0_at(0), 1.1)
+        self.assert_allclose(sp.y0_at(0), 2.2)
+        self.assert_allclose(sp.x1_at(0), 7.1)
+        self.assert_allclose(sp.y1_at(0), 8.2)
+        sp.append(1.1 * 3, 2.2 * 3, 7.1 * 3, 8.2 * 3)
+        self.assertEqual(len(sp), 2)
+        self.assert_allclose(sp.x0_at(1), 1.1 * 3)
+        self.assert_allclose(sp.y0_at(1), 2.2 * 3)
+        self.assert_allclose(sp.x1_at(1), 7.1 * 3)
+        self.assert_allclose(sp.y1_at(1), 8.2 * 3)
+        sp.append(1.1 * 3.1, 2.2 * 3.1, 7.1 * 3.1, 8.2 * 3.1)
+        self.assertEqual(len(sp), 3)
+        self.assert_allclose(sp.x0_at(2), 1.1 * 3.1)
+        self.assert_allclose(sp.y0_at(2), 2.2 * 3.1)
+        self.assert_allclose(sp.x1_at(2), 7.1 * 3.1)
+        self.assert_allclose(sp.y1_at(2), 8.2 * 3.1)
+
+        with self.assertRaisesRegex(
+                IndexError, "PointPad::append: ndim must be 3 but is 2"):
+            sp.append(3.2, 4.1, 5.7, 3.2, 4.1, 5.7)
+        self.assertEqual(len(sp), 3)
+
+        # Test batch interface
+        self.assert_allclose(sp.x0, [1.1, 1.1 * 3, 1.1 * 3.1])
+        self.assert_allclose(sp.y0, [2.2, 2.2 * 3, 2.2 * 3.1])
+        self.assert_allclose(sp.x1, [7.1, 7.1 * 3, 7.1 * 3.1])
+        self.assert_allclose(sp.y1, [8.2, 8.2 * 3, 8.2 * 3.1])
+        sp.x0[0] = -10.9
+        sp.x0.ndarray[2] = -13.2
+        sp.x1[0] = 10.9
+        sp.x1.ndarray[2] = 13.2
+        self.assert_allclose(sp.x0_at(0), -10.9)
+        self.assert_allclose(sp.x0_at(1), 1.1 * 3)
+        self.assert_allclose(sp.x0_at(2), -13.2)
+        self.assert_allclose(sp.x1_at(0), 10.9)
+        self.assert_allclose(sp.x1_at(1), 7.1 * 3)
+        self.assert_allclose(sp.x1_at(2), 13.2)
+        sp.y0[1] = -0.93
+        sp.y0.ndarray[2] = 29.1
+        sp.y1[1] = 0.93
+        sp.y1.ndarray[2] = -29.1
+        self.assert_allclose(sp.y0_at(0), 2.2)
+        self.assert_allclose(sp.y0_at(1), -0.93)
+        self.assert_allclose(sp.y0_at(2), 29.1)
+        self.assert_allclose(sp.y1_at(0), 8.2)
+        self.assert_allclose(sp.y1_at(1), 0.93)
+        self.assert_allclose(sp.y1_at(2), -29.1)
+        self.assertEqual(len(sp.z0), 0)
+        self.assertEqual(len(sp.z1), 0)
+
+    def test_append_3d(self):
+        sp = self.skls(ndim=3)
+        self.assertEqual(sp.ndim, 3)
+        self.assertEqual(len(sp), 0)
+        sp.append(1.1, 2.2, 3.3, 7.1, 8.2, 9.3)
+        self.assertEqual(len(sp), 1)
+        self.assert_allclose(sp.x0_at(0), 1.1)
+        self.assert_allclose(sp.y0_at(0), 2.2)
+        self.assert_allclose(sp.z0_at(0), 3.3)
+        self.assert_allclose(sp.x1_at(0), 7.1)
+        self.assert_allclose(sp.y1_at(0), 8.2)
+        self.assert_allclose(sp.z1_at(0), 9.3)
+        sp.append(1.1 * 5, 2.2 * 5, 3.3 * 5, 7.1 * 5, 8.2 * 5, 9.3 * 5)
+        self.assertEqual(len(sp), 2)
+        self.assert_allclose(sp.x0_at(1), 1.1 * 5)
+        self.assert_allclose(sp.y0_at(1), 2.2 * 5)
+        self.assert_allclose(sp.z0_at(1), 3.3 * 5)
+        self.assert_allclose(sp.x1_at(1), 7.1 * 5)
+        self.assert_allclose(sp.y1_at(1), 8.2 * 5)
+        self.assert_allclose(sp.z1_at(1), 9.3 * 5)
+        sp.append(1.1 * 5.1, 2.2 * 5.1, 3.3 * 5.1, 7.1 * 5.1, 8.2 * 5.1,
+                  9.3 * 5.1)
+        self.assertEqual(len(sp), 3)
+        self.assert_allclose(sp.x0_at(2), 1.1 * 5.1)
+        self.assert_allclose(sp.y0_at(2), 2.2 * 5.1)
+        self.assert_allclose(sp.z0_at(2), 3.3 * 5.1)
+        self.assert_allclose(sp.x1_at(2), 7.1 * 5.1)
+        self.assert_allclose(sp.y1_at(2), 8.2 * 5.1)
+        self.assert_allclose(sp.z1_at(2), 9.3 * 5.1)
+
+        with self.assertRaisesRegex(
+                IndexError, "PointPad::append: ndim must be 2 but is 3"):
+            sp.append(3.2, 4.1, 5.2, 6.2)
+        self.assertEqual(len(sp), 3)
+
+        # Test batch interface
+        self.assert_allclose(sp.x0, [1.1, 1.1 * 5, 1.1 * 5.1])
+        self.assert_allclose(sp.y0, [2.2, 2.2 * 5, 2.2 * 5.1])
+        self.assert_allclose(sp.z0, [3.3, 3.3 * 5, 3.3 * 5.1])
+        self.assert_allclose(sp.x1, [7.1, 7.1 * 5, 7.1 * 5.1])
+        self.assert_allclose(sp.y1, [8.2, 8.2 * 5, 8.2 * 5.1])
+        self.assert_allclose(sp.z1, [9.3, 9.3 * 5, 9.3 * 5.1])
+        sp.x0[0] = -10.9
+        sp.x0.ndarray[2] = -13.2
+        sp.x1[0] = 10.9
+        sp.x1.ndarray[2] = 13.2
+        self.assert_allclose(sp.x0_at(0), -10.9)
+        self.assert_allclose(sp.x0_at(1), 1.1 * 5)
+        self.assert_allclose(sp.x0_at(2), -13.2)
+        self.assert_allclose(sp.x1_at(0), 10.9)
+        self.assert_allclose(sp.x1_at(1), 7.1 * 5)
+        self.assert_allclose(sp.x1_at(2), 13.2)
+        sp.y0[1] = -0.93
+        sp.y0.ndarray[2] = 29.1
+        sp.y1[1] = 0.93
+        sp.y1.ndarray[2] = -29.1
+        self.assert_allclose(sp.y0_at(0), 2.2)
+        self.assert_allclose(sp.y0_at(1), -0.93)
+        self.assert_allclose(sp.y0_at(2), 29.1)
+        self.assert_allclose(sp.y1_at(0), 8.2)
+        self.assert_allclose(sp.y1_at(1), 0.93)
+        self.assert_allclose(sp.y1_at(2), -29.1)
+        sp.z0[0] = 2.31
+        sp.z0.ndarray[1] = 8.23
+        sp.z1[0] = -2.31
+        sp.z1.ndarray[1] = -8.23
+        self.assert_allclose(sp.z0_at(0), 2.31)
+        self.assert_allclose(sp.z0_at(1), 8.23)
+        self.assert_allclose(sp.z0_at(2), 3.3 * 5.1)
+        self.assert_allclose(sp.z1_at(0), -2.31)
+        self.assert_allclose(sp.z1_at(1), -8.23)
+        self.assert_allclose(sp.z1_at(2), 9.3 * 5.1)
+
+
+class SegmentPadFp32TC(SegmentPadTB, unittest.TestCase):
+
+    def setUp(self):
+        self.dtype = 'float32'
+        self.akls = modmesh.SimpleArrayFloat32
+        self.vkls = modmesh.Point3dFp32
+        self.pkls = modmesh.PointPadFp32
+        self.gkls = modmesh.Segment3dFp32
+        self.skls = modmesh.SegmentPadFp32
+
+    def assert_allclose(self, *args, **kw):
+        if 'rtol' not in kw:
+            kw['rtol'] = 1.e-7
+        return super().assert_allclose(*args, **kw)
+
+
+class SegmentPadFp64TC(SegmentPadTB, unittest.TestCase):
+
+    def setUp(self):
+        self.dtype = 'float64'
+        self.akls = modmesh.SimpleArrayFloat64
+        self.vkls = modmesh.Point3dFp64
+        self.pkls = modmesh.PointPadFp64
+        self.gkls = modmesh.Segment3dFp64
+        self.skls = modmesh.SegmentPadFp64
+
+    def assert_allclose(self, *args, **kw):
+        if 'rtol' not in kw:
+            kw['rtol'] = 1.e-15
+        return super().assert_allclose(*args, **kw)
+
+
 class WorldTB(ModMeshTB):
 
     def test_bezier(self):

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -976,7 +976,7 @@ class WorldTB(ModMeshTB):
         v = w.add_vertex(Vector(0, 1, 2))
         self.assertEqual(list(v), [0, 1, 2])
         self.assertEqual(list(w.vertex(0)), [0, 1, 2])
-        self.assertEqual(v, w.vertex(0))
+        self.assertIsNot(v, w.vertex(0))
         self.assertEqual(w.nvertex, 1)
         with self.assertRaisesRegex(
                 IndexError, "World: \\(vertex\\) i 1 >= size 1"):
@@ -986,7 +986,7 @@ class WorldTB(ModMeshTB):
         v = w.add_vertex(3.1415, 3.1416, 3.1417)
         self.assert_allclose(list(v), [3.1415, 3.1416, 3.1417])
         self.assert_allclose(list(w.vertex(1)), [3.1415, 3.1416, 3.1417])
-        self.assertEqual(v, w.vertex(1))
+        self.assertIsNot(v, w.vertex(1))
         self.assertEqual(w.nvertex, 2)
         with self.assertRaisesRegex(
                 IndexError, "World: \\(vertex\\) i 2 >= size 2"):

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -247,33 +247,33 @@ class Point3dFp64TC(Point3dTB, unittest.TestCase):
 class Segment3dTB(ModMeshTB):
 
     def test_construct(self):
-        Vector = self.vkls
-        Edge = self.ekls
+        Point = self.vkls
+        Segment = self.gkls
 
-        e = Edge(x0=0, y0=0, z0=0, x1=1, y1=1, z1=1)
-        self.assertEqual(len(e), 2)
-        self.assertEqual(tuple(e.v0), (0.0, 0.0, 0.0))
-        self.assertEqual(tuple(e.v1), (1.0, 1.0, 1.0))
+        s = Segment(x0=0, y0=0, z0=0, x1=1, y1=1, z1=1)
+        self.assertEqual(len(s), 2)
+        self.assertEqual(tuple(s.p0), (0.0, 0.0, 0.0))
+        self.assertEqual(tuple(s.p1), (1.0, 1.0, 1.0))
 
-        e.v0 = Vector(x=3, y=7, z=0)
-        e.v1 = Vector(x=-1, y=-4, z=9)
-        self.assertEqual(e.x0, 3)
-        self.assertEqual(e.y0, 7)
-        self.assertEqual(e.z0, 0)
-        self.assertEqual(e.x1, -1)
-        self.assertEqual(e.y1, -4)
-        self.assertEqual(e.z1, 9)
+        s.p0 = Point(x=3, y=7, z=0)
+        s.p1 = Point(x=-1, y=-4, z=9)
+        self.assertEqual(s.x0, 3)
+        self.assertEqual(s.y0, 7)
+        self.assertEqual(s.z0, 0)
+        self.assertEqual(s.x1, -1)
+        self.assertEqual(s.y1, -4)
+        self.assertEqual(s.z1, 9)
 
-        e = Edge(Vector(x=3.1, y=7.4, z=0.6), Vector(x=-1.2, y=-4.1, z=9.2))
-        self.assert_allclose(tuple(e.v0), (3.1, 7.4, 0.6))
-        self.assert_allclose(tuple(e.v1), (-1.2, -4.1, 9.2))
+        s = Segment(Point(x=3.1, y=7.4, z=0.6), Point(x=-1.2, y=-4.1, z=9.2))
+        self.assert_allclose(tuple(s.p0), (3.1, 7.4, 0.6))
+        self.assert_allclose(tuple(s.p1), (-1.2, -4.1, 9.2))
 
 
 class Segment3dFp32TC(Segment3dTB, unittest.TestCase):
 
     def setUp(self):
         self.vkls = modmesh.Point3dFp32
-        self.ekls = modmesh.Segment3dFp32
+        self.gkls = modmesh.Segment3dFp32
 
     def assert_allclose(self, *args, **kw):
         if 'rtol' not in kw:
@@ -285,7 +285,7 @@ class Segment3dFp64TC(Segment3dTB, unittest.TestCase):
 
     def setUp(self):
         self.vkls = modmesh.Point3dFp64
-        self.ekls = modmesh.Segment3dFp64
+        self.gkls = modmesh.Segment3dFp64
 
     def assert_allclose(self, *args, **kw):
         if 'rtol' not in kw:

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -997,11 +997,62 @@ class WorldTB(ModMeshTB):
             w.add_point(3.1415 + it, 3.1416 + it, 3.1417 + it)
             self.assertEqual(w.npoint, 2 + it + 1)
 
+        # Array/batch interface
+        pndarr = w.points.pack_array().ndarray
+        self.assertEqual(pndarr.shape, (12, 3))
+        self.assertEqual(w.npoint, 12)
+
+    def test_segment(self):
+        Segment = self.gkls
+        World = self.wkls
+
+        w = World()
+
+        # Empty
+        self.assertEqual(w.nsegment, 0)
+        with self.assertRaisesRegex(
+                IndexError, "World: \\(segment\\) i 0 >= size 0"):
+            w.segment(0)
+
+        # Add a segment by object
+        s = w.add_segment(Segment(0, 1, 2, 7.1, 8.2, 9.3))
+        self.assert_allclose(list(s), [[0, 1, 2], [7.1, 8.2, 9.3]])
+        self.assert_allclose(list(w.segment(0)), [[0, 1, 2], [7.1, 8.2, 9.3]])
+        self.assertIsNot(s, w.segment(0))
+        self.assertEqual(w.nsegment, 1)
+        with self.assertRaisesRegex(
+                IndexError, "World: \\(segment\\) i 1 >= size 1"):
+            w.segment(1)
+
+        # Add a segment by coordinate
+        s = w.add_segment(3.1415, 3.1416, 3.1417, 7.1, 8.2, 9.3)
+        self.assert_allclose(list(s),
+                             [[3.1415, 3.1416, 3.1417], [7.1, 8.2, 9.3]])
+        self.assert_allclose(list(w.segment(1)),
+                             [[3.1415, 3.1416, 3.1417], [7.1, 8.2, 9.3]])
+        self.assertIsNot(s, w.segment(1))
+        self.assertEqual(w.nsegment, 2)
+        with self.assertRaisesRegex(
+                IndexError, "World: \\(segment\\) i 2 >= size 2"):
+            w.segment(2)
+
+        # Add many segments
+        for it in range(11):
+            w.add_segment(3.1415 + it, 3.1416 + it, 3.1417 + it,
+                          7.1 + it, 8.2 + it, 9.3 + it)
+            self.assertEqual(w.nsegment, 2 + it + 1)
+
+        # Array/batch interface
+        sndarr = w.segments.pack_array().ndarray
+        self.assertEqual(sndarr.shape, (13, 6))
+        self.assertEqual(w.nsegment, 13)
+
 
 class WorldFp32TC(WorldTB, unittest.TestCase):
 
     def setUp(self):
         self.vkls = modmesh.Point3dFp32
+        self.gkls = modmesh.Segment3dFp32
         self.wkls = modmesh.WorldFp32
 
     def assert_allclose(self, *args, **kw):
@@ -1017,6 +1068,7 @@ class WorldFp64TC(WorldTB, unittest.TestCase):
 
     def setUp(self):
         self.vkls = modmesh.Point3dFp64
+        self.gkls = modmesh.Segment3dFp64
         self.wkls = modmesh.WorldFp64
 
     def assert_allclose(self, *args, **kw):

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -919,7 +919,7 @@ class SegmentPadFp64TC(SegmentPadTB, unittest.TestCase):
 class WorldTB(ModMeshTB):
 
     def test_bezier(self):
-        Vector = self.vkls
+        Point = self.vkls
         World = self.wkls
 
         w = World()
@@ -932,8 +932,8 @@ class WorldTB(ModMeshTB):
 
         # Add Bezier curve
         b = w.add_bezier(
-            [Vector(0, 0, 0), Vector(1, 1, 0), Vector(3, 1, 0),
-             Vector(4, 0, 0)])
+            [Point(0, 0, 0), Point(1, 1, 0), Point(3, 1, 0),
+             Point(4, 0, 0)])
         self.assertEqual(w.nbezier, 1)
         with self.assertRaisesRegex(
                 IndexError, "World: \\(bezier\\) i 1 >= size 1"):
@@ -960,42 +960,42 @@ class WorldTB(ModMeshTB):
         # Confirm we worked on the internal instead of copy
         self.assertEqual(w.bezier(0).nlocus, 5)
 
-    def test_vertex(self):
-        Vector = self.vkls
+    def test_point(self):
+        Point = self.vkls
         World = self.wkls
 
         w = World()
 
         # Empty
-        self.assertEqual(w.nvertex, 0)
+        self.assertEqual(w.npoint, 0)
         with self.assertRaisesRegex(
-                IndexError, "World: \\(vertex\\) i 0 >= size 0"):
-            w.vertex(0)
+                IndexError, "World: \\(point\\) i 0 >= size 0"):
+            w.point(0)
 
-        # Add a vertex by object
-        v = w.add_vertex(Vector(0, 1, 2))
-        self.assertEqual(list(v), [0, 1, 2])
-        self.assertEqual(list(w.vertex(0)), [0, 1, 2])
-        self.assertIsNot(v, w.vertex(0))
-        self.assertEqual(w.nvertex, 1)
+        # Add a point by object
+        p = w.add_point(Point(0, 1, 2))
+        self.assertEqual(list(p), [0, 1, 2])
+        self.assertEqual(list(w.point(0)), [0, 1, 2])
+        self.assertIsNot(p, w.point(0))
+        self.assertEqual(w.npoint, 1)
         with self.assertRaisesRegex(
-                IndexError, "World: \\(vertex\\) i 1 >= size 1"):
-            w.vertex(1)
+                IndexError, "World: \\(point\\) i 1 >= size 1"):
+            w.point(1)
 
-        # Add a vertex by coordinate
-        v = w.add_vertex(3.1415, 3.1416, 3.1417)
-        self.assert_allclose(list(v), [3.1415, 3.1416, 3.1417])
-        self.assert_allclose(list(w.vertex(1)), [3.1415, 3.1416, 3.1417])
-        self.assertIsNot(v, w.vertex(1))
-        self.assertEqual(w.nvertex, 2)
+        # Add a point by coordinate
+        p = w.add_point(3.1415, 3.1416, 3.1417)
+        self.assert_allclose(list(p), [3.1415, 3.1416, 3.1417])
+        self.assert_allclose(list(w.point(1)), [3.1415, 3.1416, 3.1417])
+        self.assertIsNot(p, w.point(1))
+        self.assertEqual(w.npoint, 2)
         with self.assertRaisesRegex(
-                IndexError, "World: \\(vertex\\) i 2 >= size 2"):
-            w.vertex(2)
+                IndexError, "World: \\(point\\) i 2 >= size 2"):
+            w.point(2)
 
-        # Add many vertices
+        # Add many points
         for it in range(10):
-            w.add_vertex(3.1415 + it, 3.1416 + it, 3.1417 + it)
-            self.assertEqual(w.nvertex, 2 + it + 1)
+            w.add_point(3.1415 + it, 3.1416 + it, 3.1417 + it)
+            self.assertEqual(w.npoint, 2 + it + 1)
 
 
 class WorldFp32TC(WorldTB, unittest.TestCase):


### PR DESCRIPTION
Upgrade the `PointPad` to be managed by `std::shared_ptr<PointPad>` and develop `SegmentPad` based on `PointPad`.

Make the two containers available in `World` and expose them to Python.