### PR TITLE
refactor CALLPROFILER to MODMESH

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -239,7 +239,7 @@ public:
 
     value_type median_op(small_vector<value_type> & sv) const
     {
-        USE_CALLPROFILER_PROFILE_THIS_SCOPE("SimpleArray::median_op()");
+        MODMESH_PROFILE_SCOPE("SimpleArray::median_op()");
         const size_t n = sv.size();
         if (n % 2 != 0)
         {
@@ -257,7 +257,7 @@ public:
 
     value_type median() const
     {
-        USE_CALLPROFILER_PROFILE_THIS_SCOPE("SimpleArray::median()");
+        MODMESH_PROFILE_SCOPE("SimpleArray::median()");
         auto athis = static_cast<A const *>(this);
         const size_t n = athis->size();
         small_vector<T> acopy(n);

--- a/cpp/modmesh/buffer/small_vector.hpp
+++ b/cpp/modmesh/buffer/small_vector.hpp
@@ -305,7 +305,7 @@ public:
 
     T select_kth(size_t k)
     {
-        USE_CALLPROFILER_PROFILE_THIS_SCOPE("small_vector::select_kth()");
+        MODMESH_PROFILE_SCOPE("small_vector::select_kth()");
         iterator it = quick_select(begin(), end(), k);
         return *it;
     }

--- a/cpp/modmesh/toggle/RadixTree.hpp
+++ b/cpp/modmesh/toggle/RadixTree.hpp
@@ -363,11 +363,11 @@ private:
 // ref: https://gcc.gnu.org/onlinedocs/gcc/Function-Names.html
 #define __CROSS_PRETTY_FUNCTION__ __PRETTY_FUNCTION__
 #endif
-#define USE_CALLPROFILER_PROFILE_THIS_FUNCTION() modmesh::CallProfilerProbe __profilerProbe##__COUNTER__(modmesh::CallProfiler::instance(), __CROSS_PRETTY_FUNCTION__)
-#define USE_CALLPROFILER_PROFILE_THIS_SCOPE(scopeName) modmesh::CallProfilerProbe __profilerProbe##__COUNTER__(modmesh::CallProfiler::instance(), scopeName)
+#define MODMESH_PROFILE_FUNCTION() modmesh::CallProfilerProbe __profilerProbe##__COUNTER__(modmesh::CallProfiler::instance(), __CROSS_PRETTY_FUNCTION__)
+#define MODMESH_PROFILE_SCOPE(scopeName) modmesh::CallProfilerProbe __profilerProbe##__COUNTER__(modmesh::CallProfiler::instance(), scopeName)
 #else
-#define USE_CALLPROFILER_PROFILE_THIS_FUNCTION() // do nothing
-#define USE_CALLPROFILER_PROFILE_THIS_SCOPE(scopeName) // do nothing
+#define MODMESH_PROFILE_FUNCTION() // do nothing
+#define MODMESH_PROFILE_SCOPE(scopeName) // do nothing
 #endif
 
 } /* end namespace modmesh */

--- a/gtests/test_nopython_callprofiler.cpp
+++ b/gtests/test_nopython_callprofiler.cpp
@@ -35,7 +35,7 @@ constexpr int uniqueTime3 = 7;
 
 void foo3()
 {
-    USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+    MODMESH_PROFILE_FUNCTION();
     auto start_time = std::chrono::high_resolution_clock::now();
     while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start_time).count() < uniqueTime1)
     {
@@ -45,7 +45,7 @@ void foo3()
 
 void foo2()
 {
-    USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+    MODMESH_PROFILE_FUNCTION();
     auto start_time = std::chrono::high_resolution_clock::now();
     while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start_time).count() < uniqueTime2)
     {
@@ -56,7 +56,7 @@ void foo2()
 
 void foo1()
 {
-    USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+    MODMESH_PROFILE_FUNCTION();
     foo2();
     auto start_time = std::chrono::high_resolution_clock::now();
     while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start_time).count() < uniqueTime3)
@@ -191,11 +191,11 @@ TEST_F(CallProfilerTest, cancel)
 
     auto test1 = [&]()
     {
-        USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+        MODMESH_PROFILE_FUNCTION();
 
         auto test2 = [&]()
         {
-            USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+            MODMESH_PROFILE_FUNCTION();
             pProfiler->cancel();
         };
 


### PR DESCRIPTION
Resolve Issue #563.

I don't know why the previous PR was closed.

Changes:
1. `USE_CALLPROFILER_PROFILE_THIS_FUNCTION` to `MODMESH_PROFILE_FUNCTION`.
2. `USE_CALLPROFILER_PROFILE_THIS_SCOPE` to `MODMESH_PROFILE_SCOPE`.