### PR TITLE
Develop `CurvePad` to simplify the curve (`Bezier3d`) container in `World`

### DIFF
--- a/cpp/modmesh/buffer/SimpleCollector.hpp
+++ b/cpp/modmesh/buffer/SimpleCollector.hpp
@@ -57,6 +57,13 @@ public:
     {
     }
 
+    // Always (forcefully) clone the input array when it is a const reference
+    SimpleCollector(SimpleArray<T> const & arr)
+        : m_expander(BufferExpander::construct(arr.buffer().clone(), /*clone*/ false))
+    {
+    }
+
+    // Allow sharing the buffer when the input array is an lvalue reference
     SimpleCollector(SimpleArray<T> & arr, bool clone)
         : m_expander(BufferExpander::construct(arr.buffer().shared_from_this(), clone))
     {

--- a/cpp/modmesh/pilot/RWorld.cpp
+++ b/cpp/modmesh/pilot/RWorld.cpp
@@ -132,19 +132,10 @@ RLines::RLines(std::shared_ptr<WorldFp64> const & world, Qt3DCore::QNode * paren
 {
     // Create segment pad
     std::shared_ptr<SegmentPadFp64> segments = world->segments()->clone();
-    // Create curve pad
-    std::shared_ptr<CurvePadFp64> curves = CurvePadFp64::construct(/*ndim*/ 3, /*nelem*/ world->nbezier());
-    for (size_t i = 0; i < curves->size(); ++i)
-    {
-        curves->set(i, world->bezier(i));
-    }
     // Create sampled segments in a pad from the curves
-    std::shared_ptr<SegmentPadFp64> csegs = curves->sample(/*length*/ 0.1);
-    // Append the sampled segments to the overall segment pad
-    for (size_t i = 0; i < csegs->size(); ++i)
-    {
-        segments->append(csegs->get(i));
-    }
+    std::shared_ptr<SegmentPadFp64> csegs = world->curves()->sample(/*length*/ 0.1);
+    // Extend the overall segment pad with the sampled segments
+    segments->extend_with(*csegs);
     // Number of points is twice of that of segments
     size_t npoint = segments->size() * 2;
 

--- a/cpp/modmesh/universe/World.hpp
+++ b/cpp/modmesh/universe/World.hpp
@@ -100,7 +100,7 @@ public:
         check_size(i, m_points->size(), "point");
         return m_points->get(i);
     }
-    std::shared_ptr<point_pad_type> points() { return m_points; }
+    std::shared_ptr<point_pad_type> const & points() { return m_points; }
 
     void add_segment(segment_type const & segment)
     {
@@ -117,7 +117,7 @@ public:
         check_size(i, m_segments->size(), "segment");
         return m_segments->get(i);
     }
-    std::shared_ptr<segment_pad_type> segments() { return m_segments; }
+    std::shared_ptr<segment_pad_type> const & segments() { return m_segments; }
 
     void add_bezier(point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3)
     {
@@ -130,7 +130,7 @@ public:
         check_size(i, m_curves->size(), "bezier");
         return m_curves->get_at(i);
     }
-    std::shared_ptr<curve_pad_type> curves() { return m_curves; }
+    std::shared_ptr<curve_pad_type> const & curves() { return m_curves; }
 
 private:
 

--- a/cpp/modmesh/universe/World.hpp
+++ b/cpp/modmesh/universe/World.hpp
@@ -117,9 +117,9 @@ public:
     }
     std::shared_ptr<segment_pad_type> segments() { return m_segments; }
 
-    void add_bezier(std::vector<point_type> const & controls)
+    void add_bezier(point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3)
     {
-        m_beziers.emplace_back(controls);
+        m_beziers.emplace_back(p0, p1, p2, p3);
     }
     size_t nbezier() const { return m_beziers.size(); }
     bezier_type const & bezier(size_t i) const { return m_beziers[i]; }

--- a/cpp/modmesh/universe/World.hpp
+++ b/cpp/modmesh/universe/World.hpp
@@ -63,6 +63,7 @@ public:
 
     using point_pad_type = PointPad<T>;
     using segment_pad_type = SegmentPad<T>;
+    using curve_pad_type = CurvePad<T>;
 
     template <typename... Args>
     static std::shared_ptr<World<T>> construct(Args &&... args)
@@ -73,6 +74,7 @@ public:
     explicit World(ctor_passkey const &)
         : m_points(point_pad_type::construct(/* ndim */ 3))
         , m_segments(segment_pad_type::construct(/* ndim */ 3))
+        , m_curves(curve_pad_type::construct(/* ndim */ 3))
     {
     }
 
@@ -119,21 +121,16 @@ public:
 
     void add_bezier(point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3)
     {
-        m_beziers.emplace_back(p0, p1, p2, p3);
+        m_curves->append(p0, p1, p2, p3);
     }
-    size_t nbezier() const { return m_beziers.size(); }
-    bezier_type const & bezier(size_t i) const { return m_beziers[i]; }
-    bezier_type & bezier(size_t i) { return m_beziers[i]; }
-    bezier_type const & bezier_at(size_t i) const
+    size_t nbezier() const { return m_curves->size(); }
+    bezier_type bezier(size_t i) const { return m_curves->get(i); }
+    bezier_type bezier_at(size_t i) const
     {
-        check_size(i, m_beziers.size(), "bezier");
-        return m_beziers[i];
+        check_size(i, m_curves->size(), "bezier");
+        return m_curves->get_at(i);
     }
-    bezier_type & bezier_at(size_t i)
-    {
-        check_size(i, m_beziers.size(), "bezier");
-        return m_beziers[i];
-    }
+    std::shared_ptr<curve_pad_type> curves() { return m_curves; }
 
 private:
 
@@ -147,7 +144,7 @@ private:
 
     std::shared_ptr<point_pad_type> m_points;
     std::shared_ptr<segment_pad_type> m_segments;
-    std::deque<Bezier3d<T>> m_beziers;
+    std::shared_ptr<curve_pad_type> m_curves;
 
 }; /* end class World */
 

--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -599,6 +599,16 @@ public:
     point_type const & operator[](size_t i) const { return m_data.p[i]; }
     point_type & operator[](size_t i) { return m_data.p[i]; }
 
+    bool operator==(Segment3d const & other) const
+    {
+        return m_data.p[0] == other[0] && m_data.p[1] == other[1];
+    }
+
+    bool operator!=(Segment3d const & other) const
+    {
+        return m_data.p[0] != other[0] || m_data.p[1] != other[1];
+    }
+
     point_type const & at(size_t i) const
     {
         check_size(i, 2);
@@ -743,8 +753,16 @@ public:
 
     void append(segment_type const & s)
     {
-        m_p0->append(s.x0(), s.y0(), s.z0());
-        m_p1->append(s.x1(), s.y1(), s.z1());
+        if (ndim() == 2)
+        {
+            m_p0->append(s.x0(), s.y0());
+            m_p1->append(s.x1(), s.y1());
+        }
+        else
+        {
+            m_p0->append(s.x0(), s.y0(), s.z0());
+            m_p1->append(s.x1(), s.y1(), s.z1());
+        }
     }
 
     void append(T x0, T y0, T x1, T y1)
@@ -757,6 +775,15 @@ public:
     {
         m_p0->append(x0, y0, z0);
         m_p1->append(x1, y1, z1);
+    }
+
+    void extend_with(SegmentPad<T> const & other)
+    {
+        size_t const nseg = other.size(); // Fix the number since other may be *this
+        for (size_t i = 0; i < nseg; ++i)
+        {
+            append(other.get(i));
+        }
     }
 
     uint8_t ndim() const { return m_p0->ndim(); }

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -558,45 +558,60 @@ WrapBezier3d<T>::WrapBezier3d(pybind11::module & mod, const char * pyname, const
     namespace py = pybind11;
 
     (*this)
-        .def(py::init<std::vector<point_type> const &>(), py::arg("controls"))
-        .def(
-            "__len__",
-            [](wrapped_type const & self)
-            { return self.size(); })
+        .def(py::init<point_type const &, point_type const &, point_type const &, point_type const &>(),
+             py::arg("p0"),
+             py::arg("p1"),
+             py::arg("p2"),
+             py::arg("p3"))
+        .def("__len__",
+             [](wrapped_type const &)
+             { return 4; })
         .def(
             "__getitem__",
             [](wrapped_type const & self, size_t it)
-            { return self.at(it); })
-        .def(
-            "__setitem__",
-            [](wrapped_type & self, size_t it, point_type val)
-            { self.at(it) = val; })
-        //
-        ;
-
-    // Control points
-    (*this)
-        .def_property(
-            "control_points",
-            [](wrapped_type const & self)
             {
-                std::vector<point_type> ret(self.ncontrol());
-                for (size_t i = 0; i < self.ncontrol(); ++i)
+                point_type ret;
+                switch (it)
                 {
-                    ret[i] = self.control(i);
+                case 0:
+                    ret = self.p0();
+                    break;
+                case 1:
+                    ret = self.p1();
+                    break;
+                case 2:
+                    ret = self.p2();
+                    break;
+                case 3:
+                    ret = self.p3();
+                    break;
+                default:
+                    throw std::out_of_range("Bezier3d: (control) i 4 >= size 4");
+                    break;
                 }
                 return ret;
-            },
-            [](wrapped_type & self, std::vector<point_type> const & points)
+            })
+        .def(
+            "__setitem__",
+            [](wrapped_type & self, size_t it, point_type const & p)
             {
-                if (points.size() != self.ncontrol())
+                switch (it)
                 {
-                    throw std::out_of_range(
-                        Formatter() << "Bezier3d.control_points: len(points) " << points.size() << " != ncontrol " << self.ncontrol());
-                }
-                for (size_t i = 0; i < self.ncontrol(); ++i)
-                {
-                    self.control(i) = points[i];
+                case 0:
+                    self.p0() = p;
+                    break;
+                case 1:
+                    self.p1() = p;
+                    break;
+                case 2:
+                    self.p2() = p;
+                    break;
+                case 3:
+                    self.p3() = p;
+                    break;
+                default:
+                    throw py::stop_iteration();
+                    break;
                 }
             })
         //
@@ -796,12 +811,15 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
         .def_property_readonly("segments", &wrapped_type::segments)
         .def(
             "add_bezier",
-            [](wrapped_type & self, std::vector<typename wrapped_type::point_type> const & controls) -> auto &
+            [](wrapped_type & self, point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3) -> auto &
             {
-                self.add_bezier(controls);
+                self.add_bezier(p0, p1, p2, p3);
                 return self.bezier_at(self.nbezier() - 1);
             },
-            py::arg("controls"),
+            py::arg("p0"),
+            py::arg("p1"),
+            py::arg("p2"),
+            py::arg("p3"),
             py::return_value_policy::reference_internal)
         .def_property_readonly("nbezier", &wrapped_type::nbezier)
         .def(

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -687,6 +687,13 @@ WrapCurvePad<T>::WrapCurvePad(pybind11::module & mod, const char * pyname, const
         .def_property_readonly("ndim", &wrapped_type::ndim)
         .def(
             "append",
+            [](wrapped_type & self, bezier_type const & c)
+            {
+                self.append(c);
+            },
+            py::arg("c"))
+        .def(
+            "append",
             [](wrapped_type & self, point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3)
             {
                 self.append(p0, p1, p2, p3);
@@ -697,7 +704,9 @@ WrapCurvePad<T>::WrapCurvePad(pybind11::module & mod, const char * pyname, const
             py::arg("p3"))
         .def("__len__", &wrapped_type::size)
         .def("__getitem__", &wrapped_type::get_at)
+        .def("__setitem__", &wrapped_type::set_at)
         .def("get_at", &wrapped_type::get_at)
+        .def("set_at", &wrapped_type::set_at)
         //
         ;
 

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -622,6 +622,95 @@ WrapBezier3d<T>::WrapBezier3d(pybind11::module & mod, const char * pyname, const
 }
 
 template <typename T>
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapCurvePad
+    : public WrapBase<WrapCurvePad<T>, CurvePad<T>, std::shared_ptr<CurvePad<T>>>
+{
+
+public:
+
+    using base_type = WrapBase<WrapCurvePad<T>, CurvePad<T>, std::shared_ptr<CurvePad<T>>>;
+    using wrapped_type = typename base_type::wrapped_type;
+
+    using value_type = typename base_type::wrapped_type::value_type;
+    using point_type = typename base_type::wrapped_type::point_type;
+    using segment_type = typename base_type::wrapped_type::segment_type;
+    using bezier_type = typename base_type::wrapped_type::bezier_type;
+    using point_pad_type = typename base_type::wrapped_type::point_pad_type;
+
+    friend typename base_type::root_base_type;
+
+protected:
+
+    WrapCurvePad(pybind11::module & mod, char const * pyname, char const * pydoc);
+}; /* end class WrapCurvePad */
+
+template <typename T>
+WrapCurvePad<T>::WrapCurvePad(pybind11::module & mod, const char * pyname, const char * pydoc)
+    : base_type(mod, pyname, pydoc)
+{
+    namespace py = pybind11;
+
+    // Constructors
+    (*this)
+        .def(
+            py::init(
+                [](uint8_t ndim)
+                { return wrapped_type::construct(ndim); }),
+            py::arg("ndim"))
+        .def(
+            py::init(
+                [](uint8_t ndim, size_t nelem)
+                { return wrapped_type::construct(ndim, nelem); }),
+            py::arg("ndim"),
+            py::arg("nelem"))
+        //
+        ;
+
+    (*this)
+        .def_property_readonly("ndim", &wrapped_type::ndim)
+        .def(
+            "append",
+            [](wrapped_type & self, point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3)
+            {
+                self.append(p0, p1, p2, p3);
+            },
+            py::arg("p0"),
+            py::arg("p1"),
+            py::arg("p2"),
+            py::arg("p3"))
+        .def("__len__", &wrapped_type::size)
+        .def("__getitem__", &wrapped_type::get_at)
+        .def("get_at", &wrapped_type::get_at)
+        //
+        ;
+
+    // x, y, z, point element accessors.
+#define DECL_WRAP(NAME) \
+    .def(#NAME, [](wrapped_type const & self, size_t i) { return self.NAME(i); })
+    // clang-format off
+    (*this)
+        DECL_WRAP(x0_at)
+        DECL_WRAP(y0_at)
+        DECL_WRAP(z0_at)
+        DECL_WRAP(x1_at)
+        DECL_WRAP(y1_at)
+        DECL_WRAP(z1_at)
+        DECL_WRAP(x2_at)
+        DECL_WRAP(y2_at)
+        DECL_WRAP(z2_at)
+        DECL_WRAP(x3_at)
+        DECL_WRAP(y3_at)
+        DECL_WRAP(z3_at)
+        DECL_WRAP(p0_at)
+        DECL_WRAP(p1_at)
+        DECL_WRAP(p2_at)
+        DECL_WRAP(p3_at)
+        ;
+    // clang-format on
+#undef DECL_WRAP
+}
+
+template <typename T>
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapWorld
     : public WrapBase<WrapWorld<T>, World<T>, std::shared_ptr<World<T>>>
 {
@@ -738,6 +827,8 @@ void wrap_World(pybind11::module & mod)
     WrapSegmentPad<double>::commit(mod, "SegmentPadFp64", "SegmentPadFp64");
     WrapBezier3d<float>::commit(mod, "Bezier3dFp32", "Bezier3dFp32");
     WrapBezier3d<double>::commit(mod, "Bezier3dFp64", "Bezier3dFp64");
+    WrapCurvePad<float>::commit(mod, "CurvePadFp32", "CurvePadFp32");
+    WrapCurvePad<double>::commit(mod, "CurvePadFp64", "CurvePadFp64");
     WrapWorld<float>::commit(mod, "WorldFp32", "WorldFp32");
     WrapWorld<double>::commit(mod, "WorldFp64", "WorldFp64");
 }

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -354,6 +354,13 @@ WrapSegment3d<T>::WrapSegment3d(pybind11::module & mod, const char * pyname, con
        ;
 #undef DECL_WRAP
     // clang-format on
+
+    // Wrap for operators.
+    (*this)
+        .def(py::self == py::self) // NOLINT(misc-redundant-expression)
+        .def(py::self != py::self) // NOLINT(misc-redundant-expression)
+        //
+        ;
 }
 
 template <typename T>
@@ -456,6 +463,13 @@ WrapSegmentPad<T>::WrapSegmentPad(pybind11::module & mod, const char * pyname, c
             py::arg("x1"),
             py::arg("y1"),
             py::arg("z1"))
+        .def(
+            "extend_with",
+            [](wrapped_type & self, wrapped_type const & other)
+            {
+                self.extend_with(other);
+            },
+            py::arg("segments"))
         .def_timed("pack_array", &wrapped_type::pack_array)
         .def_timed("expand", &wrapped_type::expand, py::arg("length"))
         .def("__len__", &wrapped_type::size)
@@ -827,7 +841,7 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
         .def_property_readonly("segments", &wrapped_type::segments)
         .def(
             "add_bezier",
-            [](wrapped_type & self, point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3) -> auto &
+            [](wrapped_type & self, point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3)
             {
                 self.add_bezier(p0, p1, p2, p3);
                 return self.bezier_at(self.nbezier() - 1);
@@ -835,16 +849,15 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
             py::arg("p0"),
             py::arg("p1"),
             py::arg("p2"),
-            py::arg("p3"),
-            py::return_value_policy::reference_internal)
+            py::arg("p3"))
         .def_property_readonly("nbezier", &wrapped_type::nbezier)
         .def(
             "bezier",
-            [](wrapped_type & self, size_t i) -> auto &
+            [](wrapped_type & self, size_t i)
             {
                 return self.bezier_at(i);
-            },
-            py::return_value_policy::reference_internal)
+            })
+        .def_property_readonly("curves", &wrapped_type::curves)
         //
         ;
 }

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -89,6 +89,8 @@ WrapPoint3d<T>::WrapPoint3d(pybind11::module & mod, const char * pyname, const c
 
     // Wrap for operators.
     (*this)
+        .def(py::self == py::self) // NOLINT(misc-redundant-expression)
+        .def(py::self != py::self) // NOLINT(misc-redundant-expression)
         .def(py::self += py::self)
         .def(py::self += value_type())
         .def(py::self -= py::self)
@@ -696,6 +698,11 @@ WrapCurvePad<T>::WrapCurvePad(pybind11::module & mod, const char * pyname, const
         .def("__len__", &wrapped_type::size)
         .def("__getitem__", &wrapped_type::get_at)
         .def("get_at", &wrapped_type::get_at)
+        //
+        ;
+
+    (*this)
+        .def("sample", &wrapped_type::sample, py::arg("length"))
         //
         ;
 

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -102,6 +102,8 @@ __all__ = [  # noqa: F822
     'PointPadFp64',
     'SegmentPadFp32',
     'SegmentPadFp64',
+    'CurvePadFp32',
+    'CurvePadFp64',
     'WorldFp32',
     'WorldFp64',
     'testhelper'

--- a/modmesh/pilot/airfoil/_naca.py
+++ b/modmesh/pilot/airfoil/_naca.py
@@ -256,10 +256,10 @@ class Naca4Sampler(object):
             p3 = np.array(points[it + 1])
             p1 = p0 + (1 / 3) * (p3 - p0)
             p2 = p0 + (2 / 3) * (p3 - p0)
-            b = world.add_bezier([Point(p0[0], p0[1], 0),
-                                  Point(p1[0], p1[1], 0),
-                                  Point(p2[0], p2[1], 0),
-                                  Point(p3[0], p3[1], 0)])
+            b = world.add_bezier(p0=Point(p0[0], p0[1], 0),
+                                 p1=Point(p1[0], p1[1], 0),
+                                 p2=Point(p2[0], p2[1], 0),
+                                 p3=Point(p3[0], p3[1], 0))
             b.sample(nsample[it])
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -296,13 +296,12 @@ class Segment3dFp64TC(Segment3dTB, unittest.TestCase):
 class Bezier3dTB(ModMeshTB):
 
     def test_control_points(self):
-        Vector = self.vkls
+        Point = self.vkls
         Bezier = self.bkls
 
         # Create a cubic Bezier curve
-        bzr = Bezier(
-            [Vector(0, 0, 0), Vector(1, 1, 0), Vector(3, 1, 0),
-             Vector(4, 0, 0)])
+        bzr = Bezier(p0=Point(0, 0, 0), p1=Point(1, 1, 0), p2=Point(3, 1, 0),
+                     p3=Point(4, 0, 0))
         self.assertEqual(len(bzr), 4)
         self.assertEqual(list(bzr[0]), [0, 0, 0])
         self.assertEqual(list(bzr[1]), [1, 1, 0])
@@ -314,43 +313,13 @@ class Bezier3dTB(ModMeshTB):
                                     "Bezier3d: \\(control\\) i 4 >= size 4"):
             bzr[4]
 
-        # Control point API
-        self.assertEqual(len(bzr.control_points), 4)
-        self.assertEqual(list(bzr.control_points[0]), [0, 0, 0])
-        self.assertEqual(list(bzr.control_points[1]), [1, 1, 0])
-        self.assertEqual(list(bzr.control_points[2]), [3, 1, 0])
-        self.assertEqual(list(bzr.control_points[3]), [4, 0, 0])
-
-        bzr.control_points = [Vector(4, 0, 0), Vector(3, 1, 0),
-                              Vector(1, 1, 0), Vector(0, 0, 0)]
-        self.assertEqual(list(bzr.control_points[0]), [4, 0, 0])
-        self.assertEqual(list(bzr.control_points[1]), [3, 1, 0])
-        self.assertEqual(list(bzr.control_points[2]), [1, 1, 0])
-        self.assertEqual(list(bzr.control_points[3]), [0, 0, 0])
-
-        with self.assertRaisesRegex(
-                IndexError,
-                "Bezier3d.control_points: len\\(points\\) 3 != ncontrol 4"):
-            bzr.control_points = [Vector(3, 1, 0), Vector(1, 1, 0),
-                                  Vector(0, 0, 0)]
-        with self.assertRaisesRegex(
-                IndexError,
-                "Bezier3d.control_points: len\\(points\\) 5 != ncontrol 4"):
-            bzr.control_points = [Vector(4, 0, 0), Vector(3, 1, 0),
-                                  Vector(1, 1, 0), Vector(0, 0, 0),
-                                  Vector(0, 0, 0)]
-
-        # Locus point API
-        self.assertEqual(len(bzr.locus_points), 0)
-
-    def test_local_points(self):
-        Vector = self.vkls
+    def test_locus_points(self):
+        Point = self.vkls
         Bezier = self.bkls
 
-        b = Bezier(
-            [Vector(0, 0, 0), Vector(1, 1, 0), Vector(3, 1, 0),
-             Vector(4, 0, 0)])
-        self.assertEqual(len(b.control_points), 4)
+        b = Bezier(p0=Point(0, 0, 0), p1=Point(1, 1, 0), p2=Point(3, 1, 0),
+                   p3=Point(4, 0, 0))
+        self.assertEqual(len(b), 4)
         self.assertEqual(b.nlocus, 0)
         self.assertEqual(len(b.locus_points), 0)
 
@@ -1065,34 +1034,33 @@ class WorldTB(ModMeshTB):
             w.bezier(0)
 
         # Add Bezier curve
-        b = w.add_bezier(
-            [Point(0, 0, 0), Point(1, 1, 0), Point(3, 1, 0),
-             Point(4, 0, 0)])
+        b = w.add_bezier(p0=Point(0, 0, 0), p1=Point(1, 1, 0),
+                         p2=Point(3, 1, 0), p3=Point(4, 0, 0))
         self.assertEqual(w.nbezier, 1)
         with self.assertRaisesRegex(
                 IndexError, "World: \\(bezier\\) i 1 >= size 1"):
             w.bezier(1)
 
-        # Check control points
-        self.assertEqual(len(b), 4)
-        self.assertEqual(list(b[0]), [0, 0, 0])
-        self.assertEqual(list(b[1]), [1, 1, 0])
-        self.assertEqual(list(b[2]), [3, 1, 0])
-        self.assertEqual(list(b[3]), [4, 0, 0])
+            # Check control points
+            self.assertEqual(len(b), 4)
+            self.assertEqual(list(b[0]), [0, 0, 0])
+            self.assertEqual(list(b[1]), [1, 1, 0])
+            self.assertEqual(list(b[2]), [3, 1, 0])
+            self.assertEqual(list(b[3]), [4, 0, 0])
 
-        # Check locus points
-        self.assertEqual(b.nlocus, 0)
-        self.assertEqual(len(b.locus_points), 0)
-        b.sample(5)
-        self.assertEqual(b.nlocus, 5)
-        self.assertEqual(len(b.locus_points), 5)
-        self.assert_allclose([list(p) for p in b.locus_points],
-                             [[0.0, 0.0, 0.0], [0.90625, 0.5625, 0.0],
-                              [2.0, 0.75, 0.0], [3.09375, 0.5625, 0.0],
-                              [4.0, 0.0, 0.0]])
+            # Check locus points
+            self.assertEqual(b.nlocus, 0)
+            self.assertEqual(len(b.locus_points), 0)
+            b.sample(5)
+            self.assertEqual(b.nlocus, 5)
+            self.assertEqual(len(b.locus_points), 5)
+            self.assert_allclose([list(p) for p in b.locus_points],
+                                 [[0.0, 0.0, 0.0], [0.90625, 0.5625, 0.0],
+                                  [2.0, 0.75, 0.0], [3.09375, 0.5625, 0.0],
+                                  [4.0, 0.0, 0.0]])
 
-        # Confirm we worked on the internal instead of copy
-        self.assertEqual(w.bezier(0).nlocus, 5)
+            # Confirm we worked on the internal instead of copy
+            self.assertEqual(w.bezier(0).nlocus, 5)
 
     def test_point(self):
         Point = self.vkls

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -982,6 +982,88 @@ class CurvePadTB(ModMeshTB):
         self.assertEqual(cp.y3_at(0), 0)
         self.assertEqual(cp.z3_at(0), 0)
 
+    def test_sample_2d(self):
+        CurvePad = self.ckls
+        Point3d = self.vkls
+
+        cp = CurvePad(ndim=3)
+        p0 = Point3d(0, 0, 0)
+        p1 = Point3d(1, 1, 0)
+        p2 = Point3d(3, 1, 0)
+        p3 = Point3d(4, 0, 0)
+        cp.append(p0=p0, p1=p1, p2=p2, p3=p3)
+        self.assertEqual(len(cp), 1)
+        p4 = Point3d(5, 0, 0)
+        p5 = Point3d(5.5, 1, 0)
+        p6 = Point3d(6.5, 1, 0)
+        p7 = Point3d(7, 0, 0)
+        cp.append(p0=p4, p1=p5, p2=p6, p3=p7)
+        self.assertEqual(len(cp), 2)
+
+        # Sample to create segment pad
+        sp = cp.sample(length=0.5)
+        self.assertEqual(len(sp), 10)
+
+        # The connectivity of the first curve
+        self.assertEqual(p0, sp[0].p0)
+        self.assertEqual(sp[0].p1, sp[1].p0)
+        self.assertEqual(sp[1].p1, sp[2].p0)
+        self.assertEqual(sp[2].p1, sp[3].p0)
+        self.assertEqual(sp[3].p1, sp[4].p0)
+        self.assertEqual(sp[4].p1, sp[5].p0)
+        self.assertEqual(sp[5].p1, sp[6].p0)
+        self.assertEqual(sp[6].p1, p3)
+
+        # The connectivity of the second curve
+        self.assertEqual(p4, sp[7].p0)
+        self.assertEqual(sp[7].p1, sp[8].p0)
+        self.assertEqual(sp[8].p1, sp[9].p0)
+        self.assertEqual(sp[9].p1, p7)
+
+        # Test for the segment coordinates of the first curve
+        self.assert_allclose(list(sp[0].p0),
+                             [0.0, 0.0, 0.0])
+        self.assert_allclose(list(sp[0].p1),
+                             [0.48396501457725954, 0.3673469387755103, 0.0])
+        self.assert_allclose(list(sp[1].p0),
+                             [0.48396501457725954, 0.3673469387755103, 0.0])
+        self.assert_allclose(list(sp[1].p1),
+                             [1.0553935860058308, 0.6122448979591837, 0.0])
+        self.assert_allclose(list(sp[2].p0),
+                             [1.0553935860058308, 0.6122448979591837, 0.0])
+        self.assert_allclose(list(sp[2].p1),
+                             [1.6793002915451893, 0.7346938775510203, 0.0])
+        self.assert_allclose(list(sp[3].p0),
+                             [1.6793002915451893, 0.7346938775510203, 0.0])
+        self.assert_allclose(list(sp[3].p1),
+                             [2.3206997084548107, 0.7346938775510206, 0.0])
+        self.assert_allclose(list(sp[4].p0),
+                             [2.3206997084548107, 0.7346938775510206, 0.0])
+        self.assert_allclose(list(sp[4].p1),
+                             [2.944606413994169, 0.6122448979591837, 0.0])
+        self.assert_allclose(list(sp[5].p0),
+                             [2.944606413994169, 0.6122448979591837, 0.0])
+        self.assert_allclose(list(sp[5].p1),
+                             [3.5160349854227406, 0.36734693877551033, 0.0])
+        self.assert_allclose(list(sp[6].p0),
+                             [3.5160349854227406, 0.36734693877551033, 0.0])
+        self.assert_allclose(list(sp[6].p1),
+                             [4.0, 0.0, 0.0])
+
+        # Test for the segment coordinates of the second curve
+        self.assert_allclose(list(sp[7].p0),
+                             [5.0, 0.0, 0.0])
+        self.assert_allclose(list(sp[7].p1),
+                             [5.6296296296296315, 0.6666666666666667, 0.0])
+        self.assert_allclose(list(sp[8].p0),
+                             [5.6296296296296315, 0.6666666666666667, 0.0])
+        self.assert_allclose(list(sp[8].p1),
+                             [6.370370370370371, 0.6666666666666667, 0.0])
+        self.assert_allclose(list(sp[9].p0),
+                             [6.370370370370371, 0.6666666666666667, 0.0])
+        self.assert_allclose(list(sp[9].p1),
+                             [7.0, 0.0, 0.0])
+
 
 class CurvePadFp32TC(CurvePadTB, unittest.TestCase):
 
@@ -997,7 +1079,7 @@ class CurvePadFp32TC(CurvePadTB, unittest.TestCase):
 
     def assert_allclose(self, *args, **kw):
         if 'rtol' not in kw:
-            kw['rtol'] = 1.e-7
+            kw['rtol'] = 1.5e-7
         return super().assert_allclose(*args, **kw)
 
 

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -957,6 +957,17 @@ class CurvePadTB(ModMeshTB):
         self.assertEqual(list(b[2]), [3, 1, 0])
         self.assertEqual(list(b[3]), [4, 0, 0])
 
+        p0 = self.vkls(7, 8, 0)
+        p1 = self.vkls(1, 1, 0)
+        p2 = self.vkls(3, 1, 0)
+        p3 = self.vkls(4, 0, 0)
+        b = self.bkls(p0, p1, p2, p3)
+        cp[0] = b
+        self.assertEqual(list(cp[0][0]), [7, 8, 0])
+        self.assertEqual(list(cp[0][1]), [1, 1, 0])
+        self.assertEqual(list(cp[0][2]), [3, 1, 0])
+        self.assertEqual(list(cp[0][3]), [4, 0, 0])
+
     def test_append_3d(self):
         cp = self.ckls(ndim=3)
         self.assertEqual(cp.ndim, 3)
@@ -982,9 +993,21 @@ class CurvePadTB(ModMeshTB):
         self.assertEqual(cp.y3_at(0), 0)
         self.assertEqual(cp.z3_at(0), 0)
 
+        p0 = self.vkls(7, 8, -3)
+        p1 = self.vkls(1, 1, 0)
+        p2 = self.vkls(3, 1, 0)
+        p3 = self.vkls(4, 0, 0)
+        b = self.bkls(p0, p1, p2, p3)
+        cp[0] = b
+        self.assertEqual(list(cp[0][0]), [7, 8, -3])
+        self.assertEqual(list(cp[0][1]), [1, 1, 0])
+        self.assertEqual(list(cp[0][2]), [3, 1, 0])
+        self.assertEqual(list(cp[0][3]), [4, 0, 0])
+
     def test_sample_2d(self):
         CurvePad = self.ckls
         Point3d = self.vkls
+        Bezier3d = self.bkls
 
         cp = CurvePad(ndim=3)
         p0 = Point3d(0, 0, 0)
@@ -997,7 +1020,8 @@ class CurvePadTB(ModMeshTB):
         p5 = Point3d(5.5, 1, 0)
         p6 = Point3d(6.5, 1, 0)
         p7 = Point3d(7, 0, 0)
-        cp.append(p0=p4, p1=p5, p2=p6, p3=p7)
+        c = Bezier3d(p0=p4, p1=p5, p2=p6, p3=p7)
+        cp.append(c)
         self.assertEqual(len(cp), 2)
 
         # Sample to create segment pad

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -916,6 +916,140 @@ class SegmentPadFp64TC(SegmentPadTB, unittest.TestCase):
         return super().assert_allclose(*args, **kw)
 
 
+class CurvePadTB(ModMeshTB):
+
+    def test_ndim(self):
+        cp2d = self.ckls(ndim=2)
+        self.assertEqual(cp2d.ndim, 2)
+        cp3d = self.ckls(ndim=3)
+        self.assertEqual(cp3d.ndim, 3)
+
+        with self.assertRaisesRegex(
+                ValueError, "PointPad::PointPad: ndim = 0 < 2"):
+            self.ckls(ndim=0)
+        with self.assertRaisesRegex(
+                ValueError, "PointPad::PointPad: ndim = 0 < 2"):
+            self.ckls(ndim=0, nelem=2)
+        with self.assertRaisesRegex(
+                ValueError, "PointPad::PointPad: ndim = 1 < 2"):
+            self.ckls(ndim=1)
+        with self.assertRaisesRegex(
+                ValueError, "PointPad::PointPad: ndim = 1 < 2"):
+            self.ckls(ndim=1, nelem=3)
+        with self.assertRaisesRegex(
+                ValueError, "PointPad::PointPad: ndim = 4 > 3"):
+            self.ckls(ndim=4)
+        with self.assertRaisesRegex(
+                ValueError, "PointPad::PointPad: ndim = 4 > 3"):
+            self.ckls(ndim=4, nelem=5)
+
+    def test_append_2d(self):
+        cp = self.ckls(ndim=2)
+        self.assertEqual(cp.ndim, 2)
+        self.assertEqual(len(cp), 0)
+
+        p0 = self.vkls(0, 0, 0)
+        p1 = self.vkls(1, 1, 0)
+        p2 = self.vkls(3, 1, 0)
+        p3 = self.vkls(4, 0, 0)
+        cp.append(p0=p0, p1=p1, p2=p2, p3=p3)
+        self.assertEqual(len(cp), 1)
+
+        self.assertEqual(cp.x0_at(0), 0)
+        self.assertEqual(cp.y0_at(0), 0)
+        self.assertEqual(cp.x1_at(0), 1)
+        self.assertEqual(cp.y1_at(0), 1)
+        self.assertEqual(cp.x2_at(0), 3)
+        self.assertEqual(cp.y2_at(0), 1)
+        self.assertEqual(cp.x3_at(0), 4)
+        self.assertEqual(cp.y3_at(0), 0)
+
+        with self.assertRaisesRegex(
+                IndexError,
+                "SimpleCollector: index 0 is out of bounds with size 0"):
+            cp.z0_at(0)
+        with self.assertRaisesRegex(
+                IndexError,
+                "SimpleCollector: index 0 is out of bounds with size 0"):
+            cp.z1_at(0)
+        with self.assertRaisesRegex(
+                IndexError,
+                "SimpleCollector: index 0 is out of bounds with size 0"):
+            cp.z2_at(0)
+        with self.assertRaisesRegex(
+                IndexError,
+                "SimpleCollector: index 0 is out of bounds with size 0"):
+            cp.z3_at(0)
+
+        b = cp[0]
+        self.assertEqual(len(b), 4)
+        self.assertEqual(list(b[0]), [0, 0, 0])
+        self.assertEqual(list(b[1]), [1, 1, 0])
+        self.assertEqual(list(b[2]), [3, 1, 0])
+        self.assertEqual(list(b[3]), [4, 0, 0])
+
+    def test_append_3d(self):
+        cp = self.ckls(ndim=3)
+        self.assertEqual(cp.ndim, 3)
+        self.assertEqual(len(cp), 0)
+
+        p0 = self.vkls(0, 0, 0)
+        p1 = self.vkls(1, 1, 0)
+        p2 = self.vkls(3, 1, 0)
+        p3 = self.vkls(4, 0, 0)
+        cp.append(p0=p0, p1=p1, p2=p2, p3=p3)
+        self.assertEqual(len(cp), 1)
+
+        self.assertEqual(cp.x0_at(0), 0)
+        self.assertEqual(cp.y0_at(0), 0)
+        self.assertEqual(cp.z0_at(0), 0)
+        self.assertEqual(cp.x1_at(0), 1)
+        self.assertEqual(cp.y1_at(0), 1)
+        self.assertEqual(cp.z1_at(0), 0)
+        self.assertEqual(cp.x2_at(0), 3)
+        self.assertEqual(cp.y2_at(0), 1)
+        self.assertEqual(cp.z2_at(0), 0)
+        self.assertEqual(cp.x3_at(0), 4)
+        self.assertEqual(cp.y3_at(0), 0)
+        self.assertEqual(cp.z3_at(0), 0)
+
+
+class CurvePadFp32TC(CurvePadTB, unittest.TestCase):
+
+    def setUp(self):
+        self.dtype = 'float32'
+        self.akls = modmesh.SimpleArrayFloat32
+        self.vkls = modmesh.Point3dFp32
+        self.pkls = modmesh.PointPadFp32
+        self.gkls = modmesh.Segment3dFp32
+        self.skls = modmesh.SegmentPadFp32
+        self.bkls = modmesh.Bezier3dFp32
+        self.ckls = modmesh.CurvePadFp32
+
+    def assert_allclose(self, *args, **kw):
+        if 'rtol' not in kw:
+            kw['rtol'] = 1.e-7
+        return super().assert_allclose(*args, **kw)
+
+
+class CurvePadFp64TC(CurvePadTB, unittest.TestCase):
+
+    def setUp(self):
+        self.dtype = 'float64'
+        self.akls = modmesh.SimpleArrayFloat64
+        self.vkls = modmesh.Point3dFp64
+        self.pkls = modmesh.PointPadFp64
+        self.gkls = modmesh.Segment3dFp64
+        self.skls = modmesh.SegmentPadFp64
+        self.bkls = modmesh.Bezier3dFp64
+        self.ckls = modmesh.CurvePadFp64
+
+    def assert_allclose(self, *args, **kw):
+        if 'rtol' not in kw:
+            kw['rtol'] = 1.e-15
+        return super().assert_allclose(*args, **kw)
+
+
 class WorldTB(ModMeshTB):
 
     def test_bezier(self):

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -779,6 +779,11 @@ class SegmentPadTB(ModMeshTB):
         self.assertEqual(len(sp.z0), 0)
         self.assertEqual(len(sp.z1), 0)
 
+        nseg = len(sp)
+        sp.extend_with(sp)
+        for i in range(nseg):
+            self.assertEqual(sp[i], sp[nseg + i])
+
     def test_append_3d(self):
         sp = self.skls(ndim=3)
         self.assertEqual(sp.ndim, 3)
@@ -851,6 +856,11 @@ class SegmentPadTB(ModMeshTB):
         self.assert_allclose(sp.z1_at(0), -2.31)
         self.assert_allclose(sp.z1_at(1), -8.23)
         self.assert_allclose(sp.z1_at(2), 9.3 * 5.1)
+
+        nseg = len(sp)
+        sp.extend_with(sp)
+        for i in range(nseg):
+            self.assertEqual(sp[i], sp[nseg + i])
 
 
 class SegmentPadFp32TC(SegmentPadTB, unittest.TestCase):
@@ -1147,26 +1157,23 @@ class WorldTB(ModMeshTB):
                 IndexError, "World: \\(bezier\\) i 1 >= size 1"):
             w.bezier(1)
 
-            # Check control points
-            self.assertEqual(len(b), 4)
-            self.assertEqual(list(b[0]), [0, 0, 0])
-            self.assertEqual(list(b[1]), [1, 1, 0])
-            self.assertEqual(list(b[2]), [3, 1, 0])
-            self.assertEqual(list(b[3]), [4, 0, 0])
+        # Check control points
+        self.assertEqual(len(b), 4)
+        self.assertEqual(list(b[0]), [0, 0, 0])
+        self.assertEqual(list(b[1]), [1, 1, 0])
+        self.assertEqual(list(b[2]), [3, 1, 0])
+        self.assertEqual(list(b[3]), [4, 0, 0])
 
-            # Check locus points
-            self.assertEqual(b.nlocus, 0)
-            self.assertEqual(len(b.locus_points), 0)
-            b.sample(5)
-            self.assertEqual(b.nlocus, 5)
-            self.assertEqual(len(b.locus_points), 5)
-            self.assert_allclose([list(p) for p in b.locus_points],
-                                 [[0.0, 0.0, 0.0], [0.90625, 0.5625, 0.0],
-                                  [2.0, 0.75, 0.0], [3.09375, 0.5625, 0.0],
-                                  [4.0, 0.0, 0.0]])
-
-            # Confirm we worked on the internal instead of copy
-            self.assertEqual(w.bezier(0).nlocus, 5)
+        # Check locus points
+        self.assertEqual(b.nlocus, 0)
+        self.assertEqual(len(b.locus_points), 0)
+        b.sample(5)
+        self.assertEqual(b.nlocus, 5)
+        self.assertEqual(len(b.locus_points), 5)
+        self.assert_allclose([list(p) for p in b.locus_points],
+                             [[0.0, 0.0, 0.0], [0.90625, 0.5625, 0.0],
+                              [2.0, 0.75, 0.0], [3.09375, 0.5625, 0.0],
+                              [4.0, 0.0, 0.0]])
 
     def test_point(self):
         Point = self.vkls


### PR DESCRIPTION
* Change `Bezier3d` to support only cubic Bezier curves to simplify the implementation.  This is to model SVG (paths): https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths .  Quadratic Bezier curves will be supported in the future.
* Support curve sampling on `CurvePad`.  It currently uses naive equal-t-spacing sampling.  The sampling code in `Bezier3d` will be updated and  optimized in the future.