### PR TITLE
Fancy Profiling Table

### DIFF
--- a/modmesh/profiling/__init__.py
+++ b/modmesh/profiling/__init__.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2025, Han-Xuan Huang <c1ydehhx@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from ._result import (  # noqa: F401
+    ProfilingResultPrinter
+)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/profiling/__main__.py
+++ b/modmesh/profiling/__main__.py
@@ -28,6 +28,8 @@ import functools
 import modmesh
 import numpy as np
 
+from ._result import ProfilingResultPrinter
+
 
 def profile_function(func):
     @functools.wraps(func)
@@ -35,6 +37,7 @@ def profile_function(func):
         _ = modmesh.CallProfilerProbe(func.__name__)
         result = func(*args, **kwargs)
         return result
+
     return wrapper
 
 
@@ -84,26 +87,6 @@ def profile_take_along_axis_simd(sarr, indices):
     return sarr.take_along_axis_simd(indices)
 
 
-def print_res(res):
-    out = {}
-    for r in res:
-        name = r["name"]
-        time = r["total_time"] / r["count"]
-        out[name] = time
-
-    def print_row(*cols):
-        print(str.format("| {:30s} | {:15s} | {:15s} |", *(cols[0:3])))
-
-    print_row('func', 'per call (ms)', 'cmp to np')
-    print_row('-' * 30, '-' * 15, '-' * 15)
-    npkey = [k for k in out.keys() if "np" in k][0]
-    npbase = out[npkey]
-    for k, v in out.items():
-        print_row(f"{k:8s}", f"{v:.3E}", f"{v/npbase:.3f}")
-
-    print()
-
-
 def main():
 
     N = 100000
@@ -115,7 +98,16 @@ def main():
         test_data = np.arange(0, N, dtype='uint32')
         profile_sort_np(test_data)
         profile_sort_sa(make_container(test_data))
-    print_res(modmesh.call_profiler.result()["children"])
+
+    printer = ProfilingResultPrinter(
+        modmesh.call_profiler.result()["children"]
+    )
+    printer.add_column("per call (ms)", lambda r: r.total_time)
+
+    tot = printer["profile_sort_np"].total_time
+    printer.add_column("cmp to np", lambda r: r.total_time / tot)
+
+    printer.print_result(column_width=30)
 
     print("## `sort` Descending Data\n")
     modmesh.call_profiler.reset()
@@ -123,7 +115,16 @@ def main():
         test_data = np.arange(N, 0, -1, dtype='uint32')
         profile_sort_np(test_data)
         profile_sort_sa(make_container(test_data))
-    print_res(modmesh.call_profiler.result()["children"])
+
+    printer = ProfilingResultPrinter(
+        modmesh.call_profiler.result()["children"]
+    )
+    printer.add_column("per call (ms)", lambda r: r.total_time)
+
+    tot = printer["profile_sort_np"].total_time
+    printer.add_column("cmp to np", lambda r: r.total_time / tot)
+
+    printer.print_result(column_width=30)
 
     print("## `sort` Random Data\n")
     modmesh.call_profiler.reset()
@@ -132,7 +133,16 @@ def main():
         np.random.shuffle(test_data)
         profile_sort_np(test_data)
         profile_sort_sa(make_container(test_data))
-    print_res(modmesh.call_profiler.result()["children"])
+
+    printer = ProfilingResultPrinter(
+        modmesh.call_profiler.result()["children"]
+    )
+    printer.add_column("per call (ms)", lambda r: r.total_time)
+
+    tot = printer["profile_sort_np"].total_time
+    printer.add_column("cmp to np", lambda r: r.total_time / tot)
+
+    printer.print_result(column_width=30)
 
     print("## `argsort` Ascending Data\n")
     modmesh.call_profiler.reset()
@@ -140,7 +150,16 @@ def main():
         test_data = np.arange(0, N, dtype='uint32')
         profile_argsort_np(test_data)
         profile_argsort_sa(make_container(test_data))
-    print_res(modmesh.call_profiler.result()["children"])
+
+    printer = ProfilingResultPrinter(
+        modmesh.call_profiler.result()["children"]
+    )
+    printer.add_column("per call (ms)", lambda r: r.total_time)
+
+    tot = printer["profile_argsort_np"].total_time
+    printer.add_column("cmp to np", lambda r: r.total_time / tot)
+
+    printer.print_result(column_width=30)
 
     print("## `argsort` Descending Data\n")
     modmesh.call_profiler.reset()
@@ -148,7 +167,16 @@ def main():
         test_data = np.arange(N, 0, -1, dtype='uint32')
         profile_argsort_np(test_data)
         profile_argsort_sa(make_container(test_data))
-    print_res(modmesh.call_profiler.result()["children"])
+
+    printer = ProfilingResultPrinter(
+        modmesh.call_profiler.result()["children"]
+    )
+    printer.add_column("per call (ms)", lambda r: r.total_time)
+
+    tot = printer["profile_argsort_np"].total_time
+    printer.add_column("cmp to np", lambda r: r.total_time / tot)
+
+    printer.print_result(column_width=30)
 
     print("## `argsort` Random Data\n")
     modmesh.call_profiler.reset()
@@ -157,7 +185,16 @@ def main():
         np.random.shuffle(test_data)
         profile_argsort_np(test_data)
         profile_argsort_sa(make_container(test_data))
-    print_res(modmesh.call_profiler.result()["children"])
+
+    printer = ProfilingResultPrinter(
+        modmesh.call_profiler.result()["children"]
+    )
+    printer.add_column("per call (ms)", lambda r: r.total_time)
+
+    tot = printer["profile_argsort_np"].total_time
+    printer.add_column("cmp to np", lambda r: r.total_time / tot)
+
+    printer.print_result(column_width=30)
 
     print("## `take_along_axis` Ascending Data\n")
     modmesh.call_profiler.reset()
@@ -169,7 +206,16 @@ def main():
         profile_take_along_axis_np(test_data, indices)
         profile_take_along_axis_sa(test_sa, idx_sa)
         profile_take_along_axis_simd(test_sa, idx_sa)
-    print_res(modmesh.call_profiler.result()["children"])
+
+    printer = ProfilingResultPrinter(
+        modmesh.call_profiler.result()["children"]
+    )
+    printer.add_column("per call (ms)", lambda r: r.total_time)
+
+    tot = printer["profile_take_along_axis_np"].total_time
+    printer.add_column("cmp to np", lambda r: r.total_time / tot)
+
+    printer.print_result(column_width=30)
 
     print("## `take_along_axis` Descending Data\n")
     modmesh.call_profiler.reset()
@@ -181,7 +227,16 @@ def main():
         profile_take_along_axis_np(test_data, indices)
         profile_take_along_axis_sa(test_sa, idx_sa)
         profile_take_along_axis_simd(test_sa, idx_sa)
-    print_res(modmesh.call_profiler.result()["children"])
+
+    printer = ProfilingResultPrinter(
+        modmesh.call_profiler.result()["children"]
+    )
+    printer.add_column("per call (ms)", lambda r: r.total_time)
+
+    tot = printer["profile_take_along_axis_np"].total_time
+    printer.add_column("cmp to np", lambda r: r.total_time / tot)
+
+    printer.print_result(column_width=30)
 
     print("## `take_along_axis` Random Data\n")
     modmesh.call_profiler.reset()
@@ -195,7 +250,16 @@ def main():
         profile_take_along_axis_np(test_data, indices)
         profile_take_along_axis_sa(test_sa, idx_sa)
         profile_take_along_axis_simd(test_sa, idx_sa)
-    print_res(modmesh.call_profiler.result()["children"])
+
+    printer = ProfilingResultPrinter(
+        modmesh.call_profiler.result()["children"]
+    )
+    printer.add_column("per call (ms)", lambda r: r.total_time)
+
+    tot = printer["profile_take_along_axis_np"].total_time
+    printer.add_column("cmp to np", lambda r: r.total_time / tot)
+
+    printer.print_result(column_width=30)
 
 
 if __name__ == '__main__':

--- a/modmesh/profiling/_result.py
+++ b/modmesh/profiling/_result.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2025, Han-Xuan Huang <c1ydehhx@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Any, Callable
+from dataclasses import dataclass
+
+
+@dataclass
+class ProfilingsFunctionResult:
+    name: str
+    total_time: float
+    count: float
+    children: list
+
+
+@dataclass
+class ProfilingColumnData:
+    column_name: str
+    column_value: list[float | str]
+
+
+class ProfilingTableBuilder:
+    """
+    The table builder for `ProfilingResultPrinter`.
+
+    It accept the list of `ProfilingColumnData` as attribute.
+    The column width is 30 in default,
+    the user can adjust it by modified `column_width`.
+
+    The `ProfilingColumnData` list will be convert as row datas
+    and used to generate rows by `generate_result_row_by_row`.
+
+    Attributes:
+        column_data (list[ProfilingColumnData]):
+            The column data represent list of `ProfilingColumnData`.
+        column_width (int):
+            The column width.
+    """
+
+    def __init__(
+        self,
+        column_data: list[ProfilingColumnData] = None,
+        column_width: int = 30,
+    ):
+        self.column_data = [] if column_data is None else column_data
+        self.column_width = column_width
+
+        self.row_data = []
+
+        row_count = len(self.column_data[0].column_value)
+        for i in range(row_count):
+            row_data = []
+
+            for j in range(len(self.column_data)):
+                row_data.append(self.column_data[j].column_value[i])
+
+            self.row_data.append(row_data)
+
+    def generate_header(self):
+        """
+        Generate the header with the width specific from user.
+
+        It will be the format like:
+        `| func     | column A | column B | ... |`
+        """
+        return (
+            "| "
+            + " | ".join(
+                [
+                    data.column_name.ljust(self.column_width)
+                    for data in self.column_data
+                ]
+            )
+            + " |\n"
+        )
+
+    def generate_horizontal_lines(self):
+        """
+        Generate the horizontal lines with the width specific from user.
+
+        It will be the format like:
+        `| -------- | -------- | -------- | ... |`
+        """
+        return (
+            "| "
+            + " | ".join(
+                ["".ljust(self.column_width, "-") for _ in self.column_data]
+            )
+            + " |\n"
+        )
+
+    def generate_row(self):
+        """
+        Generate the result row with the width specific from user.
+
+        It will be the format like:
+        `| func A   | 30       | 40       | ... |`
+        """
+        result = ""
+
+        if len(self.column_data) == 0:
+            return result
+
+        for row in self.row_data:
+            result += (
+                "| "
+                + " | ".join(
+                    [str(value).ljust(self.column_width) for value in row]
+                )
+                + " |\n"
+            )
+
+        return result
+
+    def generate_table_str(self):
+        """
+        Generate the table that combines header, horizontal lines and rows.
+
+        It will be the format like:
+        ```
+        | func     | column A | column B | ... |
+        | -------- | -------- | -------- | ... |
+        | func A   | 30       | 40       | ... |
+        ```
+        """
+        return (
+            self.generate_header()
+            + self.generate_horizontal_lines()
+            + self.generate_row()
+        )
+
+
+class ProfilingResultPrinter:
+    """
+    A printer that formats and displays profiling results in a table.
+
+    The profiling result should be a list of dictionaries.
+
+    Each dictionary must contain at least the following keys:
+        - "name": Name of the function (str)
+        - "total_time": Total execution time in seconds (float)
+        - "count": Number of times the function was called (int)
+        - "children": A list of child profiling results (list)
+
+    Example:
+    ```
+        [
+            {
+                "name": "numpy_arange_100",
+                "total_time": 0.002083,
+                "count": 1,
+                "children": []
+            },
+            {
+                "name": "numpy_arange_1000",
+                "total_time": 0.004096,
+                "count": 1,
+                "children": []
+            }
+        ]
+    ```
+
+    Attributes:
+        profiling_results (list[dict[str, Any]]):
+            The list of profiling data dictionaries,
+            typically generated by a profiler.
+    """
+
+    def __init__(self, profiling_result: list[dict[str, Any]] = None):
+        profiling_result = (
+            [] if profiling_result is None else profiling_result
+        )
+
+        self.profiling_result: list[ProfilingsFunctionResult] = [
+            ProfilingsFunctionResult(**result) for result in profiling_result
+        ]
+        self.column_data: list[ProfilingColumnData] = []
+
+        self.column_data.append(
+            ProfilingColumnData(
+                "func",
+                [
+                    profiling_result.name
+                    for profiling_result in self.profiling_result
+                ],
+            )
+        )
+
+    def __getitem__(self, function_name: str) -> ProfilingsFunctionResult:
+        """
+        Get the result object based on function name.
+
+        Attributes:
+            function_name (str):
+                The specific function name.
+                If function name is absent in profiling result,
+                it will raise ValueError.
+
+        Returns:
+            ProfilingsFunctionResult: The result.
+        """
+        result = list(
+            filter(lambda x: x.name == function_name, self.profiling_result)
+        )
+
+        if len(result) == 0:
+            raise ValueError(
+                "The result with specific function name is absent."
+            )
+
+        return list(result)[0]
+
+    def add_column(
+        self,
+        column_name: str,
+        callable: Callable[[ProfilingsFunctionResult], str | float],
+    ):
+        """
+        Add a new column to the output table, computed using a lambda function.
+
+        The provided function should accept a single
+        `ProfilingsFunctionResult` object and return either a string or a float
+        to be displayed in the column.
+
+        Example:
+            To add a column showing total time, use:
+                `add_column("Total Time", lambda r: r.total_time)`
+
+        Attributes:
+            column_name (str):
+                The name of the column to be added.
+            callable (Callable[[ProfilingsFunctionResult], str | float]):
+                A lambda or function that calculate value for column.
+        """
+        self.column_data.append(
+            ProfilingColumnData(
+                column_name,
+                [
+                    callable(profiling_result)
+                    for profiling_result in self.profiling_result
+                ],
+            )
+        )
+
+    def print_result(self, column_width=30):
+        """
+        Print the table.
+
+        Attributes:
+            column_width (int):
+                The width of column.
+        """
+        builder = ProfilingTableBuilder(self.column_data, column_width)
+        print(builder.generate_table_str())
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ def main():
             'modmesh.pilot',
             'modmesh.pilot.airfoil',
             'modmesh.plot',
+            'modmesh.profiling',
         ],
         ext_modules=[CMakeExtension("_modmesh")],
         cmdclass={'build_ext': cmake_build_ext},

--- a/tests/test_profiling_result.py
+++ b/tests/test_profiling_result.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2025, Han-Xuan Huang <c1ydehhx@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Any
+
+import numpy
+import unittest
+
+import modmesh
+from modmesh.profiling import (
+    ProfilingResultPrinter,
+)
+from modmesh.profiling._result import (
+    ProfilingColumnData,
+    ProfilingTableBuilder,
+)
+
+
+class TestProfilingResultPrinter(unittest.TestCase):
+    def run_profile_function(self):
+        _ = modmesh.CallProfilerProbe("numpy_arange_100")
+        numpy.arange(0, 100, dtype="uint32")
+
+    def setUp(self):
+        modmesh.call_profiler.reset()
+        self.run_profile_function()
+        result: dict[str, Any] = modmesh.call_profiler.result()["children"]
+
+        self.profiling_result_fixture = result
+
+    def test_getitem_valid_key(self) -> None:
+        printer = ProfilingResultPrinter(self.profiling_result_fixture)
+
+        expected_name = "numpy_arange_100"
+        self.assertEqual(printer["numpy_arange_100"].name, expected_name)
+
+    def test_getitem_absent_key(self) -> None:
+        printer = ProfilingResultPrinter(self.profiling_result_fixture)
+
+        with self.assertRaisesRegex(ValueError, ".* is absent."):
+            printer["numpy_arange_1000"]
+
+    def test_add_column(self) -> None:
+        printer = ProfilingResultPrinter(self.profiling_result_fixture)
+        tot: float = printer["numpy_arange_100"].total_time
+
+        printer.add_column("tot_scale_10", lambda r: r.total_time * 10)
+
+        col = list(
+            filter(
+                lambda cols: cols.column_name == "tot_scale_10",
+                printer.column_data,
+            )
+        )[0]
+        self.assertEqual(col.column_value[0], tot * 10)
+
+    def test_default_column(self) -> None:
+        printer = ProfilingResultPrinter(self.profiling_result_fixture)
+
+        printer.add_column("tot_scale_10", lambda r: r.total_time * 10)
+
+        col = list(
+            filter(
+                lambda cols: cols.column_name == "func", printer.column_data
+            )
+        )[0]
+        self.assertEqual(col.column_value[0], "numpy_arange_100")
+
+    def test_null_column(self) -> None:
+        ProfilingResultPrinter()
+
+
+class TestProfilingTableBuilder(unittest.TestCase):
+    def setUp(self):
+        self.fake_column_data = [
+            ProfilingColumnData("func", ["foo", "bar", "foobar"]),
+            ProfilingColumnData("runtime", [10, 20, 200]),
+        ]
+        self.expect_header = (
+            f'| {"func".ljust(30, " ")} | {"runtime".ljust(30, " ")} |\n'
+        )
+        self.expect_horizontal_lines = (
+            f'| {"".ljust(30, "-")} | {"".ljust(30, "-")} |\n'
+        )
+        self.expect_row_data = "".join(
+            [
+                f'| {"foo".ljust(30, " ")} | {"10".ljust(30, " ")} |\n',
+                f'| {"bar".ljust(30, " ")} | {"20".ljust(30, " ")} |\n',
+                f'| {"foobar".ljust(30, " ")} | {"200".ljust(30, " ")} |\n',
+            ]
+        )
+
+    def test_generate_header(self) -> None:
+        builder: ProfilingTableBuilder = ProfilingTableBuilder(
+            self.fake_column_data
+        )
+
+        header: str = builder.generate_header()
+
+        self.assertEqual(self.expect_header, header)
+
+    def test_generate_hr_lines(
+        self,
+    ) -> None:
+        builder: ProfilingTableBuilder = ProfilingTableBuilder(
+            self.fake_column_data
+        )
+
+        horizontal_line: str = builder.generate_horizontal_lines()
+
+        self.assertEqual(self.expect_horizontal_lines, horizontal_line)
+
+    def test_generate_row(self) -> None:
+        builder: ProfilingTableBuilder = ProfilingTableBuilder(
+            self.fake_column_data
+        )
+
+        result_rows: str = builder.generate_row()
+
+        self.assertEqual(result_rows, self.expect_row_data)
+
+    def test_generate_table_str(self) -> None:
+        builder: ProfilingTableBuilder = ProfilingTableBuilder(
+            self.fake_column_data
+        )
+
+        table_str: str = builder.generate_table_str()
+
+        expect_result = (
+            self.expect_header
+            + self.expect_horizontal_lines
+            + self.expect_row_data
+        )
+        self.assertEqual(table_str, expect_result)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_profiling_result.py
+++ b/tests/test_profiling_result.py
@@ -122,9 +122,7 @@ class TestProfilingTableBuilder(unittest.TestCase):
 
         self.assertEqual(self.expect_header, header)
 
-    def test_generate_hr_lines(
-        self,
-    ) -> None:
+    def test_generate_hr_lines(self) -> None:
         builder: ProfilingTableBuilder = ProfilingTableBuilder(
             self.fake_column_data
         )


### PR DESCRIPTION
## What's new?

In this PR, I create `ProfilingResultPrinter` to print the profiling result with markdown table format.

It support:
 - Fetch result with function name as key. You can use `printer["func_name"]` to get the profiling result.
    ```py
    printer["profile_sort_np"].total_time
    ```
 - Create column with lambda function. If you want to create a column that compare with specific value:
    ```py
    printer.add_column("cmp to np", lambda result : result.total_time / printer["profile_sort_np"].total_time)
    ```
 - Static-typing for all function. It will be helped with Pylance.
 - Adjustable column width.

I only consider the story in `profiling/profile_sort.py` to implement this feature. If you need more feature, please let me know.

## Result

Previous version:

```python
modmesh.call_profiler.reset()
for _ in range(it):
    test_data = np.arange(0, N, dtype='uint32')
    profile_sort_np(test_data)
    profile_sort_sa(make_container(test_data))
print_res(modmesh.call_profiler.result()["children"])
```

```md
| func                           | per call (ms)   | cmp to np       |
| ------------------------------ | --------------- | --------------- |
| profile_sort_np                | 1.043E+00       | 1.000           |
| profile_sort_sa                | 9.586E-02       | 0.092           |
```

Now:

```python
modmesh.call_profiler.reset()
for _ in range(it):
    test_data = np.arange(0, N, dtype="uint32")
    profile_sort_np(test_data)
    profile_sort_sa(make_container(test_data))

printer = ProfilingResultPrinter(modmesh.call_profiler.result()["children"])
printer.add_column("per call (ms)", lambda result: result.total_time)
printer.add_column(
    "cmp to np",
    lambda result: result.total_time / printer["profile_sort_np"].total_time,
)
printer.print_result(column_width=30)
```

```md
| func                           | per call (ms)                  | cmp to np                      |
| ------------------------------ | ------------------------------ | ------------------------------ |
| profile_sort_np                | 9.769251                       | 1.0                            |
| profile_sort_sa                | 0.904417                       | 0.09257792639374297            |
```

## How to review it?

 - Check `profiling/profile_sort.py` work properly.