### PR TITLE
[ci] remove aqtversion of install-qt-action

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -141,7 +141,6 @@ jobs:
     - name: install qt
       uses: jurplel/install-qt-action@v4
       with:
-        aqtversion: '==3.2.*'
         version: '6.8.1'
         host: 'linux'
         target: 'desktop'
@@ -311,7 +310,6 @@ jobs:
       - name: install qt
         uses: jurplel/install-qt-action@v4
         with:
-          aqtversion: '==3.2.*'
           version: '6.8.1'
           host: 'mac'
           target: 'desktop'
@@ -494,7 +492,6 @@ jobs:
       - name: install qt
         uses: jurplel/install-qt-action@v4
         with:
-          aqtversion: '==3.2.*'
           version: '6.8.1'
           host: 'windows'
           target: 'desktop'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -104,7 +104,6 @@ jobs:
     - name: install qt
       uses: jurplel/install-qt-action@v4
       with:
-        aqtversion: '==3.2.*'
         version: '6.8.1'
         host: 'linux'
         target: 'desktop'
@@ -230,7 +229,6 @@ jobs:
       - name: install qt
         uses: jurplel/install-qt-action@v4
         with:
-          aqtversion: '==3.2.*'
           version: '6.8.1'
           host: 'mac'
           target: 'desktop'


### PR DESCRIPTION
In this PR, we removed aqtversion: '==3.2.*' to allow the Qt installer `aqtinstall` to use the default version provided by `jurplel/install-qt-action@v4`.
This keeps us in sync with version updates.