### PR TITLE
Refactor: Use `CubicBezierSampler` to sample curves

### DIFF
--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -62,6 +62,7 @@ WrapPoint3d<T>::WrapPoint3d(pybind11::module & mod, const char * pyname, const c
     namespace py = pybind11;
 
     (*this)
+        .def(py::init<value_type, value_type>(), py::arg("x"), py::arg("y"))
         .def(py::init<value_type, value_type, value_type>(), py::arg("x"), py::arg("y"), py::arg("z"))
         .def(
             "__str__",
@@ -287,6 +288,11 @@ WrapSegment3d<T>::WrapSegment3d(pybind11::module & mod, const char * pyname, con
         .def(py::init<point_type const &, point_type const &>(),
              py::arg("p0"),
              py::arg("p1"))
+        .def(py::init<value_type, value_type, value_type, value_type>(),
+             py::arg("x0"),
+             py::arg("y0"),
+             py::arg("x1"),
+             py::arg("y1"))
         .def(py::init<value_type, value_type, value_type, value_type, value_type, value_type>(),
              py::arg("x0"),
              py::arg("y0"),
@@ -441,6 +447,21 @@ WrapSegmentPad<T>::WrapSegmentPad(pybind11::module & mod, const char * pyname, c
 
     (*this)
         .def_property_readonly("ndim", &wrapped_type::ndim)
+        .def(
+            "append",
+            [](wrapped_type & self, segment_type const & s)
+            {
+                self.append(s);
+            },
+            py::arg("s"))
+        .def(
+            "append",
+            [](wrapped_type & self, point_type const & p0, point_type const & p1)
+            {
+                self.append(p0, p1);
+            },
+            py::arg("p0"),
+            py::arg("p1"))
         .def(
             "append",
             [](wrapped_type & self, value_type x0, value_type y0, value_type x1, value_type y1)

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -654,21 +654,9 @@ WrapBezier3d<T>::WrapBezier3d(pybind11::module & mod, const char * pyname, const
         //
         ;
 
-    // Locus points
+    // Sampling
     (*this)
         .def("sample", &wrapped_type::sample, py::arg("nlocus"))
-        .def_property_readonly("nlocus", &wrapped_type::nlocus)
-        .def_property_readonly(
-            "locus_points",
-            [](wrapped_type const & self)
-            {
-                std::vector<typename wrapped_type::point_type> ret(self.nlocus());
-                for (size_t i = 0; i < self.nlocus(); ++i)
-                {
-                    ret[i] = self.locus(i);
-                }
-                return ret;
-            })
         //
         ;
 }

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -724,16 +724,19 @@ class SegmentPadTB(ModMeshTB):
         self.assert_allclose(list(packed[2]), (3, 6, 213.9, -3, -6, -213.9))
 
     def test_append_2d(self):
+        Point3d = self.vkls
+        Segment3d = self.gkls
+
         sp = self.skls(ndim=2)
         self.assertEqual(sp.ndim, 2)
         self.assertEqual(len(sp), 0)
-        sp.append(1.1, 2.2, 7.1, 8.2)
+        sp.append(Segment3d(1.1, 2.2, 7.1, 8.2))
         self.assertEqual(len(sp), 1)
         self.assert_allclose(sp.x0_at(0), 1.1)
         self.assert_allclose(sp.y0_at(0), 2.2)
         self.assert_allclose(sp.x1_at(0), 7.1)
         self.assert_allclose(sp.y1_at(0), 8.2)
-        sp.append(1.1 * 3, 2.2 * 3, 7.1 * 3, 8.2 * 3)
+        sp.append(Point3d(1.1 * 3, 2.2 * 3), Point3d(7.1 * 3, 8.2 * 3))
         self.assertEqual(len(sp), 2)
         self.assert_allclose(sp.x0_at(1), 1.1 * 3)
         self.assert_allclose(sp.y0_at(1), 2.2 * 3)
@@ -785,10 +788,13 @@ class SegmentPadTB(ModMeshTB):
             self.assertEqual(sp[i], sp[nseg + i])
 
     def test_append_3d(self):
+        Point3d = self.vkls
+        Segment3d = self.gkls
+
         sp = self.skls(ndim=3)
         self.assertEqual(sp.ndim, 3)
         self.assertEqual(len(sp), 0)
-        sp.append(1.1, 2.2, 3.3, 7.1, 8.2, 9.3)
+        sp.append(s=Segment3d(1.1, 2.2, 3.3, 7.1, 8.2, 9.3))
         self.assertEqual(len(sp), 1)
         self.assert_allclose(sp.x0_at(0), 1.1)
         self.assert_allclose(sp.y0_at(0), 2.2)
@@ -796,7 +802,8 @@ class SegmentPadTB(ModMeshTB):
         self.assert_allclose(sp.x1_at(0), 7.1)
         self.assert_allclose(sp.y1_at(0), 8.2)
         self.assert_allclose(sp.z1_at(0), 9.3)
-        sp.append(1.1 * 5, 2.2 * 5, 3.3 * 5, 7.1 * 5, 8.2 * 5, 9.3 * 5)
+        sp.append(p0=Point3d(1.1 * 5, 2.2 * 5, 3.3 * 5),
+                  p1=Point3d(7.1 * 5, 8.2 * 5, 9.3 * 5))
         self.assertEqual(len(sp), 2)
         self.assert_allclose(sp.x0_at(1), 1.1 * 5)
         self.assert_allclose(sp.y0_at(1), 2.2 * 5)
@@ -804,8 +811,8 @@ class SegmentPadTB(ModMeshTB):
         self.assert_allclose(sp.x1_at(1), 7.1 * 5)
         self.assert_allclose(sp.y1_at(1), 8.2 * 5)
         self.assert_allclose(sp.z1_at(1), 9.3 * 5)
-        sp.append(1.1 * 5.1, 2.2 * 5.1, 3.3 * 5.1, 7.1 * 5.1, 8.2 * 5.1,
-                  9.3 * 5.1)
+        sp.append(x0=1.1 * 5.1, y0=2.2 * 5.1, z0=3.3 * 5.1,
+                  x1=7.1 * 5.1, y1=8.2 * 5.1, z1=9.3 * 5.1)
         self.assertEqual(len(sp), 3)
         self.assert_allclose(sp.x0_at(2), 1.1 * 5.1)
         self.assert_allclose(sp.y0_at(2), 2.2 * 5.1)

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -320,27 +320,40 @@ class Bezier3dTB(ModMeshTB):
         b = Bezier(p0=Point(0, 0, 0), p1=Point(1, 1, 0), p2=Point(3, 1, 0),
                    p3=Point(4, 0, 0))
         self.assertEqual(len(b), 4)
-        self.assertEqual(b.nlocus, 0)
-        self.assertEqual(len(b.locus_points), 0)
 
-        b.sample(5)
-        self.assertEqual(b.nlocus, 5)
-        self.assertEqual(len(b.locus_points), 5)
-        self.assert_allclose([list(p) for p in b.locus_points],
-                             [[0.0, 0.0, 0.0], [0.90625, 0.5625, 0.0],
-                              [2.0, 0.75, 0.0], [3.09375, 0.5625, 0.0],
-                              [4.0, 0.0, 0.0]])
+        segs = b.sample(nlocus=5)
+        self.assertEqual(len(segs), 4)
+        self.assert_allclose(
+            list(segs[0]), [[0.0, 0.0, 0.0], [0.90625, 0.5625, 0.0]])
+        self.assert_allclose(
+            list(segs[1]), [[0.90625, 0.5625, 0.0], [2.0, 0.75, 0.0]])
+        self.assert_allclose(
+            list(segs[2]), [[2.0, 0.75, 0.0], [3.09375, 0.5625, 0.0]])
+        self.assert_allclose(
+            list(segs[3]), [[3.09375, 0.5625, 0.0], [4.0, 0.0, 0.0]])
 
-        b.sample(9)
-        self.assertEqual(b.nlocus, 9)
-        self.assertEqual(len(b.locus_points), 9)
-        self.assert_allclose([list(p) for p in b.locus_points],
-                             [[0.0, 0.0, 0.0], [0.41796875, 0.328125, 0.0],
-                              [0.90625, 0.5625, 0.0],
-                              [1.44140625, 0.703125, 0.0], [2.0, 0.75, 0.0],
-                              [2.55859375, 0.703125, 0.0],
-                              [3.09375, 0.5625, 0.0],
-                              [3.58203125, 0.328125, 0.0], [4.0, 0.0, 0.0]])
+        segs = b.sample(nlocus=9)
+        self.assertEqual(len(segs), 8)
+        self.assert_allclose(
+            list(segs[0]), [[0.0, 0.0, 0.0], [0.41796875, 0.328125, 0.0]])
+        self.assert_allclose(
+            list(segs[1]),
+            [[0.41796875, 0.328125, 0.0], [0.90625, 0.5625, 0.0]])
+        self.assert_allclose(
+            list(segs[2]),
+            [[0.90625, 0.5625, 0.0], [1.44140625, 0.703125, 0.0]])
+        self.assert_allclose(
+            list(segs[3]), [[1.44140625, 0.703125, 0.0], [2.0, 0.75, 0.0]])
+        self.assert_allclose(
+            list(segs[4]), [[2.0, 0.75, 0.0], [2.55859375, 0.703125, 0.0]])
+        self.assert_allclose(
+            list(segs[5]),
+            [[2.55859375, 0.703125, 0.0], [3.09375, 0.5625, 0.0]])
+        self.assert_allclose(
+            list(segs[6]),
+            [[3.09375, 0.5625, 0.0], [3.58203125, 0.328125, 0.0]])
+        self.assert_allclose(
+            list(segs[7]), [[3.58203125, 0.328125, 0.0], [4.0, 0.0, 0.0]])
 
 
 class Bezier3dFp32TC(Bezier3dTB, unittest.TestCase):
@@ -1172,15 +1185,16 @@ class WorldTB(ModMeshTB):
         self.assertEqual(list(b[3]), [4, 0, 0])
 
         # Check locus points
-        self.assertEqual(b.nlocus, 0)
-        self.assertEqual(len(b.locus_points), 0)
-        b.sample(5)
-        self.assertEqual(b.nlocus, 5)
-        self.assertEqual(len(b.locus_points), 5)
-        self.assert_allclose([list(p) for p in b.locus_points],
-                             [[0.0, 0.0, 0.0], [0.90625, 0.5625, 0.0],
-                              [2.0, 0.75, 0.0], [3.09375, 0.5625, 0.0],
-                              [4.0, 0.0, 0.0]])
+        segs = b.sample(nlocus=5)
+        self.assertEqual(len(segs), 4)
+        self.assert_allclose(
+            list(segs[0]), [[0.0, 0.0, 0.0], [0.90625, 0.5625, 0.0]])
+        self.assert_allclose(
+            list(segs[1]), [[0.90625, 0.5625, 0.0], [2.0, 0.75, 0.0]])
+        self.assert_allclose(
+            list(segs[2]), [[2.0, 0.75, 0.0], [3.09375, 0.5625, 0.0]])
+        self.assert_allclose(
+            list(segs[3]), [[3.09375, 0.5625, 0.0], [4.0, 0.0, 0.0]])
 
     def test_point(self):
         Point = self.vkls


### PR DESCRIPTION
Make a (new) common helper class template `CubicBezierSampler` to sample for a single cubic Bezier curve or a sequence of cubic Bezier curves in `CurvePad`.