### PR TITLE
Refactor SVG file loader by using the batch interface for faster runtime

### DIFF
--- a/cpp/modmesh/universe/World.hpp
+++ b/cpp/modmesh/universe/World.hpp
@@ -119,6 +119,10 @@ public:
     }
     std::shared_ptr<segment_pad_type> const & segments() { return m_segments; }
 
+    void add_bezier(bezier_type const & bezier)
+    {
+        m_curves->append(bezier);
+    }
     void add_bezier(point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3)
     {
         m_curves->append(p0, p1, p2, p3);

--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -908,8 +908,10 @@ public:
     SimpleArray<value_type> y1() { return m_p1->y(); }
     SimpleArray<value_type> z1() { return m_p1->z(); }
 
-    std::shared_ptr<point_pad_type> p0() const { return m_p0; }
-    std::shared_ptr<point_pad_type> p1() const { return m_p1; }
+    // Should not implement the const versions of p0, p1 because the returned
+    // shared pointers make the contents mutable.
+    std::shared_ptr<point_pad_type> p0() { return m_p0; }
+    std::shared_ptr<point_pad_type> p1() { return m_p1; }
 
     segment_type get_at(size_t i) const
     {
@@ -1328,6 +1330,26 @@ public:
     }
 
     // TODO: missing many accessors
+
+    SimpleArray<value_type> x0() { return m_p0->x(); }
+    SimpleArray<value_type> y0() { return m_p0->y(); }
+    SimpleArray<value_type> z0() { return m_p0->z(); }
+    SimpleArray<value_type> x1() { return m_p1->x(); }
+    SimpleArray<value_type> y1() { return m_p1->y(); }
+    SimpleArray<value_type> z1() { return m_p1->z(); }
+    SimpleArray<value_type> x2() { return m_p2->x(); }
+    SimpleArray<value_type> y2() { return m_p2->y(); }
+    SimpleArray<value_type> z2() { return m_p2->z(); }
+    SimpleArray<value_type> x3() { return m_p3->x(); }
+    SimpleArray<value_type> y3() { return m_p3->y(); }
+    SimpleArray<value_type> z3() { return m_p3->z(); }
+
+    // Should not implement the const versions of p0, p1, p2, p3 because the
+    // returned shared pointers make the contents mutable.
+    std::shared_ptr<point_pad_type> p0() { return m_p0; }
+    std::shared_ptr<point_pad_type> p1() { return m_p1; }
+    std::shared_ptr<point_pad_type> p2() { return m_p2; }
+    std::shared_ptr<point_pad_type> p3() { return m_p3; }
 
     std::shared_ptr<SegmentPad<T>> sample(value_type length) const;
 

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -751,6 +751,34 @@ WrapCurvePad<T>::WrapCurvePad(pybind11::module & mod, const char * pyname, const
         ;
     // clang-format on
 #undef DECL_WRAP
+
+    // x, y, z, point array/batch accessors.
+#define DECL_WRAP(NAME)         \
+    .def_property_readonly(     \
+        #NAME,                  \
+        [](wrapped_type & self) \
+        { return self.NAME(); })
+    // clang-format off
+    (*this)
+        DECL_WRAP(x0)
+        DECL_WRAP(y0)
+        DECL_WRAP(z0)
+        DECL_WRAP(x1)
+        DECL_WRAP(y1)
+        DECL_WRAP(z1)
+        DECL_WRAP(x2)
+        DECL_WRAP(y2)
+        DECL_WRAP(z2)
+        DECL_WRAP(x3)
+        DECL_WRAP(y3)
+        DECL_WRAP(z3)
+        DECL_WRAP(p0)
+        DECL_WRAP(p1)
+        DECL_WRAP(p2)
+        DECL_WRAP(p3)
+        ;
+#undef DECL_WRAP
+    // clang-format on
 }
 
 template <typename T>
@@ -766,7 +794,9 @@ public:
     using value_type = typename wrapped_type::value_type;
     using point_type = typename wrapped_type::point_type;
     using segment_type = typename wrapped_type::segment_type;
+    using segment_pad_type = typename wrapped_type::segment_pad_type;
     using bezier_type = typename wrapped_type::bezier_type;
+    using curve_pad_type = typename wrapped_type::curve_pad_type;
 
     friend typename base_type::root_base_type;
 
@@ -830,9 +860,27 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
             },
             py::arg("p0"),
             py::arg("p1"))
+        .def(
+            "add_segments",
+            [](wrapped_type & self, segment_pad_type const & segment_pad)
+            {
+                for (size_t i = 0; i < segment_pad.size(); ++i)
+                {
+                    self.add_segment(segment_pad.get(i));
+                }
+            },
+            py::arg("pad"))
         .def_property_readonly("nsegment", &wrapped_type::nsegment)
         .def("segment", &wrapped_type::segment_at)
         .def_property_readonly("segments", &wrapped_type::segments)
+        .def(
+            "add_bezier",
+            [](wrapped_type & self, bezier_type const & bezier)
+            {
+                self.add_bezier(bezier);
+                return self.bezier_at(self.nbezier() - 1);
+            },
+            py::arg("bezier"))
         .def(
             "add_bezier",
             [](wrapped_type & self, point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3)
@@ -844,6 +892,16 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
             py::arg("p1"),
             py::arg("p2"),
             py::arg("p3"))
+        .def(
+            "add_beziers",
+            [](wrapped_type & self, curve_pad_type const & curve_pad)
+            {
+                for (size_t i = 0; i < curve_pad.size(); ++i)
+                {
+                    self.add_bezier(curve_pad.get(i));
+                }
+            },
+            py::arg("pad"))
         .def_property_readonly("nbezier", &wrapped_type::nbezier)
         .def(
             "bezier",

--- a/cpp/modmesh/universe/pymod/wrap_World.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_World.cpp
@@ -850,7 +850,7 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
                 self.add_segment(edge);
                 return self.segment_at(self.nsegment() - 1);
             },
-            py::arg("segment"))
+            py::arg("s"))
         .def(
             "add_segment",
             [](wrapped_type & self, point_type const & p0, point_type const & p1)
@@ -880,7 +880,7 @@ WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char 
                 self.add_bezier(bezier);
                 return self.bezier_at(self.nbezier() - 1);
             },
-            py::arg("bezier"))
+            py::arg("b"))
         .def(
             "add_bezier",
             [](wrapped_type & self, point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3)

--- a/modmesh/plot/svg.py
+++ b/modmesh/plot/svg.py
@@ -440,7 +440,9 @@ class EPath(object):
 class PathParser(object):
     def __init__(self, file_path=None):
         self.file_path = file_path
-        self.epaths = None  # list of epath
+        self.epaths = []  # list of epath
+        self.spads = []  # list of SegmentPad
+        self.cpads = []  # list of CurvePad
 
     def parse(self):
         tree = ET.parse(self.file_path)
@@ -449,15 +451,15 @@ class PathParser(object):
         namespace = {'svg': 'http://www.w3.org/2000/svg'}
         pathElements = root.findall('.//svg:path', namespace)
 
-        paths = []
         for elmnt in pathElements:
             d_attr = elmnt.attrib.get('d', '')
             fill_attr = elmnt.attrib.get('fill', '')
-            paths.append(EPath(d_attr=d_attr, fill_attr=fill_attr))
-        """ d_attr = pathElements[0].attrib.get('d', '')
-        fill_attr = pathElements[0].attrib.get('fill', '')
-        paths.append(EPath(d_attr=d_attr, fill_attr=fill_attr)) """
-        self.epaths = paths
+            epath = EPath(d_attr=d_attr, fill_attr=fill_attr)
+            self.epaths.append(epath)
+            # Get SegmentPad and CurvePad from the paths
+            spad, cpad = epath.get_closed_paths()
+            self.spads.append(spad)
+            self.cpads.append(cpad)
 
     def get_epaths(self):
         return self.epaths

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -982,6 +982,14 @@ class SegmentPadTB(ModMeshTB):
         for i in range(nseg):
             self.assertEqual(sp[i], sp[nseg + i])
 
+        # Assert the equality between value array and PointPad
+        self.assert_allclose(list(sp.x0), list(sp.p0.x))
+        self.assert_allclose(list(sp.y0), list(sp.p0.y))
+        self.assert_allclose(list(sp.z0), list(sp.p0.z))
+        self.assert_allclose(list(sp.x1), list(sp.p1.x))
+        self.assert_allclose(list(sp.y1), list(sp.p1.y))
+        self.assert_allclose(list(sp.z1), list(sp.p1.z))
+
 
 class SegmentPadFp32TC(SegmentPadTB, unittest.TestCase):
 
@@ -1134,6 +1142,40 @@ class CurvePadTB(ModMeshTB):
         self.assertEqual(list(cp[0][2]), [3, 1, 0])
         self.assertEqual(list(cp[0][3]), [4, 0, 0])
 
+        b2 = self.Bezier(
+            p0=self.Point(0, 0, 1),
+            p1=self.Point(1.3, 1.921, 2),
+            p2=self.Point(3.2, 1.224, 3),
+            p3=self.Point(4.87, 0.12, 4))
+        cp.append(c=b2)
+        self.assertEqual(len(cp), 2)
+        # Assert the equality between value array and PointPad
+        self.assert_allclose(list(cp.x0), list(cp.p0.x))
+        self.assert_allclose(list(cp.y0), list(cp.p0.y))
+        self.assert_allclose(list(cp.z0), list(cp.p0.z))
+        self.assert_allclose(list(cp.x1), list(cp.p1.x))
+        self.assert_allclose(list(cp.y1), list(cp.p1.y))
+        self.assert_allclose(list(cp.z1), list(cp.p1.z))
+        self.assert_allclose(list(cp.x2), list(cp.p2.x))
+        self.assert_allclose(list(cp.y2), list(cp.p2.y))
+        self.assert_allclose(list(cp.z2), list(cp.p2.z))
+        self.assert_allclose(list(cp.x3), list(cp.p3.x))
+        self.assert_allclose(list(cp.y3), list(cp.p3.y))
+        self.assert_allclose(list(cp.z3), list(cp.p3.z))
+        # Check the value
+        self.assert_allclose(list(cp.x0), [7, 0])
+        self.assert_allclose(list(cp.y0), [8, 0])
+        self.assert_allclose(list(cp.z0), [-3, 1])
+        self.assert_allclose(list(cp.x1), [1, 1.3])
+        self.assert_allclose(list(cp.y1), [1, 1.921])
+        self.assert_allclose(list(cp.z1), [0, 2])
+        self.assert_allclose(list(cp.x2), [3, 3.2])
+        self.assert_allclose(list(cp.y2), [1, 1.224])
+        self.assert_allclose(list(cp.z2), [0, 3])
+        self.assert_allclose(list(cp.x3), [4, 4.87])
+        self.assert_allclose(list(cp.y3), [0, 0.12])
+        self.assert_allclose(list(cp.z3), [0, 4])
+
     def test_sample_2d(self):
         CurvePad = self.CurvePad
         Point = self.Point
@@ -1276,8 +1318,8 @@ class WorldTB(ModMeshTB):
         with self.assertRaisesRegex(
                 IndexError, "World: \\(bezier\\) i 1 >= size 1"):
             w.bezier(1)
-        b2 = w.add_bezier(self.Bezier(p0=Point(0, 0, 1), p1=Point(1, 1, 2),
-                                      p2=Point(3, 1, 3), p3=Point(4, 0, 4)))
+        b2 = w.add_bezier(b=self.Bezier(p0=Point(0, 0, 1), p1=Point(1, 1, 2),
+                                        p2=Point(3, 1, 3), p3=Point(4, 0, 4)))
         self.assertEqual(w.nbezier, 2)
         w.bezier(1)
         with self.assertRaisesRegex(
@@ -1386,7 +1428,7 @@ class WorldTB(ModMeshTB):
             w.segment(0)
 
         # Add a segment by object
-        s = w.add_segment(Segment(Point(0, 1, 2), Point(7.1, 8.2, 9.3)))
+        s = w.add_segment(s=Segment(Point(0, 1, 2), Point(7.1, 8.2, 9.3)))
         self.assert_allclose(list(s), [[0, 1, 2], [7.1, 8.2, 9.3]])
         self.assert_allclose(list(w.segment(0)), [[0, 1, 2], [7.1, 8.2, 9.3]])
         self.assertIsNot(s, w.segment(0))


### PR DESCRIPTION
The refactoring moves some parsing code from `SVGFileDialog` (in file `_svg_gui.py`) to `PathParser` (in file `svg.py`) to facilitate more testing and refactoring in the future.

To refactor the SVG parser and drawer, `World`, `SegmentPad`, and `CurvePad` also need improvement for their batch (array) interface.  Associated unit tests are also added.