### PR TITLE
Add profiler GUI with the table

### DIFF
--- a/cpp/modmesh/pilot/RManager.cpp
+++ b/cpp/modmesh/pilot/RManager.cpp
@@ -140,8 +140,8 @@ void RManager::setUpMenu()
     }
     m_oneMenu = m_mainWindow->menuBar()->addMenu(QString("One"));
     m_meshMenu = m_mainWindow->menuBar()->addMenu(QString("Mesh"));
-    m_windowMenu = m_mainWindow->menuBar()->addMenu(QString("Window"));
     m_profiling = m_mainWindow->menuBar()->addMenu(QString("Profiling"));
+    m_windowMenu = m_mainWindow->menuBar()->addMenu(QString("Window"));
 }
 
 void RManager::setUpCameraControllersMenuItems() const

--- a/cpp/modmesh/pilot/RManager.cpp
+++ b/cpp/modmesh/pilot/RManager.cpp
@@ -140,7 +140,7 @@ void RManager::setUpMenu()
     }
     m_oneMenu = m_mainWindow->menuBar()->addMenu(QString("One"));
     m_meshMenu = m_mainWindow->menuBar()->addMenu(QString("Mesh"));
-    m_profiling = m_mainWindow->menuBar()->addMenu(QString("Profiling"));
+    m_profilingMenu = m_mainWindow->menuBar()->addMenu(QString("Profiling"));
     m_windowMenu = m_mainWindow->menuBar()->addMenu(QString("Window"));
 }
 

--- a/cpp/modmesh/pilot/RManager.cpp
+++ b/cpp/modmesh/pilot/RManager.cpp
@@ -141,6 +141,7 @@ void RManager::setUpMenu()
     m_oneMenu = m_mainWindow->menuBar()->addMenu(QString("One"));
     m_meshMenu = m_mainWindow->menuBar()->addMenu(QString("Mesh"));
     m_windowMenu = m_mainWindow->menuBar()->addMenu(QString("Window"));
+    m_profiling = m_mainWindow->menuBar()->addMenu(QString("Profiling"));
 }
 
 void RManager::setUpCameraControllersMenuItems() const

--- a/cpp/modmesh/pilot/RManager.hpp
+++ b/cpp/modmesh/pilot/RManager.hpp
@@ -72,6 +72,7 @@ public:
     QMenu * oneMenu() { return m_oneMenu; }
     QMenu * meshMenu() { return m_meshMenu; }
     QMenu * windowMenu() { return m_windowMenu; }
+    QMenu * profilingMenu() { return m_profiling; }
 
     void quit() { m_core->quit(); }
 
@@ -101,6 +102,7 @@ private:
     QMenu * m_oneMenu = nullptr;
     QMenu * m_meshMenu = nullptr;
     QMenu * m_windowMenu = nullptr;
+    QMenu * m_profiling = nullptr;
 
     RPythonConsoleDockWidget * m_pycon = nullptr;
     QMdiArea * m_mdiArea = nullptr;

--- a/cpp/modmesh/pilot/RManager.hpp
+++ b/cpp/modmesh/pilot/RManager.hpp
@@ -71,8 +71,8 @@ public:
     QMenu * viewMenu() { return m_viewMenu; }
     QMenu * oneMenu() { return m_oneMenu; }
     QMenu * meshMenu() { return m_meshMenu; }
-    QMenu * windowMenu() { return m_windowMenu; }
     QMenu * profilingMenu() { return m_profiling; }
+    QMenu * windowMenu() { return m_windowMenu; }
 
     void quit() { m_core->quit(); }
 
@@ -101,8 +101,8 @@ private:
     QMenu * m_viewMenu = nullptr;
     QMenu * m_oneMenu = nullptr;
     QMenu * m_meshMenu = nullptr;
-    QMenu * m_windowMenu = nullptr;
     QMenu * m_profiling = nullptr;
+    QMenu * m_windowMenu = nullptr;
 
     RPythonConsoleDockWidget * m_pycon = nullptr;
     QMdiArea * m_mdiArea = nullptr;

--- a/cpp/modmesh/pilot/RManager.hpp
+++ b/cpp/modmesh/pilot/RManager.hpp
@@ -71,7 +71,7 @@ public:
     QMenu * viewMenu() { return m_viewMenu; }
     QMenu * oneMenu() { return m_oneMenu; }
     QMenu * meshMenu() { return m_meshMenu; }
-    QMenu * profilingMenu() { return m_profiling; }
+    QMenu * profilingMenu() { return m_profilingMenu; }
     QMenu * windowMenu() { return m_windowMenu; }
 
     void quit() { m_core->quit(); }
@@ -101,7 +101,7 @@ private:
     QMenu * m_viewMenu = nullptr;
     QMenu * m_oneMenu = nullptr;
     QMenu * m_meshMenu = nullptr;
-    QMenu * m_profiling = nullptr;
+    QMenu * m_profilingMenu = nullptr;
     QMenu * m_windowMenu = nullptr;
 
     RPythonConsoleDockWidget * m_pycon = nullptr;

--- a/cpp/modmesh/pilot/wrap_pilot.cpp
+++ b/cpp/modmesh/pilot/wrap_pilot.cpp
@@ -354,6 +354,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRManager
             .def_property_readonly("oneMenu", &wrapped_type::oneMenu)
             .def_property_readonly("meshMenu", &wrapped_type::meshMenu)
             .def_property_readonly("windowMenu", &wrapped_type::windowMenu)
+            .def_property_readonly("profilingMenu", &wrapped_type::profilingMenu)
             .def(
                 "quit",
                 [](wrapped_type & self)

--- a/modmesh/pilot/_gui.py
+++ b/modmesh/pilot/_gui.py
@@ -45,6 +45,7 @@ if _pcore.enable:
     from . import _burgers1d
     from . import _svg_gui
     from . import _linear_wave
+    from . import _profiling
 
 __all__ = [  # noqa: F822
     'controller',
@@ -77,6 +78,7 @@ class _Controller(metaclass=_Singleton):
         self.naca4airfoil = None
         self.eulerone = None
         self.burgers = None
+        self.profiling = None
 
     def __getattr__(self, name):
         return None if self._rmgr is None else getattr(self._rmgr, name)
@@ -94,6 +96,7 @@ class _Controller(metaclass=_Singleton):
         self.eulerone = _euler1d.Euler1DApp(mgr=self._rmgr)
         self.burgers = _burgers1d.Burgers1DApp(mgr=self._rmgr)
         self.linear_wave = _linear_wave.LinearWave1DApp(mgr=self._rmgr)
+        self.profiling = _profiling.Profiling(mgr=self._rmgr)
         self.populate_menu()
         self._rmgr.show()
         return self._rmgr.exec()
@@ -124,6 +127,7 @@ class _Controller(metaclass=_Singleton):
         self.eulerone.populate_menu()
         self.burgers.populate_menu()
         self.linear_wave.populate_menu()
+        self.profiling.populate_menu()
 
         if sys.platform != 'darwin':
             _addAction(

--- a/modmesh/pilot/_profiling.py
+++ b/modmesh/pilot/_profiling.py
@@ -92,11 +92,9 @@ class Profiling(PilotFeature):
 
             parent.appendRow([first_item, second_item])
 
-            sorted_child_data = sorted(
-                data["children"],
-                key=lambda d: d["total_time"],
-                reverse=True
-            )
+            children = data["children"]
+            key_func = lambda d: d["total_time"]
+            sorted_child_data = sorted(children, key=key_func, reverse=True)
 
             for child_data in sorted_child_data:
                 _recursive_add_item(first_item, child_data, data["total_time"])

--- a/modmesh/pilot/_profiling.py
+++ b/modmesh/pilot/_profiling.py
@@ -1,3 +1,29 @@
+# Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 import json
 from typing import Any
 
@@ -111,3 +137,5 @@ class Profiling(PilotFeature):
         self._table.setWidget(self._tree_view)
         self._table.showMaximized()
         self._table.show()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/pilot/_profiling.py
+++ b/modmesh/pilot/_profiling.py
@@ -5,8 +5,9 @@ from ._gui_common import PilotFeature
 
 from PySide6 import QtCore, QtWidgets
 from PySide6.QtWidgets import (
+    QAbstractItemView,
     QTreeView,
-    QWidget,
+    QWidget
 )
 from PySide6.QtGui import (
     QStandardItem,
@@ -109,6 +110,7 @@ class Profiling(PilotFeature):
         self._tree_view.setModel(self._model)
         self._tree_view.setColumnWidth(0, 400)
         self._tree_view.setColumnWidth(1, 200)
+        self._tree_view.setEditTriggers(QAbstractItemView.NoEditTriggers)
 
         self._table.setWidget(self._tree_view)
         self._table.showMaximized()

--- a/modmesh/pilot/_profiling.py
+++ b/modmesh/pilot/_profiling.py
@@ -1,0 +1,97 @@
+import json
+from typing import Any
+
+from ._gui_common import PilotFeature
+
+from PySide6 import QtCore, QtWidgets
+from PySide6.QtWidgets import (
+    QTableWidgetItem,
+    QTableWidget,
+    QWidget,
+    QHeaderView,
+)
+from modmesh.profiling import ProfilingResultPrinter
+
+__all__ = ["Profiling"]
+
+
+class Profiling(PilotFeature):
+    """
+    Create profiling windows.
+    """
+
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self._diag = QtWidgets.QFileDialog()
+        self._diag.setFileMode(QtWidgets.QFileDialog.ExistingFile)
+        self._diag.setWindowTitle("Open profiling file")
+
+    def populate_menu(self):
+        self._add_menu_item(
+            menu=self._mgr.profilingMenu,
+            text="Open profiling result",
+            tip="Open JSON file of profiling result",
+            func=self.open_profiling_result,
+        )
+
+    def open_profiling_result(self):
+        self._diag.open(self, QtCore.SLOT("on_finished()"))
+
+    @QtCore.Slot()
+    def on_finished(self):
+        filenames = []
+        for path in self._diag.selectedFiles():
+            filenames.append(path)
+
+        result = None
+        with open(filenames[0], "r") as f:
+            result = json.loads(f.read())
+
+        self._add_result_window(filenames[0], result)
+
+    def _add_result_window(self, file_name: str, result: list[dict[str, Any]]):
+        self._table = self._mgr.addSubWindow(QWidget())
+
+        self._table_widget = QTableWidget()
+        self._table_widget.setWindowTitle(f"Profiling Result: {file_name}")
+        self._table_widget.setEditTriggers(
+            QTableWidget.EditTrigger.NoEditTriggers
+        )
+
+        style: str = """
+            QTableView {
+                background: white;
+                color: black;
+            }
+        """
+
+        self._table_widget.setStyleSheet(style)
+
+        printer = ProfilingResultPrinter(result)
+
+        printer.add_column("total_time", lambda r: r.total_time)
+
+        column_data = printer.column_data
+        column_names = [column.column_name for column in printer.column_data]
+        column_count = len(column_names)
+
+        self._table_widget.setColumnCount(len(column_names))
+        self._table_widget.setHorizontalHeaderLabels(column_names)
+        self._table_widget.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.ResizeToContents
+        )
+
+        if len(column_names) != 0:
+            first_column = printer.column_data[0]
+            row_count = len(first_column.column_value)
+            self._table_widget.setRowCount(row_count)
+
+            for column, c_index in zip(column_data, range(column_count)):
+                column_value: list[str | float] = column.column_value
+                for value, r_index in zip(column_value, range(row_count)):
+                    item = QTableWidgetItem(str(value))
+                    self._table_widget.setItem(r_index, c_index, item)
+
+        self._table.setWidget(self._table_widget)
+        # self._table.showMaximized()
+        self._table.show()

--- a/modmesh/pilot/_profiling.py
+++ b/modmesh/pilot/_profiling.py
@@ -49,21 +49,17 @@ class Profiling(PilotFeature):
         with open(filenames[0], "r") as f:
             result = json.loads(f.read())
 
-        self._add_result_window(filenames[0], result)
+        self._add_result_window(result)
 
-    def _add_result_window(self, file_name: str, result: list[dict[str, Any]]):
+    def _add_result_window(self, result: list[dict[str, Any]]):
         self._table = self._mgr.addSubWindow(QWidget())
         self._tree_view = QTreeView(self._table)
 
         self._model = QStandardItemModel(self._tree_view)
         self._model.setHorizontalHeaderLabels(["Total Time", "Symbol Name"])
 
-        def _recursive_add_item(
-                parent: QStandardItem,
-                data: dict[str, Any],
-                total_time: float
-        ):
-            percent = data["total_time"] * 100 / total_time
+        def _recursive_add_item(parent: QStandardItem, data: dict, tot: float):
+            percent = data["total_time"] * 100 / tot
 
             first_item = QStandardItem(f"{data['total_time']} ({percent:2f}%)")
             second_item = QStandardItem(data["name"])

--- a/modmesh/pilot/_profiling.py
+++ b/modmesh/pilot/_profiling.py
@@ -93,7 +93,7 @@ class Profiling(PilotFeature):
             parent.appendRow([first_item, second_item])
 
             children = data["children"]
-            key_func = lambda d: d["total_time"]
+            def key_func(d): d["total_time"]
             sorted_child_data = sorted(children, key=key_func, reverse=True)
 
             for child_data in sorted_child_data:


### PR DESCRIPTION
## What's new?

In this PR, I trying to add profiler GUI with fixed column (that means, we don't support add_column feature to add custom column). 

Now, in modmesh pilot, we can open the json file of profiler result and open the windows contains result table.

## Implementation

I add a toolbar named profiling to place the feature related profiling.

<img width="599" height="84" alt="image" src="https://github.com/user-attachments/assets/1fc3dde4-e7f2-4db1-a399-34b4564da81e" />

<hr/>

With `Open profiling result`, it open a file explorer to let user specific JSON file. The user can open JSON file contains result.

For example, if user have a `result.json`:

```json
[
    {
        "name": "numpy_arange_100",
        "total_time": 0.002083,
        "count": 1,
        "children": []
    },
    {
        "name": "numpy_arange_1000",
        "total_time": 0.004096,
        "count": 1,
        "children": []
    }
]
```

When user open the file, it create a new window to show the table.

<img width="1920" height="1201" alt="image" src="https://github.com/user-attachments/assets/fdd5ab6a-a7fc-46c2-b1bc-b5ec6766bab1" />

## The things that I'm not sure should contain in this PR (or future work?)

 - The user can add custom column based on fomula. The one I would like to refer is [QGIS Field Calculator](https://docs.qgis.org/3.40/en/docs/user_manual/working_with_vector/attribute_table.html#id7).
 - The user can dump JSON files with `ProfilingResultPrinter`. Maybe have a function named `to_json("/abc/xyz/path")`
