### PR TITLE
Replace and disable the built‑in legacy cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,6 +65,16 @@ jobs:
     - name: event name
       run: |
         echo "github.event_name: ${{ github.event_name }}"
+    
+    # Cache the downloaded/extracted Qt bits
+    - name: Cache Qt download
+      uses: actions/cache@v3
+      with:
+        path: ${{ github.workspace }}/Qt
+        key: ${{ runner.os }}-qt-6.8.1-linux_gcc_64
+        # fallback to any previous Qt cache on this OS
+        restore-keys: |
+          ${{ runner.os }}-qt-6.8.1-
 
     - name: dependency by apt
       run: |
@@ -101,7 +111,7 @@ jobs:
         arch: 'linux_gcc_64'
         modules: 'qt3d'
         setup-python: 'false'
-        cache: true
+        cache: false
 
     - name: dependency by pip
       run: |


### PR DESCRIPTION
Caches the entire Qt/ directory under workspace using the modern actions/cache@v3.
Disables the action’s own cache: (which was pointing at GitHub’s old cache service).

<img width="984" alt="Screenshot 2025-04-17 at 11 40 34 PM" src="https://github.com/user-attachments/assets/a71b0fbd-fa7c-4eda-a0a9-d12731a4019b" />
