### PR TITLE
Add `__repr__` and `__str__` for `Point3d`, `Segment3d`, `Bezier3d`

### DIFF
--- a/cpp/modmesh/python/common.hpp
+++ b/cpp/modmesh/python/common.hpp
@@ -319,6 +319,12 @@ public:
 #undef DECL_MM_PYBIND_CLASS_METHOD_TIMED
 #undef DECL_MM_PYBIND_CLASS_METHOD
 
+    wrapper_type & def_alias(char const * from_name, char const * to_name)
+    {
+        cls().attr(to_name) = cls().attr(from_name);
+        return *static_cast<std::add_pointer_t<wrapper_type>>(this);
+    }
+
     template <typename Func>
     wrapper_type & expose_SimpleArray(char const * name, Func && f)
     {

--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -49,6 +49,18 @@ public:
 
     static_assert(std::is_arithmetic_v<T>, "T in Point3d<T> must be arithmetic type");
 
+    /**
+     * Return the values of the point object.  Do not include the opening and
+     * closing parentheses.  Example:
+     *   p.value_string(): 0.1234, -2.421, 0
+     *
+     * @return String of the values separated by comma.
+     */
+    std::string value_string() const
+    {
+        return (Formatter() << this->x() << ", " << this->y() << ", " << this->z()).str();
+    }
+
     using value_type = T;
 
     Point3d(T x, T y)

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -65,13 +65,14 @@ WrapPoint3d<T>::WrapPoint3d(pybind11::module & mod, const char * pyname, const c
         .def(py::init<value_type, value_type>(), py::arg("x"), py::arg("y"))
         .def(py::init<value_type, value_type, value_type>(), py::arg("x"), py::arg("y"), py::arg("z"))
         .def(
-            "__str__",
+            "__repr__",
             [](wrapped_type const & self)
             {
-                return (Formatter()
-                        << "Vector3d(" << self.x() << ", " << self.y() << ", " << self.z() << ")")
-                    .str();
+                // Hard-code the Python type names in the static variable before finding a systematic way.
+                static char const * ptypename = std::is_same_v<T, double> ? "Point3dFp64" : "Point3dFp32";
+                return (Formatter() << ptypename << "(" << self.value_string() << ")").str();
             })
+        .def_alias("__repr__", "__str__")
         .def(
             "__len__",
             [](wrapped_type const & self)
@@ -289,15 +290,19 @@ WrapSegment3d<T>::WrapSegment3d(pybind11::module & mod, const char * pyname, con
              py::arg("p0"),
              py::arg("p1"))
         .def(
-            "__str__",
+            "__repr__",
             [](wrapped_type const & self)
             {
+                // Hard-code the Python type names in the static variables before finding a systematic way.
+                static char const * stypename = std::is_same_v<T, double> ? "Segment3dFp64" : "Segment3dFp32";
+                static char const * ptypename = std::is_same_v<T, double> ? "Point3dFp64" : "Point3dFp32";
                 return (Formatter()
-                        << "Edge3d("
-                        << self.x0() << ", " << self.y0() << ", " << self.z0() << ", "
-                        << self.x1() << ", " << self.y1() << ", " << self.z1() << ")")
+                        << stypename << "("
+                        << ptypename << "(" << self.p0().value_string() << "), "
+                        << ptypename << "(" << self.p1().value_string() << "))")
                     .str();
             })
+        .def_alias("__repr__", "__str__")
         .def(
             "__len__",
             [](wrapped_type const & self)
@@ -588,6 +593,22 @@ WrapBezier3d<T>::WrapBezier3d(pybind11::module & mod, const char * pyname, const
              py::arg("p1"),
              py::arg("p2"),
              py::arg("p3"))
+        .def(
+            "__repr__",
+            [](wrapped_type const & self)
+            {
+                // Hard-code the Python type names in the static variables before finding a systematic way.
+                static char const * btypename = std::is_same_v<T, double> ? "Bezier3dFp64" : "Bezier3dFp32";
+                static char const * ptypename = std::is_same_v<T, double> ? "Point3dFp64" : "Point3dFp32";
+                return (Formatter()
+                        << btypename << "("
+                        << ptypename << "(" << self.p0().value_string() << "), "
+                        << ptypename << "(" << self.p1().value_string() << "), "
+                        << ptypename << "(" << self.p2().value_string() << "), "
+                        << ptypename << "(" << self.p3().value_string() << "))")
+                    .str();
+            })
+        .def_alias("__repr__", "__str__")
         .def("__len__",
              [](wrapped_type const &)
              { return 4; })
@@ -598,21 +619,11 @@ WrapBezier3d<T>::WrapBezier3d(pybind11::module & mod, const char * pyname, const
                 point_type ret;
                 switch (it)
                 {
-                case 0:
-                    ret = self.p0();
-                    break;
-                case 1:
-                    ret = self.p1();
-                    break;
-                case 2:
-                    ret = self.p2();
-                    break;
-                case 3:
-                    ret = self.p3();
-                    break;
-                default:
-                    throw std::out_of_range("Bezier3d: (control) i 4 >= size 4");
-                    break;
+                case 0: ret = self.p0(); break;
+                case 1: ret = self.p1(); break;
+                case 2: ret = self.p2(); break;
+                case 3: ret = self.p3(); break;
+                default: throw std::out_of_range("Bezier3d: (control) i 4 >= size 4"); break;
                 }
                 return ret;
             })
@@ -622,21 +633,11 @@ WrapBezier3d<T>::WrapBezier3d(pybind11::module & mod, const char * pyname, const
             {
                 switch (it)
                 {
-                case 0:
-                    self.p0() = p;
-                    break;
-                case 1:
-                    self.p1() = p;
-                    break;
-                case 2:
-                    self.p2() = p;
-                    break;
-                case 3:
-                    self.p3() = p;
-                    break;
-                default:
-                    throw py::stop_iteration();
-                    break;
+                case 0: self.p0() = p; break;
+                case 1: self.p1() = p; break;
+                case 2: self.p2() = p; break;
+                case 3: self.p3() = p; break;
+                default: throw py::stop_iteration(); break;
                 }
             })
         //

--- a/modmesh/pilot/_svg_gui.py
+++ b/modmesh/pilot/_svg_gui.py
@@ -34,6 +34,7 @@ from PySide6 import QtCore, QtWidgets
 
 
 from .. import core
+from .. import apputil
 from ..plot import svg
 from ._gui_common import PilotFeature
 
@@ -131,5 +132,10 @@ class SVGFileDialog(PilotFeature):
         wid = self._mgr.add3DWidget()
         wid.updateWorld(world)
         wid.showMark()
+
+        # Add the data objects to the appenv for command-line access.
+        cae = apputil.get_current_appenv()
+        cae.locals['world'] = world
+        cae.locals['widget'] = wid
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -229,6 +229,17 @@ class Point3dFp32TC(Point3dTB, unittest.TestCase):
     def test_type(self):
         self.assertIs(modmesh.Point3dFp32, self.Point)
 
+    def test_repr_str(self):
+        from modmesh import Point3dFp32
+        p = Point3dFp32(607.7, -64.2, 0)
+        golden = "Point3dFp32(607.7, -64.2, 0)"
+        # __repr__ is the same as __str__ for Point3d
+        self.assertEqual(repr(p), golden)
+        self.assertEqual(str(p), golden)
+        # Evaluate the string and test the result
+        e = eval(golden)
+        self.assertEqual(p, e)
+
 
 class Point3dFp64TC(Point3dTB, unittest.TestCase):
 
@@ -242,6 +253,17 @@ class Point3dFp64TC(Point3dTB, unittest.TestCase):
 
     def test_type(self):
         self.assertIs(modmesh.Point3dFp64, self.Point)
+
+    def test_repr_str(self):
+        from modmesh import Point3dFp64
+        p = Point3dFp64(607.7, -64.2, 0)
+        golden = "Point3dFp64(607.7, -64.2, 0)"
+        # __repr__ is the same as __str__ for Point3d
+        self.assertEqual(repr(p), golden)
+        self.assertEqual(str(p), golden)
+        # Evaluate the string and test the result
+        e = eval(golden)
+        self.assertEqual(p, e)
 
 
 class Segment3dTB(ModMeshTB):
@@ -280,6 +302,19 @@ class Segment3dFp32TC(Segment3dTB, unittest.TestCase):
             kw['rtol'] = 1.e-7
         return super().assert_allclose(*args, **kw)
 
+    def test_repr_str(self):
+        from modmesh import Point3dFp32, Segment3dFp32
+        s = Segment3dFp32(Point3dFp32(504.8, -64.2, 0),
+                          Point3dFp32(421.4, -250.5, 0))
+        golden = ("Segment3dFp32(Point3dFp32(504.8, -64.2, 0), "
+                  "Point3dFp32(421.4, -250.5, 0))")
+        # __repr__ is the same as __str__ for Segment3d
+        self.assertEqual(repr(s), golden)
+        self.assertEqual(str(s), golden)
+        # Evaluate the string and test the result
+        e = eval(golden)
+        self.assertEqual(s, e)
+
 
 class Segment3dFp64TC(Segment3dTB, unittest.TestCase):
 
@@ -291,6 +326,19 @@ class Segment3dFp64TC(Segment3dTB, unittest.TestCase):
         if 'rtol' not in kw:
             kw['rtol'] = 1.e-15
         return super().assert_allclose(*args, **kw)
+
+    def test_repr_str(self):
+        from modmesh import Point3dFp64, Segment3dFp64
+        s = Segment3dFp64(Point3dFp64(504.8, -64.2, 0),
+                          Point3dFp64(421.4, -250.5, 0))
+        golden = ("Segment3dFp64(Point3dFp64(504.8, -64.2, 0), "
+                  "Point3dFp64(421.4, -250.5, 0))")
+        # __repr__ is the same as __str__ for Segment3d
+        self.assertEqual(repr(s), golden)
+        self.assertEqual(str(s), golden)
+        # Evaluate the string and test the result
+        e = eval(golden)
+        self.assertEqual(s, e)
 
 
 class Bezier3dTB(ModMeshTB):
@@ -367,6 +415,28 @@ class Bezier3dFp32TC(Bezier3dTB, unittest.TestCase):
             kw['rtol'] = 1.e-7
         return super().assert_allclose(*args, **kw)
 
+    def test_repr_str(self):
+        from modmesh import Point3dFp32, Bezier3dFp32
+        b = Bezier3dFp32(Point3dFp32(607.7, -64.2, 0),
+                         Point3dFp32(504.8, -64.2, 0),
+                         Point3dFp32(421.4, -147.6, 0),
+                         Point3dFp32(421.4, -250.5, 0))
+        golden = ("Bezier3dFp32(Point3dFp32(607.7, -64.2, 0), "
+                  "Point3dFp32(504.8, -64.2, 0), "
+                  "Point3dFp32(421.4, -147.6, 0), "
+                  "Point3dFp32(421.4, -250.5, 0))")
+        # __repr__ is the same as __str__ for Bezier3d
+        self.assertEqual(repr(b), golden)
+        self.assertEqual(str(b), golden)
+        # Evaluate the string and test the result
+        e = eval(golden)
+        # FIXME: Bezier3d does not have equality operator
+        # Tracked in https://github.com/solvcon/modmesh/issues/568
+        self.assertEqual(b[0], e[0])
+        self.assertEqual(b[1], e[1])
+        self.assertEqual(b[2], e[2])
+        self.assertEqual(b[3], e[3])
+
 
 class Bezier3dFp64TC(Bezier3dTB, unittest.TestCase):
 
@@ -378,6 +448,28 @@ class Bezier3dFp64TC(Bezier3dTB, unittest.TestCase):
         if 'rtol' not in kw:
             kw['rtol'] = 1.e-15
         return super().assert_allclose(*args, **kw)
+
+    def test_repr_str(self):
+        from modmesh import Point3dFp64, Bezier3dFp64
+        b = Bezier3dFp64(Point3dFp64(607.7, -64.2, 0),
+                         Point3dFp64(504.8, -64.2, 0),
+                         Point3dFp64(421.4, -147.6, 0),
+                         Point3dFp64(421.4, -250.5, 0))
+        golden = ("Bezier3dFp64(Point3dFp64(607.7, -64.2, 0), "
+                  "Point3dFp64(504.8, -64.2, 0), "
+                  "Point3dFp64(421.4, -147.6, 0), "
+                  "Point3dFp64(421.4, -250.5, 0))")
+        # __repr__ is the same as __str__ for Bezier3d
+        self.assertEqual(repr(b), golden)
+        self.assertEqual(str(b), golden)
+        # Evaluate the string and test the result
+        e = eval(golden)
+        # FIXME: Bezier3d does not have equality operator
+        # Tracked in https://github.com/solvcon/modmesh/issues/568
+        self.assertEqual(b[0], e[0])
+        self.assertEqual(b[1], e[1])
+        self.assertEqual(b[2], e[2])
+        self.assertEqual(b[3], e[3])
 
 
 class PointPadTB(ModMeshTB):
@@ -630,9 +722,9 @@ class SegmentPadTB(ModMeshTB):
         x0arr = self.SimpleArray(array=np.array([1, 2, 3], dtype=self.dtype))
         y0arr = self.SimpleArray(array=np.array([4, 5, 6], dtype=self.dtype))
         x1arr = self.SimpleArray(array=np.array([-1, -2, -3],
-                                 dtype=self.dtype))
+                                                dtype=self.dtype))
         y1arr = self.SimpleArray(array=np.array([-4, -5, -6],
-                                 dtype=self.dtype))
+                                                dtype=self.dtype))
         sp = self.SegmentPad(x0=x0arr, y0=y0arr, x1=x1arr, y1=y1arr,
                              clone=False)
         self.assertEqual(sp.ndim, 2)
@@ -676,11 +768,11 @@ class SegmentPadTB(ModMeshTB):
         y0arr = self.SimpleArray(array=np.array([4, 5, 6], dtype=self.dtype))
         z0arr = self.SimpleArray(array=np.array([7, 8, 9], dtype=self.dtype))
         x1arr = self.SimpleArray(array=np.array([-1, -2, -3],
-                                 dtype=self.dtype))
+                                                dtype=self.dtype))
         y1arr = self.SimpleArray(array=np.array([-4, -5, -6],
-                                 dtype=self.dtype))
+                                                dtype=self.dtype))
         z1arr = self.SimpleArray(array=np.array([-7, -8, -9],
-                                 dtype=self.dtype))
+                                                dtype=self.dtype))
         sp = self.SegmentPad(x0=x0arr, y0=y0arr, z0=z0arr,
                              x1=x1arr, y1=y1arr, z1=z1arr, clone=False)
         self.assertEqual(sp.ndim, 3)


### PR DESCRIPTION
Implement the string representing helpers `__repr__` and `__str__` for the Python classes `Point3d`, `Segment3d`, and `Bezier3d` (both the `Fp32` and `Fp64` flavors).  It helps analyze the graphical objects in the "World" object in the modmesh pilot command-line window.

Also add the objects `world` and `wid` of the SVG app to the appenv (application environment) so that users can access them from the command line.