### PR TITLE
Fix: Duplicate dft operation the result should be the same

### DIFF
--- a/cpp/modmesh/transform/fourier.hpp
+++ b/cpp/modmesh/transform/fourier.hpp
@@ -103,6 +103,7 @@ public:
         size_t N = in.size();
         for (size_t i = 0; i < N; ++i)
         {
+            out[i] = 0;
             for (size_t j = 0; j < N; ++j)
             {
                 T2 tmp = -2.0 * pi<T2> * i * j / static_cast<T2>(N);

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -60,6 +60,25 @@ class FourierTransformTB(mm.testing.TestBase):
             self.assert_allclose(mm_output[i].real, np_output[i].real)
             self.assert_allclose(mm_output[i].imag, np_output[i].imag)
 
+    def test_numpy_duplicate_dft_comparison(self):
+        input_size = 100
+
+        mm_input = self.SimpleArray(input_size)
+        for i in range(input_size):
+            mm_input[i] = self.complex(self.real_rng(), self.imag_rng())
+
+        np_input = np.array(mm_input, copy=False)
+
+        mm_output = self.SimpleArray(input_size, self.complex())
+        mm.FourierTransform.dft(mm_input, mm_output)
+        mm.FourierTransform.dft(mm_input, mm_output)
+
+        np_output = np.fft.fft(np_input)
+
+        for i in range(input_size):
+            self.assert_allclose(mm_output[i].real, np_output[i].real)
+            self.assert_allclose(mm_output[i].imag, np_output[i].imag)
+
     def test_numpy_fft_comparison(self):
         input_size = 100
 


### PR DESCRIPTION
## What's the problem?

Just take a look about #547, the expected output of duplicate `dft` function with the same input should be the same. Since output `SimpleArray` is not initialize before filled the value, the first `dft` operation and second `dft` operation may not have the same result. 

## How I fix this?

Initialize output `SimpleArray` by fill 0. I also write a testcase to check it work properly. 

## How to review it?

Check `test_numpy_duplicate_dft_comparison` is passed.

Resolved: #547 