### PR TITLE
Do not delete `R3DWidget` instance explicitly from unit-testing code

### DIFF
--- a/cpp/modmesh/pilot/R3DWidget.cpp
+++ b/cpp/modmesh/pilot/R3DWidget.cpp
@@ -113,12 +113,6 @@ void R3DWidget::updateWorld(std::shared_ptr<WorldFp64> const & world)
     cameraController()->setFarPlane(dist + half_height * 2);
 }
 
-void R3DWidget::closeAndDestroy()
-{
-    this->close();
-    this->deleteLater();
-}
-
 void R3DWidget::resizeEvent(QResizeEvent * event)
 {
     QWidget::resizeEvent(event);

--- a/cpp/modmesh/pilot/R3DWidget.hpp
+++ b/cpp/modmesh/pilot/R3DWidget.hpp
@@ -125,8 +125,6 @@ public:
     void updateMesh(std::shared_ptr<StaticMesh> const & mesh);
     void updateWorld(std::shared_ptr<WorldFp64> const & world);
 
-    void closeAndDestroy();
-
     std::shared_ptr<StaticMesh> mesh() const { return m_mesh; }
 
 private:

--- a/cpp/modmesh/pilot/RManager.cpp
+++ b/cpp/modmesh/pilot/RManager.cpp
@@ -86,7 +86,7 @@ R3DWidget * RManager::add3DWidget()
     R3DWidget * viewer = nullptr;
     if (m_mdiArea)
     {
-        viewer = new R3DWidget();
+        viewer = new R3DWidget(/*window*/ nullptr, /*scene*/ nullptr, /*parent*/ m_mdiArea);
         viewer->setWindowTitle("3D viewer");
         viewer->show();
         auto * subwin = this->addSubWindow(viewer);

--- a/cpp/modmesh/pilot/wrap_pilot.cpp
+++ b/cpp/modmesh/pilot/wrap_pilot.cpp
@@ -173,10 +173,6 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapR3DWidget
                 },
                 py::arg("filename"))
             .def(
-                "close_and_destroy",
-                [](wrapped_base_type & self)
-                { return self.closeAndDestroy(); })
-            .def(
                 "setCameraType",
                 [](wrapped_type & self, std::string const & name)
                 {

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -68,7 +68,7 @@ class PilotCameraTB:
     @classmethod
     def tearDownClass(cls):
         if modmesh.HAS_PILOT:
-            cls.widget.close_and_destroy()
+            cls.widget = None
 
     def angle_axis(self, angle_deg, axis):
         a = axis


### PR DESCRIPTION
Deleting `R3DWidget` through `closeAndDestroy()` causes `Segmentation fault: 11` when running Python unit tests.  The error is raised through `~R3Dwidget::R3DWidget()` with a null pointer in the Qt thread cleanup code.

I am not 100% sure about the root cause which requires deeper understanding to how Qt handles Qt3d instances.  But it is certain that `R3DWidget` instances should use a parent when construction.  This PR is to fix the apparent issue.