### PR TITLE
feat: add inverse Fourier transform implementation

### DIFF
--- a/cpp/modmesh/math/Complex.hpp
+++ b/cpp/modmesh/math/Complex.hpp
@@ -133,6 +133,7 @@ struct ComplexImpl
     T real() const { return real_v; }
     T imag() const { return imag_v; }
     T norm() const { return real_v * real_v + imag_v * imag_v; }
+    ComplexImpl<T> conj() const { return {real_v, -imag_v}; }
 }; /* end struct ComplexImpl */
 
 } /* end namespace detail */

--- a/cpp/modmesh/math/pymod/wrap_Complex.cpp
+++ b/cpp/modmesh/math/pymod/wrap_Complex.cpp
@@ -87,6 +87,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapComplex
             .def_readonly("real", &wrapped_type::real_v)
             .def_readonly("imag", &wrapped_type::imag_v)
             .def("norm", &wrapped_type::norm)
+            .def("conj", &wrapped_type::conj)
             .def("dtype",
                  []()
                  { return complex_dtype; });

--- a/cpp/modmesh/transform/fourier.hpp
+++ b/cpp/modmesh/transform/fourier.hpp
@@ -68,6 +68,25 @@ void fft(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
     }
 }
 
+template <template <typename> class T1, typename T2>
+void ifft(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
+{
+    auto N = in.size();
+    SimpleArray<T1<T2>> in_conj(N);
+
+    for (size_t i = 0; i < N; ++i)
+    {
+        in_conj[i] = in[i].conj();
+    }
+
+    fft<T1, T2>(in_conj, out);
+
+    for (size_t i = 0; i < N; ++i)
+    {
+        out[i] = out[i].conj() / static_cast<T2>(N);
+    }
+}
+
 } /* end namespace transform */
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/transform/fourier.hpp
+++ b/cpp/modmesh/transform/fourier.hpp
@@ -35,7 +35,7 @@ void dft(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
 template <template <typename> class T1, typename T2>
 void fft(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
 {
-    auto N = in.size();
+    size_t N = in.size();
     const unsigned int bits = static_cast<unsigned int>(std::log2(N));
 
     // bit reversed reordering
@@ -71,7 +71,7 @@ void fft(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
 template <template <typename> class T1, typename T2>
 void ifft(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
 {
-    auto N = in.size();
+    size_t N = in.size();
     SimpleArray<T1<T2>> in_conj(N);
 
     for (size_t i = 0; i < N; ++i)

--- a/cpp/modmesh/transform/fourier.hpp
+++ b/cpp/modmesh/transform/fourier.hpp
@@ -29,9 +29,6 @@ void dft(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
             T1<T2> twiddle_factor{std::cos(tmp), std::sin(tmp)};
             out[i] += in[j] * twiddle_factor;
         }
-
-        // Normalize dft output
-        out[i] = out[i] / std::sqrt(static_cast<T2>(N));
     }
 }
 
@@ -68,12 +65,6 @@ void fft(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
                 out[i + k + half_size] = even - odd;
             }
         }
-    }
-
-    // Normalize fft output
-    for (size_t i = 0; i < N; ++i)
-    {
-        out[i] = out[i] / std::sqrt(static_cast<T2>(N));
     }
 }
 

--- a/gtests/test_nopython_transform.cpp
+++ b/gtests/test_nopython_transform.cpp
@@ -38,7 +38,7 @@ protected:
         for (unsigned int i = 0; i < VN; ++i)
         {
             psd_sig += signal[i].norm();
-            psd_out += out[i].norm();
+            psd_out += out[i].norm() / VN;
         }
 
         // TODO: When FFT / DFT uses float, the accumulation error is around 1e-3,
@@ -71,7 +71,7 @@ protected:
     void verify_delta_function()
     {
         // Transformation of delta is constant in all bins with magnitude = 1/N because of normalization
-        T expected_mag = static_cast<T>(1.0) / static_cast<T>(VN);
+        T expected_mag = static_cast<T>(1.0);
 
         for (unsigned int i = 0; i < VN; ++i)
         {

--- a/gtests/test_nopython_transform.cpp
+++ b/gtests/test_nopython_transform.cpp
@@ -70,7 +70,6 @@ protected:
 
     void verify_delta_function()
     {
-        // Transformation of delta is constant in all bins with magnitude = 1/N because of normalization
         T expected_mag = static_cast<T>(1.0);
 
         for (unsigned int i = 0; i < VN; ++i)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -298,3 +298,17 @@ class ComplexTC(unittest.TestCase, mm.testing.TestBase):
 
         self.assertEqual(sarr.ndarray.dtype, ndarr.dtype)
         self.assertEqual(10 * 8 * 2, sarr.nbytes)
+
+    def test_complex_conj_float32(self):
+        cplx = mm.complex64(self.real1_32, self.imag1_32)
+        cplx_conj = mm.complex64(self.real1_32, -self.imag1_32)
+
+        self.assertEqual(cplx.conj().real, cplx_conj.real)
+        self.assertEqual(cplx.conj().imag, cplx_conj.imag)
+
+    def test_complex_conj_float64(self):
+        cplx = mm.complex128(self.real1_64, self.imag1_64)
+        cplx_conj = mm.complex128(self.real1_64, -self.imag1_64)
+
+        self.assertEqual(cplx.conj().real, cplx_conj.real)
+        self.assertEqual(cplx.conj().imag, cplx_conj.imag)


### PR DESCRIPTION
In this PR I have added:

- Complex conjugate function
- Inverse Fourier transform
- Removed normalization from forward Fourier transform and moved it to Parseval test. Usually, forward Fourier transform does not apply normalization to its results