### PR TITLE
Reorder segment data by coordinate axis

### DIFF
--- a/cpp/modmesh/universe/World.hpp
+++ b/cpp/modmesh/universe/World.hpp
@@ -106,9 +106,9 @@ public:
     {
         m_segments->append(segment);
     }
-    void add_segment(value_type x0, value_type y0, value_type z0, value_type x1, value_type y1, value_type z1)
+    void add_segment(point_type const & p0, point_type const & p1)
     {
-        add_segment(segment_type(x0, y0, z0, x1, y1, z1));
+        add_segment(segment_type(p0, p1));
     }
     size_t nsegment() const { return m_segments->size(); }
     segment_type segment(size_t i) const { return m_segments->get(i); }

--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -47,6 +47,8 @@ class Point3d
 
 public:
 
+    static_assert(std::is_arithmetic_v<T>, "T in Point3d<T> must be arithmetic type");
+
     using value_type = T;
 
     Point3d(T x, T y)
@@ -521,17 +523,15 @@ using PointPadFp64 = PointPad<double>;
 namespace detail
 {
 
-// TODO: change the layout to be x0, x1, y0, y1, z0, z1
 template <typename T>
 struct Segment3dNamed
 {
-    T x0, y0, z0, x1, y1, z1;
+    T x0, x1, y0, y1, z0, z1;
 }; /* end struct Segment3dNamed */
 
 template <typename T>
 union Segment3dData
 {
-    Point3d<T> p[2];
     T v[6];
     Segment3dNamed<T> f;
 }; /* end union Segment3dData */
@@ -550,21 +550,13 @@ class Segment3d
 
 public:
 
+    static_assert(std::is_arithmetic_v<T>, "T in Segment3d<T> must be arithmetic type");
+
     using point_type = Point3d<T>;
     using value_type = typename point_type::value_type;
 
-    Segment3d(point_type const & v0, point_type const & v1)
-        : m_data{v0, v1}
-    {
-    }
-
-    Segment3d(value_type x0, value_type y0, value_type x1, value_type y1)
-        : Segment3d(x0, y0, /*z0*/ 0.0, x1, y1, /*z1*/ 0.0)
-    {
-    }
-
-    Segment3d(value_type x0, value_type y0, value_type z0, value_type x1, value_type y1, value_type z1)
-        : m_data{point_type{x0, y0, z0}, point_type{x1, y1, z1}}
+    Segment3d(point_type const & p0, point_type const & p1)
+        : m_data{p0.x(), p1.x(), p0.y(), p1.y(), p0.z(), p1.z()}
     {
     }
 
@@ -575,59 +567,71 @@ public:
     Segment3d & operator=(Segment3d &&) = default;
     ~Segment3d() = default;
 
-    point_type const & p0() const { return m_data.p[0]; }
-    point_type & p0() { return m_data.p[0]; }
-    void set_p0(point_type const & v) { m_data.p[0] = v; }
-    point_type const & p1() const { return m_data.p[1]; }
-    point_type & p1() { return m_data.p[1]; }
-    void set_p1(point_type const & v) { m_data.p[1] = v; }
+    point_type p0() const { return point_type(m_data.f.x0, m_data.f.y0, m_data.f.z0); }
+    void set_p0(point_type const & p)
+    {
+        m_data.f.x0 = p.x();
+        m_data.f.y0 = p.y();
+        m_data.f.z0 = p.z();
+    }
+    point_type p1() const { return point_type(m_data.f.x1, m_data.f.y1, m_data.f.z1); }
+    void set_p1(point_type const & p)
+    {
+        m_data.f.x1 = p.x();
+        m_data.f.y1 = p.y();
+        m_data.f.z1 = p.z();
+    }
 
-    value_type x0() const { return m_data.p[0].x(); }
-    value_type & x0() { return m_data.p[0].x(); }
-    void set_x0(value_type v) { m_data.p[0].set_x(v); }
+    value_type x0() const { return m_data.f.x0; }
+    value_type & x0() { return m_data.f.x0; }
+    void set_x0(value_type v) { m_data.f.x0 = v; }
 
-    value_type y0() const { return m_data.p[0].y(); }
-    value_type & y0() { return m_data.p[0].y(); }
-    void set_y0(value_type v) { m_data.p[0].set_y(v); }
+    value_type y0() const { return m_data.f.y0; }
+    value_type & y0() { return m_data.f.y0; }
+    void set_y0(value_type v) { m_data.f.y0 = v; }
 
-    value_type z0() const { return m_data.p[0].z(); }
-    value_type & z0() { return m_data.p[0].z(); }
-    void set_z0(value_type v) { m_data.p[0].set_z(v); }
+    value_type z0() const { return m_data.f.z0; }
+    value_type & z0() { return m_data.f.z0; }
+    void set_z0(value_type v) { m_data.f.z0 = v; }
 
-    value_type x1() const { return m_data.p[1].x(); }
-    value_type & x1() { return m_data.p[1].x(); }
-    void set_x1(value_type v) { m_data.p[1].set_x(v); }
+    value_type x1() const { return m_data.f.x1; }
+    value_type & x1() { return m_data.f.x1; }
+    void set_x1(value_type v) { m_data.f.x1 = v; }
 
-    value_type y1() const { return m_data.p[1].y(); }
-    value_type & y1() { return m_data.p[1].y(); }
-    void set_y1(value_type v) { m_data.p[1].set_y(v); }
+    value_type y1() const { return m_data.f.y1; }
+    value_type & y1() { return m_data.f.y1; }
+    void set_y1(value_type v) { m_data.f.y1 = v; }
 
-    value_type z1() const { return m_data.p[1].z(); }
-    value_type & z1() { return m_data.p[1].z(); }
-    void set_z1(value_type v) { m_data.p[1].set_z(v); }
+    value_type z1() const { return m_data.f.z1; }
+    value_type & z1() { return m_data.f.z1; }
+    void set_z1(value_type v) { m_data.f.z1 = v; }
 
-    point_type const & operator[](size_t i) const { return m_data.p[i]; }
-    point_type & operator[](size_t i) { return m_data.p[i]; }
+    point_type operator[](size_t i) const { return point_type(m_data.v[i], m_data.v[i + 2], m_data.v[i + 4]); }
 
     bool operator==(Segment3d const & other) const
     {
-        return m_data.p[0] == other[0] && m_data.p[1] == other[1];
+        return m_data.v[0] == other.m_data.v[0] &&
+               m_data.v[1] == other.m_data.v[1] &&
+               m_data.v[2] == other.m_data.v[2] &&
+               m_data.v[3] == other.m_data.v[3] &&
+               m_data.v[4] == other.m_data.v[4] &&
+               m_data.v[5] == other.m_data.v[5];
     }
 
     bool operator!=(Segment3d const & other) const
     {
-        return m_data.p[0] != other[0] || m_data.p[1] != other[1];
+        return m_data.v[0] != other.m_data.v[0] ||
+               m_data.v[1] != other.m_data.v[1] ||
+               m_data.v[2] != other.m_data.v[2] ||
+               m_data.v[3] != other.m_data.v[3] ||
+               m_data.v[4] != other.m_data.v[4] ||
+               m_data.v[5] != other.m_data.v[5];
     }
 
-    point_type const & at(size_t i) const
+    point_type at(size_t i) const
     {
         check_size(i, 2);
-        return m_data.p[i];
-    }
-    point_type & at(size_t i)
-    {
-        check_size(i, 2);
-        return m_data.p[i];
+        return (*this)[i];
     }
 
     size_t size() const { return 2; }
@@ -899,11 +903,11 @@ public:
     {
         if (ndim() == 3)
         {
-            return segment_type(x0_at(i), y0_at(i), z0_at(i), x1_at(i), y1_at(i), z1_at(i));
+            return segment_type(point_type(x0_at(i), y0_at(i), z0_at(i)), point_type(x1_at(i), y1_at(i), z1_at(i)));
         }
         else
         {
-            return segment_type(x0_at(i), y0_at(i), 0.0, x1_at(i), y1_at(i), 0.0);
+            return segment_type(point_type(x0_at(i), y0_at(i), 0.0), point_type(x1_at(i), y1_at(i), 0.0));
         }
     }
     void set_at(size_t i, segment_type const & s)
@@ -954,11 +958,11 @@ public:
     {
         if (ndim() == 3)
         {
-            return segment_type(x0(i), y0(i), z0(i), x1(i), y1(i), z1(i));
+            return segment_type(point_type(x0(i), y0(i), z0(i)), point_type(x1(i), y1(i), z1(i)));
         }
         else
         {
-            return segment_type(x0(i), y0(i), 0.0, x1(i), y1(i), 0.0);
+            return segment_type(point_type(x0(i), y0(i), 0.0), point_type(x1(i), y1(i), 0.0));
         }
     }
     void set(size_t i, segment_type const & s)
@@ -1056,6 +1060,8 @@ class Bezier3d
 {
 
 public:
+
+    static_assert(std::is_floating_point_v<T>, "T in Bezier3d<T> must be floating-point type");
 
     using point_type = Point3d<T>;
     using value_type = typename point_type::value_type;

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -288,18 +288,6 @@ WrapSegment3d<T>::WrapSegment3d(pybind11::module & mod, const char * pyname, con
         .def(py::init<point_type const &, point_type const &>(),
              py::arg("p0"),
              py::arg("p1"))
-        .def(py::init<value_type, value_type, value_type, value_type>(),
-             py::arg("x0"),
-             py::arg("y0"),
-             py::arg("x1"),
-             py::arg("y1"))
-        .def(py::init<value_type, value_type, value_type, value_type, value_type, value_type>(),
-             py::arg("x0"),
-             py::arg("y0"),
-             py::arg("z0"),
-             py::arg("x1"),
-             py::arg("y1"),
-             py::arg("z1"))
         .def(
             "__str__",
             [](wrapped_type const & self)
@@ -332,7 +320,7 @@ WrapSegment3d<T>::WrapSegment3d(pybind11::module & mod, const char * pyname, con
         [](wrapped_type const & self)                 \
         { return self.NAME(); },                      \
         [](wrapped_type & self, point_type const & v) \
-        { self.NAME() = v; })
+        { self.set_##NAME(v); })
     // clang-format off
     (*this)
         DECL_WRAP(p0)
@@ -348,7 +336,7 @@ WrapSegment3d<T>::WrapSegment3d(pybind11::module & mod, const char * pyname, con
         [](wrapped_type const & self)                                \
         { return self.NAME(); },                                     \
         [](wrapped_type & self, typename wrapped_type::value_type v) \
-        { self.NAME() = v; })
+        { self.set_##NAME(v); })
     // clang-format off
    (*this)
        DECL_WRAP(x0)
@@ -834,17 +822,13 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
             py::arg("segment"))
         .def(
             "add_segment",
-            [](wrapped_type & self, value_type x0, value_type y0, value_type z0, value_type x1, value_type y1, value_type z1)
+            [](wrapped_type & self, point_type const & p0, point_type const & p1)
             {
-                self.add_segment(x0, y0, z0, x1, y1, z1);
+                self.add_segment(p0, p1);
                 return self.segment_at(self.nsegment() - 1);
             },
-            py::arg("x0"),
-            py::arg("y0"),
-            py::arg("z0"),
-            py::arg("x1"),
-            py::arg("y1"),
-            py::arg("z1"))
+            py::arg("p0"),
+            py::arg("p1"))
         .def_property_readonly("nsegment", &wrapped_type::nsegment)
         .def("segment", &wrapped_type::segment_at)
         .def_property_readonly("segments", &wrapped_type::segments)

--- a/modmesh/pilot/airfoil/_naca.py
+++ b/modmesh/pilot/airfoil/_naca.py
@@ -228,12 +228,13 @@ class Naca4Sampler(object):
 
         :return: None
         """
+        Point = core.Point3dFp64
         points = self.points
         world = self.world
         for it in range(len(points) - 1):
             p0 = points.get_at(it)
             p1 = points.get_at(it + 1)
-            world.add_edge(p0.x, p0.y, 0, p1.x, p1.y, 0)
+            world.add_segment(Point(p0.x, p0.y, 0), Point(p1.x, p1.y, 0))
 
     def draw_cbc(self, spacing=0.01):
         """

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -250,7 +250,7 @@ class Segment3dTB(ModMeshTB):
         Point = self.vkls
         Segment = self.gkls
 
-        s = Segment(x0=0, y0=0, z0=0, x1=1, y1=1, z1=1)
+        s = Segment(p0=Point(x=0, y=0, z=0), p1=Point(x=1, y=1, z=1))
         self.assertEqual(len(s), 2)
         self.assertEqual(tuple(s.p0), (0.0, 0.0, 0.0))
         self.assertEqual(tuple(s.p1), (1.0, 1.0, 1.0))
@@ -667,6 +667,8 @@ class SegmentPadTB(ModMeshTB):
         self.assert_allclose(list(packed[2]), (3, 6, -3, -6))
 
     def test_construct_3d(self):
+        Point = self.vkls
+
         x0arr = self.akls(array=np.array([1, 2, 3], dtype=self.dtype))
         y0arr = self.akls(array=np.array([4, 5, 6], dtype=self.dtype))
         z0arr = self.akls(array=np.array([7, 8, 9], dtype=self.dtype))
@@ -706,7 +708,7 @@ class SegmentPadTB(ModMeshTB):
         with self.assertRaisesRegex(
                 IndexError,
                 "SimpleCollector: index 3 is out of bounds with size 3"):
-            sp.set_at(3, self.gkls(0, 0, 0, 0, 0, 0))
+            sp.set_at(3, self.gkls(Point(0, 0, 0), Point(0, 0, 0)))
 
         # Test zero-copy writing
         sp.x0[1] = 200.2
@@ -737,19 +739,19 @@ class SegmentPadTB(ModMeshTB):
         self.assert_allclose(list(packed[2]), (3, 6, 213.9, -3, -6, -213.9))
 
     def test_append_2d(self):
-        Point3d = self.vkls
-        Segment3d = self.gkls
+        Point = self.vkls
+        Segment = self.gkls
 
         sp = self.skls(ndim=2)
         self.assertEqual(sp.ndim, 2)
         self.assertEqual(len(sp), 0)
-        sp.append(Segment3d(1.1, 2.2, 7.1, 8.2))
+        sp.append(Segment(Point(1.1, 2.2, 0.0), Point(7.1, 8.2, 0.0)))
         self.assertEqual(len(sp), 1)
         self.assert_allclose(sp.x0_at(0), 1.1)
         self.assert_allclose(sp.y0_at(0), 2.2)
         self.assert_allclose(sp.x1_at(0), 7.1)
         self.assert_allclose(sp.y1_at(0), 8.2)
-        sp.append(Point3d(1.1 * 3, 2.2 * 3), Point3d(7.1 * 3, 8.2 * 3))
+        sp.append(Point(1.1 * 3, 2.2 * 3), Point(7.1 * 3, 8.2 * 3))
         self.assertEqual(len(sp), 2)
         self.assert_allclose(sp.x0_at(1), 1.1 * 3)
         self.assert_allclose(sp.y0_at(1), 2.2 * 3)
@@ -801,13 +803,13 @@ class SegmentPadTB(ModMeshTB):
             self.assertEqual(sp[i], sp[nseg + i])
 
     def test_append_3d(self):
-        Point3d = self.vkls
-        Segment3d = self.gkls
+        Point = self.vkls
+        Segment = self.gkls
 
         sp = self.skls(ndim=3)
         self.assertEqual(sp.ndim, 3)
         self.assertEqual(len(sp), 0)
-        sp.append(s=Segment3d(1.1, 2.2, 3.3, 7.1, 8.2, 9.3))
+        sp.append(s=Segment(Point(1.1, 2.2, 3.3), Point(7.1, 8.2, 9.3)))
         self.assertEqual(len(sp), 1)
         self.assert_allclose(sp.x0_at(0), 1.1)
         self.assert_allclose(sp.y0_at(0), 2.2)
@@ -815,8 +817,8 @@ class SegmentPadTB(ModMeshTB):
         self.assert_allclose(sp.x1_at(0), 7.1)
         self.assert_allclose(sp.y1_at(0), 8.2)
         self.assert_allclose(sp.z1_at(0), 9.3)
-        sp.append(p0=Point3d(1.1 * 5, 2.2 * 5, 3.3 * 5),
-                  p1=Point3d(7.1 * 5, 8.2 * 5, 9.3 * 5))
+        sp.append(p0=Point(1.1 * 5, 2.2 * 5, 3.3 * 5),
+                  p1=Point(7.1 * 5, 8.2 * 5, 9.3 * 5))
         self.assertEqual(len(sp), 2)
         self.assert_allclose(sp.x0_at(1), 1.1 * 5)
         self.assert_allclose(sp.y0_at(1), 2.2 * 5)
@@ -1239,6 +1241,7 @@ class WorldTB(ModMeshTB):
         self.assertEqual(w.npoint, 12)
 
     def test_segment(self):
+        Point = self.vkls
         Segment = self.gkls
         World = self.wkls
 
@@ -1251,7 +1254,7 @@ class WorldTB(ModMeshTB):
             w.segment(0)
 
         # Add a segment by object
-        s = w.add_segment(Segment(0, 1, 2, 7.1, 8.2, 9.3))
+        s = w.add_segment(Segment(Point(0, 1, 2), Point(7.1, 8.2, 9.3)))
         self.assert_allclose(list(s), [[0, 1, 2], [7.1, 8.2, 9.3]])
         self.assert_allclose(list(w.segment(0)), [[0, 1, 2], [7.1, 8.2, 9.3]])
         self.assertIsNot(s, w.segment(0))
@@ -1261,7 +1264,7 @@ class WorldTB(ModMeshTB):
             w.segment(1)
 
         # Add a segment by coordinate
-        s = w.add_segment(3.1415, 3.1416, 3.1417, 7.1, 8.2, 9.3)
+        s = w.add_segment(Point(3.1415, 3.1416, 3.1417), Point(7.1, 8.2, 9.3))
         self.assert_allclose(list(s),
                              [[3.1415, 3.1416, 3.1417], [7.1, 8.2, 9.3]])
         self.assert_allclose(list(w.segment(1)),
@@ -1274,8 +1277,8 @@ class WorldTB(ModMeshTB):
 
         # Add many segments
         for it in range(11):
-            w.add_segment(3.1415 + it, 3.1416 + it, 3.1417 + it,
-                          7.1 + it, 8.2 + it, 9.3 + it)
+            w.add_segment(Point(3.1415 + it, 3.1416 + it, 3.1417 + it),
+                          Point(7.1 + it, 8.2 + it, 9.3 + it))
             self.assertEqual(w.nsegment, 2 + it + 1)
 
         # Array/batch interface


### PR DESCRIPTION
Reorder from `{x0, y0, z0, x1, y1, z1}` (by point) to `{x0, x1, y0, y1, z0, z1}` (by coordinate axis) and remove point view.