### PR TITLE
Refactor: Fix code quality issues highlighted with clang-tidy v21 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ Checks: >
     -clang-diagnostic-ignored-optimization-argument,
     -altera-*,
     -abseil-*,
+    -boost-*,
     -bugprone-macro-parentheses,
     -bugprone-narrowing-conversions,-cppcoreguidelines-narrowing-conversions,
     -llvmlibc-*,
@@ -28,13 +29,16 @@ Checks: >
     -llvm-header-guard,
     -llvm-include-order,
     -performance-noexcept-move-constructor,
+    -performance-avoid-endl,
     -readability-identifier-length,
     -readability-implicit-bool-conversion,
     -readability-named-parameter,
     -readability-magic-numbers,
     -readability-redundant-access-specifiers,
     -misc-non-private-member-variables-in-classes,
-    -misc-confusable-identifiers
+    -misc-confusable-identifiers,
+    -misc-include-cleaner,
+    -misc-use-internal-linkage
 WarningsAsErrors: ''
 HeaderFilterRegex: 'modmesh.*'
 AnalyzeTemporaryDtors: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -221,10 +221,10 @@ jobs:
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
           # This has been replaced by the 'install qt' section below to manage
           # qt6 versioning independently from the OS.
-          # brew install llvm@16 qt6
-          brew install llvm@16
-          ln -s "$(brew --prefix llvm@16)/bin/clang-format" "/usr/local/bin/clang-format"
-          ln -s "$(brew --prefix llvm@16)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
+          # brew install llvm@21 qt6
+          brew install llvm@21
+          ln -s "$(brew --prefix llvm@21)/bin/clang-format" "/usr/local/bin/clang-format"
+          ln -s "$(brew --prefix llvm@21)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
 
       - name: install qt
         uses: jurplel/install-qt-action@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ if(MODMESH_PROFILE)
 endif()
 
 if(BUILD_METAL)
-include_directories("${CMAKE_CURRENT_LIST_DIR}/thirdparty/install/metal-cpp")
+include_directories(SYSTEM "${CMAKE_CURRENT_LIST_DIR}/thirdparty/install/metal-cpp")
 endif()
 
 # Pybind11 2.12.0 is the first version that supports compiling for numpy 2.0.0.

--- a/cpp/modmesh/buffer/SimpleArray.cpp
+++ b/cpp/modmesh/buffer/SimpleArray.cpp
@@ -329,7 +329,7 @@ SimpleArrayPlex::SimpleArrayPlex(SimpleArrayPlex const & other)
     }
 }
 
-SimpleArrayPlex::SimpleArrayPlex(SimpleArrayPlex && other)
+SimpleArrayPlex::SimpleArrayPlex(SimpleArrayPlex && other) noexcept
     : m_data_type(other.m_data_type)
 {
     if (!other.m_instance_ptr)
@@ -461,7 +461,7 @@ SimpleArrayPlex & SimpleArrayPlex::operator=(SimpleArrayPlex const & other)
     return *this;
 }
 
-SimpleArrayPlex & SimpleArrayPlex::operator=(SimpleArrayPlex && other)
+SimpleArrayPlex & SimpleArrayPlex::operator=(SimpleArrayPlex && other) noexcept
 {
     m_data_type = other.m_data_type;
 

--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -1645,9 +1645,9 @@ public:
     }
 
     SimpleArrayPlex(SimpleArrayPlex const & other);
-    SimpleArrayPlex(SimpleArrayPlex && other);
+    SimpleArrayPlex(SimpleArrayPlex && other) noexcept;
     SimpleArrayPlex & operator=(SimpleArrayPlex const & other);
-    SimpleArrayPlex & operator=(SimpleArrayPlex && other);
+    SimpleArrayPlex & operator=(SimpleArrayPlex && other) noexcept;
 
     ~SimpleArrayPlex();
 

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -116,7 +116,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                             owner = next;
                         }
 
-                        char * base_ptr = static_cast<char *>(owner.mutable_data());
+                        char const * base_ptr = static_cast<char *>(owner.mutable_data());
                         char * view_ptr = static_cast<char *>(arr_in.mutable_data());
                         const ptrdiff_t offset_bytes = view_ptr - base_ptr;
                         if (offset_bytes < 0)

--- a/cpp/modmesh/math/pymod/wrap_Complex.cpp
+++ b/cpp/modmesh/math/pymod/wrap_Complex.cpp
@@ -52,7 +52,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapComplex
         : WrapBase<WrapComplex<value_type>, modmesh::Complex<value_type>, std::shared_ptr<modmesh::Complex<value_type>>>(mod, pyname, pydoc)
     {
         namespace py = pybind11; // NOLINT(misc-unused-alias-decls)
-        static const auto complex_dtype = py::dtype(std::is_same<value_type, float>::value ? "complex64" : "complex128");
+        static const auto complex_dtype = py::dtype(std::is_same_v<value_type, float> ? "complex64" : "complex128");
 
         PYBIND11_NUMPY_DTYPE(wrapped_type, real_v, imag_v);
 

--- a/cpp/modmesh/mesh/StaticMesh.hpp
+++ b/cpp/modmesh/mesh/StaticMesh.hpp
@@ -89,7 +89,7 @@ struct CellType : NumberBase<int32_t, double>
     uint8_t nnode() const { return m_attrs[NNODE_IDX]; }
     uint8_t nedge() const { return m_attrs[NEDGE_IDX]; }
     uint8_t nsurface() const { return m_attrs[NSURFACE_IDX]; }
-    uint8_t nface() const { return m_attrs[m_ndim - 1]; }
+    uint8_t nface() const { return m_attrs[m_ndim - 1]; } // FIXME: Review the suppression NOLINT(clang-analyzer-security.ArrayBound)
 
     const char * name() const
     {

--- a/cpp/modmesh/mesh/StaticMesh_boundary.cpp
+++ b/cpp/modmesh/mesh/StaticMesh_boundary.cpp
@@ -261,7 +261,7 @@ inline void StaticMesh::fill_ghost()
                 }
                 for (size_t idm = 0; idm < m_ndim; ++idm)
                 {
-                    m_ndcrd(ignd, idm) = m_ndcrd(ind, idm) + 2 * dist * m_fcnml(ibfc, idm);
+                    m_ndcrd(ignd, idm) = m_ndcrd(ind, idm) + 2 * dist * m_fcnml(ibfc, idm); // NOLINT(readability-math-missing-parentheses)
                 }
                 // decrement ghost node counter.
                 ignd -= 1;
@@ -355,6 +355,7 @@ inline void StaticMesh::fill_ghost()
             real_type voc = 0.0;
             for (size_t inf = 1; inf <= nnd; ++inf)
             {
+                // NOLINTBEGIN(readability-math-missing-parentheses)
                 std::array<real_type, 3> crd; // NOLINT(cppcoreguidelines-pro-type-member-init)
                 crd[0] = (cfd[0][0] + cfd[inf][0] + cfd[inf + 1][0]) / 3;
                 crd[1] = (cfd[0][1] + cfd[inf][1] + cfd[inf + 1][1]) / 3;
@@ -373,6 +374,7 @@ inline void StaticMesh::fill_ghost()
                 m_fccnd(ifc, 1) += crd[1] * vob;
                 m_fccnd(ifc, 2) += crd[2] * vob;
                 voc += vob;
+                // NOLINTEND(readability-math-missing-parentheses)
             }
             m_fccnd(ifc, 0) /= voc;
             m_fccnd(ifc, 1) /= voc;
@@ -391,7 +393,7 @@ inline void StaticMesh::fill_ghost()
             // face normal.
             m_fcnml(ifc, 0) = m_ndcrd(jnd, 1) - m_ndcrd(ind, 1);
             m_fcnml(ifc, 1) = m_ndcrd(ind, 0) - m_ndcrd(jnd, 0);
-            // face ara.
+            // face area. NOLINTNEXTLINE(readability-math-missing-parentheses)
             m_fcara(ifc) = std::sqrt(m_fcnml(ifc, 0) * m_fcnml(ifc, 0) + m_fcnml(ifc, 1) * m_fcnml(ifc, 1));
             // normalize face normal.
             m_fcnml(ifc, 0) /= m_fcara(ifc);
@@ -412,6 +414,7 @@ inline void StaticMesh::fill_ghost()
                 radvec[inf][1] = m_ndcrd(ind, 1) - m_fccnd(ifc, 1);
                 radvec[inf][2] = m_ndcrd(ind, 2) - m_fccnd(ifc, 2);
             }
+            // NOLINTBEGIN(readability-math-missing-parentheses)
             // compute cross product.
             m_fcnml(ifc, 0) = radvec[nnd - 1][1] * radvec[0][2] - radvec[nnd - 1][2] * radvec[0][1];
             m_fcnml(ifc, 1) = radvec[nnd - 1][2] * radvec[0][0] - radvec[nnd - 1][0] * radvec[0][2];
@@ -425,6 +428,7 @@ inline void StaticMesh::fill_ghost()
             // compute face area.
             m_fcara(ifc, 0) = std::sqrt(
                 m_fcnml(ifc, 0) * m_fcnml(ifc, 0) + m_fcnml(ifc, 1) * m_fcnml(ifc, 1) + m_fcnml(ifc, 2) * m_fcnml(ifc, 2));
+            // NOLINTEND(readability-math-missing-parentheses)
             // normalize normal vector.
             m_fcnml(ifc, 0) /= m_fcnml(ifc);
             m_fcnml(ifc, 1) /= m_fcnml(ifc);
@@ -457,6 +461,7 @@ inline void StaticMesh::fill_ghost()
             size_t const nfc = m_clfcs(icl, 0);
             for (size_t ifl = 1; ifl <= nfc; ++ifl)
             {
+                // NOLINTBEGIN(readability-math-missing-parentheses)
                 int_type const ifc = m_clfcs(icl, ifl);
                 real_type const du0 = crd[0] - m_fccnd(ifc, 0);
                 real_type const du1 = crd[1] - m_fccnd(ifc, 1);
@@ -466,6 +471,7 @@ inline void StaticMesh::fill_ghost()
                 real_type const dv1 = m_fccnd(ifc, 1) + du1 / 3;
                 m_clcnd(icl, 0) += dv0 * vob;
                 m_clcnd(icl, 1) += dv1 * vob;
+                // NOLINTEND(readability-math-missing-parentheses)
             }
             m_clcnd(icl, 0) /= voc;
             m_clcnd(icl, 1) /= voc;
@@ -494,6 +500,7 @@ inline void StaticMesh::fill_ghost()
             size_t const nfc = m_clfcs(icl, 0);
             for (size_t ifl = 1; ifl <= nfc; ++ifl)
             {
+                // NOLINTBEGIN(readability-math-missing-parentheses)
                 int_type const ifc = m_clfcs(icl, ifl);
                 real_type const du0 = crd[0] - m_fccnd(ifc, 0);
                 real_type const du1 = crd[1] - m_fccnd(ifc, 1);
@@ -512,6 +519,7 @@ inline void StaticMesh::fill_ghost()
                 m_clcnd(icl, 0) += dv0 * vob;
                 m_clcnd(icl, 1) += dv1 * vob;
                 m_clcnd(icl, 2) += dv2 * vob;
+                // NOLINTEND(readability-math-missing-parentheses)
             }
             m_clcnd(icl, 0) /= voc;
             m_clcnd(icl, 1) /= voc;

--- a/cpp/modmesh/mesh/StaticMesh_interior.cpp
+++ b/cpp/modmesh/mesh/StaticMesh_interior.cpp
@@ -698,6 +698,7 @@ void StaticMesh::calc_metric()
             m_fccnd(ifc, 0) = m_fccnd(ifc, 1) = m_fccnd(ifc, 2) = 0.0;
             for (size_t inf = 1 ; inf <= nnd ; ++inf)
             {
+                // NOLINTBEGIN(readability-math-missing-parentheses)
                 crd[0] = (cfd[0][0] + cfd[inf][0] + cfd[inf+1][0])/3;
                 crd[1] = (cfd[0][1] + cfd[inf][1] + cfd[inf+1][1])/3;
                 crd[2] = (cfd[0][2] + cfd[inf][2] + cfd[inf+1][2])/3;
@@ -715,6 +716,7 @@ void StaticMesh::calc_metric()
                 m_fccnd(ifc, 1) += crd[1] * vob;
                 m_fccnd(ifc, 2) += crd[2] * vob;
                 voc += vob;
+                // NOLINTEND(readability-math-missing-parentheses)
             }
             m_fccnd(ifc, 0) /= voc;
             m_fccnd(ifc, 1) /= voc;
@@ -733,7 +735,7 @@ void StaticMesh::calc_metric()
             // face normal.
             m_fcnml(ifc, 0) = m_ndcrd(ind2, 1) - m_ndcrd(ind1, 1);
             m_fcnml(ifc, 1) = m_ndcrd(ind1, 0) - m_ndcrd(ind2, 0);
-            // face ara.
+            // face area. NOLINTNEXTLINE(readability-math-missing-parentheses)
             m_fcara(ifc) = std::sqrt(m_fcnml(ifc, 0)*m_fcnml(ifc, 0) + m_fcnml(ifc, 1)*m_fcnml(ifc, 1));
             // normalize face normal.
             m_fcnml(ifc, 0) /= m_fcara(ifc);
@@ -755,6 +757,7 @@ void StaticMesh::calc_metric()
                 radvec[inf][2] = m_ndcrd(ind, 2) - m_fccnd(ifc, 2);
             }
             // compute cross product.
+            // NOLINTBEGIN(readability-math-missing-parentheses)
             m_fcnml(ifc, 0) = radvec[nnd-1][1]*radvec[0][2]
                             - radvec[nnd-1][2]*radvec[0][1];
             m_fcnml(ifc, 1) = radvec[nnd-1][2]*radvec[0][0]
@@ -777,6 +780,7 @@ void StaticMesh::calc_metric()
               + m_fcnml(ifc, 1)*m_fcnml(ifc, 1)
               + m_fcnml(ifc, 2)*m_fcnml(ifc, 2)
             );
+            // NOLINTEND(readability-math-missing-parentheses)
             // normalize normal vector.
             m_fcnml(ifc, 0) /= m_fcara(ifc);
             m_fcnml(ifc, 1) /= m_fcara(ifc);
@@ -838,6 +842,7 @@ void StaticMesh::calc_metric()
                 size_t const nfc = m_clfcs(icl, 0);
                 for (size_t ifl = 1 ; ifl <= nfc ; ++ifl)
                 {
+                    // NOLINTBEGIN(readability-math-missing-parentheses)
                     int_type const ifc = m_clfcs(icl, ifl);
                     real_type const du0 = crd[0] - m_fccnd(ifc, 0);
                     real_type const du1 = crd[1] - m_fccnd(ifc, 1);
@@ -847,6 +852,7 @@ void StaticMesh::calc_metric()
                     real_type const dv1 = m_fccnd(ifc, 1) + du1/3;
                     m_clcnd(icl, 0) += dv0 * vob;
                     m_clcnd(icl, 1) += dv1 * vob;
+                    // NOLINTEND(readability-math-missing-parentheses)
                 }
                 m_clcnd(icl, 0) /= voc;
                 m_clcnd(icl, 1) /= voc;
@@ -918,6 +924,7 @@ void StaticMesh::calc_metric()
                 size_t const nfc = m_clfcs(icl, 0);
                 for (size_t ifl = 1 ; ifl <= nfc ; ++ifl)
                 {
+                    // NOLINTBEGIN(readability-math-missing-parentheses)
                     int_type const ifc = m_clfcs(icl, ifl);
                     real_type const du0 = crd[0] - m_fccnd(ifc, 0);
                     real_type const du1 = crd[1] - m_fccnd(ifc, 1);
@@ -930,6 +937,7 @@ void StaticMesh::calc_metric()
                     m_clcnd(icl, 0) += dv0 * vob;
                     m_clcnd(icl, 1) += dv1 * vob;
                     m_clcnd(icl, 2) += dv2 * vob;
+                    // NOLINTEND(readability-math-missing-parentheses)
                 }
                 m_clcnd(icl, 0) /= voc;
                 m_clcnd(icl, 1) /= voc;

--- a/cpp/modmesh/mesh/pymod/wrap_StaticGrid.cpp
+++ b/cpp/modmesh/mesh/pymod/wrap_StaticGrid.cpp
@@ -52,6 +52,7 @@ public:
 
 protected:
 
+    // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
     WrapStaticGridBase(pybind11::module & mod, char const * pyname, char const * pydoc)
         : base_type(mod, pyname, pydoc)
     {

--- a/cpp/modmesh/onedim/Euler1DCore.cpp
+++ b/cpp/modmesh/onedim/Euler1DCore.cpp
@@ -105,7 +105,7 @@ void Euler1DCore::update_cfl(bool odd_plane)
         const double ke = wspd / (2.0 * m_so0(it, 0));
         double pr = (ga - 1.0) * (m_so0(it, 2) - ke);
         pr = (pr + std::abs(pr)) / 2.0;
-        wspd = std::sqrt(ga * pr / m_so0(it, 0)) + std::sqrt(wspd) / m_so0(it, 0);
+        wspd = std::sqrt(ga * pr / m_so0(it, 0)) + std::sqrt(wspd) / m_so0(it, 0); // NOLINT(readability-math-missing-parentheses)
         // CFL.
         const double dxpos = m_coord(it + 1) - m_coord(it);
         const double dxneg = m_coord(it) - m_coord(it - 1);

--- a/cpp/modmesh/simd/simd_support.cpp
+++ b/cpp/modmesh/simd/simd_support.cpp
@@ -71,7 +71,7 @@ SimdFeature detect_simd()
 #elif defined(__APPLE__)
     int neon_supported = 0;
     size_t size = sizeof(neon_supported);
-    if (sysctlbyname("hw.optional.neon", &neon_supported, &size, NULL, 0) == 0 && neon_supported)
+    if (sysctlbyname("hw.optional.neon", &neon_supported, &size, nullptr, 0) == 0 && neon_supported)
     {
         CurrentFeature = SIMD_NEON;
     }

--- a/cpp/modmesh/spacetime/core.cpp
+++ b/cpp/modmesh/spacetime/core.cpp
@@ -63,17 +63,17 @@ void Grid::init_from_array(array_type const & xloc)
     m_xmin = xloc[0];
     m_xmax = xloc[m_ncelm];
     // Mark the boundary of conservation celms.
-    const size_t nx = m_ncelm * 2 + (1 + BOUND_COUNT * 2);
+    const size_t nx = m_ncelm * 2 + (1 + BOUND_COUNT * 2); // NOLINT(readability-math-missing-parentheses)
     m_agrid = modmesh::AscendantGrid1d(nx);
     // Fill x-coordinates at CE boundary.
     for (size_t it = 0; it < xloc.size(); ++it)
     {
-        m_agrid[it * 2 + BOUND_COUNT] = xloc[it];
+        m_agrid[it * 2 + BOUND_COUNT] = xloc[it]; // NOLINT(readability-math-missing-parentheses)
     }
     // Fill x-coordinates at CE center.
     for (size_t it = 0; it < m_ncelm; ++it)
     {
-        const size_t ref = it * 2 + BOUND_COUNT + 1;
+        const size_t ref = it * 2 + BOUND_COUNT + 1; // NOLINT(readability-math-missing-parentheses)
         m_agrid[ref] = (m_agrid[ref - 1] + m_agrid[ref + 1]) / 2;
     }
     // Fill the front and back value.

--- a/cpp/modmesh/toggle/RadixTree.cpp
+++ b/cpp/modmesh/toggle/RadixTree.cpp
@@ -80,7 +80,7 @@ void CallProfiler::print_profiling_result(const RadixTreeNode<CallerProfile> & n
         outstream << "  ";
     }
 
-    auto profile = node.data();
+    auto const & profile = node.data();
 
     if (depth == 0)
     {

--- a/cpp/modmesh/toggle/RadixTree.hpp
+++ b/cpp/modmesh/toggle/RadixTree.hpp
@@ -334,6 +334,7 @@ public:
     CallProfilerProbe & operator=(CallProfilerProbe const &) = delete;
     CallProfilerProbe & operator=(CallProfilerProbe &&) = delete;
 
+    // FIXME: Remove the suppression NOLINTNEXTLINE(bugprone-exception-escape)
     ~CallProfilerProbe()
     {
         if (!m_cancel)

--- a/cpp/modmesh/toggle/toggle.cpp
+++ b/cpp/modmesh/toggle/toggle.cpp
@@ -144,7 +144,7 @@ HierarchicalToggleAccess HierarchicalToggleAccess::get_subkey(const std::string 
 
 void HierarchicalToggleAccess::add_subkey(const std::string & key)
 {
-    return m_table->add_subkey(rekey(key));
+    m_table->add_subkey(rekey(key));
 }
 
 void DynamicToggleTable::add_subkey(std::string const & key)
@@ -194,9 +194,9 @@ ProcessInfo & ProcessInfo::set_environment_variables()
 // At the time of testing (Qt 6.4), RHI is not stable.  A workaround is to use
 // OpenGL instead of RHI.  See more detail at
 // https://doc.qt.io/qtforpython/overviews/qt3drender-porting-to-rhi.html
-#if defined(QT3D_USE_RHI)
+#ifdef QT3D_USE_RHI
     setenv("QT3D_RENDERER", "rhi", 1);
-#else
+#else // QT3D_USE_RHI
     setenv("QT3D_RENDERER", "opengl", 1);
 #endif // QT3D_USE_RHI
 


### PR DESCRIPTION
Update the macos clang-tidy job to use v21.  (The latest version is v22, but I have not found it in homebrew.)

Fix code for the issues reported by clang-tidy v21:
* cppcoreguidelines-noexcept-move-operations
* misc-const-correctness
* modernize-type-traits
* modernize-use-nullptr
* performance-unnecessary-copy-initialization
* readability-avoid-return-with-void-value
* readability-use-concise-preprocessor-directives

Add local suppressions:
* clang-analyzer-security.ArrayBound (needs future review for necessity)
* cppcoreguidelines-missing-std-forward
* bugprone-crtp-constructor-accessibility
* bugprone-exception-escape (needs future review for necessity)
* readability-math-missing-parentheses

Add global suppressions:
* boost-*
* performance-avoid-endl
* misc-include-cleaner (it is too tedious to add all header files)
* misc-use-internal-linkage

Associated code changes:
* Beautify the intentation style in some pybind11 wrapping lambdas.