### PR TITLE
ci: upgrade MacOS runners to Tahoe (macos-26)

### DIFF
--- a/.github/actions/setup_macos/action.yml
+++ b/.github/actions/setup_macos/action.yml
@@ -25,12 +25,12 @@ runs:
         # qt6 versioning independently from the OS.
         # brew install llvm@21 qt6
         brew install llvm@21
-        # The macos-15 runner ships with Homebrew llvm@18 linked into
+        # The macos-26 runner ships with Homebrew llvm@20 linked into
         # /usr/local/bin/ (clang, clang++, clang-format, clang-tidy, etc.).
         # Use -sf to overwrite the existing clang-format/clang-tidy with
         # our llvm@21 versions, and remove clang/clang++ so that
         # ccache-action (create-symlink: true) can create its own symlinks.
-        # Ref: https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
+        # Ref: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
         ln -sf "$(brew --prefix llvm@21)/bin/clang-format" "/usr/local/bin/clang-format"
         ln -sf "$(brew --prefix llvm@21)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
         rm -f /usr/local/bin/clang /usr/local/bin/clang++
@@ -39,7 +39,9 @@ runs:
       if: "${{ inputs.workflow == 'lint' || inputs.workflow == 'build' }}"
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.1'
+        # Use a newer Qt build to avoid -framework AGL linker failures on Tahoe.
+        # Ref: https://qt-project.atlassian.net/browse/QTBUG-137687
+        version: '6.9.2'
         host: 'mac'
         target: 'desktop'
         arch: 'clang_64'

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -68,7 +68,7 @@ jobs:
 
     strategy:
         matrix:
-          os: [ubuntu-24.04, macos-15]
+          os: [ubuntu-24.04, macos-26]
           cmake_build_type: [Release]
 
         fail-fast: false
@@ -122,7 +122,7 @@ jobs:
       run: |
         python3 -c "import modmesh; assert modmesh.HAS_PILOT == False"
         JOB_MAKE_ARGS="${JOB_MAKE_ARGS} VERBOSE=1"
-        if [ "${{ matrix.os }}" == "macos-15" ] ; then \
+        if [ "${{ matrix.os }}" == "macos-26" ] ; then \
           JOB_MAKE_ARGS="${JOB_MAKE_ARGS} BUILD_METAL=ON" ; \
         fi
         make pytest ${JOB_MAKE_ARGS}
@@ -141,7 +141,7 @@ jobs:
       run: |
         python3 -c "import modmesh; assert modmesh.HAS_PILOT == True"
         JOB_MAKE_ARGS="${JOB_MAKE_ARGS} VERBOSE=1"
-        if [ "${{ matrix.os }}" == "macos-15" ] ; then \
+        if [ "${{ matrix.os }}" == "macos-26" ] ; then \
           # PySide6 installed by pip will bundle with a prebuilt Qt,
           # this will cause duplicated symbol.
           # Solve this issue by removed PySide6 prebuilt Qt library

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,9 +67,9 @@ jobs:
 
     strategy:
       matrix:
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
-        # use macos-15-intel to have bigger 14 GB RAM; otherwise, macos-15 only has 7GB RAM
-        os: [ubuntu-24.04, macos-15-intel]
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
+        # use macos-26-intel to have bigger 14 GB RAM; otherwise, macos-26-arm64 only has 7GB RAM
+        os: [ubuntu-24.04, macos-26-intel]
         cmake_build_type: [Debug]
 
       fail-fast: false

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -21,8 +21,8 @@ jobs:
 
     strategy:
       matrix:
-      # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
-        os: [ubuntu-24.04, macos-15]
+      # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
+        os: [ubuntu-24.04, macos-26]
 
       fail-fast: false
 

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-15]
+        os: [ubuntu-24.04, macos-26]
       fail-fast: false
 
     steps:

--- a/thirdparty/metal-cpp.sh
+++ b/thirdparty/metal-cpp.sh
@@ -45,6 +45,10 @@ if [ $(uname) == Darwin ] ; then
     filename=metal-cpp_macOS15.2_iOS18.2.zip
     url=https://developer.apple.com/metal/cpp/files/metal-cpp_macOS15.2_iOS18.2.zip
     checksum=3437e4abfbd3d45217f34772ef3502f3
+  elif [ ${ver:0:2} == "26" ] ; then
+    filename=metal-cpp_26.4.zip
+    url=https://developer.apple.com/metal/cpp/files/metal-cpp_26.4.zip
+    checksum=9065f9930f2e9f1bb48eb0094da46e73
   else
     echo "Unsupported macOS version $ver"
     exit 1


### PR DESCRIPTION
This PR is for https://github.com/solvcon/modmesh/issues/729.

Besides revising matrix in original workflow, I upgrade Qt version for MacOS so that missing AGL framework failure can be fixed. Another is adding macos-26 support in `thirdparty/metal-cpp.sh`.