### PR TITLE
Add customizable profiling runner in pilot

### DIFF
--- a/modmesh/pilot/_gui.py
+++ b/modmesh/pilot/_gui.py
@@ -78,7 +78,8 @@ class _Controller(metaclass=_Singleton):
         self.naca4airfoil = None
         self.eulerone = None
         self.burgers = None
-        self.profiling = None
+        self.openprofiledata = None
+        self.runprofiling = None
 
     def __getattr__(self, name):
         return None if self._rmgr is None else getattr(self._rmgr, name)
@@ -96,7 +97,8 @@ class _Controller(metaclass=_Singleton):
         self.eulerone = _euler1d.Euler1DApp(mgr=self._rmgr)
         self.burgers = _burgers1d.Burgers1DApp(mgr=self._rmgr)
         self.linear_wave = _linear_wave.LinearWave1DApp(mgr=self._rmgr)
-        self.profiling = _profiling.Profiling(mgr=self._rmgr)
+        self.openprofiledata = _profiling.Profiling(mgr=self._rmgr)
+        self.runprofiling = _profiling.RunProfiling(mgr=self._rmgr)
         self.populate_menu()
         self._rmgr.show()
         return self._rmgr.exec()
@@ -127,7 +129,8 @@ class _Controller(metaclass=_Singleton):
         self.eulerone.populate_menu()
         self.burgers.populate_menu()
         self.linear_wave.populate_menu()
-        self.profiling.populate_menu()
+        self.openprofiledata.populate_menu()
+        self.runprofiling.populate_menu()
 
         if sys.platform != 'darwin':
             _addAction(

--- a/modmesh/pilot/_profiling.py
+++ b/modmesh/pilot/_profiling.py
@@ -26,15 +26,29 @@
 
 import json
 from typing import Any
+import functools
+import itertools
+import importlib.util
 
 from ._gui_common import PilotFeature
+
+from .. import call_profiler
+from .. import apputil
 
 from PySide6 import QtCore, QtWidgets
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QTreeView,
-    QWidget
+    QWidget,
+    QDockWidget,
+    QCheckBox,
+    QVBoxLayout,
+    QLabel,
+    QPushButton
 )
+
+from PySide6.QtCore import Qt
+
 from PySide6.QtGui import (
     QStandardItem,
     QStandardItemModel
@@ -134,6 +148,195 @@ class Profiling(PilotFeature):
 
         self._table.setWidget(self._tree_view)
         self._table.showMaximized()
+        self._table.show()
+
+
+class ProfileConfigWidget(QWidget):
+    def __init__(self, app, parent=None):
+        super().__init__(parent)
+        self.app = app
+
+    def init_ui(self, options):
+        main_layout = QVBoxLayout(self)
+
+        def on_check_change(check_state, opt, item):
+            if check_state == Qt.Checked:
+                self.app.add_opt(opt, item)
+            else:
+                self.app.rm_opt(opt, item)
+
+        for opt in options:
+            title = opt[0]
+            choices = opt[1]
+
+            vbox = QVBoxLayout()
+            vbox.setStretch(0, 4)
+
+            title_label = QLabel(title)
+            vbox.addWidget(title_label)
+
+            for c in choices:
+                checkbox = QCheckBox(c)
+                checkbox.setTristate(False)
+                cbfunc = functools.partial(on_check_change, opt=title, item=c)
+                checkbox.checkStateChanged.connect(cbfunc)
+                vbox.addWidget(checkbox)
+
+            main_layout.addLayout(vbox)
+
+        cmd_vbox = QVBoxLayout()
+        cmd_vbox.setStretch(0, 4)
+
+        command_label = QLabel("Command")
+        cmd_vbox.addWidget(command_label)
+
+        run_button = QPushButton("run")
+        run_button.clicked.connect(self.app.run_profiling)
+        cmd_vbox.addWidget(run_button)
+
+        main_layout.addLayout(cmd_vbox)
+
+        self.setLayout(main_layout)
+
+
+class RunProfiling(PilotFeature):
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self._diag = QtWidgets.QFileDialog()
+        self._diag.setFileMode(QtWidgets.QFileDialog.ExistingFile)
+        self._diag.setWindowTitle("Open profiling file")
+        self.module = None
+        self.prof_candidate = {}
+        self.prof_opt = {}
+
+    def populate_menu(self):
+        self._add_menu_item(
+            menu=self._mgr.profilingMenu,
+            text="Profiling script",
+            tip="Run profiling from script",
+            func=self.load_profile_util,
+        )
+
+    def load_profile_util(self):
+        self._diag.open(self, QtCore.SLOT("on_finished()"))
+
+    @QtCore.Slot()
+    def on_finished(self):
+        filenames = []
+        for path in self._diag.selectedFiles():
+            filenames.append(path)
+
+        self.setup_profile_config(filenames[0])
+
+    def import_profile_module(self, filename):
+        spec = importlib.util.spec_from_file_location("profile_mod", filename)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def setup_profile_config(self, filename):
+        self.module = self.import_profile_module(filename)
+        options = self.module.get_options()
+
+        # Add profiling module to appenv for commamd-line access
+        cae = apputil.get_current_appenv()
+        cae.locals['profile_module'] = self.module
+
+        self.init_ui(options)
+
+    def add_opt(self, opt, item):
+        if self.prof_opt.get(opt, None) is None:
+            self.prof_opt[opt] = set()
+
+        self.prof_opt[opt].add(item)
+
+    def rm_opt(self, opt, item):
+        if self.prof_opt.get(opt, None) is None:
+            return
+
+        self.prof_opt[opt].remove(item)
+
+    def init_ui(self, options):
+        config_window = ProfileConfigWidget(self)
+        config_window.init_ui(options)
+        config_widget = QDockWidget("config")
+        config_widget.setWidget(config_window)
+        self._mgr.mainWindow.addDockWidget(
+            Qt.LeftDockWidgetArea, config_widget)
+
+    def run_profiling(self):
+
+        call_profiler.reset()
+
+        opt_values = [[(k, vv) for vv in v] for k, v in self.prof_opt.items()]
+
+        for case in itertools.product(*opt_values):
+            self.module.run({k: v for k, v in case})
+
+        result = call_profiler.result().get("children", None)
+        if result is not None:
+            self._add_result_window(result)
+
+    def _add_result_window(self, result):
+        self._table = self._mgr.addSubWindow(QWidget())
+        self._tree_view = QTreeView(self._table)
+
+        self._model = QStandardItemModel(self._tree_view)
+        self._model.setHorizontalHeaderLabels(
+            ["Symbol Name", "Total Time", "Count"])
+
+        def _recursive_add_item(parent: QStandardItem, data: dict, tot: float):
+            percent = data["total_time"] * 100 / tot
+
+            first = QStandardItem(data["name"])
+            second = QStandardItem(f"{data['total_time']} ({percent:2f}%)")
+            third = QStandardItem(f"{data['count']}")
+
+            parent.appendRow([first, second, third])
+
+            children = data["children"]
+            def key_func(d): d["total_time"]
+            sorted_child_data = sorted(children, key=key_func, reverse=True)
+
+            for child_data in sorted_child_data:
+                _recursive_add_item(first, child_data, tot)
+
+        for data in result:
+            first = QStandardItem(data["name"])
+            second = QStandardItem(f"{data['total_time']} (100%)")
+            third = QStandardItem(f"{data['count']}")
+
+            self._model.appendRow([first, second, third])
+
+            for child_data in data["children"]:
+                _recursive_add_item(first, child_data, data['total_time'])
+
+        self._tree_view.setStyleSheet(
+            """
+            QTreeView {
+                background-color: #2e2e2e;
+                color: #dcdcdc;
+                border: 1px solid #555555;
+            }
+            QTreeView::item {
+                border: 1px solid #3c3c3c;
+                border-right: none;
+                border-bottom: none;
+            }
+            QTreeView::item:selected {
+                background-color: #4f4f4f;
+                color: white;
+            }
+            """
+        )
+
+        self._tree_view.setModel(self._model)
+        self._tree_view.setColumnWidth(0, 200)
+        self._tree_view.setColumnWidth(1, 200)
+        self._tree_view.setColumnWidth(1, 200)
+        self._tree_view.setEditTriggers(QAbstractItemView.NoEditTriggers)
+
+        self._table.setWidget(self._tree_view)
         self._table.show()
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/profiling/profile_arithmetic.py
+++ b/profiling/profile_arithmetic.py
@@ -1,0 +1,253 @@
+from enum import IntEnum
+import functools
+import numpy as np
+import modmesh
+
+
+def _profile_function(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        _ = modmesh.CallProfilerProbe(func.__name__)
+        result = func(*args, **kwargs)
+        return result
+    return wrapper
+
+
+def _make_container(data):
+    if np.isdtype(data.dtype, np.uint8):
+        return modmesh.SimpleArrayUint8(array=data)
+    elif np.isdtype(data.dtype, np.uint16):
+        return modmesh.SimpleArrayUint16(array=data)
+    elif np.isdtype(data.dtype, np.uint32):
+        return modmesh.SimpleArrayUint32(array=data)
+    elif np.isdtype(data.dtype, np.uint64):
+        return modmesh.SimpleArrayUint64(array=data)
+    if np.isdtype(data.dtype, np.int8):
+        return modmesh.SimpleArrayInt8(array=data)
+    elif np.isdtype(data.dtype, np.int16):
+        return modmesh.SimpleArrayInt16(array=data)
+    elif np.isdtype(data.dtype, np.int32):
+        return modmesh.SimpleArrayInt32(array=data)
+    elif np.isdtype(data.dtype, np.int64):
+        return modmesh.SimpleArrayInt64(array=data)
+    elif np.isdtype(data.dtype, np.float32):
+        return modmesh.SimpleArrayFloat32(array=data)
+    elif np.isdtype(data.dtype, np.float64):
+        return modmesh.SimpleArrayFloat64(array=data)
+
+
+class OpList(IntEnum):
+    ADD = 0
+    SUB = 1
+    MUL = 2
+    DIV = 3
+
+
+@_profile_function
+def add_np(src1, src2):
+    return np.add(src1, src2)
+
+
+@_profile_function
+def add_sa(src1, src2):
+    return src1.add(src2)
+
+
+@_profile_function
+def add_simd(src1, src2):
+    return src1.add_simd(src2)
+
+
+@_profile_function
+def sub_np(src1, src2):
+    return np.subtract(src1, src2)
+
+
+@_profile_function
+def sub_sa(src1, src2):
+    return src1.sub(src2)
+
+
+@_profile_function
+def sub_simd(src1, src2):
+    return src1.sub_simd(src2)
+
+
+@_profile_function
+def mul_np(src1, src2):
+    return np.multiply(src1, src2)
+
+
+@_profile_function
+def mul_sa(src1, src2):
+    return src1.mul(src2)
+
+
+@_profile_function
+def mul_simd(src1, src2):
+    return src1.mul_simd(src2)
+
+
+@_profile_function
+def div_np(src1, src2):
+    return np.divide(src1, src2)
+
+
+@_profile_function
+def div_sa(src1, src2):
+    return src1.div(src2)
+
+
+@_profile_function
+def div_simd(src1, src2):
+    return src1.div_simd(src2)
+
+
+@_profile_function
+def iadd_np(src1, src2):
+    src1 += src2
+
+
+@_profile_function
+def iadd_sa(src1, src2):
+    src1.iadd(src2)
+
+
+@_profile_function
+def iadd_simd(src1, src2):
+    src1.iadd_simd(src2)
+
+
+@_profile_function
+def isub_np(src1, src2):
+    src1 -= src2
+
+
+@_profile_function
+def isub_sa(src1, src2):
+    src1.isub(src2)
+
+
+@_profile_function
+def isub_simd(src1, src2):
+    src1.isub_simd(src2)
+
+
+@_profile_function
+def imul_np(src1, src2):
+    src1 *= src2
+
+
+@_profile_function
+def imul_sa(src1, src2):
+    src1.imul(src2)
+
+
+@_profile_function
+def imul_simd(src1, src2):
+    src1.imul_simd(src2)
+
+
+@_profile_function
+def idiv_np(src1, src2):
+    src1 /= src2
+
+
+@_profile_function
+def idiv_sa(src1, src2):
+    src1.idiv(src2)
+
+
+@_profile_function
+def idiv_simd(src1, src2):
+    src1.idiv_simd(src2)
+
+
+def profile_np(lhs, rhs, op, inplace=False, **kwargs):
+    if not inplace:
+        func = [add_np, sub_np, mul_np, div_np]
+    else:
+        func = [iadd_np, isub_np, imul_np, idiv_np]
+
+    func[op](lhs, rhs)
+
+
+def _profile_sa(lhs, rhs, op, inplace=False, **kwargs):
+    if not inplace:
+        func = [add_sa, sub_sa, mul_sa, div_sa]
+    else:
+        func = [iadd_sa, isub_sa, imul_sa, idiv_sa]
+
+    func[op](lhs, rhs)
+
+
+def _profile_sa_simd(lhs, rhs, op, inplace=False, **kwargs):
+    if not inplace:
+        func = [add_simd, sub_simd, mul_simd, div_simd]
+    else:
+        func = [iadd_simd, isub_simd, imul_simd, idiv_simd]
+
+    func[op](lhs, rhs)
+
+
+def profile_sa(lhs, rhs, op, inplace=False, **kwargs):
+    _profile_sa(_make_container(lhs), _make_container(rhs), op, inplace)
+
+
+def profile_sa_simd(lhs, rhs, op, inplace=False, **kwargs):
+    _profile_sa_simd(_make_container(lhs), _make_container(rhs), op, inplace)
+
+
+def get_options():
+    return [(k, v.keys()) for k, v in StaticData.opt_dict.items()]
+
+
+def run(options):
+    func = StaticData.opt_dict["function"][options["function"]]
+    type_max = StaticData.opt_dict["type"][options["type"]][1]
+    lhs_base = (StaticData.lhs * type_max).astype(options["type"])
+    rhs_base = (StaticData.rhs * type_max).astype(options["type"])
+    operation = StaticData.opt_dict["operation"][options["operation"]]
+    inplace = StaticData.opt_dict["In-place"][options["In-place"]]
+
+    for _ in range(10):
+        func(lhs_base.copy(), rhs_base.copy(), operation, inplace)
+
+
+class StaticData:
+    N = 2 ** 22
+    lhs = np.random.rand(N)
+    rhs = np.random.rand(N)
+    opt_dict = {
+        "function": {
+            "profile_np": profile_np,
+            "profile_sa": profile_sa,
+            "profile_sa_simd": profile_sa_simd,
+        },
+        "operation": {
+            "Addition": OpList.ADD,
+            "Subtraction": OpList.SUB,
+            "Multiplication": OpList.MUL,
+            "Division": OpList.DIV
+        },
+        "type": {
+            "uint8": (0, 2 ** 8 - 1),
+            "uint16": (0, 2 ** 16 - 1),
+            "uint32": (0, 2 ** 32 - 1),
+            "uint64": (0, 2 ** 64 - 1),
+            "int8": (-(2 ** 7), 2 ** 7 - 1),
+            "int16": (-(2 ** 15), 2 ** 15 - 1),
+            "int32": (-(2 ** 31), 2 ** 31 - 1),
+            "int64": (-(2 ** 63), 2 ** 63 - 1),
+            "float32": (-(2.0 ** 32), 2.0 ** 32),
+            "float64": (-(2.0 ** 64), 2.0 ** 64),
+        },
+        "In-place": {
+            "In-place": True,
+            "Out-of-place": False
+        }
+    }
+
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
# Description

This PR adds a tool to run profiling from profiling setting script.

## User steps

A new menu SimpleArray Arithmetic Profiling is added as sub-item of "Profiling" in menu bar. 

<img width="1512" height="982" alt="Screenshot 2025-08-17 at 14 14 00" src="https://github.com/user-attachments/assets/95b80662-e051-40a7-bdf5-c8b76b658621" />

After clicking it, a dialog for selecting files pops up. Choose the newly added file "`Profiling/profile_arithmetic_setting.py`" to open the setting.

<img width="1512" height="982" alt="Screenshot 2025-08-17 at 18 23 33" src="https://github.com/user-attachments/assets/1c9c45b8-e7b1-42e9-af73-b70a47f03ee9" />

And then a menu as following screenshot will be set up. 

<img width="1624" height="1056" alt="Screenshot 2025-08-17 at 18 30 24" src="https://github.com/user-attachments/assets/f329e5fc-970b-4503-91b2-b18c19891a87" />

Choose the combination that you want to profile from the configuration panel and then press "run", the result of profiling will pop up as a new window.

<img width="1624" height="1056" alt="Screenshot 2025-08-17 at 14 14 55" src="https://github.com/user-attachments/assets/c2e7641e-a544-4662-a5cc-24b8a5ad0f36" />

## Setting script manual

The "profile_arithmetic_setting.py" script acts as a module that can setup the configuration panel so other python scripts that follows the following rules can be also loaded.

### Rules

There should be the following three global functions in the script.
1. `get_options() -> dict`
2. `run(option: dict)`

`get_options` function should return a dictionary containing different categories of available options. 
The return value should be a python dictionary of which the keys are the title of option categories and the values are the available options in the category. 

For example, the return value of `get_options` in file `Profiling/profile_arithmetic_setting.py` is the following. 
```python
{
    "function": [
        "profile_np",
        "profile_sa",
        "profile_sa_simd",
    ],
    "operation": [
        "Addition", "Subtraction",
        "Multiplication", "Division",
    ],
    "type": [
        "uint8", "uint16", "uint32", "uint64",
        "int8", "int16", "int32", "int64",
        "float32", "float64",
    ],
    "In-place": [ 
         "In-place", "Out-of-place"
    ]
}
```

And then, the `run(options)` function takes a dictionary of option as arguments and then run functions with profiling marks of `modmesh.CallProfileProbe`. 

For example, an available input of the `run` function in `Profiling/profile_arithmetic_setting.py` is 
```python
{
    "function": "profile_np",
    "operation": "Multiplication",
    "type": "int32",
    "In-place":  "Out-of-place"
}
```

The `run` button in configure panel will run all possible combination of the selected options once and then collect the profiling result.