### PR TITLE
Make `WrapBase` uncopyable

### DIFF
--- a/cpp/modmesh/python/common.hpp
+++ b/cpp/modmesh/python/common.hpp
@@ -274,9 +274,9 @@ public:
     }
 
     WrapBase() = delete;
-    WrapBase(WrapBase const &) = default;
+    WrapBase(WrapBase const &) = delete;
     WrapBase(WrapBase &&) = delete;
-    WrapBase & operator=(WrapBase const &) = default;
+    WrapBase & operator=(WrapBase const &) = delete;
     WrapBase & operator=(WrapBase &&) = delete;
     ~WrapBase() = default;
 


### PR DESCRIPTION
`modmesh::python::WrapBase` does not need to be copyable.

The copyable implementation could be a left-over from early prototype.