### PR TITLE
Profile matmul operation

### DIFF
--- a/profiling/profile_matrix_ops.py
+++ b/profiling/profile_matrix_ops.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, Chun-Shih Chang <austin20463@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import functools
+
+import numpy as np
+import modmesh
+
+
+def profile_function(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        _ = modmesh.CallProfilerProbe(func.__name__)
+        result = func(*args, **kwargs)
+        return result
+
+    return wrapper
+
+
+def make_container(data):
+    if np.issubdtype(data.dtype, np.float32):
+        return modmesh.SimpleArrayFloat32(array=data)
+    elif np.issubdtype(data.dtype, np.float64):
+        return modmesh.SimpleArrayFloat64(array=data)
+    raise ValueError(f"Unsupported dtype: {data.dtype}")
+
+
+@profile_function
+def profile_matmul_np(lhs, rhs):
+    return np.matmul(lhs, rhs)
+
+
+@profile_function
+def profile_matmul_sa(lhs, rhs):
+    return lhs.matmul(rhs)
+
+
+def make_data(dtype, shape):
+    return np.random.rand(*shape).astype(dtype)
+
+
+def profile_matmul_operation(dtype, shapes, it=10):
+    for m in shapes:
+        lhs = make_data(dtype, (m, m))
+        rhs = make_data(dtype, (m, m))
+        lhs_sa = make_container(lhs)
+        rhs_sa = make_container(rhs)
+        modmesh.call_profiler.reset()
+        for _ in range(it):
+            profile_matmul_np(lhs, rhs)
+            profile_matmul_sa(lhs_sa, rhs_sa)
+
+        res = modmesh.call_profiler.result()["children"]
+        out = {}
+        for r in res:
+            name = r["name"].replace("profile_matmul_", "")
+            out[name] = r["total_time"] / r["count"]
+
+        print(f"## 2D x 2D shape: ({m}, {m}) x ({m}, {m}) dtype:"
+              f"`{np.dtype(dtype)}`\n")
+
+        def print_row(*cols):
+            print(str.format("| {:10s} | {:15s} | {:15s} |", *(cols[0:3])))
+
+        print_row("func", "per call (ms)", "cmp to np")
+        print_row("-" * 10, "-" * 15, "-" * 15)
+        npbase = out["np"]
+        for key in ("np", "sa"):
+            value = out[key]
+            print_row(f"{key:8s}", f"{value:.3E}", f"{value / npbase:.3f}")
+        print()
+
+
+def main():
+    shapes = [4, 16, 64, 256, 1024]
+
+    for dtype in (np.float32, np.float64):
+        profile_matmul_operation(dtype, shapes)
+
+    shapes = [9, 27, 81, 243, 729]
+
+    for dtype in (np.float32, np.float64):
+        profile_matmul_operation(dtype, shapes)
+
+
+if __name__ == "__main__":
+    main()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
For issue #715, it is necessary to profile and make a baseline for `matmul` operation before accelerating it, and this pull request add new script for profiling `matmul` operation.

The experiment is measured on MacBook Air with M1 chip and 8GB DRAM. As for the profiling result, see the following chart. When the 2D array is small, the operation of SimpleArray is faster than numpy. On the contrary, if the 2D array is big, the operation of SimpleArray is 100 times slower than numpy.

<img width="1578" height="970" alt="image" src="https://github.com/user-attachments/assets/94811dff-eed3-47a5-8e6c-3acafd6621c9" />
<img width="1578" height="970" alt="image" src="https://github.com/user-attachments/assets/37babc04-1b1c-436e-ba8b-4ab8fb99cdd4" />
<img width="1578" height="970" alt="image" src="https://github.com/user-attachments/assets/71cfdaed-b6c2-4324-ad6c-c45f2f0c7b16" />
<img width="1578" height="970" alt="image" src="https://github.com/user-attachments/assets/c32446e7-bb79-4534-b288-df74a568cd14" />

The exact number could be found in the following sheet.
## 2D x 2D shape: (4, 4) x (4, 4) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 5.013E-03       | 1.000           |
| sa         | 1.900E-03       | 0.379           |

## 2D x 2D shape: (16, 16) x (16, 16) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.600E-01       | 1.000           |
| sa         | 4.679E-03       | 0.029           |

## 2D x 2D shape: (64, 64) x (64, 64) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 4.200E-03       | 1.000           |
| sa         | 2.702E-01       | 64.325          |

## 2D x 2D shape: (256, 256) x (256, 256) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 9.147E-02       | 1.000           |
| sa         | 2.987E+01       | 326.602         |

## 2D x 2D shape: (1024, 1024) x (1024, 1024) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 3.144E+00       | 1.000           |
| sa         | 2.108E+03       | 670.442         |

## 2D x 2D shape: (4, 4) x (4, 4) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 4.263E-03       | 1.000           |
| sa         | 1.700E-03       | 0.399           |

## 2D x 2D shape: (16, 16) x (16, 16) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 4.612E-03       | 1.000           |
| sa         | 3.967E-03       | 0.860           |

## 2D x 2D shape: (64, 64) x (64, 64) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 5.775E-03       | 1.000           |
| sa         | 2.385E-01       | 41.290          |

## 2D x 2D shape: (256, 256) x (256, 256) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.619E-01       | 1.000           |
| sa         | 2.463E+01       | 152.193         |

## 2D x 2D shape: (1024, 1024) x (1024, 1024) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.110E+01       | 1.000           |
| sa         | 2.181E+03       | 196.470         |

## 2D x 2D shape: (9, 9) x (9, 9) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 3.621E-03       | 1.000           |
| sa         | 1.967E-03       | 0.543           |

## 2D x 2D shape: (27, 27) x (27, 27) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 4.579E-03       | 1.000           |
| sa         | 1.366E-02       | 2.984           |

## 2D x 2D shape: (81, 81) x (81, 81) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 7.537E-03       | 1.000           |
| sa         | 5.515E-01       | 73.165          |

## 2D x 2D shape: (243, 243) x (243, 243) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 5.908E-02       | 1.000           |
| sa         | 2.024E+01       | 342.594         |

## 2D x 2D shape: (729, 729) x (729, 729) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.053E+00       | 1.000           |
| sa         | 7.116E+02       | 675.963         |

## 2D x 2D shape: (9, 9) x (9, 9) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 3.592E-03       | 1.000           |
| sa         | 1.925E-03       | 0.536           |

## 2D x 2D shape: (27, 27) x (27, 27) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 4.512E-03       | 1.000           |
| sa         | 1.335E-02       | 2.959           |

## 2D x 2D shape: (81, 81) x (81, 81) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.300E-02       | 1.000           |
| sa         | 5.659E-01       | 43.543          |

## 2D x 2D shape: (243, 243) x (243, 243) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.610E-01       | 1.000           |
| sa         | 2.038E+01       | 126.570         |

## 2D x 2D shape: (729, 729) x (729, 729) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 3.735E+00       | 1.000           |
| sa         | 7.161E+02       | 191.724         |

