### PR TITLE
refactor function `transpose` and add the property `.T`

### DIFF
--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -149,35 +149,29 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 { return self.reshape(make_shape(shape)); })
             .def(
                 "transpose",
-                [](wrapped_type & self, py::object const & axis, bool const & inplace) -> py::object
+                [](wrapped_type & self, py::object const & axis, bool const & inplace)
                 {
-                    if (inplace)
-                    {
-                        if (axis.is_none())
-                        {
-                            self.transpose();
-                        }
-                        else
-                        {
-                            self.transpose(make_shape(axis));
-                        }
-                        return py::none();
-                    }
-
-                    wrapped_type self_copy(self);
+                    wrapped_type * ret = inplace ? &self : new wrapped_type(self);
                     if (axis.is_none())
                     {
-                        self_copy.transpose();
+                        ret->transpose();
                     }
                     else
                     {
-                        self_copy.transpose(make_shape(axis));
+                        ret->transpose(make_shape(axis));
                     }
-                    return py::cast(std::move(self_copy));
+                    return *ret;
                 },
                 py::arg("axis") = py::none(),
                 py::arg("inplace") = true)
-
+            .def_property_readonly(
+                "T",
+                [](wrapped_type & self)
+                {
+                    auto ret = wrapped_type(self);
+                    ret.transpose();
+                    return ret;
+                })
             .def_property_readonly("has_ghost", &wrapped_type::has_ghost)
             .def_property("nghost", &wrapped_type::nghost, &wrapped_type::set_nghost)
             .def_property_readonly("nbody", &wrapped_type::nbody)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -223,7 +223,7 @@ class SimpleArrayBasicTC(unittest.TestCase):
         self.assertEqual(sarr_clone[3], 2.0)  # should be the original value
 
     def test_SimpleArray_transpose(self):
-        def check_identical(sarr, ndarr):
+        def check_equal(sarr, ndarr):
             self.assertEqual(sarr.shape, ndarr.shape)
             shape = sarr.shape
             for idx1 in range(shape[0]):
@@ -239,24 +239,36 @@ class SimpleArrayBasicTC(unittest.TestCase):
         ndarrT = ndarr.transpose()
 
         sarr = modmesh.SimpleArrayFloat64(array=ndarr)
-        noarr = sarr.transpose()
-        check_identical(sarr, ndarrT)
-        self.assertEqual(noarr, None)
+        sarr2 = sarr.transpose()
+        check_equal(sarr, ndarrT)
+        check_equal(sarr2, ndarrT)
+        self.assertEqual(memoryview(sarr), memoryview(sarr2))
 
         sarr = modmesh.SimpleArrayFloat64(array=ndarr)
-        sarr = sarr.transpose(inplace=False)
-        check_identical(sarr, ndarrT)
+        sarr2 = sarr.transpose(inplace=False)
+        check_equal(sarr, ndarr)
+        check_equal(sarr2, ndarrT)
+        self.assertNotEqual(memoryview(sarr), memoryview(sarr2))
+
+        sarr = modmesh.SimpleArrayFloat64(array=ndarr)
+        sarr2 = sarr.T
+        check_equal(sarr, ndarr)
+        check_equal(sarr2, ndarrT)
+        self.assertNotEqual(memoryview(sarr), memoryview(sarr2))
 
         ndarrT = ndarr.transpose(0, 3, 2, 1)
 
         sarr = modmesh.SimpleArrayFloat64(array=ndarr)
-        noarr = sarr.transpose((0, 3, 2, 1))
-        check_identical(sarr, ndarrT)
-        self.assertEqual(noarr, None)
+        sarr2 = sarr.transpose((0, 3, 2, 1))
+        check_equal(sarr, ndarrT)
+        check_equal(sarr2, ndarrT)
+        self.assertEqual(memoryview(sarr), memoryview(sarr2))
 
         sarr = modmesh.SimpleArrayFloat64(array=ndarr)
-        sarr = sarr.transpose((0, 3, 2, 1), inplace=False)
-        check_identical(sarr, ndarrT)
+        sarr2 = sarr.transpose((0, 3, 2, 1), inplace=False)
+        check_equal(sarr, ndarr)
+        check_equal(sarr2, ndarrT)
+        self.assertNotEqual(memoryview(sarr), memoryview(sarr2))
 
     def test_SimpleArray_ghost_1d(self):
 


### PR DESCRIPTION
In this pull request, I refactor the function `SimpleArray::transpose()`.