### PR TITLE
Turn on/off the console (toggle)

### DIFF
--- a/cpp/modmesh/pilot/RManager.cpp
+++ b/cpp/modmesh/pilot/RManager.cpp
@@ -95,6 +95,17 @@ R3DWidget * RManager::add3DWidget()
     return viewer;
 }
 
+void RManager::toggleConsole()
+{
+    if (m_pycon)
+    {
+        if (m_pycon->isVisible())
+            m_pycon->hide();
+        else
+            m_pycon->show();
+    }
+}
+
 void RManager::setUpConsole()
 {
     m_pycon = new RPythonConsoleDockWidget(QString("Console"), m_mainWindow);

--- a/cpp/modmesh/pilot/RManager.cpp
+++ b/cpp/modmesh/pilot/RManager.cpp
@@ -100,9 +100,13 @@ void RManager::toggleConsole()
     if (m_pycon)
     {
         if (m_pycon->isVisible())
+        {
             m_pycon->hide();
+        }
         else
+        {
             m_pycon->show();
+        }
     }
 }
 

--- a/cpp/modmesh/pilot/RManager.hpp
+++ b/cpp/modmesh/pilot/RManager.hpp
@@ -76,6 +76,8 @@ public:
 
     void quit() { m_core->quit(); }
 
+    void toggleConsole();
+
 private:
 
     RManager();

--- a/cpp/modmesh/pilot/wrap_pilot.cpp
+++ b/cpp/modmesh/pilot/wrap_pilot.cpp
@@ -326,6 +326,12 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 {
                     return self.add3DWidget();
                 })
+            .def(
+                "toggleConsole",
+                [](wrapped_type & self)
+                {
+                    return self.toggleConsole();
+                })
             //
             ;
 

--- a/modmesh/pilot/_gui.py
+++ b/modmesh/pilot/_gui.py
@@ -99,9 +99,12 @@ class _Controller(metaclass=_Singleton):
     def populate_menu(self):
         wm = self._rmgr
 
-        def _addAction(menu, text, tip, func):
+        def _addAction(menu, text, tip, func, checkable=False, checked=False):
             act = QAction(text, wm.mainWindow)
             act.setStatusTip(tip)
+            act.setCheckable(checkable)
+            if checkable:
+                act.setChecked(checked)
             if callable(func):
                 act.triggered.connect(lambda *a: func())
             elif func:
@@ -143,9 +146,11 @@ class _Controller(metaclass=_Singleton):
 
         _addAction(
             menu=wm.windowMenu,
-            text="(empty)",
-            tip="(empty)",
-            func=None,
+            text="Console",
+            tip="Open / Close Console",
+            func=wm.toggleConsole,
+            checkable=True,
+            checked=True,
         )
 
 


### PR DESCRIPTION
This PR is related to https://github.com/solvcon/modmesh/issues/498. It adds a function to open/close the console and bind this function in Window/console.

![image](https://github.com/user-attachments/assets/e35e1b4c-3b1c-4137-988f-78ddcb1374ee)
![image](https://github.com/user-attachments/assets/ec723982-38e0-4776-9020-3655195bd861)

By clicking the menu, you can turn on/off the console. The content in console will remain since it only `hide()` the widget.