### PR TITLE
Rename modmesh profiling macro

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -248,7 +248,7 @@ public:
 
     value_type median() const
     {
-        USE_CALLPROFILER_PROFILE_THIS_SCOPE("SimpleArray::median()");
+        MODMESH_PROFILE_SCOPE("SimpleArray::median()");
         auto athis = static_cast<A const *>(this);
         const size_t n = athis->size();
         small_vector<T> acopy(n);
@@ -733,7 +733,7 @@ template <typename A, typename T>
 typename detail::SimpleArrayMixinCalculators<A, T>::value_type
 detail::SimpleArrayMixinCalculators<A, T>::median_op(small_vector<value_type> & sv) const
 {
-    USE_CALLPROFILER_PROFILE_THIS_SCOPE("SimpleArray::median_op()");
+    MODMESH_PROFILE_SCOPE("SimpleArray::median_op()");
     const size_t n = sv.size();
 
     if constexpr (std::is_same_v<value_type, int8_t> ||
@@ -773,7 +773,7 @@ template <typename A, typename T>
 typename detail::SimpleArrayMixinCalculators<A, T>::value_type
 detail::SimpleArrayMixinCalculators<A, T>::median_freq(small_vector<value_type> & sv) const
 {
-    USE_CALLPROFILER_PROFILE_THIS_SCOPE("SimpleArray::median_freq()");
+    MODMESH_PROFILE_SCOPE("SimpleArray::median_freq()");
 
     const size_t n = sv.size();
     if (n == 0)

--- a/cpp/modmesh/buffer/small_vector.hpp
+++ b/cpp/modmesh/buffer/small_vector.hpp
@@ -305,7 +305,7 @@ public:
 
     T select_kth(size_t k)
     {
-        USE_CALLPROFILER_PROFILE_THIS_SCOPE("small_vector::select_kth()");
+        MODMESH_PROFILE_SCOPE("small_vector::select_kth()");
         iterator it = quick_select(begin(), end(), k);
         return *it;
     }
@@ -314,7 +314,7 @@ public:
     {
         // For performance debugging, uncomment below for an additional profiling node,
         // but do not turn it on by default.
-        // USE_CALLPROFILER_PROFILE_THIS_SCOPE("small_vector::choose_pivot()");
+        // MODMESH_PROFILE_SCOPE("small_vector::choose_pivot()");
         iterator first = left;
         iterator mid = left + (right - left) / 2;
         iterator last = right - 1;
@@ -366,7 +366,7 @@ small_vector<T, N>::partition(iterator left, iterator right, iterator pivot)
 {
     // For performance debugging, uncomment below for an additional profiling node,
     // but do not turn it on by default.
-    // USE_CALLPROFILER_PROFILE_THIS_SCOPE("small_vector::partition()");
+    // MODMESH_PROFILE_SCOPE("small_vector::partition()");
 
     const std::size_t len = right - left;
     if (len == 0)
@@ -419,7 +419,7 @@ template <typename T, size_t N>
 typename small_vector<T, N>::iterator
 small_vector<T, N>::quick_select(iterator first, iterator last, size_t k)
 {
-    USE_CALLPROFILER_PROFILE_THIS_SCOPE("small_vector::quick_select()");
+    MODMESH_PROFILE_SCOPE("small_vector::quick_select()");
     size_t len = last - first;
     if (k >= len)
     {

--- a/cpp/modmesh/toggle/RadixTree.hpp
+++ b/cpp/modmesh/toggle/RadixTree.hpp
@@ -364,11 +364,11 @@ private:
 // ref: https://gcc.gnu.org/onlinedocs/gcc/Function-Names.html
 #define __CROSS_PRETTY_FUNCTION__ __PRETTY_FUNCTION__
 #endif
-#define USE_CALLPROFILER_PROFILE_THIS_FUNCTION() modmesh::CallProfilerProbe __profilerProbe##__COUNTER__(modmesh::CallProfiler::instance(), __CROSS_PRETTY_FUNCTION__)
-#define USE_CALLPROFILER_PROFILE_THIS_SCOPE(scopeName) modmesh::CallProfilerProbe __profilerProbe##__COUNTER__(modmesh::CallProfiler::instance(), scopeName)
+#define MODMESH_PROFILE_FUNCTION() modmesh::CallProfilerProbe __profilerProbe##__COUNTER__(modmesh::CallProfiler::instance(), __CROSS_PRETTY_FUNCTION__)
+#define MODMESH_PROFILE_SCOPE(scopeName) modmesh::CallProfilerProbe __profilerProbe##__COUNTER__(modmesh::CallProfiler::instance(), scopeName)
 #else
-#define USE_CALLPROFILER_PROFILE_THIS_FUNCTION() // do nothing
-#define USE_CALLPROFILER_PROFILE_THIS_SCOPE(scopeName) // do nothing
+#define MODMESH_PROFILE_FUNCTION() // do nothing
+#define MODMESH_PROFILE_SCOPE(scopeName) // do nothing
 #endif
 
 } /* end namespace modmesh */

--- a/gtests/test_nopython_callprofiler.cpp
+++ b/gtests/test_nopython_callprofiler.cpp
@@ -35,7 +35,7 @@ constexpr int uniqueTime3 = 7;
 
 void foo3()
 {
-    USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+    MODMESH_PROFILE_FUNCTION();
     auto start_time = std::chrono::high_resolution_clock::now();
     while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start_time).count() < uniqueTime1)
     {
@@ -45,7 +45,7 @@ void foo3()
 
 void foo2()
 {
-    USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+    MODMESH_PROFILE_FUNCTION();
     auto start_time = std::chrono::high_resolution_clock::now();
     while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start_time).count() < uniqueTime2)
     {
@@ -56,7 +56,7 @@ void foo2()
 
 void foo1()
 {
-    USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+    MODMESH_PROFILE_FUNCTION();
     foo2();
     auto start_time = std::chrono::high_resolution_clock::now();
     while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start_time).count() < uniqueTime3)
@@ -191,11 +191,11 @@ TEST_F(CallProfilerTest, cancel)
 
     auto test1 = [&]()
     {
-        USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+        MODMESH_PROFILE_FUNCTION();
 
         auto test2 = [&]()
         {
-            USE_CALLPROFILER_PROFILE_THIS_FUNCTION();
+            MODMESH_PROFILE_FUNCTION();
             pProfiler->cancel();
         };
 


### PR DESCRIPTION
In this PR, I rename modmesh profiling macro to continue #563 tasks. 

I rename `USE_CALLPROFILER_PROFILE_THIS_FUNCTION` into `MODMESH_PROFILE_FUNCTION`, and rename `USE_CALLPROFILER_PROFILE_THIS_SCOPE` into  `MODMESH_PROFILE_SCOPE`.

## How to review it?

Build modmesh with `make MODMESH_PROFILE=on`, and run `make pyprof`. 

You may review `profiling/results/profile_median.output` have non-null value, and check other profiling result is correct.

