### PR TITLE
Speed up flake8 CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,116 +65,23 @@ jobs:
     - name: event name
       run: |
         echo "github.event_name: ${{ github.event_name }}"
-    
-    # Cache the downloaded/extracted Qt bits
-    - name: Cache Qt download
-      uses: actions/cache@v3
-      with:
-        path: ${{ github.workspace }}/Qt
-        key: ${{ runner.os }}-qt-6.8.1-linux_gcc_64
-        # fallback to any previous Qt cache on this OS
-        restore-keys: |
-          ${{ runner.os }}-qt-6.8.1-
 
     - name: dependency by apt
       run: |
-        VERSION_ID=$(bash -c 'source /etc/os-release ; echo $VERSION_ID')        
-        if [ "20.04" == "$VERSION_ID" ] ; then CLANG_TIDY_VERSION=10 ; else CLANG_TIDY_VERSION=14 ; fi
-        sudo apt-get -qqy update
-        sudo apt-get -qy install \
-            sudo curl git build-essential make cmake libc6-dev gcc g++ silversearcher-ag \
-            clang-tidy-${CLANG_TIDY_VERSION} \
-            python3 python3-dev python3-venv
-        sudo ln -fs "$(which clang-tidy-${CLANG_TIDY_VERSION})" "$(dirname $(which clang-tidy-${CLANG_TIDY_VERSION}))/clang-tidy"
-        # Install qt6 only with ubuntu-22.04
-        # This page explains why we need libgl1-mesa-dev
-        # https://doc-snapshots.qt.io/qt6-dev/linux.html
-        #
-        # In short, OpenGL libraries and headers are required. Without
-        # installing this package, cmake won't find the correct lib path.
-        # This has been replaced by the 'install qt' section below to manage
-        # qt6 versioning independently from the OS.
-
-        # if [ "${{ matrix.os }}" == "ubuntu-22.04" ] ; then \
-        #   sudo apt-get -qy install \
-        #       qt6-3d-dev xvfb \
-        #       libgl1-mesa-dev
-        # fi
-
-    - name: install qt
-      uses: jurplel/install-qt-action@v4
-      with:
-        version: '6.8.1'
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        modules: 'qt3d'
-        setup-python: 'false'
-        cache: false
+        sudo apt-get -qy install python3 python3-dev python3-venv
 
     - name: dependency by pip
       run: |
-        sudo pip3 install setuptools
-        sudo pip3 install numpy matplotlib pytest flake8 jsonschema pyside6==$(qmake6 -query QT_VERSION)
-
-    - name: dependency (manual)
-      run: sudo ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
+        python3 -m pip -v install flake8
 
     - name: show dependency
       # Copy the commands from contrib/dependency/showdep.sh
       run: |
-        echo "gcc path: $(which gcc)"
-        echo "gcc version: $(gcc --version)"
-        echo "cmake path: $(which cmake)"
-        echo "cmake version: $(cmake --version)"
-        echo "python3 path: $(which python3)"
-        echo "python3 version: $(python3 --version)"
-        echo "python3-config --prefix: $(python3-config --prefix)"
-        echo "python3-config --exec-prefix: $(python3-config --exec-prefix)"
-        echo "python3-config --includes: $(python3-config --includes)"
-        echo "python3-config --libs: $(python3-config --libs)"
-        echo "python3-config --cflags: $(python3-config --cflags)"
-        echo "python3-config --ldflags: $(python3-config --ldflags)"
-        echo "pip3 path: $(which pip3)"
-        python3 -c 'import numpy as np; print("np.__version__:", np.__version__, np.get_include())'
-        echo "pytest path: $(which pytest)"
-        echo "pytest version: $(pytest --version)"
-        echo "clang-tidy path: $(which clang-tidy)"
-        echo "clang-tidy version: $(clang-tidy -version)"
         echo "flake8 path: $(which flake8)"
         echo "flake8 version: $(flake8 --version)"
 
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: ${{ runner.os }}-tidy-${{ matrix.cmake_build_type }}
-        restore-keys: ${{ runner.os }}-tidy-${{ matrix.cmake_build_type }}
-        create-symlink: true
-
-    - name: make cinclude (check_include)
-      run: make cinclude
-
-    - name: make pilot
-      run: |
-        make pilot \
-          ${JOB_MAKE_ARGS} \
-          CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON"
-
-    - name: make run_pilot_pytest
-      run: |
-        export LD_LIBRARY_PATH=$(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
-        make run_pilot_pytest \
-          ${JOB_MAKE_ARGS} \
-          CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON"
-
     - name: make flake8
-      run: |
-        make flake8 \
-          ${JOB_MAKE_ARGS} \
-          CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+      run: flake8
 
   tidy_flake8_macos:
 
@@ -215,28 +122,6 @@ jobs:
           # Some mac runner does not have /usr/local/include and cmake sometimes crashes
           sudo mkdir -p /usr/local/include
 
-      - name: dependency by homebrew
-        run: |
-          export HOMEBREW_NO_AUTO_UPDATE=1
-          export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-          # This has been replaced by the 'install qt' section below to manage
-          # qt6 versioning independently from the OS.
-          # brew install llvm@16 qt6
-          brew install llvm@16
-          ln -s "$(brew --prefix llvm@16)/bin/clang-format" "/usr/local/bin/clang-format"
-          ln -s "$(brew --prefix llvm@16)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
-
-      - name: install qt
-        uses: jurplel/install-qt-action@v4
-        with:
-          version: '6.8.1'
-          host: 'mac'
-          target: 'desktop'
-          arch: 'clang_64'
-          modules: 'qt3d'
-          setup-python: 'false'
-          cache: true
-
       - name: dependency by pip
         run: |
           echo "which python3: $(which python3)"
@@ -244,77 +129,13 @@ jobs:
           # suppress the warning of pip because brew forces PEP668 since python3.12
           python3 -m pip -v install --upgrade setuptools --break-system-packages
           python3 -m pip -v install --upgrade pip --break-system-packages
-          python3 -m pip -v install --upgrade numpy matplotlib pytest flake8 jsonschema
-          # For now (2024/10/22), pyside6 6.6.3 does not support Python 3.13.
-          # Use --ignore-requires-python to force installation.
-          python3 -m pip -v install --upgrade pyside6==$(qmake -query QT_VERSION) --ignore-requires-python
-
-      - name: dependency (manual)
-        run: sudo NO_INSTALL_PREFIX=1 ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
+          python3 -m pip -v install --upgrade flake8
 
       - name: show dependency
         # Copy the commands from contrib/dependency/showdep.sh
         run: |
-          echo "gcc path: $(which gcc)"
-          echo "gcc version: $(gcc --version)"
-          echo "cmake path: $(which cmake)"
-          echo "cmake version: $(cmake --version)"
-          echo "python3 path: $(which python3)"
-          echo "python3 version: $(python3 --version)"
-          echo "python3-config --prefix: $(python3-config --prefix)"
-          echo "python3-config --exec-prefix: $(python3-config --exec-prefix)"
-          echo "python3-config --includes: $(python3-config --includes)"
-          echo "python3-config --libs: $(python3-config --libs)"
-          echo "python3-config --cflags: $(python3-config --cflags)"
-          echo "python3-config --ldflags: $(python3-config --ldflags)"
-          echo "pip3 path: $(which pip3)"
-          python3 -c 'import numpy as np; print("np.__version__:", np.__version__, np.get_include())'
-          echo "pytest path: $(which pytest)"
-          echo "pytest version: $(pytest --version)"
-          echo "clang-tidy path: $(which clang-tidy)"
-          echo "clang-tidy version: $(clang-tidy -version)"
           echo "flake8 path: $(which flake8)"
           echo "flake8 version: $(flake8 --version)"
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ runner.os }}-tidy-${{ matrix.cmake_build_type }}
-          restore-keys: ${{ runner.os }}-tidy-${{ matrix.cmake_build_type }}
-          create-symlink: true
-
-      - name: make cinclude (check_include)
-        run: make cinclude
-
-      - name: make pilot USE_PYTEST_HELPER_BINDING=OFF
-        run: |
-          make pilot \
-            ${JOB_MAKE_ARGS} \
-            CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON"
-
-      - name: make pilot USE_PYTEST_HELPER_BINDING=ON
-        run: |
-          rm -f build/*/Makefile
-          make pilot \
-            ${JOB_MAKE_ARGS} \
-            CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_PYTEST_HELPER_BINDING=ON"
-
-      - name: make run_pilot_pytest
-        run: |
-          # PySide6 installed by pip will bundle with a prebuilt Qt,
-          # this will cause duplicated symbol.
-          # Solve this issue by removed PySide6 prebuilt Qt library
-          rm -rf $(python3 -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))")/Qt/lib/*.framework
-          make run_pilot_pytest \
-            ${JOB_MAKE_ARGS} \
-            CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
-
       - name: make flake8
-        run: |
-          make flake8 \
-            ${JOB_MAKE_ARGS} \
-            CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+        run: flake8


### PR DESCRIPTION
## What's new?

In this PR, I optimize the speed on flake8 CI by skip unnecessary phase.  Since flake8 check doesn't need to build Qt, skip it will reduce lot of processing time. 

Therefore, I delete unnecessary phase in CI to speed up the CI.

## Result

In #554 said, flake8 CI will cost:
 - [macOS (22m~25m)](https://github.com/solvcon/modmesh/actions/runs/15698590151/job/44228470405).
 - [ubuntu (12m~15m)](https://github.com/ntut-xuan/modmesh/actions/runs/16491656471/job/46627563182).

<img width="350" height="55" alt="image" src="https://github.com/user-attachments/assets/cd263d9d-a601-4efd-9983-3c624d2a7ac9" />

<img width="350" height="55" alt="image" src="https://github.com/user-attachments/assets/6a316041-9fe2-473f-8632-086b6209be59" />

In this PR, the time cost on CI will be:
 - [ubuntu (25s)](https://github.com/ntut-xuan/modmesh/actions/runs/16491656471/job/46627563182).
 - [macOS (20s)](https://github.com/ntut-xuan/modmesh/actions/runs/16491369940/job/46626598036).

<img width="350" height="55" alt="image" src="https://github.com/user-attachments/assets/749bef01-a57a-41fe-9bcb-5dcdb94baafb" />

<img width="350" height="55" alt="image" src="https://github.com/user-attachments/assets/4ac03b34-86c0-4ddb-8e1d-46e51148a491" />

In speed up about 75x on macOS and 56.25x on ubuntu.

It also work properly. See [Failed case](https://github.com/ntut-xuan/modmesh/actions/runs/16491557705/job/46627236028). It can indicate that have blank line in my commit.

<img width="616" height="490" alt="image" src="https://github.com/user-attachments/assets/7144137b-de7b-41c5-8dd4-69e6af46cad9" />

Resolved: #554
