### PR TITLE
Migrate process_attribute precall postcall into CallProfiler

### DIFF
--- a/contrib/standalone_buffer/Makefile
+++ b/contrib/standalone_buffer/Makefile
@@ -56,6 +56,12 @@ $(SETUPROOT)/simd_support.o: $(SETUPROOT)/modmesh/simd/simd_support.cpp Makefile
 $(SETUPROOT)/modbuf.o: modbuf.cpp
 	c++ $(CFLAGS) -c $< -o $@
 
+$(SETUPROOT)/profile.o: $(SETUPROOT)/modmesh/toggle/profile.cpp Makefile
+	c++ $(CFLAGS) -c $< -o $@
+
+$(SETUPROOT)/radix_tree.o: $(SETUPROOT)/modmesh/toggle/RadixTree.cpp Makefile
+	c++ $(CFLAGS) -c $< -o $@
+
 OBJS = \
 	$(SETUPROOT)/BufferExpander.o \
 	$(SETUPROOT)/SimpleArray.o \
@@ -64,6 +70,8 @@ OBJS = \
 	$(SETUPROOT)/wrap_SimpleArrayPlex.o \
 	$(SETUPROOT)/buffer_pymod.o \
 	$(SETUPROOT)/simd_support.o \
+	$(SETUPROOT)/radix_tree.o \
+	$(SETUPROOT)/profile.o \
 	$(SETUPROOT)/modbuf.o
 
 $(MODPATH): Makefile $(OBJS)

--- a/cpp/modmesh/python/common.hpp
+++ b/cpp/modmesh/python/common.hpp
@@ -124,15 +124,15 @@ struct process_attribute<modmesh::python::mmtag>
     {
         if (modmesh::python::WrapperProfilerStatus::me().enabled())
         {
-            modmesh::TimeRegistry::me().entry(get_name(call)).start();
+            modmesh::CallProfiler::instance().start_caller(get_name(call), nullptr);
         }
     }
 
-    static void postcall(function_call & call, handle &)
+    static void postcall(function_call &, handle &)
     {
         if (modmesh::python::WrapperProfilerStatus::me().enabled())
         {
-            modmesh::TimeRegistry::me().entry(get_name(call)).stop();
+            modmesh::CallProfiler::instance().end_caller();
         }
     }
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -98,48 +98,4 @@ class TimeRegistryTC(unittest.TestCase):
         ret = modmesh.time_registry.report()
         self.assertEqual("", ret)
 
-    def test_status(self):
-
-        modmesh.wrapper_profiler_status.disable()
-        self.assertFalse(modmesh.wrapper_profiler_status.enabled)
-
-        modmesh.time_registry.clear()
-        buf = modmesh.ConcreteBuffer(10)
-        self.assertEqual([], modmesh.time_registry.names)
-
-        modmesh.wrapper_profiler_status.enable()
-        modmesh.time_registry.clear()
-        buf = modmesh.ConcreteBuffer(10)  # noqa: F841
-        self.assertEqual(
-            ['ConcreteBuffer.__init__'],
-            modmesh.time_registry.names)
-
-    def test_names(self):
-
-        modmesh.time_registry.clear()
-        buf = modmesh.ConcreteBuffer(10)
-        buf2 = buf.clone()  # noqa: F841
-        self.assertEqual(
-            ['ConcreteBuffer.__init__', 'ConcreteBuffer.clone'],
-            modmesh.time_registry.names)
-
-    def test_entry(self):
-
-        modmesh.time_registry.clear()
-        buf = modmesh.ConcreteBuffer(10)
-        buf2 = buf.clone()  # noqa: F841
-        buf2 = buf.clone()  # noqa: F841
-        self.assertEqual(
-            1,
-            modmesh.time_registry.entry('ConcreteBuffer.__init__').count)
-        self.assertGreater(
-            modmesh.time_registry.entry('ConcreteBuffer.__init__').time,
-            0)
-        self.assertEqual(
-            2,
-            modmesh.time_registry.entry('ConcreteBuffer.clone').count)
-        self.assertGreater(
-            modmesh.time_registry.entry('ConcreteBuffer.clone').time,
-            0)
-
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
In this PR, I migrate TimeRegistry into CallProfiler to remove TimeRegistry in the future.

## How to use it?

Since `precall()` and `postcall()` will be a hook when a module that enter and exit C++ function, you may add mmtag struct for your pybind11 function. 

For example, in file `wrap_SimpleArray.cpp:L257`, add mmtag structure:
```cpp
            .def(
                "median",
                [](wrapped_type const & self)
                {
                    return self.median();
                }, modmesh::python::mmtag{})
```

## How to review it?

After you add mmtag structure, you may run `./profiling/profile_median.py`, to check new record that caused by precall and postcall is appear in profiling JSON.

```json
[
    {
        "name": "SimpleArrayUint8.median", # New record caused by precall/postcall
        "total_time": 29.891959,
        "count": 1,
        "children": [
            {
                "name": "SimpleArray::median()",
                "total_time": 29.887417,
                "count": 1,
                "children": [
                    {
                        "name": "SimpleArray::median_op()",
                        "total_time": 0.891292,
                        "count": 1,
                        "children": [
                            {
                                "name": "SimpleArray::median_freq()",
                                "total_time": 0.888875,
                                "count": 1,
                                "children": []
                            }
                        ]
                    }
                ]
            }
        ]
    }
]
```

You may check this to verify the implmentation is correct.

## Test Migration

Since we have TimeRegistry testcase to test precall/postcall work properly, I just migrate these test from TimeRegistry testcase into CallProfiler testcases.

For example, we have a testcase to check behavior with different status in `test_profile.py`.

```py
def test_status(self):

        modmesh.wrapper_profiler_status.disable()
        self.assertFalse(modmesh.wrapper_profiler_status.enabled)

        modmesh.time_registry.clear()
        buf = modmesh.ConcreteBuffer(10)
        self.assertEqual([], modmesh.time_registry.names)

        modmesh.wrapper_profiler_status.enable()
        modmesh.time_registry.clear()
        buf = modmesh.ConcreteBuffer(10)  # noqa: F841
        self.assertEqual(
            ['ConcreteBuffer.__init__'],
            modmesh.time_registry.names)
```

Now we have new `test_status` for CallProfiler in `test_callprofiler.py`.

```py
def test_status(self):
        modmesh.wrapper_profiler_status.disable()
        self.assertFalse(modmesh.wrapper_profiler_status.enabled)

        modmesh.call_profiler.reset()
        buf = modmesh.ConcreteBuffer(10)
        result = modmesh.call_profiler.result()
        self.assertEqual({}, result)

        modmesh.wrapper_profiler_status.enable()
        modmesh.call_profiler.reset()
        buf = modmesh.ConcreteBuffer(10)  # noqa: F841
        result = modmesh.call_profiler.result().get("children")
        names = [data["name"] for data in result]
        self.assertEqual(['ConcreteBuffer.__init__'], names)
```