### PR TITLE
Add wave diagram in Burgers1DApp

### DIFF
--- a/modmesh/pilot/_base_app.py
+++ b/modmesh/pilot/_base_app.py
@@ -385,12 +385,6 @@ class OneDimBaseApp(PilotFeature):
         self._mgr.mainWindow.addDockWidget(Qt.LeftDockWidgetArea,
                                            config_widget)
 
-        # A new sub-window (`QMdiSubWindow`) for the plot area
-        self._subwin = self._mgr.addSubWindow(QWidget())
-        self._subwin.setWidget(PlotArea(self))
-        self._subwin.showMaximized()
-        self._subwin.show()
-
     def setup_app(self):
         """
         Create the window for solver.
@@ -544,9 +538,6 @@ class OneDimBaseApp(PilotFeature):
         self.set_solver_config()
         self.setup_timer()
         self.update_layout()
-
-        # Update PlotArea while click set button
-        self._subwin.setWidget(PlotArea(self))
 
     def update_layout(self):
         """
@@ -834,15 +825,15 @@ class PlotArea(QWidget):
     Methods:
         - :meth:`init_ui()`: Define the GUI layout of the window.
     """
-    def __init__(self, app, parent=None):
+    def __init__(self, plot, parent=None):
         super().__init__(parent)
-        self.app = app
+        self.app_plot = plot
         self.init_ui()
 
     def init_ui(self):
         layout = QVBoxLayout(self)
-        layout.addWidget(NavigationToolbar2QT(self.app.plot, None))
-        layout.addWidget(self.app.plot)
+        layout.addWidget(NavigationToolbar2QT(self.app_plot, None))
+        layout.addWidget(self.app_plot)
 
         self.setLayout(layout)
 

--- a/modmesh/pilot/_euler1d.py
+++ b/modmesh/pilot/_euler1d.py
@@ -27,7 +27,8 @@
 
 from ..onedim import euler1d
 
-from ._base_app import QuantityLine, SolverConfig, OneDimBaseApp
+from ._base_app import (QuantityLine, SolverConfig, OneDimBaseApp,
+                        PlotArea, QWidget)
 
 
 class Euler1DApp(OneDimBaseApp):
@@ -45,6 +46,24 @@ class Euler1DApp(OneDimBaseApp):
             tip="One-dimensional shock-tube problem with Euler solver",
             func=self.run,
         )
+
+    def run(self):
+        """
+        Create the GUI environment.
+        """
+        super().run()
+        # Create sub-window
+        self._subwin = self._mgr.addSubWindow(QWidget())
+        self._subwin.setWidget(PlotArea(self.plot))
+        self._subwin.showMaximized()
+        self._subwin.show()
+
+    def set(self):
+        """
+        Set the solver configurations and update the timer.
+        """
+        super().set()
+        self._subwin.setWidget(PlotArea(self.plot))
 
     def init_solver_config(self):
         """


### PR DESCRIPTION
This PR adds wave diagram sub window in Burgers1DApp.

The new window looks like:
<img width="1440" alt="截圖 2025-05-29 中午12 40 05" src="https://github.com/user-attachments/assets/09f1fec0-d730-4f26-88b2-bc7af3664c86" />

But I hope the wave diagram becomes:
<img width="723" alt="截圖 2025-05-29 中午12 46 45" src="https://github.com/user-attachments/assets/4f093260-0189-4a41-a805-a51bb2a4384b" />

Obviously, there are still some things to do in the wave diagram:
- plot the shock/expansion waves
- hide the wavefronts after they interset
- add a horizontal line which move from bottom to top along time

