### PR TITLE
ci: use reuse workflow for send email on fail

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -705,34 +705,16 @@ jobs:
           path: modmesh-pilot-win64/
 
   send_email_on_failure:
-    name: send_emails_when_fails
     needs: [standalone_buffer, build_ubuntu, build_macos, build_windows]
-    runs-on: ubuntu-latest
     # Run if any of the dependencies failed in master branch
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
-    steps:
-      - name: Get current date and set to env
-        run: |
-          echo "DATE=$(date +%m/%d)" >> $GITHUB_ENV
-      - name: Send mail to mailing list
-        uses: dawidd6/action-send-mail@v6
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{ secrets.EMAIL_USERNAME }}
-          password: ${{ secrets.EMAIL_PASSWORD }}
-          # Subject: Uses the Repository name
-          subject: ${{ env.DATE }} CI Failure in ${{ github.repository }} ${{ github.workflow }} workflow
-          # Body: Lists the result of every job
-          body: |
-            The workflow ${{ github.workflow }} has failed.
-            Job Status Report:
-            ------------------
-            - standalone_buffer: ${{ needs.standalone_buffer.result }}
-            - build_ubuntu: ${{ needs.build_ubuntu.result }}
-            - build_macos: ${{ needs.build_macos.result }}
-            - build_windows: ${{ needs.build_windows.result }}
-
-            Check the details at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          to: solvcon@googlegroups.com
-          from: solvcon_notification
+    uses: ./.github/workflows/send_email_on_fail.yml
+    with:
+      job_results: |
+        - standalone_buffer: ${{ needs.standalone_buffer.result }}
+        - build_ubuntu: ${{ needs.build_ubuntu.result }}
+        - build_macos: ${{ needs.build_macos.result }}
+        - build_windows: ${{ needs.build_windows.result }}
+    secrets:
+      EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -379,33 +379,15 @@ jobs:
             CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
 
   send_email_on_failure:
-    name: send_emails_when_fails
     needs: [clang_format_check, tidy_flake8_ubuntu, tidy_flake8_macos]
-    runs-on: ubuntu-latest
     # Run if any of the dependencies failed in master branch
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
-    steps:
-      - name: Get current date and set to env
-        run: |
-          echo "DATE=$(date +%m/%d)" >> $GITHUB_ENV
-      - name: Send mail to mailing list
-        uses: dawidd6/action-send-mail@v6
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{ secrets.EMAIL_USERNAME }}
-          password: ${{ secrets.EMAIL_PASSWORD }}
-          # Subject: Uses the Repository name
-          subject: ${{ env.DATE }} CI Failure in ${{ github.repository }} ${{ github.workflow }} workflow
-          # Body: Lists the result of every job
-          body: |
-            The workflow ${{ github.workflow }} has failed.
-            Job Status Report:
-            ------------------
-            - clang_format_check: ${{ needs.clang_format_check.result }}
-            - tidy_flake8_ubuntu: ${{ needs.tidy_flake8_ubuntu.result }}
-            - tidy_flake8_macos: ${{ needs.tidy_flake8_macos.result }}
-
-            Check the details at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          to: solvcon@googlegroups.com
-          from: solvcon_notification
+    uses: ./.github/workflows/send_email_on_fail.yml
+    with:
+      job_results: |
+        - clang_format_check: ${{ needs.clang_format_check.result }}
+        - tidy_flake8_ubuntu: ${{ needs.tidy_flake8_ubuntu.result }}
+        - tidy_flake8_macos: ${{ needs.tidy_flake8_macos.result }}
+    secrets:
+      EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -228,32 +228,14 @@ jobs:
           cd ..
 
   send_email_on_failure:
-    name: send_emails_when_fails
     needs: [nouse_install_ubuntu, nouse_install_macos]
-    runs-on: ubuntu-latest
     # Run if any of the dependencies failed in master branch
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
-    steps:
-      - name: Get current date and set to env
-        run: |
-          echo "DATE=$(date +%m/%d)" >> $GITHUB_ENV
-      - name: Send mail to mailing list
-        uses: dawidd6/action-send-mail@v6
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{ secrets.EMAIL_USERNAME }}
-          password: ${{ secrets.EMAIL_PASSWORD }}
-          # Subject: Uses the Repository name
-          subject: ${{ env.DATE }} CI Failure in ${{ github.repository }} ${{ github.workflow }} workflow
-          # Body: Lists the result of every job
-          body: |
-            The workflow ${{ github.workflow }} has failed.
-            Job Status Report:
-            ------------------
-            - nouse_install_ubuntu: ${{ needs.nouse_install_ubuntu.result }}
-            - nouse_install_macos: ${{ needs.nouse_install_macos.result }}
-
-            Check the details at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          to: solvcon@googlegroups.com
-          from: solvcon_notification
+    uses: ./.github/workflows/send_email_on_fail.yml
+    with:
+      job_results: |
+        - nouse_install_ubuntu: ${{ needs.nouse_install_ubuntu.result }}
+        - nouse_install_macos: ${{ needs.nouse_install_macos.result }}
+    secrets:
+      EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/.github/workflows/send_email_on_fail.yml
+++ b/.github/workflows/send_email_on_fail.yml
@@ -1,0 +1,43 @@
+name: Send Email on Failure
+
+on:
+  workflow_call:
+    inputs:
+      job_results:
+        description: 'String of job results'
+        required: true
+        type: string
+    secrets:
+      EMAIL_USERNAME:
+        required: true
+      EMAIL_PASSWORD:
+        required: true
+
+jobs:
+  send_email_on_failure:
+    name: send_emails_when_fails
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current date and set to env
+        run: |
+          echo "DATE=$(date +%m/%d)" >> $GITHUB_ENV
+
+      - name: Send mail to mailing list
+        uses: dawidd6/action-send-mail@v6
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          # Subject: Uses the Repository name
+          subject: ${{ env.DATE }} CI Failure in ${{ github.repository }} ${{ github.workflow }} workflow
+          # Body: Lists the result of every job
+          body: |
+            The workflow ${{ github.workflow }} has failed.
+            Job Status Report:
+            ------------------
+            ${{ inputs.job_results }}
+
+            Check the details at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          to: solvcon@googlegroups.com
+          from: solvcon_notification


### PR DESCRIPTION
To remove duplicate steps in CI which is mentioned in https://github.com/solvcon/modmesh/issues/677, I use [reuse workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows) provided by Github to combine sending email on failure ones.

With this PR, we only need to maintain one workflow about email sending and other workflows only need to reuse it.

I have tested this on my local fork and ensure it works ([ref](https://github.com/ExplorerRay/modmesh/actions/runs/22229357166)). And the email body looks like below: 
<img width="575" height="202" alt="image" src="https://github.com/user-attachments/assets/d900ceed-2c6b-44f2-a891-dfb76fc08230" />