### PR TITLE
Feat: Speed up the median operation

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -261,7 +261,22 @@ public:
             acopy[i] = athis->at(sidx);
             ++i;
         } while (athis->next_sidx(sidx));
-        return median_op(acopy);
+        return simd::generic::median(acopy.begin(), acopy.end());
+    }
+
+    value_type parallel_median() const
+    {
+        auto athis = static_cast<A const *>(this);
+        const size_t n = athis->size();
+        small_vector<T> acopy(n);
+        auto sidx = athis->first_sidx();
+        size_t i = 0;
+        do
+        {
+            acopy[i] = athis->at(sidx);
+            ++i;
+        } while (athis->next_sidx(sidx));
+        return simd::median(acopy.begin(), acopy.end());
     }
 
     value_type average_op(small_vector<value_type> & sv, small_vector<value_type> & weight) const

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -260,6 +260,10 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 { return self.median(make_shape(axis)); },
                 py::arg("axis"))
             .def(
+                "parallel_median",
+                [](wrapped_type const & self)
+                { return self.parallel_median(); })
+            .def(
                 "average",
                 [](wrapped_type const & self, py::object const & weight)
                 {

--- a/cpp/modmesh/simd/neon/neon.hpp
+++ b/cpp/modmesh/simd/neon/neon.hpp
@@ -31,6 +31,8 @@
 #include <modmesh/simd/simd_generic.hpp>
 #include <modmesh/simd/neon/neon_type.hpp>
 #include <modmesh/simd/neon/neon_alias.hpp>
+#include <algorithm>
+#include <stdexcept>
 
 #if defined(__aarch64__)
 #include <arm_neon.h>
@@ -222,6 +224,267 @@ void div(T * dest, T const * dest_end, T const * src1, T const * src2)
     }
 }
 
+/**
+ * @brief 使用SIMD加速的三数取中法选择pivot
+ *
+ * 这个函数实现了快速排序中的pivot选择策略，使用NEON SIMD指令加速比较操作。
+ * 三数取中法通过比较数组的首、中、尾三个元素，选择中间值作为pivot，
+ * 这样可以避免在已排序数组上的最坏情况性能。
+ *
+ * @param left 数组左边界指针
+ * @param right 数组右边界指针（指向最后一个元素的下一个位置）
+ * @return 选择的pivot位置指针
+ */
+template <typename T>
+T * choose_pivot_simd(T * left, T * right)
+{
+    // 选择三个位置：首、中、尾
+    T * first = left; // 第一个元素
+    T * mid = left + (right - left) / 2; // 中间元素
+    T * last = right - 1; // 最后一个元素
+
+    // 检查类型是否支持SIMD向量化
+    if constexpr (type::has_vectype<T>)
+    {
+        using vec_t = type::vector_t<T>; // SIMD向量类型
+        constexpr size_t N_lane = type::vector_lane<T>; // 向量中的元素数量
+
+        // 只有当数组足够大时才使用SIMD，避免小数组的开销
+        if (right - left >= N_lane * 2)
+        {
+            // 将三个值广播到SIMD向量中，每个向量元素都是相同的值
+            vec_t first_vec = vdupq<T>(*first); // 将first值复制到向量的每个位置
+            vec_t mid_vec = vdupq<T>(*mid); // 将mid值复制到向量的每个位置
+            vec_t last_vec = vdupq<T>(*last); // 将last值复制到向量的每个位置
+
+            // 使用SIMD比较：mid < first
+            // vcltq<T> 执行向量化的"小于"比较，返回布尔掩码
+            auto cmp_mid_first = vcltq<T>(mid_vec, first_vec);
+            // 检查比较结果：vgetq提取向量的第0和第1个64位元素
+            // 如果任一位置为真，说明mid < first
+            if (vgetq<uint64_t, 0>(cmp_mid_first) || vgetq<uint64_t, 1>(cmp_mid_first))
+            {
+                std::iter_swap(mid, first); // 交换mid和first
+            }
+
+            // 使用SIMD比较：last < first
+            auto cmp_last_first = vcltq<T>(last_vec, first_vec);
+            if (vgetq<uint64_t, 0>(cmp_last_first) || vgetq<uint64_t, 1>(cmp_last_first))
+            {
+                std::iter_swap(last, first); // 交换last和first
+            }
+
+            // 使用SIMD比较：last < mid
+            auto cmp_last_mid = vcltq<T>(last_vec, mid_vec);
+            if (vgetq<uint64_t, 0>(cmp_last_mid) || vgetq<uint64_t, 1>(cmp_last_mid))
+            {
+                std::iter_swap(last, mid); // 交换last和mid
+            }
+        }
+        else
+        {
+            // 对于小数组，使用标准的标量比较操作
+            if (*mid < *first)
+            {
+                std::iter_swap(mid, first);
+            }
+            if (*last < *first)
+            {
+                std::iter_swap(last, first);
+            }
+            if (*last < *mid)
+            {
+                std::iter_swap(last, mid);
+            }
+        }
+    }
+    else
+    {
+        // 对于不支持SIMD的类型，使用标准的标量比较操作
+        if (*mid < *first)
+        {
+            std::iter_swap(mid, first);
+        }
+        if (*last < *first)
+        {
+            std::iter_swap(last, first);
+        }
+        if (*last < *mid)
+        {
+            std::iter_swap(last, mid);
+        }
+    }
+
+    return mid; // 返回中间位置作为pivot
+}
+
+/**
+ * @brief 使用SIMD加速的数组分区操作
+ *
+ * 这个函数实现了快速排序中的分区操作，将数组分为两部分：
+ * 左边部分的所有元素都小于pivot，右边部分的所有元素都大于等于pivot。
+ * 使用NEON SIMD指令加速比较和交换操作。
+ *
+ * @param left 数组左边界指针
+ * @param right 数组右边界指针
+ * @param pivot_pos pivot元素的位置指针
+ * @return pivot元素的最终位置指针
+ */
+template <typename T>
+T * partition_simd(T * left, T * right, T * pivot_pos)
+{
+    // 将pivot元素移动到数组的最右边，便于后续处理
+    std::iter_swap(pivot_pos, right - 1);
+    T * store = left; // store指针指向下一个小于pivot的元素应该放置的位置
+
+    // 检查类型是否支持SIMD向量化
+    if constexpr (type::has_vectype<T>)
+    {
+        using vec_t = type::vector_t<T>; // SIMD向量类型
+        constexpr size_t N_lane = type::vector_lane<T>; // 向量中的元素数量
+        T pivot_val = *(right - 1); // 获取pivot值
+        vec_t pivot_vec = vdupq<T>(pivot_val); // 将pivot值广播到SIMD向量
+
+        // SIMD加速的分区操作：每次处理N_lane个元素
+        T * it = left; // 当前处理位置
+        T * simd_end = right - 1 - N_lane; // SIMD处理的结束位置
+
+        // 使用SIMD批量处理数组元素
+        for (; it <= simd_end; it += N_lane)
+        {
+            // vld1q<T> 从内存加载N_lane个元素到SIMD向量
+            vec_t data_vec = vld1q<T>(it);
+            // vcltq<T> 执行向量化的"小于"比较：data_vec < pivot_vec
+            // 返回布尔掩码，每个元素表示对应位置是否小于pivot
+            auto cmp_vec = vcltq<T>(data_vec, pivot_vec);
+
+            // 将SIMD向量数据存储到临时数组，以便逐个处理
+            T temp_data[N_lane];
+            vst1q<T>(temp_data, data_vec); // 存储原始数据
+            T temp_cmp[N_lane];
+            vst1q<T>(temp_cmp, cmp_vec); // 存储比较结果（布尔掩码）
+
+            // 逐个处理SIMD向量中的每个元素
+            for (size_t i = 0; i < N_lane; ++i)
+            {
+                if (temp_cmp[i]) // 如果当前元素小于pivot
+                {
+                    // 将当前元素交换到store位置，并移动store指针
+                    std::iter_swap(it + i, store);
+                    ++store;
+                }
+            }
+        }
+
+        // 处理剩余的元素（无法用SIMD批量处理的部分）
+        for (; it < right - 1; ++it)
+        {
+            if (*it < pivot_val)
+            {
+                std::iter_swap(it, store);
+                ++store;
+            }
+        }
+    }
+    else
+    {
+        // 对于不支持SIMD的类型，使用标准的标量分区算法
+        for (T * it = left; it < right - 1; ++it)
+        {
+            if (*it < *(right - 1))
+            {
+                std::iter_swap(it, store);
+                ++store;
+            }
+        }
+    }
+
+    // 将pivot元素放到正确的位置（store指针位置）
+    std::iter_swap(store, right - 1);
+    return store; // 返回pivot的最终位置
+}
+
+/**
+ * @brief 使用SIMD加速的快速选择算法
+ *
+ * 这个函数实现了快速选择算法，用于在未排序数组中查找第k小的元素。
+ * 算法基于快速排序的分区思想，但只递归处理包含目标元素的那一半数组，
+ * 平均时间复杂度为O(n)，最坏情况为O(n²)。
+ * 使用NEON SIMD指令加速pivot选择和分区操作。
+ *
+ * @param left 数组左边界指针
+ * @param right 数组右边界指针（指向最后一个元素的下一个位置）
+ * @param k 要查找的元素排名（0-based，0表示最小元素）
+ * @return 第k小的元素值
+ * @throws std::out_of_range 当k超出数组范围时抛出异常
+ */
+template <typename T>
+T quick_select_simd(T * left, T * right, size_t k)
+{
+    size_t len = right - left; // 计算数组长度
+    if (k >= len)
+    {
+        throw std::out_of_range("quick_select_simd: k out of range");
+    }
+
+    // 主循环：不断分区直到找到第k小的元素
+    while (true)
+    {
+        // 使用SIMD加速的三数取中法选择pivot
+        // T * pivot_it = choose_pivot_simd<T>(left, right);
+        T * pivot_it = generic::choose_pivot<T>(left, right);
+        // 使用SIMD加速的分区操作，将pivot放到正确位置
+        T * store = partition_simd<T>(left, right, pivot_it);
+        // 计算pivot在分区后的排名（相对于left的位置）
+        size_t pivot_rank = store - left;
+
+        if (pivot_rank == k)
+        {
+            // 找到目标元素：pivot正好是第k小的元素
+            return *store;
+        }
+        else if (pivot_rank < k)
+        {
+            // pivot排名小于k，目标元素在右半部分
+            k -= pivot_rank + 1; // 调整k值（减去左半部分和pivot的数量）
+            left = store + 1; // 将搜索范围缩小到右半部分
+        }
+        else
+        {
+            // pivot排名大于k，目标元素在左半部分
+            right = store; // 将搜索范围缩小到左半部分
+        }
+    }
+}
+
+template <typename T>
+T median(T * dest, T * dest_end)
+{
+    const size_t n = dest_end - dest;
+    if (n == 0)
+    {
+        throw std::runtime_error("median: empty array");
+    }
+
+    // 对于小数组，直接使用通用算法
+    if (n < type::vector_lane<T> * 4)
+    {
+        return generic::median<T>(dest, dest_end);
+    }
+
+    // 对于大数组，使用SIMD加速的quick_select
+    if (n & 1)
+    {
+        return quick_select_simd<T>(dest, dest_end, n / 2);
+    }
+    else
+    {
+        T v1 = quick_select_simd<T>(dest, dest_end, n / 2 - 1);
+        T v2 = quick_select_simd<T>(dest, dest_end, n / 2);
+        return static_cast<T>(v1 + v2) / static_cast<T>(2.0);
+    }
+}
+
 #else
 template <typename T>
 const T * check_between(T const * start, T const * end, T const & min_val, T const & max_val)
@@ -251,6 +514,12 @@ template <typename T>
 void div(T * dest, T const * dest_end, T const * src1, T const * src2)
 {
     generic::div<T>(dest, dest_end, src1, src2);
+}
+
+template <typename T>
+T median(T * dest, T * dest_end)
+{
+    return generic::median<T>(dest, dest_end);
 }
 
 #endif /* defined(__aarch64__) */

--- a/cpp/modmesh/simd/simd.hpp
+++ b/cpp/modmesh/simd/simd.hpp
@@ -33,6 +33,9 @@
 
 #include <modmesh/simd/neon/neon.hpp>
 
+#include <modmesh/buffer/small_vector.hpp>
+#include <modmesh/buffer/SimpleArray.hpp>
+
 namespace modmesh
 {
 
@@ -112,6 +115,21 @@ void div(T * dest, T const * dest_end, T const * src1, T const * src2)
 
     default:
         return generic::div<T>(dest, dest_end, src1, src2);
+    }
+}
+
+template <typename T>
+T median(T * dest, T * dest_end)
+{
+    using namespace detail;
+    switch (detect_simd())
+    {
+    case SIMD_NEON:
+        return neon::median<T>(dest, dest_end);
+        break;
+
+    default:
+        return generic::median<T>(dest, dest_end);
     }
 }
 

--- a/cpp/modmesh/simd/simd_generic.hpp
+++ b/cpp/modmesh/simd/simd_generic.hpp
@@ -28,6 +28,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <algorithm>
+#include <stdexcept>
+
 namespace modmesh
 {
 
@@ -102,6 +105,101 @@ void div(T * dest, T const * dest_end, T const * src1, T const * src2)
         ++ptr;
         ++src1;
         ++src2;
+    }
+}
+
+template <typename T>
+T * choose_pivot(T * left, T * right)
+{
+    T * first = left;
+    T * mid = left + (right - left) / 2;
+    T * last = right - 1;
+    if (*mid < *first)
+    {
+        std::iter_swap(mid, first);
+    }
+    if (*last < *first)
+    {
+        std::iter_swap(last, first);
+    }
+    if (*last < *mid)
+    {
+        std::iter_swap(last, mid);
+    }
+    return mid;
+}
+
+template <typename T>
+T * partition(T * left, T * right, T * pivot_pos)
+{
+    // 将pivot移到最右边
+    std::iter_swap(pivot_pos, right - 1);
+    T * store = left;
+
+    // 将小于pivot的元素移到左边
+    for (T * it = left; it < right - 1; ++it)
+    {
+        if (*it < *(right - 1))
+        {
+            std::iter_swap(it, store);
+            ++store;
+        }
+    }
+
+    // 将pivot放到正确位置
+    std::iter_swap(store, right - 1);
+    return store;
+}
+
+template <typename T>
+T quick_select(T * left, T * right, size_t k)
+{
+    size_t len = right - left;
+    if (k >= len)
+    {
+        throw std::out_of_range("quick_select: k out of range");
+    }
+
+    while (true)
+    {
+        T * pivot_it = choose_pivot(left, right);
+        T * store = partition(left, right, pivot_it);
+        size_t pivot_rank = store - left;
+
+        if (pivot_rank == k)
+        {
+            return *store;
+        }
+        else if (pivot_rank < k)
+        {
+            k -= pivot_rank + 1;
+            left = store + 1;
+        }
+        else
+        {
+            right = store;
+        }
+    }
+}
+
+template <typename T>
+T median(T * dest, T * dest_end)
+{
+    const size_t n = dest_end - dest;
+    if (n == 0)
+    {
+        throw std::runtime_error("median: empty array");
+    }
+
+    if (n & 1)
+    {
+        return quick_select(dest, dest_end, n / 2);
+    }
+    else
+    {
+        T v1 = quick_select(dest, dest_end, n / 2 - 1);
+        T v2 = quick_select(dest, dest_end, n / 2);
+        return static_cast<T>(v1 + v2) / static_cast<T>(2.0);
     }
 }
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1095,6 +1095,54 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         smed = smed.ndarray
         self.assertTrue(np.array_equal(npmed, smed))
 
+    def test_parallel_median(self):
+        nparr = np.arange(24, dtype='float64')
+        np.random.shuffle(nparr)
+        sarr = modmesh.SimpleArrayFloat64(array=nparr)
+        npmed = np.median(nparr)
+        smed = sarr.parallel_median()
+        self.assertEqual(npmed, smed)
+
+        nparr = np.arange(24, dtype='float64').reshape((2, 3, 4))
+        np.random.shuffle(nparr)
+        sarr = modmesh.SimpleArrayFloat64(array=nparr)
+        npmed = np.median(nparr)
+        smed = sarr.parallel_median()
+        self.assertEqual(npmed, smed)
+
+        nparr = np.arange(81, dtype='float64').reshape((3, 3, 3, 3))
+        np.random.shuffle(nparr)
+        sarr = modmesh.SimpleArrayFloat64(array=nparr)
+        npmed = np.median(nparr)
+        smed = sarr.parallel_median()
+        self.assertEqual(npmed, smed)
+
+        nparr = np.arange(24, dtype='complex128').reshape((2, 3, 4))
+        npimg = nparr.copy()
+        np.random.shuffle(nparr)
+        np.random.shuffle(npimg)
+        nparr = nparr + 1j * npimg
+        sarr = modmesh.SimpleArrayComplex128(array=nparr)
+        npmed = np.median(nparr)
+        smed = sarr.parallel_median()
+        self.assertEqual(npmed.real, smed.real)
+        self.assertEqual(npmed.imag, smed.imag)
+
+        # Reference: https://github.com/numpy/numpy/issues/12943
+        nparr = np.array([1+10j, 2+1j, 3+0j, 0+3j], dtype='complex128')
+        sarr = modmesh.SimpleArrayComplex128(array=nparr)
+        npmed = np.median(nparr)
+        smed = sarr.parallel_median()
+        self.assertEqual(npmed.real, smed.real)
+        self.assertEqual(npmed.imag, smed.imag)
+
+        nparr = np.arange(24, dtype='float64').reshape((2, 3, 4))
+        nparr = nparr[::2, ::2, ::2]
+        sarr = modmesh.SimpleArrayFloat64(array=nparr)
+        npavg = np.median(nparr)
+        savg = sarr.parallel_median()
+        self.assertEqual(npavg, savg)
+
     def test_average(self):
         nparr = np.arange(24, dtype='float64')
         np.random.shuffle(nparr)


### PR DESCRIPTION
In this pull request, I try to speed up the operation `median()`.
By the way, the work is in progress. 

Feature:
 - [x] Accelerate the function `partition` with SIMD.
 - [ ] Accelerate the process to move the elements from `SimpleArray` to `small_vector`.

Invalid attempt:
 - [x] Block partition.
 - [x] Floyd-Rivest Algorithm.

Result:
The effectiveness of `partition_simd` is slight.

# median (dtype=<class 'numpy.float64'>)
## N = 1000
| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.968E+00       | 1.000           |
| sa         | 9.629E-03       | 0.005           |
| simd_sa    | 9.400E-03       | 0.005           |

## N = 10000
| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 7.739E-02       | 1.000           |
| sa         | 1.107E-01       | 1.430           |
| simd_sa    | 1.089E-01       | 1.408           |

## N = 100000
| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 9.781E-01       | 1.000           |
| sa         | 1.650E+00       | 1.687           |
| simd_sa    | 1.648E+00       | 1.685           |

## N = 1000000
| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 9.245E+00       | 1.000           |
| sa         | 1.371E+01       | 1.483           |
| simd_sa    | 1.362E+01       | 1.473           |

## N = 10000000
| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 8.719E+01       | 1.000           |
| sa         | 1.299E+02       | 1.490           |
| simd_sa    | 1.303E+02       | 1.495           |

# median (dtype=<class 'numpy.float64'>) (non-contiguous)
## N = 1000
| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.668E-02       | 1.000           |
| sa         | 4.367E-03       | 0.262           |
| simd_sa    | 3.892E-03       | 0.233           |

## N = 10000
| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 6.396E-02       | 1.000           |
| sa         | 6.823E-02       | 1.067           |
| simd_sa    | 6.726E-02       | 1.052           |

## N = 100000
| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 4.492E-01       | 1.000           |
| sa         | 5.413E-01       | 1.205           |
| simd_sa    | 5.427E-01       | 1.208           |

## N = 1000000
| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 5.322E+00       | 1.000           |
| sa         | 6.207E+00       | 1.166           |
| simd_sa    | 6.216E+00       | 1.168           |

## N = 10000000
| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 5.239E+01       | 1.000           |
| sa         | 8.148E+01       | 1.555           |
| simd_sa    | 8.133E+01       | 1.553           |

