### PR TITLE
refactor CALLPROFILER to MODMESH

### DIFF
--- a/cpp/modmesh/toggle/RadixTree.hpp
+++ b/cpp/modmesh/toggle/RadixTree.hpp
@@ -362,11 +362,11 @@ private:
 // ref: https://gcc.gnu.org/onlinedocs/gcc/Function-Names.html
 #define __CROSS_PRETTY_FUNCTION__ __PRETTY_FUNCTION__
 #endif
-#define USE_CALLPROFILER_PROFILE_THIS_FUNCTION() modmesh::CallProfilerProbe __profilerProbe##__COUNTER__(modmesh::CallProfiler::instance(), __CROSS_PRETTY_FUNCTION__)
-#define USE_CALLPROFILER_PROFILE_THIS_SCOPE(scopeName) modmesh::CallProfilerProbe __profilerProbe##__COUNTER__(modmesh::CallProfiler::instance(), scopeName)
+#define MODMESH_PROFILE_FUNCTION() modmesh::CallProfilerProbe __profilerProbe##__COUNTER__(modmesh::CallProfiler::instance(), __CROSS_PRETTY_FUNCTION__)
+#define MODMESH_PROFILE_SCOPE(scopeName) modmesh::CallProfilerProbe __profilerProbe##__COUNTER__(modmesh::CallProfiler::instance(), scopeName)
 #else
-#define USE_CALLPROFILER_PROFILE_THIS_FUNCTION() // do nothing
-#define USE_CALLPROFILER_PROFILE_THIS_SCOPE(scopeName) // do nothing
+#define MODMESH_PROFILE_FUNCTION() // do nothing
+#define MODMESH_PROFILE_SCOPE(scopeName) // do nothing
 #endif
 
 } /* end namespace modmesh */

--- a/gtests/test_nopython_callprofiler.cpp
+++ b/gtests/test_nopython_callprofiler.cpp
@@ -35,7 +35,7 @@ constexpr int uniqueTime3 = 7;
 
 void foo3()
 {
-    USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+    MODMESH_PROFILE_FUNCTION();
     auto start_time = std::chrono::high_resolution_clock::now();
     while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start_time).count() < uniqueTime1)
     {
@@ -45,7 +45,7 @@ void foo3()
 
 void foo2()
 {
-    USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+    MODMESH_PROFILE_FUNCTION();
     auto start_time = std::chrono::high_resolution_clock::now();
     while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start_time).count() < uniqueTime2)
     {
@@ -56,7 +56,7 @@ void foo2()
 
 void foo1()
 {
-    USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+    MODMESH_PROFILE_FUNCTION();
     foo2();
     auto start_time = std::chrono::high_resolution_clock::now();
     while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start_time).count() < uniqueTime3)
@@ -191,11 +191,11 @@ TEST_F(CallProfilerTest, cancel)
 
     auto test1 = [&]()
     {
-        USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+        MODMESH_PROFILE_FUNCTION();
 
         auto test2 = [&]()
         {
-            USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+            MODMESH_PROFILE_FUNCTION();
             pProfiler->cancel();
         };
 


### PR DESCRIPTION
I have renamed the following macros:
1. `USE_CALLPROFILER_PROFILE_THIS_FUNCTION` to `MODMESH_PROFILE_FUNCTION`.
2. `USE_CALLPROFILER_PROFILE_THIS_SCOPE` to `MODMESH_PROFILE_SCOPE`.

For Issue #561 