### PR TITLE
Add profiling on median function

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -32,6 +32,11 @@
 #include <modmesh/math/math.hpp>
 #include <modmesh/simd/simd.hpp>
 
+// TODO: Solve circular include between <modmesh/toggle/toggle.hpp> and SimpleArray class.
+// Since it will happen circulate include when using <modmesh/toggle/toggle.hpp>,
+// I use <modmesh/toggle/RadixTree.hpp> instead.
+#include <modmesh/toggle/RadixTree.hpp>
+
 #include <limits>
 #include <stdexcept>
 #include <functional>
@@ -234,6 +239,7 @@ public:
 
     value_type median_op(small_vector<value_type> & sv) const
     {
+        USE_CALLPROFILER_PROFILE_THIS_SCOPE("SimpleArray::median_op()");
         const size_t n = sv.size();
         if (n % 2 != 0)
         {
@@ -251,6 +257,7 @@ public:
 
     value_type median() const
     {
+        USE_CALLPROFILER_PROFILE_THIS_SCOPE("SimpleArray::median()");
         auto athis = static_cast<A const *>(this);
         const size_t n = athis->size();
         small_vector<T> acopy(n);

--- a/cpp/modmesh/buffer/small_vector.hpp
+++ b/cpp/modmesh/buffer/small_vector.hpp
@@ -33,6 +33,10 @@
 #include <vector>
 #include <algorithm>
 
+// TODO: Solve circular include between <modmesh/toggle/toggle.hpp> and SimpleArray class.
+// buffer/ (higher level) should depend on toggle/ (lower level).
+#include <modmesh/toggle/RadixTree.hpp>
+
 namespace modmesh
 {
 
@@ -301,6 +305,7 @@ public:
 
     T select_kth(size_t k)
     {
+        USE_CALLPROFILER_PROFILE_THIS_SCOPE("small_vector::select_kth()");
         iterator it = quick_select(begin(), end(), k);
         return *it;
     }

--- a/cpp/modmesh/toggle/RadixTree.hpp
+++ b/cpp/modmesh/toggle/RadixTree.hpp
@@ -353,7 +353,8 @@ private:
     CallProfiler & m_profiler;
 }; /* end struct CallProfilerProbe */
 
-#ifdef CALLPROFILER
+// TODO: https://github.com/solvcon/modmesh/pull/559
+#ifdef MODMESH_PROFILE
 
 #ifdef _MSC_VER
 // ref: https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros

--- a/cpp/modmesh/toggle/profile.hpp
+++ b/cpp/modmesh/toggle/profile.hpp
@@ -273,6 +273,7 @@ private:
 /*
  * MODMESH_PROFILE defined: Enable profiling API.
  */
+// TODO: https://github.com/solvcon/modmesh/pull/559
 #ifdef MODMESH_PROFILE
 
 #define MODMESH_TIME(NAME) \

--- a/gtests/test_nopython_callprofiler.cpp
+++ b/gtests/test_nopython_callprofiler.cpp
@@ -5,7 +5,7 @@
 #error "Python.h should not be included."
 #endif
 
-#define CALLPROFILER 1
+#define MODMESH_PROFILE 1
 #include <modmesh/toggle/RadixTree.hpp>
 namespace modmesh
 {

--- a/profiling/profile_median.py
+++ b/profiling/profile_median.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025, Han-Xuan Huang <c1ydehhx@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import json
+
+import numpy
+import modmesh
+
+
+def make_container(data):
+    if numpy.isdtype(data.dtype, numpy.uint8):
+        return modmesh.SimpleArrayUint8(array=data)
+    elif numpy.isdtype(data.dtype, numpy.uint16):
+        return modmesh.SimpleArrayUint16(array=data)
+    elif numpy.isdtype(data.dtype, numpy.uint32):
+        return modmesh.SimpleArrayUint32(array=data)
+    elif numpy.isdtype(data.dtype, numpy.uint64):
+        return modmesh.SimpleArrayUint64(array=data)
+
+
+def main():
+    modmesh.call_profiler.reset()
+    simple_array = make_container(numpy.arange(0, 1e6, dtype="uint8"))
+    simple_array.median()
+
+    print(json.dumps(modmesh.call_profiler.result().get("children"), indent=4))
+
+
+if __name__ == "__main__":
+    main()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
## What's new?

In this PR, I add profiling macro on median function to measure the bottleneck of median function. I create `profiling/profile_median.py` also. 

The reason why I create this script is, `MODMESH_TIME` macro use `TimeRegistry` class, which is not tree structure. We need to migrate `MODMESH_TIME` from `TimeRegistry` to `ProfileCallProble`, which support tree struct. And I can use this script to generate call stack result.

## The result

I create 1000000 size of `SimpleArray` and do median. The following output shows the profiling result.

```
median() : count = 1 , time = 2.33615 (second)
median::copy() : count = 1 , time = 0.028013 (second)
median::init() : count = 1 , time = 1.292e-06 (second)
median::run() : count = 1 , time = 2.30812 (second)
median::select_kth_1() : count = 1 , time = 4.2e-08 (second)
median::select_kth_2() : count = 1 , time = 0.0166571 (second)
median::select_kth_3() : count = 1 , time = 2.29145 (second)
median_op() : count = 1 , time = 2.30812 (second)
```

The tree struct (I manually create by keyboard) should be:

```
median_op() : count = 1 , time = 2.30812 (second)
    median::select_kth_1() : count = 1 , time = 4.2e-08 (second)
    median::select_kth_2() : count = 1 , time = 0.0166571 (second)
    median::select_kth_3() : count = 1 , time = 2.29145 (second)
 
median() : count = 1 , time = 2.33615 (second)
    median::run() : count = 1 , time = 2.30812 (second)
    median::copy() : count = 1 , time = 0.028013 (second)
    median::init() : count = 1 , time = 1.292e-06 (second)
```