### PR TITLE
Add the transpose function for SimpleArray

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -654,6 +654,37 @@ public:
         }
     }
 
+    void transpose()
+    {
+        std::reverse(m_shape.begin(), m_shape.end());
+        std::reverse(m_stride.begin(), m_stride.end());
+    }
+
+    void transpose(shape_type const & axis)
+    {
+        if (axis.size() != m_shape.size())
+        {
+            throw std::runtime_error("SimpleArray: axis size mismatch");
+        }
+        shape_type new_shape(m_shape.size(), -1);
+        shape_type new_stride(m_stride.size());
+        for (size_t it = 0; it < m_shape.size(); ++it)
+        {
+            if (axis[it] >= m_shape.size() || axis[it] < 0)
+            {
+                throw std::runtime_error("SimpleArray: axis out of range");
+            }
+            if (new_shape[it] != -1)
+            {
+                throw std::runtime_error("SimpleArray: axis already set");
+            }
+            new_shape[it] = m_shape[axis[it]];
+            new_stride[it] = m_stride[axis[it]];
+        }
+        m_shape = new_shape;
+        m_stride = new_stride;
+    }
+
     template <typename... Args>
     value_type const & operator()(Args... args) const { return *vptr(args...); }
     template <typename... Args>

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -147,6 +147,37 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 "reshape",
                 [](wrapped_type const & self, py::object const & shape)
                 { return self.reshape(make_shape(shape)); })
+            .def(
+                "transpose",
+                [](wrapped_type & self, py::object const & axis, bool const & inplace) -> py::object
+                {
+                    if (inplace)
+                    {
+                        if (axis.is_none())
+                        {
+                            self.transpose();
+                        }
+                        else
+                        {
+                            self.transpose(make_shape(axis));
+                        }
+                        return py::none();
+                    }
+
+                    wrapped_type self_copy(self);
+                    if (axis.is_none())
+                    {
+                        self_copy.transpose();
+                    }
+                    else
+                    {
+                        self_copy.transpose(make_shape(axis));
+                    }
+                    return py::cast(std::move(self_copy));
+                },
+                py::arg("axis") = py::none(),
+                py::arg("inplace") = true)
+
             .def_property_readonly("has_ghost", &wrapped_type::has_ghost)
             .def_property("nghost", &wrapped_type::nghost, &wrapped_type::set_nghost)
             .def_property_readonly("nbody", &wrapped_type::nbody)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -222,6 +222,42 @@ class SimpleArrayBasicTC(unittest.TestCase):
         self.assertEqual(sarr_ref[3], 3.0)
         self.assertEqual(sarr_clone[3], 2.0)  # should be the original value
 
+    def test_SimpleArray_transpose(self):
+        def check_identical(sarr, ndarr):
+            self.assertEqual(sarr.shape, ndarr.shape)
+            shape = sarr.shape
+            for idx1 in range(shape[0]):
+                for idx2 in range(shape[1]):
+                    for idx3 in range(shape[2]):
+                        for idx4 in range(shape[3]):
+                            ndnum = ndarr[idx1, idx2, idx3, idx4]
+                            sarrnum = sarr[idx1, idx2, idx3, idx4]
+                            self.assertEqual(ndnum, sarrnum)
+
+        ndarr = np.arange(2 * 3 * 4 * 5, dtype='float64')
+        ndarr = ndarr.reshape((2, 3, 4, 5))
+        ndarrT = ndarr.transpose()
+
+        sarr = modmesh.SimpleArrayFloat64(array=ndarr)
+        noarr = sarr.transpose()
+        check_identical(sarr, ndarrT)
+        self.assertEqual(noarr, None)
+
+        sarr = modmesh.SimpleArrayFloat64(array=ndarr)
+        sarr = sarr.transpose(inplace=False)
+        check_identical(sarr, ndarrT)
+
+        ndarrT = ndarr.transpose(0, 3, 2, 1)
+
+        sarr = modmesh.SimpleArrayFloat64(array=ndarr)
+        noarr = sarr.transpose((0, 3, 2, 1))
+        check_identical(sarr, ndarrT)
+        self.assertEqual(noarr, None)
+
+        sarr = modmesh.SimpleArrayFloat64(array=ndarr)
+        sarr = sarr.transpose((0, 3, 2, 1), inplace=False)
+        check_identical(sarr, ndarrT)
+
     def test_SimpleArray_ghost_1d(self):
 
         sarr = modmesh.SimpleArrayFloat64(4 * 3 * 2)


### PR DESCRIPTION
According to issue #506 , I implement the `void SimpleArray::reverse()` and wrap it to the python.