### PR TITLE
fix: prevent plot freeze when euler1d is running

### DIFF
--- a/modmesh/pilot/_euler1d.py
+++ b/modmesh/pilot/_euler1d.py
@@ -360,10 +360,10 @@ class Euler1DApp(PilotFeature):
                                            config_widget)
 
         # A new sub-window (`QMdiSubWindow`) for the plot area
-        _subwin = self._mgr.addSubWindow(QWidget())
-        _subwin.setWidget(PlotArea(self))
-        _subwin.showMaximized()
-        _subwin.show()
+        self._subwin = self._mgr.addSubWindow(QWidget())
+        self._subwin.setWidget(PlotArea(self))
+        self._subwin.showMaximized()
+        self._subwin.show()
 
     def setup_app(self):
         self.solver_config_data = [
@@ -622,6 +622,9 @@ class Euler1DApp(PilotFeature):
         self.set_solver_config()
         self.setup_timer()
         self.update_layout()
+
+        # Update PlotArea while click set button
+        self._subwin.setWidget(PlotArea(self))
 
     def stop(self):
         """


### PR DESCRIPTION
Fix https://github.com/solvcon/modmesh/issues/478 by updating plot object at `set` button callback function and keep `_subwin` as an attribute in `Euler1DApp` to prevent python's garbage collection from delete it because it's reference count is 0.

Screenshot : 
<img width="1578" alt="image" src="https://github.com/user-attachments/assets/4d66956b-d554-4997-ba39-5b15580293a4" />
