### PR TITLE
Implement `SimpleArray` member functions for searching

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -240,6 +240,51 @@ void SimpleArrayMixinSort<A, T>::sort(void)
     std::sort(athis->begin(), athis->end());
 }
 
+template <typename A, typename T>
+class SimpleArrayMixinSearch
+{
+
+private:
+
+    using internal_types = detail::SimpleArrayInternalTypes<T>;
+
+public:
+
+    using value_type = typename internal_types::value_type;
+
+    size_t argmin() const
+    {
+        size_t min_index = 0;
+        value_type min_value = std::numeric_limits<value_type>::max();
+        auto athis = static_cast<A const *>(this);
+        for (size_t i = 0; i < athis->size(); ++i)
+        {
+            if (athis->data(i) < min_value)
+            {
+                min_value = athis->data(i);
+                min_index = i;
+            }
+        }
+        return min_index;
+    }
+
+    size_t argmax() const
+    {
+        size_t max_index = 0;
+        value_type max_value = std::numeric_limits<value_type>::lowest();
+        auto athis = static_cast<A const *>(this);
+        for (size_t i = 0; i < athis->size(); ++i)
+        {
+            if (athis->data(i) > max_value)
+            {
+                max_value = athis->data(i);
+                max_index = i;
+            }
+        }
+        return max_index;
+    }
+}; /* end class SimpleArrayMixinSearch */
+
 } /* end namespace detail */
 
 /**
@@ -252,6 +297,7 @@ class SimpleArray
     : public detail::SimpleArrayMixinModifiers<SimpleArray<T>, T>
     , public detail::SimpleArrayMixinCalculators<SimpleArray<T>, T>
     , public detail::SimpleArrayMixinSort<SimpleArray<T>, T>
+    , public detail::SimpleArrayMixinSearch<SimpleArray<T>, T>
 {
 
 private:

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -180,6 +180,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .wrap_modifiers()
             .wrap_calculators()
             .wrap_sort()
+            .wrap_search()
             // ATTENTION: always keep the same interface between WrapSimpleArrayPlex and WrapSimpleArray
             ;
     }
@@ -230,6 +231,19 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def("take_along_axis",
                  [](wrapped_type & self, py::object const & indices)
                  { return pybind11::cast(self.take_along_axis(indices.cast<SimpleArrayUint64>())); })
+            //
+            ;
+
+        return *this;
+    }
+
+    wrapper_type & wrap_search()
+    {
+        namespace py = pybind11; // NOLINT(misc-unused-alias-decls)
+
+        (*this)
+            .def("argmin", &wrapped_type::argmin)
+            .def("argmax", &wrapped_type::argmax)
             //
             ;
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -983,6 +983,29 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         self.assertEqual(sarr.sum(), True)
 
 
+class SimpleArraySearchTC(unittest.TestCase):
+
+    def test_argminmax(self):
+        # test 1-D data
+        data = [1, 3, 5, 7, 9]
+        narr = np.array(data, dtype='uint64')
+        sarr = modmesh.SimpleArrayUint64(array=narr)
+
+        self.assertEqual(sarr.argmin(), 0)
+        self.assertEqual(sarr.argmax(), 4)
+        self.assertEqual(narr.argmin(), sarr.argmin())
+        self.assertEqual(narr.argmax(), sarr.argmax())
+
+        # test N-D data
+        data = [[1, 3, 5, 7, 9], [2, 4, 6, 8, 10], [1, 10, 1, 10, 1]]
+        narr = np.array(data, dtype='float64')
+        sarr = modmesh.SimpleArrayFloat64(array=narr)
+        self.assertEqual(sarr.argmin(), 0)
+        self.assertEqual(sarr.argmax(), 9)
+        self.assertEqual(narr.argmin(), sarr.argmin())
+        self.assertEqual(narr.argmax(), sarr.argmax())
+
+
 class SimpleArrayPlexTC(unittest.TestCase):
 
     def test_SimpleArrayPlex_constructor(self):


### PR DESCRIPTION
Implement SimpleArray member functions for selected searching operations (both C++ and Python wrapper and test in Python):

- [ ] [numpy.argmax()](https://numpy.org/doc/2.2/reference/generated/numpy.argmax.html#numpy.argmax) as SimpleArray::argmax()

- [ ] [numpy.argmin()](https://numpy.org/doc/2.2/reference/generated/numpy.argmin.html#numpy.argmin) as SimpleArray::argmin()

- [ ] [numpy.argwhere()](https://numpy.org/doc/2.2/reference/generated/numpy.argwhere.html#numpy.argwhere) as SimpleArray::argwhere()

- [ ] [numpy.where()](https://numpy.org/doc/2.2/reference/generated/numpy.where.html#numpy.where) as SimpleArray::where()