### PR TITLE
Turn off pip upgrade on macos to its failure on macos 14

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -324,7 +324,8 @@ jobs:
           ls -al $(which python3)
           # suppress the warning of pip because brew forces PEP668 since python3.12
           python3 -m pip -v install --upgrade setuptools
-          python3 -m pip -v install --upgrade pip
+          # Sometimes pip upgrade fails with macos-14, turn off temporarily (2025/4/27).
+          #python3 -m pip -v install --upgrade pip
           python3 -m pip -v install --upgrade numpy matplotlib pytest flake8 jsonschema
           # For now (2024/10/22), pyside6 6.6.3 does not support Python 3.13.
           # Use --ignore-requires-python to force installation.


### PR DESCRIPTION
Upgrading pip to 25.1 currently fails on macos-14 runner.  Turning it off temporarily.