### PR TITLE
Add equality and inequality operators for Bezier3d class 

### DIFF
--- a/cpp/modmesh/universe/bezier.hpp
+++ b/cpp/modmesh/universe/bezier.hpp
@@ -90,6 +90,38 @@ public:
     Bezier3d & operator=(Bezier3d &&) = default;
     ~Bezier3d() = default;
 
+    bool operator==(Bezier3d const & other) const
+    {
+        return m_data.v[0] == other.m_data.v[0] &&
+               m_data.v[1] == other.m_data.v[1] &&
+               m_data.v[2] == other.m_data.v[2] &&
+               m_data.v[3] == other.m_data.v[3] &&
+               m_data.v[4] == other.m_data.v[4] &&
+               m_data.v[5] == other.m_data.v[5] &&
+               m_data.v[6] == other.m_data.v[6] &&
+               m_data.v[7] == other.m_data.v[7] &&
+               m_data.v[8] == other.m_data.v[8] &&
+               m_data.v[9] == other.m_data.v[9] &&
+               m_data.v[10] == other.m_data.v[10] &&
+               m_data.v[11] == other.m_data.v[11];
+    }
+
+    bool operator!=(Bezier3d const & other) const
+    {
+        return m_data.v[0] != other.m_data.v[0] ||
+               m_data.v[1] != other.m_data.v[1] ||
+               m_data.v[2] != other.m_data.v[2] ||
+               m_data.v[3] != other.m_data.v[3] ||
+               m_data.v[4] != other.m_data.v[4] ||
+               m_data.v[5] != other.m_data.v[5] ||
+               m_data.v[6] != other.m_data.v[6] ||
+               m_data.v[7] != other.m_data.v[7] ||
+               m_data.v[8] != other.m_data.v[8] ||
+               m_data.v[9] != other.m_data.v[9] ||
+               m_data.v[10] != other.m_data.v[10] ||
+               m_data.v[11] != other.m_data.v[11];
+    }
+
 #define DECL_VALUE_ACCESSOR(C, I)                     \
     value_type C##I() const { return m_data.f.C##I; } \
     value_type & C##I() { return m_data.f.C##I; }

--- a/cpp/modmesh/universe/pymod/wrap_shape1d.cpp
+++ b/cpp/modmesh/universe/pymod/wrap_shape1d.cpp
@@ -528,6 +528,7 @@ protected:
     WrapBezier3d(pybind11::module & mod, char const * pyname, char const * pydoc);
 
     WrapBezier3d & wrap_management();
+    WrapBezier3d & wrap_operator();
     WrapBezier3d & wrap_accessor();
     WrapBezier3d & wrap_geometry();
 }; /* end class WrapBezier3d */
@@ -540,6 +541,7 @@ WrapBezier3d<T>::WrapBezier3d(pybind11::module & mod, const char * pyname, const
 
     (*this)
         .wrap_management()
+        .wrap_operator()
         .wrap_accessor()
         .wrap_geometry()
         //
@@ -575,6 +577,20 @@ WrapBezier3d<T> & WrapBezier3d<T>::wrap_management()
                                    self.p3().value_string());
             })
         .def_alias("__repr__", "__str__")
+        //
+        ;
+
+    return *this;
+}
+
+template <typename T>
+WrapBezier3d<T> & WrapBezier3d<T>::wrap_operator()
+{
+    namespace py = pybind11;
+
+    (*this)
+        .def(py::self == py::self) // NOLINT(misc-redundant-expression)
+        .def(py::self != py::self) // NOLINT(misc-redundant-expression)
         //
         ;
 

--- a/tests/test_universe_shape1d.py
+++ b/tests/test_universe_shape1d.py
@@ -150,6 +150,15 @@ class Bezier3dTB(testing.TestBase):
         self.assertEqual(list(bzr[2]), [3, 1, 0])
         self.assertEqual(list(bzr[3]), [4, 0, 0])
 
+        # Test equality and inequality comparison operators
+        bzr_copy = Bezier(p0=Point(0, 0, 0), p1=Point(1, 1, 0),
+                          p2=Point(3, 1, 0), p3=Point(4, 0, 0))
+        self.assertTrue(bzr_copy == bzr)
+
+        bzr1 = Bezier(p0=Point(0, 0, 0), p1=Point(1, 1, 0), p2=Point(3, 1, 0),
+                      p3=Point(4, 4, 4))
+        self.assertTrue(bzr1 != bzr)
+
         # Range error in C++
         with self.assertRaisesRegex(IndexError,
                                     "Bezier3d: \\(control\\) i 4 >= size 4"):
@@ -263,12 +272,7 @@ class Bezier3dFp32TC(Bezier3dTB, unittest.TestCase):
         self.assertEqual(str(b), golden)
         # Evaluate the string and test the result
         e = eval(golden, vars(modmesh))
-        # FIXME: Bezier3d does not have equality operator
-        # Tracked in https://github.com/solvcon/modmesh/issues/568
-        self.assertEqual(b[0], e[0])
-        self.assertEqual(b[1], e[1])
-        self.assertEqual(b[2], e[2])
-        self.assertEqual(b[3], e[3])
+        self.assertEqual(b, e)
 
 
 class Bezier3dFp64TC(Bezier3dTB, unittest.TestCase):
@@ -297,12 +301,7 @@ class Bezier3dFp64TC(Bezier3dTB, unittest.TestCase):
         self.assertEqual(str(b), golden)
         # Evaluate the string and test the result
         e = eval(golden, vars(modmesh))
-        # FIXME: Bezier3d does not have equality operator
-        # Tracked in https://github.com/solvcon/modmesh/issues/568
-        self.assertEqual(b[0], e[0])
-        self.assertEqual(b[1], e[1])
-        self.assertEqual(b[2], e[2])
-        self.assertEqual(b[3], e[3])
+        self.assertEqual(b, e)
 
 
 class SegmentPadTB(testing.TestBase):


### PR DESCRIPTION
For #568. This PR adds equality (`==`) and inequality (`!=`) operators for `Bezier3d` class. It also includes Python bindings for these two operators and add corresponding unit tests for them.