### PR TITLE
Accelerate the mean operations without axis

### DIFF
--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -986,6 +986,12 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         self.assertEqual(sarr.min(), -2.3)
         self.assertEqual(sarr.max(), 9.2)
 
+    def test_sum_non_contiguous(self):
+        nparr = np.arange(625, dtype='float64').reshape((5, 5, 5, 5))
+        nparr = nparr[:3:2, 1:4:2, :3:3, 3:4:2]
+        sarr = modmesh.SimpleArrayFloat64(array=nparr)
+        self.assertEqual(sarr.sum(), np.sum(nparr))
+
     def test_abs(self):
         sarr = modmesh.SimpleArrayInt64(shape=(3, 2), value=-2)
         self.assertEqual(sarr.sum(), -2 * 3 * 2)


### PR DESCRIPTION
In this pull request, I accelerate the mean operations.
For 1D contiguous array(unrolling, wo simd):
<img width="4466" height="5881" alt="performance_1d_mean" src="https://github.com/user-attachments/assets/d844c2eb-bb59-4867-bbc8-f2efac5b296a" />

For 3D non contiguous array(unrolling + multithread):
<img width="4466" height="5881" alt="performance_3d_non_contiguous_mean_1E7" src="https://github.com/user-attachments/assets/dfbd6284-3957-471e-9775-f907c3bc10ab" />
