### PR TITLE
Implemente Arithmetic operation for `SimpleArray`

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -207,6 +207,102 @@ public:
         }
         return ret;
     }
+
+    A add(A const & other) const
+    {
+        return A(*static_cast<A const *>(this)).iadd(other);
+    }
+
+    A sub(A const & other) const
+    {
+        return A(*static_cast<A const *>(this)).isub(other);
+    }
+
+    A mul(A const & other) const
+    {
+        return A(*static_cast<A const *>(this)).imul(other);
+    }
+
+    A div(A const & other) const
+    {
+        return A(*static_cast<A const *>(this)).idiv(other);
+    }
+
+    A & iadd(A const & other)
+    {
+        auto athis = static_cast<A *>(this);
+        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            for (size_t i = 0; i < athis->size(); ++i)
+            {
+                athis->data(i) += other.data(i);
+            }
+        }
+        else
+        {
+            for (size_t i = 0; i < athis->size(); ++i)
+            {
+                athis->data(i) = athis->data(i) || other.data(i);
+            }
+        }
+
+        return *athis;
+    }
+
+    A & isub(A const & other)
+    {
+        auto athis = static_cast<A *>(this);
+        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            for (size_t i = 0; i < athis->size(); ++i)
+            {
+                athis->data(i) -= other.data(i);
+            }
+        }
+        else
+        {
+            throw std::runtime_error(Formatter() << "SimpleArray<bool>::isub(): boolean value doesn't support this operation");
+        }
+        return *athis;
+    }
+
+    A & imul(A const & other)
+    {
+        auto athis = static_cast<A *>(this);
+        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            for (size_t i = 0; i < athis->size(); ++i)
+            {
+                athis->data(i) *= other.data(i);
+            }
+        }
+        else
+        {
+            for (size_t i = 0; i < athis->size(); ++i)
+            {
+                athis->data(i) = athis->data(i) && other.data(i);
+            }
+        }
+        return *athis;
+    }
+
+    A & idiv(A const & other)
+    {
+        auto athis = static_cast<A *>(this);
+        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            for (size_t i = 0; i < athis->size(); ++i)
+            {
+                athis->data(i) /= other.data(i);
+            }
+        }
+        else
+        {
+            throw std::runtime_error(Formatter() << "SimpleArray<bool>::idiv(): boolean value doesn't support this operation");
+        }
+        return *athis;
+    }
+
 }; /* end class SimpleArrayMixinCalculators */
 
 template <typename A, typename T>

--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -303,6 +303,82 @@ public:
         return *athis;
     }
 
+    A add_simd(A const & other) const
+    {
+        return A(*static_cast<A const *>(this)).iadd_simd(other);
+    }
+
+    A sub_simd(A const & other) const
+    {
+        return A(*static_cast<A const *>(this)).isub_simd(other);
+    }
+
+    A mul_simd(A const & other) const
+    {
+        return A(*static_cast<A const *>(this)).imul_simd(other);
+    }
+
+    A div_simd(A const & other) const
+    {
+        return A(*static_cast<A const *>(this)).idiv_simd(other);
+    }
+
+    A & iadd_simd(A const & other)
+    {
+        auto athis = static_cast<A *>(this);
+        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            simd::add<T>(athis->begin(), athis->end(), athis->begin(), other.begin());
+            return *athis;
+        }
+        else
+        {
+            return athis->iadd(other);
+        }
+    }
+
+    A & isub_simd(A const & other)
+    {
+        auto athis = static_cast<A *>(this);
+        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            simd::sub<T>(athis->begin(), athis->end(), athis->begin(), other.begin());
+            return *athis;
+        }
+        else
+        {
+            return athis->isub(other);
+        }
+    }
+
+    A & imul_simd(A const & other)
+    {
+        auto athis = static_cast<A *>(this);
+        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            simd::mul<T>(athis->begin(), athis->end(), athis->begin(), other.begin());
+            return *athis;
+        }
+        else
+        {
+            return athis->imul(other);
+        }
+    }
+
+    A & idiv_simd(A const & other)
+    {
+        auto athis = static_cast<A *>(this);
+        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            simd::div<T>(athis->begin(), athis->end(), athis->begin(), other.begin());
+            return *athis;
+        }
+        else
+        {
+            return athis->idiv(other);
+        }
+    }
+
 }; /* end class SimpleArrayMixinCalculators */
 
 template <typename A, typename T>

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -212,6 +212,18 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def("max", &wrapped_type::max)
             .def("sum", &wrapped_type::sum)
             .def("abs", &wrapped_type::abs)
+            .def("add", &wrapped_type::add)
+            .def("sub", &wrapped_type::sub)
+            .def("mul", &wrapped_type::mul)
+            .def("div", &wrapped_type::div)
+            .def("iadd", [](wrapped_type & self, wrapped_type const & other)
+                 { self.iadd(other); })
+            .def("isub", [](wrapped_type & self, wrapped_type const & other)
+                 { self.isub(other); })
+            .def("imul", [](wrapped_type & self, wrapped_type const & other)
+                 { self.imul(other); })
+            .def("idiv", [](wrapped_type & self, wrapped_type const & other)
+                 { self.idiv(other); })
             //
             ;
 

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -224,6 +224,18 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                  { self.imul(other); })
             .def("idiv", [](wrapped_type & self, wrapped_type const & other)
                  { self.idiv(other); })
+            .def("add_simd", &wrapped_type::add_simd)
+            .def("sub_simd", &wrapped_type::sub_simd)
+            .def("mul_simd", &wrapped_type::mul_simd)
+            .def("div_simd", &wrapped_type::div_simd)
+            .def("iadd_simd", [](wrapped_type & self, wrapped_type const & other)
+                 { self.iadd_simd(other); })
+            .def("isub_simd", [](wrapped_type & self, wrapped_type const & other)
+                 { self.isub_simd(other); })
+            .def("imul_simd", [](wrapped_type & self, wrapped_type const & other)
+                 { self.imul_simd(other); })
+            .def("idiv_simd", [](wrapped_type & self, wrapped_type const & other)
+                 { self.idiv_simd(other); })
             //
             ;
 

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -216,6 +216,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def("sub", &wrapped_type::sub)
             .def("mul", &wrapped_type::mul)
             .def("div", &wrapped_type::div)
+            // TODO: In-place operation should return reference to self to support function chaining
             .def("iadd", [](wrapped_type & self, wrapped_type const & other)
                  { self.iadd(other); })
             .def("isub", [](wrapped_type & self, wrapped_type const & other)

--- a/cpp/modmesh/simd/neon/neon_alias.cpp
+++ b/cpp/modmesh/simd/neon/neon_alias.cpp
@@ -61,6 +61,18 @@ DECL_MM_IMPL_VDUPQ(64)
 
 #undef DECL_MM_IMPL_VDUPQ
 
+template <>
+type::vector_t<float> vdupq<float>(float val)
+{
+    return vdupq_n_f32(val);
+}
+
+template <>
+type::vector_t<double> vdupq<double>(double val)
+{
+    return vdupq_n_f64(val);
+}
+
 #define DECL_MM_IMPL_VLD1Q(N)                                            \
     template <>                                                          \
     type::vector_t<utype_t(N)> vld1q<utype_t(N)>(utype_t(N) * ptr)       \
@@ -90,6 +102,30 @@ DECL_MM_IMPL_VLD1Q(64)
 
 #undef DECL_MM_IMPL_VLD1Q
 
+template <>
+type::vector_t<float> vld1q<float>(float * ptr)
+{
+    return vld1q_f32(ptr);
+}
+
+template <>
+type::vector_t<float> vld1q<float>(float const * ptr)
+{
+    return vld1q_f32(ptr);
+}
+
+template <>
+type::vector_t<double> vld1q<double>(double * ptr)
+{
+    return vld1q_f64(ptr);
+}
+
+template <>
+type::vector_t<double> vld1q<double>(double const * ptr)
+{
+    return vld1q_f64(ptr);
+}
+
 #define DECL_MM_IMPL_VST1Q(N)                                                \
     template <>                                                              \
     void vst1q<utype_t(N)>(utype_t(N) * ptr, type::vector_t<utype_t(N)> vec) \
@@ -108,6 +144,18 @@ DECL_MM_IMPL_VST1Q(32)
 DECL_MM_IMPL_VST1Q(64)
 
 #undef DECL_MM_IMPL_VST1Q
+
+template <>
+void vst1q<float>(float * ptr, type::vector_t<float> vec)
+{
+    return vst1q_f32(ptr, vec);
+}
+
+template <>
+void vst1q<double>(double * ptr, type::vector_t<double> vec)
+{
+    return vst1q_f64(ptr, vec);
+}
 
 #define DECL_MM_IMPL_VCGEQ(N)                                                                                        \
     template <>                                                                                                      \
@@ -128,6 +176,18 @@ DECL_MM_IMPL_VCGEQ(64)
 
 #undef DECL_MM_IMPL_VCGEQ
 
+template <>
+type::vector_t<float> vcgeq<float>(type::vector_t<float> vec_a, type::vector_t<float> vec_b)
+{
+    return vcgeq_f32(vec_a, vec_b);
+}
+
+template <>
+type::vector_t<double> vcgeq<double>(type::vector_t<double> vec_a, type::vector_t<double> vec_b)
+{
+    return vcgeq_f64(vec_a, vec_b);
+}
+
 #define DECL_MM_IMPL_VCLTQ(N)                                                                                        \
     template <>                                                                                                      \
     type::vector_t<utype_t(N)> vcltq<utype_t(N)>(type::vector_t<utype_t(N)> vec_a, type::vector_t<utype_t(N)> vec_b) \
@@ -146,6 +206,19 @@ DECL_MM_IMPL_VCLTQ(32)
 DECL_MM_IMPL_VCLTQ(64)
 
 #undef DECL_MM_IMPL_VCLTQ
+
+template <>
+type::vector_t<float> vcltq<float>(type::vector_t<float> vec_a, type::vector_t<float> vec_b)
+{
+    return vcltq_f32(vec_a, vec_b);
+}
+
+template <>
+type::vector_t<double> vcltq<double>(type::vector_t<double> vec_a, type::vector_t<double> vec_b)
+{
+    return vcltq_f64(vec_a, vec_b);
+}
+
 #undef stype_t
 #undef utype_t
 

--- a/cpp/modmesh/simd/neon/neon_alias.cpp
+++ b/cpp/modmesh/simd/neon/neon_alias.cpp
@@ -219,6 +219,110 @@ type::vector_t<double> vcltq<double>(type::vector_t<double> vec_a, type::vector_
     return vcltq_f64(vec_a, vec_b);
 }
 
+#define DECL_MM_IMPL_VADDQ(N)                                                                                        \
+    template <>                                                                                                      \
+    type::vector_t<utype_t(N)> vaddq<utype_t(N)>(type::vector_t<utype_t(N)> vec_a, type::vector_t<utype_t(N)> vec_b) \
+    {                                                                                                                \
+        return vaddq_u##N(vec_a, vec_b);                                                                             \
+    }                                                                                                                \
+    template <>                                                                                                      \
+    type::vector_t<stype_t(N)> vaddq<stype_t(N)>(type::vector_t<stype_t(N)> vec_a, type::vector_t<stype_t(N)> vec_b) \
+    {                                                                                                                \
+        return vaddq_s##N(vec_a, vec_b);                                                                             \
+    }
+
+DECL_MM_IMPL_VADDQ(8)
+DECL_MM_IMPL_VADDQ(16)
+DECL_MM_IMPL_VADDQ(32)
+DECL_MM_IMPL_VADDQ(64)
+
+#undef DECL_MM_IMPL_VADDQ
+
+template <>
+type::vector_t<float> vaddq<float>(type::vector_t<float> vec_a, type::vector_t<float> vec_b)
+{
+    return vaddq_f32(vec_a, vec_b);
+}
+
+template <>
+type::vector_t<double> vaddq<double>(type::vector_t<double> vec_a, type::vector_t<double> vec_b)
+{
+    return vaddq_f64(vec_a, vec_b);
+}
+
+#define DECL_MM_IMPL_VSUBQ(N)                                                                                        \
+    template <>                                                                                                      \
+    type::vector_t<utype_t(N)> vsubq<utype_t(N)>(type::vector_t<utype_t(N)> vec_a, type::vector_t<utype_t(N)> vec_b) \
+    {                                                                                                                \
+        return vsubq_u##N(vec_a, vec_b);                                                                             \
+    }                                                                                                                \
+    template <>                                                                                                      \
+    type::vector_t<stype_t(N)> vsubq<stype_t(N)>(type::vector_t<stype_t(N)> vec_a, type::vector_t<stype_t(N)> vec_b) \
+    {                                                                                                                \
+        return vsubq_s##N(vec_a, vec_b);                                                                             \
+    }
+
+DECL_MM_IMPL_VSUBQ(8)
+DECL_MM_IMPL_VSUBQ(16)
+DECL_MM_IMPL_VSUBQ(32)
+DECL_MM_IMPL_VSUBQ(64)
+
+#undef DECL_MM_IMPL_VSUBQ
+
+template <>
+type::vector_t<float> vsubq<float>(type::vector_t<float> vec_a, type::vector_t<float> vec_b)
+{
+    return vsubq_f32(vec_a, vec_b);
+}
+
+template <>
+type::vector_t<double> vsubq<double>(type::vector_t<double> vec_a, type::vector_t<double> vec_b)
+{
+    return vsubq_f64(vec_a, vec_b);
+}
+
+#define DECL_MM_IMPL_VMULQ(N)                                                                                        \
+    template <>                                                                                                      \
+    type::vector_t<utype_t(N)> vmulq<utype_t(N)>(type::vector_t<utype_t(N)> vec_a, type::vector_t<utype_t(N)> vec_b) \
+    {                                                                                                                \
+        return vmulq_u##N(vec_a, vec_b);                                                                             \
+    }                                                                                                                \
+    template <>                                                                                                      \
+    type::vector_t<stype_t(N)> vmulq<stype_t(N)>(type::vector_t<stype_t(N)> vec_a, type::vector_t<stype_t(N)> vec_b) \
+    {                                                                                                                \
+        return vmulq_s##N(vec_a, vec_b);                                                                             \
+    }
+
+DECL_MM_IMPL_VMULQ(8)
+DECL_MM_IMPL_VMULQ(16)
+DECL_MM_IMPL_VMULQ(32)
+
+#undef DECL_MM_IMPL_VMULQ
+
+template <>
+type::vector_t<float> vmulq<float>(type::vector_t<float> vec_a, type::vector_t<float> vec_b)
+{
+    return vmulq_f32(vec_a, vec_b);
+}
+
+template <>
+type::vector_t<double> vmulq<double>(type::vector_t<double> vec_a, type::vector_t<double> vec_b)
+{
+    return vmulq_f64(vec_a, vec_b);
+}
+
+template <>
+type::vector_t<float> vdivq<float>(type::vector_t<float> vec_a, type::vector_t<float> vec_b)
+{
+    return vdivq_f32(vec_a, vec_b);
+}
+
+template <>
+type::vector_t<double> vdivq<double>(type::vector_t<double> vec_a, type::vector_t<double> vec_b)
+{
+    return vdivq_f64(vec_a, vec_b);
+}
+
 #undef stype_t
 #undef utype_t
 

--- a/cpp/modmesh/simd/neon/neon_alias.hpp
+++ b/cpp/modmesh/simd/neon/neon_alias.hpp
@@ -92,6 +92,18 @@ DECL_MM_IMPL_VGETQ(64)
 #undef stype_t
 #undef utype_t
 
+template <typename base_type, typename = std::enable_if_t<type::has_vectype<base_type>>>
+type::vector_t<base_type> vaddq(type::vector_t<base_type> vec_a, type::vector_t<base_type> vec_b);
+
+template <typename base_type, typename = std::enable_if_t<type::has_vectype<base_type>>>
+type::vector_t<base_type> vsubq(type::vector_t<base_type> vec_a, type::vector_t<base_type> vec_b);
+
+template <typename base_type, typename = std::enable_if_t<2 < type::vector_lane<base_type> || std::is_floating_point_v<base_type>>>
+type::vector_t<base_type> vmulq(type::vector_t<base_type> vec_a, type::vector_t<base_type> vec_b);
+
+template <typename base_type, typename = std::enable_if_t<std::is_floating_point_v<base_type>>>
+type::vector_t<base_type> vdivq(type::vector_t<base_type> vec_a, type::vector_t<base_type> vec_b);
+
 } /* namespace neon */
 
 } /* namespace simd */

--- a/cpp/modmesh/simd/neon/neon_type.hpp
+++ b/cpp/modmesh/simd/neon/neon_type.hpp
@@ -110,6 +110,20 @@ struct vector<int64_t>
     static constexpr size_t N_lane = 2;
 };
 
+template <>
+struct vector<float>
+{
+    using type = float32x4_t;
+    static constexpr size_t N_lane = 4;
+};
+
+template <>
+struct vector<double>
+{
+    using type = float64x2_t;
+    static constexpr size_t N_lane = 2;
+};
+
 } /* namespace detail */
 
 template <typename T>

--- a/cpp/modmesh/simd/simd.hpp
+++ b/cpp/modmesh/simd/simd.hpp
@@ -55,6 +55,66 @@ const T * check_between(T const * start, T const * end, T const & min_val, T con
     }
 }
 
+template <typename T>
+void add(T * dest, T const * dest_end, T const * src1, T const * src2)
+{
+    using namespace detail;
+    switch (detect_simd())
+    {
+    case SIMD_NEON:
+        return neon::add<T>(dest, dest_end, src1, src2);
+        break;
+
+    default:
+        return generic::add<T>(dest, dest_end, src1, src2);
+    }
+}
+
+template <typename T>
+void sub(T * dest, T const * dest_end, T const * src1, T const * src2)
+{
+    using namespace detail;
+    switch (detect_simd())
+    {
+    case SIMD_NEON:
+        return neon::sub<T>(dest, dest_end, src1, src2);
+        break;
+
+    default:
+        return generic::sub<T>(dest, dest_end, src1, src2);
+    }
+}
+
+template <typename T>
+void mul(T * dest, T const * dest_end, T const * src1, T const * src2)
+{
+    using namespace detail;
+    switch (detect_simd())
+    {
+    case SIMD_NEON:
+        return neon::mul<T>(dest, dest_end, src1, src2);
+        break;
+
+    default:
+        return generic::mul<T>(dest, dest_end, src1, src2);
+    }
+}
+
+template <typename T>
+void div(T * dest, T const * dest_end, T const * src1, T const * src2)
+{
+    using namespace detail;
+    switch (detect_simd())
+    {
+    case SIMD_NEON:
+        return neon::div<T>(dest, dest_end, src1, src2);
+        break;
+
+    default:
+        return generic::div<T>(dest, dest_end, src1, src2);
+    }
+}
+
 } /* namespace simd */
 
 } /* namespace modmesh */

--- a/cpp/modmesh/simd/simd_generic.hpp
+++ b/cpp/modmesh/simd/simd_generic.hpp
@@ -53,6 +53,58 @@ const T * check_between(T const * start, T const * end, T const & min_val, T con
     return nullptr;
 }
 
+template <typename T>
+void add(T * dest, T const * dest_end, T const * src1, T const * src2)
+{
+    T * ptr = dest;
+    while (ptr < dest_end)
+    {
+        *ptr = *src1 + *src2;
+        ++ptr;
+        ++src1;
+        ++src2;
+    }
+}
+
+template <typename T>
+void sub(T * dest, T const * dest_end, T const * src1, T const * src2)
+{
+    T * ptr = dest;
+    while (ptr < dest_end)
+    {
+        *ptr = *src1 - *src2;
+        ++ptr;
+        ++src1;
+        ++src2;
+    }
+}
+
+template <typename T>
+void mul(T * dest, T const * dest_end, T const * src1, T const * src2)
+{
+    T * ptr = dest;
+    while (ptr < dest_end)
+    {
+        *ptr = *src1 * *src2;
+        ++ptr;
+        ++src1;
+        ++src2;
+    }
+}
+
+template <typename T>
+void div(T * dest, T const * dest_end, T const * src1, T const * src2)
+{
+    T * ptr = dest;
+    while (ptr < dest_end)
+    {
+        *ptr = *src1 / *src2;
+        ++ptr;
+        ++src1;
+        ++src2;
+    }
+}
+
 } /* namespace generic */
 
 } /* namespace simd */

--- a/profiling/profile_arithmetic_simd.py
+++ b/profiling/profile_arithmetic_simd.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2025, Kuan-Hsien Lee <khlee870529@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import functools
+import numpy as np
+import modmesh
+
+
+def profile_function(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        _ = modmesh.CallProfilerProbe(func.__name__)
+        result = func(*args, **kwargs)
+        return result
+    return wrapper
+
+
+def make_container(data):
+    if np.isdtype(data.dtype, np.uint8):
+        return modmesh.SimpleArrayUint8(array=data)
+    elif np.isdtype(data.dtype, np.uint16):
+        return modmesh.SimpleArrayUint16(array=data)
+    elif np.isdtype(data.dtype, np.uint32):
+        return modmesh.SimpleArrayUint32(array=data)
+    elif np.isdtype(data.dtype, np.uint64):
+        return modmesh.SimpleArrayUint64(array=data)
+    if np.isdtype(data.dtype, np.int8):
+        return modmesh.SimpleArrayInt8(array=data)
+    elif np.isdtype(data.dtype, np.int16):
+        return modmesh.SimpleArrayInt16(array=data)
+    elif np.isdtype(data.dtype, np.int32):
+        return modmesh.SimpleArrayInt32(array=data)
+    elif np.isdtype(data.dtype, np.int64):
+        return modmesh.SimpleArrayInt64(array=data)
+    elif np.isdtype(data.dtype, np.float32):
+        return modmesh.SimpleArrayFloat32(array=data)
+    elif np.isdtype(data.dtype, np.float64):
+        return modmesh.SimpleArrayFloat64(array=data)
+
+
+@profile_function
+def profile_add_np(src1, src2):
+    return np.add(src1, src2)
+
+
+@profile_function
+def profile_add_sa(src1, src2):
+    return src1.add(src2)
+
+
+@profile_function
+def profile_add_simd(src1, src2):
+    return src1.add_simd(src2)
+
+
+@profile_function
+def profile_sub_np(src1, src2):
+    return np.subtract(src1, src2)
+
+
+@profile_function
+def profile_sub_sa(src1, src2):
+    return src1.sub(src2)
+
+
+@profile_function
+def profile_sub_simd(src1, src2):
+    return src1.sub_simd(src2)
+
+
+@profile_function
+def profile_mul_np(src1, src2):
+    return np.multiply(src1, src2)
+
+
+@profile_function
+def profile_mul_sa(src1, src2):
+    return src1.mul(src2)
+
+
+@profile_function
+def profile_mul_simd(src1, src2):
+    return src1.mul_simd(src2)
+
+
+@profile_function
+def profile_div_np(src1, src2):
+    return np.divide(src1, src2)
+
+
+@profile_function
+def profile_div_sa(src1, src2):
+    return src1.div(src2)
+
+
+@profile_function
+def profile_div_simd(src1, src2):
+    return src1.div_simd(src2)
+
+
+def prof_add(src1, src2):
+    src1_sa = make_container(src1)
+    src2_sa = make_container(src2)
+    profile_add_np(src1, src2)
+    profile_add_sa(src1_sa, src2_sa)
+    profile_add_simd(src1_sa, src2_sa)
+
+
+def prof_sub(src1, src2):
+    src1_sa = make_container(src1)
+    src2_sa = make_container(src2)
+    profile_sub_np(src1, src2)
+    profile_sub_sa(src1_sa, src2_sa)
+    profile_sub_simd(src1_sa, src2_sa)
+
+
+def prof_mul(src1, src2):
+    src1_sa = make_container(src1)
+    src2_sa = make_container(src2)
+    profile_mul_np(src1, src2)
+    profile_mul_sa(src1_sa, src2_sa)
+    profile_mul_simd(src1_sa, src2_sa)
+
+
+def prof_div(src1, src2):
+    src1_sa = make_container(src1)
+    src2_sa = make_container(src2)
+    profile_div_np(src1, src2)
+    profile_div_sa(src1_sa, src2_sa)
+    profile_div_simd(src1_sa, src2_sa)
+
+
+def make_data(dtype, min_val, max_val, N=2 ** 22):
+    if "float" in dtype:
+        ret = np.random.rand(N).astype(dtype, copy=False)
+        ret = ret * (max_val - min_val) + min_val
+        return ret
+    else:
+        return np.random.randint(min_val, max_val, N, dtype=dtype)
+
+
+def profile_arithmetic_operation(op, val_range, prof_func, dtype, it=10):
+    N = 2 ** 22
+
+    modmesh.call_profiler.reset()
+    for _ in range(it):
+        src1 = make_data(dtype, val_range[0], val_range[1], N)
+        src2 = make_data(dtype, val_range[0], val_range[1], N)
+        prof_func(src1, src2)
+
+    res = modmesh.call_profiler.result()["children"]
+
+    print(f"## {op} N = 4M range: $[{val_range[0]}, {val_range[1]}]$ "
+          f"type: `{dtype}`\n")
+    out = {}
+    for r in res:
+        name = r["name"].replace(f"profile_{op}_", "")
+        time = r["total_time"] / r["count"]
+        out[name] = time
+
+    def print_row(*cols):
+        print(str.format("| {:10s} | {:15s} | {:15s} |" " {:15s} |",
+                         *(cols[0:4])))
+
+    print_row('func', 'per call (ms)', 'cmp to np', 'cmp to sa')
+    print_row('-' * 10, '-' * 15, '-' * 15, '-' * 15)
+    npbase = out["np"]
+    sabase = out["sa"]
+    for k, v in out.items():
+        print_row(f"{k:8s}", f"{v:.3E}", f"{v/npbase:.3f}", f"{v/sabase:.3f}")
+
+    print()
+
+
+def profile_operation(op):
+    dtypes_range = {
+        "uint8": (0, 2 ** 8 - 1),
+        "uint16": (0, 2 ** 16 - 1),
+        "uint32": (0, 2 ** 32 - 1),
+        "uint64": (0, 2 ** 64 - 1),
+        "int8": (-(2 ** 7), 2 ** 7 - 1),
+        "int16": (-(2 ** 15), 2 ** 15 - 1),
+        "int32": (-(2 ** 31), 2 ** 31 - 1),
+        "int64": (-(2 ** 63), 2 ** 63 - 1),
+        "float32": (-(2.0 ** 32), 2.0 ** 32),
+        "float64": (-(2.0 ** 64), 2.0 ** 64),
+    }
+
+    op_to_func = {
+        "add": prof_add,
+        "sub": prof_sub,
+        "mul": prof_mul,
+        "div": prof_div,
+    }
+
+    div_test_dtypes = ["float32", "float64"]
+    types_to_test = dtypes_range.keys() if op != "div" else div_test_dtypes
+
+    for dtype in types_to_test:
+        profile_arithmetic_operation(op,
+                                     dtypes_range[dtype],
+                                     op_to_func[op],
+                                     dtype)
+
+
+def main():
+    for operation in ["add", "sub", "mul", "div"]:
+        profile_operation(operation)
+
+
+if __name__ == "__main__":
+    main()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -998,6 +998,230 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         sarr = sarr.abs()
         self.assertEqual(sarr.sum(), True)
 
+    def type_convertor(self, dtype):
+        return {
+            'int8': modmesh.SimpleArrayInt8,
+            'int16': modmesh.SimpleArrayInt16,
+            'int32': modmesh.SimpleArrayInt32,
+            'int64': modmesh.SimpleArrayInt64,
+            'uint8': modmesh.SimpleArrayUint8,
+            'uint16': modmesh.SimpleArrayUint16,
+            'uint32': modmesh.SimpleArrayUint32,
+            'uint64': modmesh.SimpleArrayUint64,
+            'float32': modmesh.SimpleArrayFloat32,
+            'float64': modmesh.SimpleArrayFloat64,
+        }[dtype]
+
+    def test_add(self):
+        # test integer
+        def test_add_type(type):
+            arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            arr2 = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+            res = [3, 6, 9, 12, 15, 18, 21, 24, 27, 30]
+            narr1 = np.array(arr1, dtype=type)
+            narr2 = np.array(arr2, dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+            nres = np.add(narr1, narr2)
+            sres = sarr1.add(sarr2)
+            simdres = sarr1.add_simd(sarr2)
+            sarr1.iadd(sarr2)
+            for i in range(len(res)):
+                self.assertEqual(sres[i], res[i])
+                self.assertEqual(sarr1[i], res[i])
+                self.assertEqual(simdres[i], res[i])
+                self.assertEqual(sres[i], nres[i])
+
+        test_add_type('int8')
+        test_add_type('int16')
+        test_add_type('int32')
+        test_add_type('int64')
+        test_add_type('uint8')
+        test_add_type('uint16')
+        test_add_type('uint32')
+        test_add_type('uint64')
+        test_add_type('float32')
+        test_add_type('float64')
+
+        # test boolean
+        arr1 = [True, True, True, False, False, False]
+        arr2 = [True, False, True, False, True, False]
+        res = [True, True, True, False, True, False]
+        narr1 = np.array(arr1, dtype='bool')
+        narr2 = np.array(arr2, dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        sarr2 = modmesh.SimpleArrayBool(array=narr2)
+        nres = np.add(narr1, narr2)
+        sres = sarr1.add(sarr2)
+        sarr1.iadd(sarr2)
+        for i in range(len(res)):
+            self.assertEqual(sres[i], res[i])
+            self.assertEqual(sarr1[i], res[i])
+            self.assertEqual(sres[i], nres[i])
+
+    def test_sub(self):
+        # test integer
+        def test_sub_type(type):
+            arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            arr2 = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+            narr1 = np.array(arr1, dtype=type)
+            narr2 = np.array(arr2, dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+            nres = np.subtract(narr2, narr1)
+            sres = sarr2.sub(sarr1)
+            simdres = sarr2.sub_simd(sarr1)
+            sarr2.isub(sarr1)
+            for i in range(len(arr1)):
+                self.assertEqual(sres[i], arr1[i])
+                self.assertEqual(sarr2[i], arr1[i])
+                self.assertEqual(simdres[i], arr1[i])
+                self.assertEqual(sres[i], nres[i])
+
+        test_sub_type('int8')
+        test_sub_type('int16')
+        test_sub_type('int32')
+        test_sub_type('int64')
+        test_sub_type('uint8')
+        test_sub_type('uint16')
+        test_sub_type('uint32')
+        test_sub_type('uint64')
+        test_sub_type('float32')
+        test_sub_type('float64')
+
+        # test boolean
+        arr1 = [True, True, True, False, False, False]
+        arr2 = [True, False, True, False, True, False]
+        narr1 = np.array(arr1, dtype='bool')
+        narr2 = np.array(arr2, dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        sarr2 = modmesh.SimpleArrayBool(array=narr2)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::isub\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr2.sub(sarr1)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::isub\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr2.isub(sarr1)
+
+    def test_mul(self):
+        def test_mul_type(type):
+            arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            arr2 = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+            res = [2, 8, 18, 32, 50, 72, 98, 128, 162, 200]
+            narr1 = np.array(arr1, dtype=type)
+            narr2 = np.array(arr2, dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+            nres = np.multiply(narr2, narr1)
+            sres = sarr1.mul(sarr2)
+            simdres = sarr1.mul_simd(sarr2)
+            sarr1.imul(sarr2)
+            for i in range(len(res)):
+                self.assertEqual(sres[i], res[i])
+                self.assertEqual(sarr1[i], res[i])
+                self.assertEqual(simdres[i], res[i])
+                self.assertEqual(sres[i], nres[i])
+
+        test_mul_type('int16')
+        test_mul_type('int32')
+        test_mul_type('int64')
+        test_mul_type('uint8')
+        test_mul_type('uint16')
+        test_mul_type('uint32')
+        test_mul_type('uint64')
+        test_mul_type('float32')
+        test_mul_type('float64')
+
+        # test boolean
+        arr1 = [True, True, True, False, False, False]
+        arr2 = [True, False, True, False, True, False]
+        res = [True, False, True, False, False, False]
+        narr1 = np.array(arr1, dtype='bool')
+        narr2 = np.array(arr2, dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        sarr2 = modmesh.SimpleArrayBool(array=narr2)
+        nres = np.multiply(narr2, narr1)
+        sres = sarr1.mul(sarr2)
+        sarr1.imul(sarr2)
+        for i in range(len(res)):
+            self.assertEqual(sres[i], res[i])
+            self.assertEqual(sarr1[i], res[i])
+            self.assertEqual(sres[i], nres[i])
+
+    def test_div(self):
+        arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        arr2 = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+
+        def test_div_type(type):
+            res = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+            narr1 = np.array(arr1, dtype=type)
+            narr2 = np.array(arr2, dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+            nres = np.divide(narr2, narr1)
+            sres = sarr2.div(sarr1)
+            simdres = sarr2.div_simd(sarr1)
+            sarr2.idiv(sarr1)
+            for i in range(len(res)):
+                self.assertEqual(sres[i], res[i])
+                self.assertEqual(sarr2[i], res[i])
+                self.assertEqual(simdres[i], res[i])
+                self.assertEqual(sres[i], nres[i])
+
+        test_div_type('int8')
+        test_div_type('int16')
+        test_div_type('int32')
+        test_div_type('int64')
+        test_div_type('uint8')
+        test_div_type('uint16')
+        test_div_type('uint32')
+        test_div_type('uint64')
+
+        # test float
+        res = [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0]
+        narr1 = np.array(arr1, dtype='float64') / 5
+        narr2 = np.array(arr2, dtype='float64') / 2
+        sarr1 = modmesh.SimpleArrayFloat64(array=narr1)
+        sarr2 = modmesh.SimpleArrayFloat64(array=narr2)
+        nres = np.divide(narr2, narr1)
+        sres = sarr2.div(sarr1)
+        simdres = sarr2.div_simd(sarr1)
+        sarr2.idiv(sarr1)
+        for i in range(len(res)):
+            self.assertEqual(sres[i], res[i])
+            self.assertEqual(sarr2[i], res[i])
+            self.assertEqual(simdres[i], res[i])
+            self.assertEqual(sres[i], nres[i])
+
+        # test boolean
+        arr1 = [True, True, True, False, False, False]
+        arr2 = [True, False, True, False, True, False]
+        res = [True, True, True, False, True, False]
+        narr1 = np.array(arr1, dtype='bool')
+        narr2 = np.array(arr2, dtype='bool')
+        sarr1 = modmesh.SimpleArrayBool(array=narr1)
+        sarr2 = modmesh.SimpleArrayBool(array=narr2)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::idiv\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr2.div(sarr1)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::idiv\(\): "
+            r"boolean value doesn't support this operation"
+        ):
+            sarr2.idiv(sarr1)
+
 
 class SimpleArraySearchTC(unittest.TestCase):
 


### PR DESCRIPTION
In issue #514, arithmetic operation functions is planned to be implemented to SimpleArray.
This PR implements element-wise addition, substraction,  multiplication, and division of `SimpleArray` with operator overload in c++ and python class operator interfaces. 
SIMD integration and its profiling is also done with the profiling result listed below.

# Profiling results

## add N = 4M range: $[0, 255]$ type: `uint8`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.784E+00       | 1.000           | 0.470           |
| sa         | 3.794E+00       | 2.127           | 1.000           |
| simd       | 2.126E+00       | 1.192           | 0.560           |

## add N = 4M range: $[0, 65535]$ type: `uint16`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.987E+00       | 1.000           | 1.621           |
| sa         | 1.226E+00       | 0.617           | 1.000           |
| simd       | 1.219E+00       | 0.613           | 0.994           |

## add N = 4M range: $[0, 4294967295]$ type: `uint32`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 2.544E+00       | 1.000           | 0.871           |
| sa         | 2.921E+00       | 1.148           | 1.000           |
| simd       | 2.761E+00       | 1.085           | 0.945           |

## add N = 4M range: $[0, 18446744073709551615]$ type: `uint64`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 3.608E+00       | 1.000           | 0.635           |
| sa         | 5.683E+00       | 1.575           | 1.000           |
| simd       | 5.634E+00       | 1.561           | 0.991           |

## add N = 4M range: $[-128, 127]$ type: `int8`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.758E+00       | 1.000           | 0.468           |
| sa         | 3.754E+00       | 2.136           | 1.000           |
| simd       | 2.127E+00       | 1.210           | 0.567           |

## add N = 4M range: $[-32768, 32767]$ type: `int16`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.913E+00       | 1.000           | 1.625           |
| sa         | 1.178E+00       | 0.615           | 1.000           |
| simd       | 1.199E+00       | 0.627           | 1.018           |

## add N = 4M range: $[-2147483648, 2147483647]$ type: `int32`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 2.462E+00       | 1.000           | 0.955           |
| sa         | 2.577E+00       | 1.047           | 1.000           |
| simd       | 2.586E+00       | 1.051           | 1.004           |

## add N = 4M range: $[-9223372036854775808, 9223372036854775807]$ type: `int64`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 3.257E+00       | 1.000           | 0.628           |
| sa         | 5.186E+00       | 1.592           | 1.000           |
| simd       | 5.093E+00       | 1.564           | 0.982           |

## add N = 4M range: $[-4294967296.0, 4294967296.0]$ type: `float32`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.386E+00       | 1.000           | 0.605           |
| sa         | 2.290E+00       | 1.653           | 1.000           |
| simd       | 2.330E+00       | 1.681           | 1.017           |

## add N = 4M range: $[-1.8446744073709552e+19, 1.8446744073709552e+19]$ type: `float64`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 2.925E+00       | 1.000           | 0.602           |
| sa         | 4.862E+00       | 1.662           | 1.000           |
| simd       | 4.814E+00       | 1.646           | 0.990           |

## sub N = 4M range: $[0, 255]$ type: `uint8`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.722E+00       | 1.000           | 0.466           |
| sa         | 3.696E+00       | 2.147           | 1.000           |
| simd       | 2.061E+00       | 1.197           | 0.557           |

## sub N = 4M range: $[0, 65535]$ type: `uint16`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.881E+00       | 1.000           | 1.714           |
| sa         | 1.097E+00       | 0.583           | 1.000           |
| simd       | 1.110E+00       | 0.590           | 1.012           |

## sub N = 4M range: $[0, 4294967295]$ type: `uint32`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 2.399E+00       | 1.000           | 0.990           |
| sa         | 2.424E+00       | 1.010           | 1.000           |
| simd       | 2.418E+00       | 1.008           | 0.998           |

## sub N = 4M range: $[0, 18446744073709551615]$ type: `uint64`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 3.170E+00       | 1.000           | 0.655           |
| sa         | 4.839E+00       | 1.527           | 1.000           |
| simd       | 4.750E+00       | 1.499           | 0.982           |

## sub N = 4M range: $[-128, 127]$ type: `int8`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.740E+00       | 1.000           | 0.468           |
| sa         | 3.718E+00       | 2.137           | 1.000           |
| simd       | 2.081E+00       | 1.196           | 0.560           |

## sub N = 4M range: $[-32768, 32767]$ type: `int16`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.892E+00       | 1.000           | 1.717           |
| sa         | 1.102E+00       | 0.582           | 1.000           |
| simd       | 1.140E+00       | 0.603           | 1.035           |

## sub N = 4M range: $[-2147483648, 2147483647]$ type: `int32`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 2.369E+00       | 1.000           | 0.992           |
| sa         | 2.389E+00       | 1.009           | 1.000           |
| simd       | 2.368E+00       | 1.000           | 0.991           |

## sub N = 4M range: $[-9223372036854775808, 9223372036854775807]$ type: `int64`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 3.162E+00       | 1.000           | 0.608           |
| sa         | 5.201E+00       | 1.645           | 1.000           |
| simd       | 4.959E+00       | 1.568           | 0.953           |

## sub N = 4M range: $[-4294967296.0, 4294967296.0]$ type: `float32`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.441E+00       | 1.000           | 0.600           |
| sa         | 2.402E+00       | 1.666           | 1.000           |
| simd       | 2.501E+00       | 1.735           | 1.041           |

## sub N = 4M range: $[-1.8446744073709552e+19, 1.8446744073709552e+19]$ type: `float64`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 2.928E+00       | 1.000           | 0.601           |
| sa         | 4.870E+00       | 1.663           | 1.000           |
| simd       | 4.971E+00       | 1.698           | 1.021           |

## mul N = 4M range: $[0, 255]$ type: `uint8`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.612E+00       | 1.000           | 0.390           |
| sa         | 4.130E+00       | 2.563           | 1.000           |
| simd       | 1.998E+00       | 1.240           | 0.484           |

## mul N = 4M range: $[0, 65535]$ type: `uint16`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.802E+00       | 1.000           | 1.663           |
| sa         | 1.083E+00       | 0.601           | 1.000           |
| simd       | 1.110E+00       | 0.616           | 1.025           |

## mul N = 4M range: $[0, 4294967295]$ type: `uint32`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 2.293E+00       | 1.000           | 0.987           |
| sa         | 2.323E+00       | 1.013           | 1.000           |
| simd       | 2.355E+00       | 1.027           | 1.014           |

## mul N = 4M range: $[0, 18446744073709551615]$ type: `uint64`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 3.028E+00       | 1.000           | 0.588           |
| sa         | 5.153E+00       | 1.702           | 1.000           |
| simd       | 5.071E+00       | 1.675           | 0.984           |

## mul N = 4M range: $[-128, 127]$ type: `int8`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.610E+00       | 1.000           | 0.436           |
| sa         | 3.687E+00       | 2.291           | 1.000           |
| simd       | 1.994E+00       | 1.239           | 0.541           |

## mul N = 4M range: $[-32768, 32767]$ type: `int16`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.813E+00       | 1.000           | 1.661           |
| sa         | 1.091E+00       | 0.602           | 1.000           |
| simd       | 1.117E+00       | 0.616           | 1.024           |

## mul N = 4M range: $[-2147483648, 2147483647]$ type: `int32`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 2.290E+00       | 1.000           | 0.990           |
| sa         | 2.314E+00       | 1.010           | 1.000           |
| simd       | 2.336E+00       | 1.020           | 1.010           |

## mul N = 4M range: $[-9223372036854775808, 9223372036854775807]$ type: `int64`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 3.068E+00       | 1.000           | 0.576           |
| sa         | 5.324E+00       | 1.735           | 1.000           |
| simd       | 5.223E+00       | 1.703           | 0.981           |

## mul N = 4M range: $[-4294967296.0, 4294967296.0]$ type: `float32`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.377E+00       | 1.000           | 0.593           |
| sa         | 2.321E+00       | 1.686           | 1.000           |
| simd       | 2.360E+00       | 1.714           | 1.017           |

## mul N = 4M range: $[-1.8446744073709552e+19, 1.8446744073709552e+19]$ type: `float64`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 2.970E+00       | 1.000           | 0.583           |
| sa         | 5.091E+00       | 1.714           | 1.000           |
| simd       | 5.055E+00       | 1.702           | 0.993           |

## div N = 4M range: $[-4294967296.0, 4294967296.0]$ type: `float32`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 1.741E+00       | 1.000           | 0.638           |
| sa         | 2.731E+00       | 1.568           | 1.000           |
| simd       | 2.698E+00       | 1.549           | 0.988           |

## div N = 4M range: $[-1.8446744073709552e+19, 1.8446744073709552e+19]$ type: `float64`

| func       | per call (ms)   | cmp to np       | cmp to sa       |
| ---------- | --------------- | --------------- | --------------- |
| np         | 3.654E+00       | 1.000           | 0.599           |
| sa         | 6.104E+00       | 1.671           | 1.000           |
| simd       | 5.704E+00       | 1.561           | 0.934           |
