### PR TITLE
Add LU decomposition with partial pivoting

### DIFF
--- a/cpp/modmesh/linalg/CMakeLists.txt
+++ b/cpp/modmesh/linalg/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required(VERSION 4.0.1)
 set(MODMESH_LINALG_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/linalg.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/factorization.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/lu_factorization.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kalman_filter.hpp
     CACHE FILEPATH "" FORCE)
 

--- a/cpp/modmesh/linalg/linalg.hpp
+++ b/cpp/modmesh/linalg/linalg.hpp
@@ -33,6 +33,7 @@
  */
 
 #include <modmesh/linalg/factorization.hpp>
+#include <modmesh/linalg/lu_factorization.hpp>
 #include <modmesh/linalg/kalman_filter.hpp>
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/linalg/lu_factorization.hpp
+++ b/cpp/modmesh/linalg/lu_factorization.hpp
@@ -1,0 +1,456 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, Anchi Liu <phy.tiger@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <algorithm>
+#include <format>
+#include <limits>
+#include <numeric>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include <modmesh/buffer/buffer.hpp>
+
+namespace modmesh
+{
+
+namespace detail
+{
+
+/**
+ * LU decomposition with partial pivoting for general (non-symmetric) matrices.
+ *
+ * Given an n-by-n matrix A, this class computes the factorization PA = LU,
+ * where:
+ *   - P is a permutation matrix (represented as a pivot index vector),
+ *   - L is a unit lower triangular matrix (diagonal elements are implicitly 1),
+ *   - U is an upper triangular matrix.
+ *
+ * L and U are stored compactly in a single n-by-n array: the strictly lower
+ * triangle holds L (excluding the unit diagonal), and the upper triangle
+ * (including the diagonal) holds U.
+ *
+ * The pivot vector piv[k] records that row k was swapped with row piv[k]
+ * during the k-th elimination step.  Swaps are applied sequentially from
+ * k = 0 to k = n-1.
+ *
+ * Supported element types: float, double, Complex<float>, Complex<double>.
+ */
+template <typename T>
+class Lu
+{
+
+    static_assert(
+        std::is_floating_point_v<T> || is_complex_v<T>,
+        "Lu<T> requires T to be a floating-point or complex type");
+
+private:
+
+    using value_type = T;
+    using real_type = typename detail::select_real_t<value_type>::type;
+    using array_type = SimpleArray<value_type>;
+
+    // Helper: format a SimpleArray shape as "(d0, d1, ...)" for error messages.
+    static std::string format_shape(array_type const & arr)
+    {
+        std::string result = "(";
+        for (size_t i = 0; i < arr.ndim(); ++i)
+        {
+            if (i > 0)
+            {
+                result += ", ";
+            }
+            result += std::to_string(arr.shape(i));
+        }
+        result += ")";
+        return result;
+    }
+
+public:
+
+    /**
+     * Compute the LU factorization with partial pivoting: PA = LU.
+     *
+     * @param a  Square 2D SimpleArray (the matrix to factorize).
+     * @return   A pair of (lu_matrix, pivot_vector):
+     *           - lu_matrix: n-by-n array with L in the strictly lower triangle
+     *             and U in the upper triangle (including diagonal).
+     *           - pivot_vector: length-n vector where piv[k] is the row index
+     *             that was swapped with row k at step k.
+     * @throws std::invalid_argument if a is not a square 2D array.
+     * @throws std::runtime_error    if the matrix is singular or near-singular.
+     */
+    static std::pair<array_type, std::vector<ssize_t>> factorize(array_type const & a);
+
+    /**
+     * Solve the linear system Ax = b using LU factorization.
+     *
+     * @param a  Square 2D SimpleArray (the coefficient matrix).
+     * @param b  1D or 2D SimpleArray (the right-hand side).
+     *           If 1D, it is treated as a single column vector.
+     *           If 2D with shape (n, m), each column is a separate RHS.
+     * @return   The solution x with the same shape as b.
+     * @throws std::invalid_argument if a is not square, b has wrong rank, or
+     *         dimensions are incompatible.
+     * @throws std::runtime_error    if a is singular.
+     */
+    static array_type solve(array_type const & a, array_type const & b);
+
+    /**
+     * Compute the matrix inverse A^(-1).
+     *
+     * Internally solves AX = I where I is the identity matrix.
+     *
+     * @param a  Square 2D SimpleArray.
+     * @return   The inverse matrix A^(-1) with the same shape as a.
+     * @throws std::invalid_argument if a is not a square 2D array.
+     * @throws std::runtime_error    if a is singular.
+     */
+    static array_type inv(array_type const & a);
+
+private:
+
+    /**
+     * Forward substitution: solve Ly = Pb.
+     *
+     * Applies the row permutation recorded in piv to b, then solves the
+     * unit lower triangular system.  L is stored in the strictly lower
+     * triangle of the combined lu matrix (diagonal of L is implicitly 1).
+     *
+     * @param lu   Combined LU matrix from factorize().
+     * @param piv  Pivot vector from factorize().
+     * @param b    2D RHS matrix (already reshaped if originally 1D).
+     * @return     The intermediate result y.
+     */
+    static array_type forward_substitution(array_type const & lu, std::vector<ssize_t> const & piv, array_type const & b);
+
+    /**
+     * Backward substitution: solve Ux = y.
+     *
+     * U is stored in the upper triangle (including diagonal) of the
+     * combined lu matrix.
+     *
+     * @param lu  Combined LU matrix from factorize().
+     * @param y   The result of forward_substitution().
+     * @return    The final solution x.
+     */
+    static array_type backward_substitution(array_type const & lu, array_type const & y);
+
+}; /* end class Lu */
+
+template <typename T>
+auto Lu<T>::factorize(array_type const & a) -> std::pair<array_type, std::vector<ssize_t>>
+{
+    if (a.ndim() != 2 || a.shape(0) != a.shape(1))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::factorize: a must be a square 2D SimpleArray, but got shape {}",
+            format_shape(a)));
+    }
+
+    const auto n = static_cast<ssize_t>(a.shape(0));
+
+    // Create a working copy of the input matrix.  The algorithm modifies
+    // this array in-place, overwriting it with the combined L and U factors.
+    auto lu = array_type(a.shape(), value_type{0});
+    std::copy(a.begin(), a.end(), lu.begin());
+
+    // piv[k] records which row was swapped with row k at step k.
+    // Initialize with std::iota so piv[k] = k (identity permutation).
+    std::vector<ssize_t> piv(n);
+    std::iota(piv.begin(), piv.end(), ssize_t{0});
+
+    const auto eps = std::numeric_limits<real_type>::epsilon();
+
+    // Main elimination loop.  For each column k, we:
+    //   1. Search column k (rows k..n-1) for the largest absolute value
+    //      (partial pivoting) to improve numerical stability.
+    //   2. Swap the pivot row with row k.
+    //   3. Check for singularity.
+    //   4. Compute multipliers and update the trailing submatrix.
+    for (ssize_t k = 0; k < n; ++k)
+    {
+        // Step 1: Find the pivot -- the row in [k, n) with the largest
+        // absolute value in column k.  Note: abs() returns real_type even
+        // for complex value_type, so all comparison variables must be real.
+        real_type max_val = abs(lu(k, k));
+        ssize_t max_row = k;
+        for (ssize_t i = k + 1; i < n; ++i)
+        {
+            real_type val = abs(lu(i, k));
+            if (val > max_val)
+            {
+                max_val = val;
+                max_row = i;
+            }
+        }
+        piv[k] = max_row;
+
+        // Step 2: Swap rows k and max_row in the full working matrix.
+        if (max_row != k)
+        {
+            for (ssize_t j = 0; j < n; ++j)
+            {
+                std::swap(lu(k, j), lu(max_row, j));
+            }
+        }
+
+        // Step 3: After pivoting, if the diagonal element is still
+        // negligible the matrix is (numerically) singular.  Tolerance is
+        // scaled relative to the column's largest magnitude.
+        real_type const pivot = abs(lu(k, k));
+        real_type const tol = max_val * real_type(100) * eps;
+        if (pivot <= tol)
+        {
+            throw std::runtime_error("Lu::factorize: LU decomposition failed: singular or near-singular matrix.");
+        }
+
+        // Step 4: Gaussian elimination.  For each row below the pivot,
+        // compute the multiplier l(i,k) = a(i,k) / a(k,k) and store it
+        // in the lower triangle.  Then subtract l(i,k) * row_k from row_i
+        // in the trailing submatrix (columns k+1..n-1).
+        for (ssize_t i = k + 1; i < n; ++i)
+        {
+            lu(i, k) = lu(i, k) / lu(k, k); // multiplier stored in L
+            for (ssize_t j = k + 1; j < n; ++j)
+            {
+                lu(i, j) = lu(i, j) - lu(i, k) * lu(k, j);
+            }
+        }
+    }
+
+    return {lu, piv};
+}
+
+template <typename T>
+auto Lu<T>::forward_substitution(array_type const & lu, std::vector<ssize_t> const & piv, array_type const & b) -> array_type
+{
+    if (lu.ndim() != 2 || lu.shape(0) != lu.shape(1))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::forward_substitution: lu must be a square 2D SimpleArray, but got shape {}",
+            format_shape(lu)));
+    }
+    if (b.ndim() != 2 || b.shape(0) != lu.shape(0))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::forward_substitution: b must be a 2D SimpleArray with first dimension matching lu, but got shape {}",
+            format_shape(b)));
+    }
+
+    const auto m = static_cast<ssize_t>(lu.shape(0));
+    const auto ncols = static_cast<ssize_t>(b.shape(1));
+    small_vector<size_t> y_shape{static_cast<size_t>(m), static_cast<size_t>(ncols)};
+
+    // Copy b into y so we can apply the permutation in-place.
+    array_type y(y_shape);
+    std::copy(b.begin(), b.end(), y.begin());
+
+    // Apply the row permutation P to b.  The swaps are replayed in the
+    // same order they were recorded during factorization (k = 0, 1, ...).
+    for (ssize_t i = 0; i < m; ++i)
+    {
+        if (piv[i] != i)
+        {
+            for (ssize_t k = 0; k < ncols; ++k)
+            {
+                std::swap(y(i, k), y(piv[i], k));
+            }
+        }
+    }
+
+    // Solve Ly = Pb by forward substitution.  L is unit lower triangular
+    // (diagonal is implicitly 1), so the formula for each element is:
+    //   y(i, k) = y(i, k) - sum_{j=0}^{i-1} L(i,j) * y(j, k)
+    for (ssize_t k = 0; k < ncols; ++k)
+    {
+        for (ssize_t i = 1; i < m; ++i)
+        {
+            value_type sum{0};
+            for (ssize_t j = 0; j < i; ++j)
+            {
+                sum += lu(i, j) * y(j, k);
+            }
+            y(i, k) = y(i, k) - sum;
+        }
+    }
+
+    return y;
+}
+
+template <typename T>
+auto Lu<T>::backward_substitution(array_type const & lu, array_type const & y) -> array_type
+{
+    if (lu.ndim() != 2 || lu.shape(0) != lu.shape(1))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::backward_substitution: lu must be a square 2D SimpleArray, but got shape {}",
+            format_shape(lu)));
+    }
+    if (y.ndim() != 2 || y.shape(0) != lu.shape(0))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::backward_substitution: y must be a 2D SimpleArray with first dimension matching lu, but got shape {}",
+            format_shape(y)));
+    }
+
+    const auto m = static_cast<ssize_t>(lu.shape(0));
+    const auto ncols = static_cast<ssize_t>(y.shape(1));
+    small_vector<size_t> x_shape{static_cast<size_t>(m), static_cast<size_t>(ncols)};
+    array_type x(x_shape);
+
+    // Solve Ux = y by backward substitution.  U occupies the upper triangle
+    // (including diagonal) of the combined lu matrix.  The formula is:
+    //   x(i, k) = (y(i, k) - sum_{j=i+1}^{m-1} U(i,j) * x(j, k)) / U(i,i)
+    for (ssize_t k = 0; k < ncols; ++k)
+    {
+        for (ssize_t i = m - 1; i >= 0; --i)
+        {
+            value_type sum{0};
+            for (ssize_t j = i + 1; j < m; ++j)
+            {
+                sum += lu(i, j) * x(j, k);
+            }
+            x(i, k) = (y(i, k) - sum) / lu(i, i);
+        }
+    }
+
+    return x;
+}
+
+template <typename T>
+auto Lu<T>::solve(array_type const & a, array_type const & b) -> array_type
+{
+    if (a.ndim() != 2 || a.shape(0) != a.shape(1))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::solve: a must be a square 2D SimpleArray, but got shape {}",
+            format_shape(a)));
+    }
+    if (b.ndim() != 1 && b.ndim() != 2)
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::solve: b must be 1D or 2D, but got {}D",
+            b.ndim()));
+    }
+    if (a.shape(0) != b.shape(0))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::solve: dimension mismatch: a.shape[0]={}, b.shape[0]={}",
+            a.shape(0),
+            b.shape(0)));
+    }
+
+    // Factorize A into PA = LU, then solve by:
+    //   1. Forward substitution:  Ly = Pb
+    //   2. Backward substitution: Ux = y
+    auto [lu, piv] = factorize(a);
+
+    // If b is 1D, reshape to a column matrix (n, 1), solve, then reshape
+    // the result back to 1D so the caller gets the same shape they passed in.
+    bool const was_1d = (b.ndim() == 1);
+    if (was_1d)
+    {
+        auto b_2d = b.reshape(small_vector<size_t>{b.shape(0), 1});
+        auto y = forward_substitution(lu, piv, b_2d);
+        auto x = backward_substitution(lu, y);
+        return x.reshape(small_vector<size_t>{x.shape(0)});
+    }
+    else
+    {
+        auto y = forward_substitution(lu, piv, b);
+        auto x = backward_substitution(lu, y);
+        return x;
+    }
+}
+
+template <typename T>
+auto Lu<T>::inv(array_type const & a) -> array_type
+{
+    if (a.ndim() != 2 || a.shape(0) != a.shape(1))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::inv: a must be a square 2D SimpleArray, but got shape {}",
+            format_shape(a)));
+    }
+
+    // Matrix inversion is equivalent to solving AX = I for X, where I is the
+    // n-by-n identity matrix.  Each column of X is the solution to A * x_j = e_j.
+    const auto n = static_cast<ssize_t>(a.shape(0));
+    auto identity = array_type::eye(n);
+
+    auto [lu, piv] = factorize(a);
+    auto y = forward_substitution(lu, piv, identity);
+    auto x = backward_substitution(lu, y);
+    return x;
+}
+
+} /* end namespace detail */
+
+/**
+ * Free function wrapper for LU factorization with partial pivoting.
+ *
+ * @param a  Square 2D SimpleArray.
+ * @return   (lu_matrix, pivot_vector) pair.  See detail::Lu<T>::factorize().
+ */
+template <typename T>
+std::pair<SimpleArray<T>, std::vector<ssize_t>> lu_factorization(SimpleArray<T> const & a)
+{
+    return detail::Lu<T>::factorize(a);
+}
+
+/**
+ * Free function wrapper for solving Ax = b via LU decomposition.
+ *
+ * @param a  Square 2D SimpleArray (coefficient matrix).
+ * @param b  1D or 2D SimpleArray (right-hand side).
+ * @return   The solution x with the same shape as b.
+ */
+template <typename T>
+SimpleArray<T> lu_solve(SimpleArray<T> const & a, SimpleArray<T> const & b)
+{
+    return detail::Lu<T>::solve(a, b);
+}
+
+/**
+ * Free function wrapper for computing the matrix inverse via LU decomposition.
+ *
+ * @param a  Square 2D SimpleArray.
+ * @return   The inverse A^(-1).
+ */
+template <typename T>
+SimpleArray<T> lu_inv(SimpleArray<T> const & a)
+{
+    return detail::Lu<T>::inv(a);
+}
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/linalg/lu_factorization.hpp
+++ b/cpp/modmesh/linalg/lu_factorization.hpp
@@ -1,0 +1,460 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, Anchi Liu <phy.tiger@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <algorithm>
+#include <format>
+#include <limits>
+#include <numeric>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include <modmesh/buffer/buffer.hpp>
+
+namespace modmesh
+{
+
+namespace detail
+{
+
+/**
+ * LU decomposition with partial pivoting for general (non-symmetric) matrices.
+ *
+ * Given an n-by-n matrix A, this class computes the factorization PA = LU,
+ * where:
+ *   - P is a permutation matrix (represented as a pivot index vector),
+ *   - L is a unit lower triangular matrix (diagonal elements are implicitly 1),
+ *   - U is an upper triangular matrix.
+ *
+ * L and U are stored compactly in a single n-by-n array: the strictly lower
+ * triangle holds L (excluding the unit diagonal), and the upper triangle
+ * (including the diagonal) holds U.
+ *
+ * The pivot vector piv[k] records that row k was swapped with row piv[k]
+ * during the k-th elimination step.  Swaps are applied sequentially from
+ * k = 0 to k = n-1.
+ *
+ * Supported element types: float, double, Complex<float>, Complex<double>.
+ */
+template <typename T>
+class Lu
+{
+
+    static_assert(
+        is_real_v<T> || is_complex_v<T>,
+        "Lu<T> requires T to be a real or complex number type");
+
+private:
+
+    using value_type = T;
+    using real_type = typename detail::select_real_t<value_type>::type;
+    using array_type = SimpleArray<value_type>;
+
+    // Helper: format a SimpleArray shape as "(d0, d1, ...)" for error messages.
+    static std::string format_shape(array_type const & arr);
+
+public:
+
+    /**
+     * Compute the LU factorization with partial pivoting: PA = LU.
+     *
+     * @param a  Square 2D SimpleArray (the matrix to factorize).
+     * @return   A pair of (lu_matrix, pivot_vector):
+     *           - lu_matrix: n-by-n array with L in the strictly lower triangle
+     *             and U in the upper triangle (including diagonal).
+     *           - pivot_vector: length-n vector where piv[k] is the row index
+     *             that was swapped with row k at step k.
+     * @throws std::invalid_argument if a is not a square 2D array.
+     * @throws std::runtime_error    if the matrix is singular or near-singular.
+     */
+    static std::pair<array_type, std::vector<ssize_t>> factorize(array_type const & a);
+
+    /**
+     * Solve the linear system Ax = b using LU factorization.
+     *
+     * @param a  Square 2D SimpleArray (the coefficient matrix).
+     * @param b  1D or 2D SimpleArray (the right-hand side).
+     *           If 1D, it is treated as a single column vector.
+     *           If 2D with shape (n, m), each column is a separate RHS.
+     * @return   The solution x with the same shape as b.
+     * @throws std::invalid_argument if a is not square, b has wrong rank, or
+     *         dimensions are incompatible.
+     * @throws std::runtime_error    if a is singular.
+     */
+    static array_type solve(array_type const & a, array_type const & b);
+
+    /**
+     * Compute the matrix inverse A^(-1).
+     *
+     * Internally solves AX = I where I is the identity matrix.
+     *
+     * @param a  Square 2D SimpleArray.
+     * @return   The inverse matrix A^(-1) with the same shape as a.
+     * @throws std::invalid_argument if a is not a square 2D array.
+     * @throws std::runtime_error    if a is singular.
+     */
+    static array_type inv(array_type const & a);
+
+private:
+
+    /**
+     * Forward substitution: solve Ly = Pb.
+     *
+     * Applies the row permutation recorded in piv to b, then solves the
+     * unit lower triangular system.  L is stored in the strictly lower
+     * triangle of the combined lu matrix (diagonal of L is implicitly 1).
+     *
+     * @param lu   Combined LU matrix from factorize().
+     * @param piv  Pivot vector from factorize().
+     * @param b    2D RHS matrix (already reshaped if originally 1D).
+     * @return     The intermediate result y.
+     */
+    static array_type forward_substitution(array_type const & lu, std::vector<ssize_t> const & piv, array_type const & b);
+
+    /**
+     * Backward substitution: solve Ux = y.
+     *
+     * U is stored in the upper triangle (including diagonal) of the
+     * combined lu matrix.
+     *
+     * @param lu  Combined LU matrix from factorize().
+     * @param y   The result of forward_substitution().
+     * @return    The final solution x.
+     */
+    static array_type backward_substitution(array_type const & lu, array_type const & y);
+
+}; /* end class Lu */
+
+template <typename T>
+auto Lu<T>::format_shape(array_type const & arr) -> std::string
+{
+    std::string result = "(";
+    for (size_t i = 0; i < arr.ndim(); ++i)
+    {
+        if (i > 0)
+        {
+            result += ", ";
+        }
+        result += std::to_string(arr.shape(i));
+    }
+    result += ")";
+    return result;
+}
+
+template <typename T>
+auto Lu<T>::factorize(array_type const & a) -> std::pair<array_type, std::vector<ssize_t>>
+{
+    if (a.ndim() != 2 || a.shape(0) != a.shape(1))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::factorize: a must be a square 2D SimpleArray, but got shape {}",
+            format_shape(a)));
+    }
+
+    const auto n = static_cast<ssize_t>(a.shape(0));
+
+    // Create a working copy of the input matrix.  The algorithm modifies
+    // this array in-place, overwriting it with the combined L and U factors.
+    auto lu = array_type(a.shape(), value_type{0});
+    std::copy(a.begin(), a.end(), lu.begin());
+
+    // piv[k] records which row was swapped with row k at step k.
+    // Initialize with std::iota so piv[k] = k (identity permutation).
+    std::vector<ssize_t> piv(n);
+    std::iota(piv.begin(), piv.end(), ssize_t{0});
+
+    // Main elimination loop.  For each column k, we:
+    //   1. Search column k (rows k..n-1) for the largest absolute value
+    //      (partial pivoting) to improve numerical stability.
+    //   2. Swap the pivot row with row k.
+    //   3. Check for singularity.
+    //   4. Compute multipliers and update the trailing submatrix.
+    for (ssize_t k = 0; k < n; ++k)
+    {
+        // Step 1: Find the pivot -- the row in [k, n) with the largest
+        // absolute value in column k.  Note: abs() returns real_type even
+        // for complex value_type, so all comparison variables must be real.
+        real_type max_val = abs(lu(k, k));
+        ssize_t max_row = k;
+        for (ssize_t i = k + 1; i < n; ++i)
+        {
+            real_type val = abs(lu(i, k));
+            if (val > max_val)
+            {
+                max_val = val;
+                max_row = i;
+            }
+        }
+        piv[k] = max_row;
+
+        // Step 2: Swap rows k and max_row in the full working matrix.
+        if (max_row != k)
+        {
+            for (ssize_t j = 0; j < n; ++j)
+            {
+                std::swap(lu(k, j), lu(max_row, j));
+            }
+        }
+
+        // Step 3: Reject both exact singularity (pivot = 0, e.g. duplicate
+        // rows) and near-singularity (pivot at noise level).
+        real_type const pivot = abs(lu(k, k));
+        const auto eps = std::numeric_limits<real_type>::epsilon();
+
+        // Absolute threshold (~100 * machine eps); works for well-scaled inputs.
+        // TODO: make it relative to matrix/column magnitude for better robustness.
+        real_type const singular_tol = real_type(100) * eps;
+        if (pivot <= singular_tol)
+        {
+            throw std::runtime_error("Lu::factorize: LU decomposition failed: singular or near-singular matrix.");
+        }
+
+        // Step 4: Gaussian elimination.  For each row below the pivot,
+        // compute the multiplier l(i,k) = a(i,k) / a(k,k) and store it
+        // in the lower triangle.  Then subtract l(i,k) * row_k from row_i
+        // in the trailing submatrix (columns k+1..n-1).
+        for (ssize_t i = k + 1; i < n; ++i)
+        {
+            lu(i, k) = lu(i, k) / lu(k, k); // multiplier stored in L
+            for (ssize_t j = k + 1; j < n; ++j)
+            {
+                lu(i, j) = lu(i, j) - lu(i, k) * lu(k, j);
+            }
+        }
+    }
+
+    return {lu, piv};
+}
+
+template <typename T>
+auto Lu<T>::forward_substitution(array_type const & lu, std::vector<ssize_t> const & piv, array_type const & b) -> array_type
+{
+    if (lu.ndim() != 2 || lu.shape(0) != lu.shape(1))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::forward_substitution: lu must be a square 2D SimpleArray, but got shape {}",
+            format_shape(lu)));
+    }
+    if (b.ndim() != 2 || b.shape(0) != lu.shape(0))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::forward_substitution: b must be a 2D SimpleArray with first dimension matching lu, but got shape {}",
+            format_shape(b)));
+    }
+
+    const auto m = static_cast<ssize_t>(lu.shape(0));
+    const auto ncols = static_cast<ssize_t>(b.shape(1));
+    small_vector<size_t> y_shape{static_cast<size_t>(m), static_cast<size_t>(ncols)};
+
+    // Copy b into y so we can apply the permutation in-place.
+    array_type y(y_shape);
+    std::copy(b.begin(), b.end(), y.begin());
+
+    // Apply the row permutation P to b.  The swaps are replayed in the
+    // same order they were recorded during factorization (k = 0, 1, ...).
+    for (ssize_t i = 0; i < m; ++i)
+    {
+        if (piv[i] != i)
+        {
+            for (ssize_t k = 0; k < ncols; ++k)
+            {
+                std::swap(y(i, k), y(piv[i], k));
+            }
+        }
+    }
+
+    // Solve Ly = Pb by forward substitution.  L is unit lower triangular
+    // (diagonal is implicitly 1), so the formula for each element is:
+    //   y(i, k) = y(i, k) - sum_{j=0}^{i-1} L(i,j) * y(j, k)
+    for (ssize_t k = 0; k < ncols; ++k)
+    {
+        for (ssize_t i = 1; i < m; ++i)
+        {
+            value_type sum{0};
+            for (ssize_t j = 0; j < i; ++j)
+            {
+                sum += lu(i, j) * y(j, k);
+            }
+            y(i, k) = y(i, k) - sum;
+        }
+    }
+
+    return y;
+}
+
+template <typename T>
+auto Lu<T>::backward_substitution(array_type const & lu, array_type const & y) -> array_type
+{
+    if (lu.ndim() != 2 || lu.shape(0) != lu.shape(1))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::backward_substitution: lu must be a square 2D SimpleArray, but got shape {}",
+            format_shape(lu)));
+    }
+    if (y.ndim() != 2 || y.shape(0) != lu.shape(0))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::backward_substitution: y must be a 2D SimpleArray with first dimension matching lu, but got shape {}",
+            format_shape(y)));
+    }
+
+    const auto m = static_cast<ssize_t>(lu.shape(0));
+    const auto ncols = static_cast<ssize_t>(y.shape(1));
+    small_vector<size_t> x_shape{static_cast<size_t>(m), static_cast<size_t>(ncols)};
+    array_type x(x_shape);
+
+    // Solve Ux = y by backward substitution.  U occupies the upper triangle
+    // (including diagonal) of the combined lu matrix.  The formula is:
+    //   x(i, k) = (y(i, k) - sum_{j=i+1}^{m-1} U(i,j) * x(j, k)) / U(i,i)
+    for (ssize_t k = 0; k < ncols; ++k)
+    {
+        for (ssize_t i = m - 1; i >= 0; --i)
+        {
+            value_type sum{0};
+            for (ssize_t j = i + 1; j < m; ++j)
+            {
+                sum += lu(i, j) * x(j, k);
+            }
+            x(i, k) = (y(i, k) - sum) / lu(i, i);
+        }
+    }
+
+    return x;
+}
+
+template <typename T>
+auto Lu<T>::solve(array_type const & a, array_type const & b) -> array_type
+{
+    if (a.ndim() != 2 || a.shape(0) != a.shape(1))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::solve: a must be a square 2D SimpleArray, but got shape {}",
+            format_shape(a)));
+    }
+    if (b.ndim() != 1 && b.ndim() != 2)
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::solve: b must be 1D or 2D, but got {}D",
+            b.ndim()));
+    }
+    if (a.shape(0) != b.shape(0))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::solve: dimension mismatch: a.shape[0]={}, b.shape[0]={}",
+            a.shape(0),
+            b.shape(0)));
+    }
+
+    // Factorize A into PA = LU, then solve by:
+    //   1. Forward substitution:  Ly = Pb
+    //   2. Backward substitution: Ux = y
+    auto [lu, piv] = factorize(a);
+
+    // If b is 1D, reshape to a column matrix (n, 1), solve, then reshape
+    // the result back to 1D so the caller gets the same shape they passed in.
+    bool const was_1d = (b.ndim() == 1);
+    if (was_1d)
+    {
+        auto b_2d = b.reshape(small_vector<size_t>{b.shape(0), 1});
+        auto y = forward_substitution(lu, piv, b_2d);
+        auto x = backward_substitution(lu, y);
+        return x.reshape(small_vector<size_t>{x.shape(0)});
+    }
+    else
+    {
+        auto y = forward_substitution(lu, piv, b);
+        auto x = backward_substitution(lu, y);
+        return x;
+    }
+}
+
+template <typename T>
+auto Lu<T>::inv(array_type const & a) -> array_type
+{
+    if (a.ndim() != 2 || a.shape(0) != a.shape(1))
+    {
+        throw std::invalid_argument(std::format(
+            "Lu::inv: a must be a square 2D SimpleArray, but got shape {}",
+            format_shape(a)));
+    }
+
+    // Matrix inversion is equivalent to solving AX = I for X, where I is the
+    // n-by-n identity matrix.  Each column of X is the solution to A * x_j = e_j.
+    const auto n = static_cast<ssize_t>(a.shape(0));
+    auto identity = array_type::eye(n);
+
+    auto [lu, piv] = factorize(a);
+    auto y = forward_substitution(lu, piv, identity);
+    auto x = backward_substitution(lu, y);
+    return x;
+}
+
+} /* end namespace detail */
+
+/**
+ * Free function wrapper for LU factorization with partial pivoting.
+ *
+ * @param a  Square 2D SimpleArray.
+ * @return   (lu_matrix, pivot_vector) pair.  See detail::Lu<T>::factorize().
+ */
+template <typename T>
+std::pair<SimpleArray<T>, std::vector<ssize_t>> lu_factorization(SimpleArray<T> const & a)
+{
+    return detail::Lu<T>::factorize(a);
+}
+
+/**
+ * Free function wrapper for solving Ax = b via LU decomposition.
+ *
+ * @param a  Square 2D SimpleArray (coefficient matrix).
+ * @param b  1D or 2D SimpleArray (right-hand side).
+ * @return   The solution x with the same shape as b.
+ */
+template <typename T>
+SimpleArray<T> lu_solve(SimpleArray<T> const & a, SimpleArray<T> const & b)
+{
+    return detail::Lu<T>::solve(a, b);
+}
+
+/**
+ * Free function wrapper for computing the matrix inverse via LU decomposition.
+ *
+ * @param a  Square 2D SimpleArray.
+ * @return   The inverse A^(-1).
+ */
+template <typename T>
+SimpleArray<T> lu_inv(SimpleArray<T> const & a)
+{
+    return detail::Lu<T>::inv(a);
+}
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/linalg/pymod/wrap_factorization.cpp
+++ b/cpp/modmesh/linalg/pymod/wrap_factorization.cpp
@@ -53,6 +53,62 @@ void def_llt_solve(pybind11::module & mod)
         pybind11::arg("b"));
 }
 
+// Python binding for lu_factorization().  Returns a tuple (lu_array, piv_list)
+// where lu_array is the combined LU matrix and piv_list is the pivot vector.
+template <typename T>
+void def_lu_factorization(pybind11::module & mod)
+{
+    mod.def(
+        "lu_factorization", [](SimpleArray<T> const & a)
+        {
+            auto [lu, piv] = lu_factorization(a);
+            return pybind11::make_tuple(lu, piv); },
+        pybind11::arg("a"));
+}
+
+// Python binding for lu_solve().  Solves Ax = b for general matrices.
+template <typename T>
+void def_lu_solve(pybind11::module & mod)
+{
+    mod.def(
+        "lu_solve", [](SimpleArray<T> const & a, SimpleArray<T> const & b)
+        { return lu_solve(a, b); },
+        pybind11::arg("a"),
+        pybind11::arg("b"));
+}
+
+// Python binding for lu_inv().  Computes A^(-1) for general matrices.
+template <typename T>
+void def_lu_inv(pybind11::module & mod)
+{
+    mod.def(
+        "lu_inv", [](SimpleArray<T> const & a)
+        { return lu_inv(a); },
+        pybind11::arg("a"));
+}
+
+// Attach .solve() and .inv() methods to an already-registered SimpleArray
+// class.  The buffer module (where SimpleArray is defined) intentionally has
+// no dependency on linalg/, so LU-based methods are injected here from the
+// linalg module after the class has been registered.
+template <typename T>
+void add_simple_array_lu_methods(pybind11::module & mod, char const * pyname)
+{
+    namespace py = pybind11;
+    py::object cls = mod.attr(pyname);
+    cls.attr("solve") = py::cpp_function(
+        [](SimpleArray<T> const & self, SimpleArray<T> const & b)
+        { return lu_solve(self, b); },
+        py::arg("b"),
+        py::is_method(cls),
+        "Solve linear system self @ x = b, returns x");
+    cls.attr("inv") = py::cpp_function(
+        [](SimpleArray<T> const & self)
+        { return lu_inv(self); },
+        py::is_method(cls),
+        "Compute matrix inverse");
+}
+
 void wrap_factorization(pybind11::module & mod)
 {
     def_llt_factorization<float>(mod);
@@ -64,6 +120,28 @@ void wrap_factorization(pybind11::module & mod)
     def_llt_solve<double>(mod);
     def_llt_solve<Complex<float>>(mod);
     def_llt_solve<Complex<double>>(mod);
+
+    def_lu_factorization<float>(mod);
+    def_lu_factorization<double>(mod);
+    def_lu_factorization<Complex<float>>(mod);
+    def_lu_factorization<Complex<double>>(mod);
+
+    def_lu_solve<float>(mod);
+    def_lu_solve<double>(mod);
+    def_lu_solve<Complex<float>>(mod);
+    def_lu_solve<Complex<double>>(mod);
+
+    def_lu_inv<float>(mod);
+    def_lu_inv<double>(mod);
+    def_lu_inv<Complex<float>>(mod);
+    def_lu_inv<Complex<double>>(mod);
+
+    // Integer arrays are deliberately excluded: LU decomposition involves
+    // division, which would silently truncate under integer arithmetic.
+    add_simple_array_lu_methods<float>(mod, "SimpleArrayFloat32");
+    add_simple_array_lu_methods<double>(mod, "SimpleArrayFloat64");
+    add_simple_array_lu_methods<Complex<float>>(mod, "SimpleArrayComplex64");
+    add_simple_array_lu_methods<Complex<double>>(mod, "SimpleArrayComplex128");
 }
 
 } /* end namespace python */

--- a/cpp/modmesh/math/Complex.hpp
+++ b/cpp/modmesh/math/Complex.hpp
@@ -264,10 +264,16 @@ struct is_complex : std::false_type {};
 
 template <typename T>
 struct is_complex<Complex<T>> : std::true_type {};
+
+template <typename T>
+struct is_real : std::is_floating_point<T> {};
 // clang-format on
 
 template <typename T>
 constexpr bool is_complex_v = is_complex<T>::value;
+
+template <typename T>
+constexpr bool is_real_v = is_real<T>::value;
 
 } /* end namespace modmesh */
 

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -124,6 +124,9 @@ list_of_transform = [
 list_of_linalg = [
     'llt_factorization',
     'llt_solve',
+    'lu_factorization',
+    'lu_solve',
+    'lu_inv',
     'KalmanStateInfoFp32',
     'KalmanStateInfoFp64',
     'KalmanStateInfoComplex64',

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -758,4 +758,424 @@ class KalmanFilterBatchFilterTC(unittest.TestCase):
         np.testing.assert_allclose(xs_upd, xs_upd_np, atol=1e-12, rtol=0.0)
         np.testing.assert_allclose(ps_upd, ps_upd_np, atol=1e-12, rtol=0.0)
 
+
+def _assert_PA_equals_LU(A_np, lu_np, piv, rtol, atol):
+    """Assert PA == L @ U for Lu::factorize output.
+
+    Lu::factorize stores L in the strictly lower triangle (unit diagonal)
+    and U in the upper triangle (including diagonal) of a single array.
+    piv[k] is the row swapped with row k at step k; swaps are replayed
+    sequentially from k = 0 to k = n - 1.
+    """
+    n = A_np.shape[0]
+    L = np.eye(n, dtype=lu_np.dtype)
+    U = np.zeros_like(lu_np)
+    for i in range(n):
+        for j in range(n):
+            if i > j:
+                L[i, j] = lu_np[i, j]
+            else:
+                U[i, j] = lu_np[i, j]
+    PA = A_np.astype(lu_np.dtype, copy=True)
+    for k in range(n):
+        if piv[k] != k:
+            PA[[k, piv[k]]] = PA[[piv[k], k]]
+    np.testing.assert_allclose(L @ U, PA, rtol=rtol, atol=atol)
+
+
+class TestLuFactorization(unittest.TestCase):
+    """Verify lu_factorization() produces a decomposition with PA = LU."""
+
+    def setUp(self):
+        # 3x3 invertible matrix with no zero pivots.
+        self.A_3x3 = np.array([
+            [2.0, 1.0, 1.0],
+            [4.0, -6.0, 0.0],
+            [-2.0, 7.0, 2.0],
+        ])
+        # 4x4 whose leading element is not the column-max, so partial
+        # pivoting must trigger.
+        self.A_4x4 = np.array([
+            [1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 8.0, 8.0],
+            [9.0, 10.0, 11.0, 16.0],
+            [13.0, 15.0, 16.0, 17.0],
+        ])
+        # 3x3 whose A[0][0] is negligibly small; a correct implementation
+        # must pivot away from it.
+        self.A_tiny_pivot = np.array([
+            [1e-15, 1.0, 0.0],
+            [1.0, 1.0, 1.0],
+            [0.0, 1.0, 2.0],
+        ])
+        # 3x3 complex matrix for complex-path coverage.
+        self.A_complex_3x3 = np.array([
+            [2.0 + 1.0j, 1.0 + 0.0j, 3.0 - 1.0j],
+            [4.0 + 0.0j, -1.0 + 2.0j, 1.0 + 1.0j],
+            [1.0 - 1.0j, 5.0 + 0.0j, 2.0 + 3.0j],
+        ], dtype=np.complex128)
+
+    def test_factorize_3x3_reconstructs_PA(self):
+        # Baseline: well-conditioned 3x3, also checks output shape/piv length.
+        A = mm.SimpleArrayFloat64(array=self.A_3x3)
+        lu, piv = mm.lu_factorization(A)
+        lu_np = np.array(lu)
+        self.assertEqual(lu_np.shape, (3, 3))
+        self.assertEqual(len(piv), 3)
+        _assert_PA_equals_LU(self.A_3x3, lu_np, piv, rtol=1e-12, atol=1e-14)
+
+    def test_factorize_4x4_reconstructs_PA(self):
+        # Larger 4x4 where partial pivoting must trigger on the first column.
+        A = mm.SimpleArrayFloat64(array=self.A_4x4)
+        lu, piv = mm.lu_factorization(A)
+        lu_np = np.array(lu)
+        _assert_PA_equals_LU(self.A_4x4, lu_np, piv, rtol=1e-12, atol=1e-12)
+
+    def test_factorize_complex_3x3_reconstructs_PA(self):
+        # Complex128 path: exercises the complex template instantiation.
+        A = mm.SimpleArrayComplex128(array=self.A_complex_3x3)
+        lu, piv = mm.lu_factorization(A)
+        lu_np = np.array(lu)
+        _assert_PA_equals_LU(
+            self.A_complex_3x3, lu_np, piv, rtol=1e-12, atol=1e-12)
+
+    def test_factorize_pivots_away_from_tiny_diagonal(self):
+        # Numerical stability: A[0][0] ~ 1e-15 forces a row swap at step 0.
+        A = mm.SimpleArrayFloat64(array=self.A_tiny_pivot)
+        lu, piv = mm.lu_factorization(A)
+        self.assertNotEqual(piv[0], 0)
+        lu_np = np.array(lu)
+        _assert_PA_equals_LU(
+            self.A_tiny_pivot, lu_np, piv, rtol=1e-10, atol=1e-10)
+
+    def test_factorize_float32_reconstructs_PA(self):
+        # Float32 path: same input as 3x3 case but in single precision.
+        A_np = self.A_3x3.astype(np.float32)
+        A = mm.SimpleArrayFloat32(array=A_np)
+        lu, piv = mm.lu_factorization(A)
+        lu_np = np.array(lu)
+        _assert_PA_equals_LU(A_np, lu_np, piv, rtol=1e-5, atol=1e-5)
+
+
+class TestLuSolve(unittest.TestCase):
+    """Verify lu_solve() against explicit systems with known solutions."""
+
+    def setUp(self):
+        # 2x2: [[2, 3], [4, 7]] x = [5, 11]  =>  x = [1, 1]
+        self.A_2x2 = np.array([[2.0, 3.0], [4.0, 7.0]])
+        self.b_2x2 = np.array([5.0, 11.0])
+        self.x_2x2_expected = np.array([1.0, 1.0])
+
+        # 3x3 system with known exact solution x = [1, 1, 2].
+        self.A_3x3 = np.array([
+            [2.0, 1.0, 1.0],
+            [4.0, -6.0, 0.0],
+            [-2.0, 7.0, 2.0],
+        ])
+        self.b_3x3 = np.array([5.0, -2.0, 9.0])
+        self.x_3x3_expected = np.array([1.0, 1.0, 2.0])
+
+        # 2x2 complex: (2 + j)x + (1 - j)y = 4 + 3j, jx + 3y = 6 + j
+        # Chosen so x = [1 + j, 2] is exact.
+        self.A_c2x2 = np.array([
+            [2.0 + 1.0j, 1.0 - 1.0j],
+            [0.0 + 1.0j, 3.0 + 0.0j],
+        ], dtype=np.complex128)
+        self.x_c2x2_expected = np.array([1.0 + 1.0j, 2.0], dtype=np.complex128)
+        self.b_c2x2 = self.A_c2x2 @ self.x_c2x2_expected
+
+    def test_solve_2x2_matches_known_solution(self):
+        # Smallest case: 2x2 with 1D rhs, also checks output shape.
+        A = mm.SimpleArrayFloat64(array=self.A_2x2)
+        b = mm.SimpleArrayFloat64(array=self.b_2x2)
+        x = mm.lu_solve(A, b)
+        self.assertEqual(x.shape, (2,))
+        np.testing.assert_allclose(
+            np.array(x), self.x_2x2_expected, rtol=1e-12, atol=1e-14)
+
+    def test_solve_3x3_matches_known_solution(self):
+        # 3x3 with 1D rhs against a precomputed exact solution.
+        A = mm.SimpleArrayFloat64(array=self.A_3x3)
+        b = mm.SimpleArrayFloat64(array=self.b_3x3)
+        x = mm.lu_solve(A, b)
+        self.assertEqual(x.shape, (3,))
+        np.testing.assert_allclose(
+            np.array(x), self.x_3x3_expected, rtol=1e-12, atol=1e-14)
+
+    def test_solve_float32(self):
+        # Float32 path: same 3x3 system in single precision.
+        A = mm.SimpleArrayFloat32(array=self.A_3x3.astype(np.float32))
+        b = mm.SimpleArrayFloat32(array=self.b_3x3.astype(np.float32))
+        x = mm.lu_solve(A, b)
+        np.testing.assert_allclose(
+            np.array(x), self.x_3x3_expected.astype(np.float32),
+            rtol=1e-5, atol=1e-5)
+
+    def test_solve_complex128_matches_known_solution(self):
+        # Complex128 path with a known exact complex solution.
+        A = mm.SimpleArrayComplex128(array=self.A_c2x2)
+        b = mm.SimpleArrayComplex128(array=self.b_c2x2)
+        x = mm.lu_solve(A, b)
+        np.testing.assert_allclose(
+            np.array(x), self.x_c2x2_expected, rtol=1e-12, atol=1e-14)
+
+    def test_solve_complex64(self):
+        # Complex64 path: same complex system in single precision.
+        A_np = self.A_c2x2.astype(np.complex64)
+        b_np = self.b_c2x2.astype(np.complex64)
+        A = mm.SimpleArrayComplex64(array=A_np)
+        b = mm.SimpleArrayComplex64(array=b_np)
+        x = mm.lu_solve(A, b)
+        np.testing.assert_allclose(
+            np.array(x), self.x_c2x2_expected.astype(np.complex64),
+            rtol=1e-5, atol=1e-5)
+
+    def test_solve_2d_multi_rhs(self):
+        # 2D rhs: each column of B yields an independent solution column in X.
+        B_np = np.array([
+            [5.0, 4.0, 6.0],
+            [-2.0, -10.0, -8.0],
+            [9.0, 3.0, 15.0],
+        ])
+        A = mm.SimpleArrayFloat64(array=self.A_3x3)
+        B = mm.SimpleArrayFloat64(array=B_np)
+        X = mm.lu_solve(A, B)
+        self.assertEqual(X.shape, (3, 3))
+        np.testing.assert_allclose(
+            self.A_3x3 @ np.array(X), B_np, rtol=1e-12, atol=1e-12)
+
+    def test_solve_complex_multi_rhs(self):
+        # 2D complex rhs: exercises multi-column solve on the complex path.
+        B_np = np.column_stack([
+            self.b_c2x2,
+            self.b_c2x2 * (1.0 + 0.5j),
+            self.b_c2x2.conj(),
+        ])
+        A = mm.SimpleArrayComplex128(array=self.A_c2x2)
+        B = mm.SimpleArrayComplex128(array=B_np)
+        X = mm.lu_solve(A, B)
+        self.assertEqual(X.shape, (2, 3))
+        np.testing.assert_allclose(
+            self.A_c2x2 @ np.array(X), B_np, rtol=1e-12, atol=1e-12)
+
+
+class TestLuInv(unittest.TestCase):
+    """Verify lu_inv() against matrices with known inverses."""
+
+    def setUp(self):
+        # A = [[4, 7], [2, 6]]; det = 10; A^-1 = [[0.6, -0.7], [-0.2, 0.4]].
+        self.A_2x2 = np.array([[4.0, 7.0], [2.0, 6.0]])
+        self.A_2x2_inv_expected = np.array([[0.6, -0.7], [-0.2, 0.4]])
+        # A 3x3 diagonal matrix whose inverse is 1/diag.
+        self.A_diag = np.diag([2.0, 4.0, 5.0])
+        self.A_diag_inv_expected = np.diag([0.5, 0.25, 0.2])
+
+    def test_inv_2x2_matches_known_inverse(self):
+        # 2x2 against a hand-computed inverse, also checks output shape.
+        A = mm.SimpleArrayFloat64(array=self.A_2x2)
+        A_inv = mm.lu_inv(A)
+        self.assertEqual(A_inv.shape, (2, 2))
+        np.testing.assert_allclose(
+            np.array(A_inv), self.A_2x2_inv_expected,
+            rtol=1e-12, atol=1e-14)
+
+    def test_inv_diagonal_matches_elementwise_reciprocal(self):
+        # Diagonal matrix: inverse must be elementwise 1/diag.
+        A = mm.SimpleArrayFloat64(array=self.A_diag)
+        A_inv = np.array(mm.lu_inv(A))
+        np.testing.assert_allclose(
+            A_inv, self.A_diag_inv_expected, rtol=1e-12, atol=1e-14)
+
+    def test_inv_of_identity_is_identity(self):
+        # Identity edge case: inv(I) must be I.
+        identity = np.eye(4)
+        A = mm.SimpleArrayFloat64(array=identity)
+        A_inv = np.array(mm.lu_inv(A))
+        np.testing.assert_allclose(A_inv, identity, rtol=1e-12, atol=1e-14)
+
+    def test_inv_times_A_equals_identity(self):
+        # Round-trip identity: checks A @ A_inv and A_inv @ A both equal I.
+        A_np = np.array([
+            [2.0, 1.0, 1.0],
+            [4.0, -6.0, 0.0],
+            [-2.0, 7.0, 2.0],
+        ])
+        A = mm.SimpleArrayFloat64(array=A_np)
+        A_inv = np.array(mm.lu_inv(A))
+        np.testing.assert_allclose(
+            A_np @ A_inv, np.eye(3), rtol=1e-12, atol=1e-12)
+        np.testing.assert_allclose(
+            A_inv @ A_np, np.eye(3), rtol=1e-12, atol=1e-12)
+
+    def test_inv_complex(self):
+        # Complex128 path: verifies A @ A_inv == I for a complex matrix.
+        A_np = np.array([
+            [2.0 + 1.0j, 1.0 - 1.0j],
+            [0.0 + 1.0j, 3.0 + 0.0j],
+        ], dtype=np.complex128)
+        A = mm.SimpleArrayComplex128(array=A_np)
+        A_inv = np.array(mm.lu_inv(A))
+        np.testing.assert_allclose(
+            A_np @ A_inv, np.eye(2, dtype=np.complex128),
+            rtol=1e-12, atol=1e-12)
+
+
+class TestLuSimpleArrayMethods(unittest.TestCase):
+    """Verify .solve()/.inv() work for all floating and complex types and
+    are absent on integer types."""
+
+    # (SimpleArray class, numpy dtype, tolerance)
+    _FLOAT_CASES = [
+        (mm.SimpleArrayFloat32, np.float32, 1e-5),
+        (mm.SimpleArrayFloat64, np.float64, 1e-12),
+        (mm.SimpleArrayComplex64, np.complex64, 1e-5),
+        (mm.SimpleArrayComplex128, np.complex128, 1e-12),
+    ]
+
+    @staticmethod
+    def _build_system(np_dtype):
+        # A = [[4, 7], [2, 6]]; det = 10.  b = [11, 8]  =>  x = [1, 1].
+        A = np.array([[4.0, 7.0], [2.0, 6.0]], dtype=np_dtype)
+        b = np.array([11.0, 8.0], dtype=np_dtype)
+        return A, b
+
+    def test_solve_method_matches_free_function_for_all_dtypes(self):
+        # A.solve(b) must match mm.lu_solve(A, b) across float/complex dtypes.
+        for sa_cls, np_dtype, tol in self._FLOAT_CASES:
+            with self.subTest(cls=sa_cls.__name__):
+                A_np, b_np = self._build_system(np_dtype)
+                A = sa_cls(array=A_np)
+                b = sa_cls(array=b_np)
+                x_free = np.array(mm.lu_solve(A, b))
+                x_method = np.array(A.solve(b))
+                np.testing.assert_allclose(
+                    x_method, x_free, rtol=tol, atol=tol)
+                np.testing.assert_allclose(
+                    A_np @ x_method, b_np, rtol=tol, atol=tol)
+
+    def test_inv_method_matches_free_function_for_all_dtypes(self):
+        # A.inv() must match mm.lu_inv(A) across all float/complex dtypes.
+        for sa_cls, np_dtype, tol in self._FLOAT_CASES:
+            with self.subTest(cls=sa_cls.__name__):
+                A_np, _ = self._build_system(np_dtype)
+                A = sa_cls(array=A_np)
+                inv_free = np.array(mm.lu_inv(A))
+                inv_method = np.array(A.inv())
+                np.testing.assert_allclose(
+                    inv_method, inv_free, rtol=tol, atol=tol)
+                np.testing.assert_allclose(
+                    A_np @ inv_method, np.eye(2, dtype=np_dtype),
+                    rtol=tol, atol=tol)
+
+    def test_solve_inv_absent_on_integer_types(self):
+        # Integer/bool SimpleArrays must not expose .solve()/.inv().
+        int_classes = (
+            mm.SimpleArrayBool,
+            mm.SimpleArrayInt8, mm.SimpleArrayInt16,
+            mm.SimpleArrayInt32, mm.SimpleArrayInt64,
+            mm.SimpleArrayUint8, mm.SimpleArrayUint16,
+            mm.SimpleArrayUint32, mm.SimpleArrayUint64,
+        )
+        for cls in int_classes:
+            with self.subTest(cls=cls.__name__):
+                A = cls([2, 2])
+                self.assertFalse(hasattr(A, 'solve'))
+                self.assertFalse(hasattr(A, 'inv'))
+
+
+class TestLuErrorHandling(unittest.TestCase):
+    """Verify LU routines reject invalid inputs with clear errors."""
+
+    def test_factorize_rejects_non_square(self):
+        # Rectangular 2D input must raise a clear shape error.
+        A_rect = mm.SimpleArrayFloat64(array=np.array([
+            [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+        with self.assertRaisesRegex(
+                ValueError, r"must be a square 2D SimpleArray"):
+            mm.lu_factorization(A_rect)
+
+    def test_factorize_rejects_1d_input(self):
+        # 1D input must raise the same shape error (not silently reshape).
+        A_1d = mm.SimpleArrayFloat64(array=np.array([1.0, 2.0, 3.0]))
+        with self.assertRaisesRegex(
+                ValueError, r"must be a square 2D SimpleArray"):
+            mm.lu_factorization(A_1d)
+
+    def test_factorize_rejects_singular_duplicate_row(self):
+        # Singular matrix (duplicate row) must raise the singular error.
+        A_sing = np.array([
+            [1.0, 2.0, 3.0],
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+        ])
+        A = mm.SimpleArrayFloat64(array=A_sing)
+        with self.assertRaisesRegex(
+                RuntimeError, r"singular or near-singular"):
+            mm.lu_factorization(A)
+
+    def test_solve_rejects_non_square_A(self):
+        # lu_solve must reject rectangular A with the same shape error.
+        A_rect = mm.SimpleArrayFloat64(array=np.array([
+            [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+        b = mm.SimpleArrayFloat64(array=np.array([1.0, 2.0]))
+        with self.assertRaisesRegex(
+                ValueError, r"must be a square 2D SimpleArray"):
+            mm.lu_solve(A_rect, b)
+
+    def test_solve_rejects_1d_dimension_mismatch(self):
+        # 1D rhs length must match A's dimension; otherwise raise.
+        A = mm.SimpleArrayFloat64(array=np.array([[1.0, 2.0], [3.0, 4.0]]))
+        b_wrong = mm.SimpleArrayFloat64(array=np.array([1.0, 2.0, 3.0]))
+        with self.assertRaisesRegex(ValueError, r"dimension mismatch"):
+            mm.lu_solve(A, b_wrong)
+
+    def test_solve_rejects_2d_dimension_mismatch(self):
+        # 2D rhs row-count must match A's dimension; otherwise raise.
+        A = mm.SimpleArrayFloat64(array=np.array([[1.0, 2.0], [3.0, 4.0]]))
+        B_wrong = mm.SimpleArrayFloat64(array=np.array([
+            [1.0, 2.0], [3.0, 4.0], [5.0, 6.0],
+        ]))
+        with self.assertRaisesRegex(ValueError, r"dimension mismatch"):
+            mm.lu_solve(A, B_wrong)
+
+    def test_solve_rejects_3d_rhs(self):
+        # rhs must be 1D or 2D; 3D input must raise.
+        A = mm.SimpleArrayFloat64(array=np.array([[1.0, 2.0], [3.0, 4.0]]))
+        b_3d = mm.SimpleArrayFloat64(array=np.array(
+            [[[1.0], [2.0]], [[3.0], [4.0]]]))
+        with self.assertRaisesRegex(ValueError, r"b must be 1D or 2D"):
+            mm.lu_solve(A, b_3d)
+
+    def test_solve_rejects_singular(self):
+        # Singular A must cause lu_solve to raise rather than return garbage.
+        A_sing = np.array([
+            [1.0, 2.0, 3.0],
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+        ])
+        A = mm.SimpleArrayFloat64(array=A_sing)
+        b = mm.SimpleArrayFloat64(array=np.array([1.0, 2.0, 3.0]))
+        with self.assertRaises(RuntimeError):
+            mm.lu_solve(A, b)
+
+    def test_inv_rejects_non_square(self):
+        # lu_inv must reject rectangular input with the same shape error.
+        A_rect = mm.SimpleArrayFloat64(array=np.array([
+            [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+        with self.assertRaisesRegex(
+                ValueError, r"must be a square 2D SimpleArray"):
+            mm.lu_inv(A_rect)
+
+    def test_inv_rejects_singular(self):
+        # Singular A must cause lu_inv to raise rather than return garbage.
+        A_sing = np.array([
+            [1.0, 2.0, 3.0],
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+        ])
+        A = mm.SimpleArrayFloat64(array=A_sing)
+        with self.assertRaises(RuntimeError):
+            mm.lu_inv(A)
+
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -758,4 +758,451 @@ class KalmanFilterBatchFilterTC(unittest.TestCase):
         np.testing.assert_allclose(xs_upd, xs_upd_np, atol=1e-12, rtol=0.0)
         np.testing.assert_allclose(ps_upd, ps_upd_np, atol=1e-12, rtol=0.0)
 
+
+def _assert_PA_equals_LU(A_np, lu_np, piv, rtol, atol):
+    """Assert PA == L @ U for Lu::factorize output.
+
+    Lu::factorize stores L in the strictly lower triangle (unit diagonal)
+    and U in the upper triangle (including diagonal) of a single array.
+    piv[k] is the row swapped with row k at step k; swaps are replayed
+    sequentially from k = 0 to k = n - 1.
+    """
+    n = A_np.shape[0]
+    L = np.eye(n, dtype=lu_np.dtype)
+    U = np.zeros_like(lu_np)
+    for i in range(n):
+        for j in range(n):
+            if i > j:
+                L[i, j] = lu_np[i, j]
+            else:
+                U[i, j] = lu_np[i, j]
+    PA = A_np.astype(lu_np.dtype, copy=True)
+    for k in range(n):
+        if piv[k] != k:
+            PA[[k, piv[k]]] = PA[[piv[k], k]]
+    np.testing.assert_allclose(L @ U, PA, rtol=rtol, atol=atol)
+
+
+class TestLuFactorization(unittest.TestCase):
+    """Verify lu_factorization() produces a decomposition with PA = LU."""
+
+    def setUp(self):
+        # 3x3 invertible matrix with no zero pivots.
+        self.A_3x3 = np.array([
+            [2.0, 1.0, 1.0],
+            [4.0, -6.0, 0.0],
+            [-2.0, 7.0, 2.0],
+        ], dtype="float64")
+        # 4x4 whose leading element is not the column-max, so partial
+        # pivoting must trigger.
+        self.A_4x4 = np.array([
+            [1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 8.0, 8.0],
+            [9.0, 10.0, 11.0, 16.0],
+            [13.0, 15.0, 16.0, 17.0],
+        ], dtype="float64")
+        # 3x3 whose A[0][0] is negligibly small; a correct implementation
+        # must pivot away from it.
+        self.A_tiny_pivot = np.array([
+            [1e-15, 1.0, 0.0],
+            [1.0, 1.0, 1.0],
+            [0.0, 1.0, 2.0],
+        ], dtype="float64")
+        # 3x3 complex matrix to exercise Lu<T> instantiated for
+        # Complex<double>.
+        self.A_complex_3x3 = np.array([
+            [2.0 + 1.0j, 1.0 + 0.0j, 3.0 - 1.0j],
+            [4.0 + 0.0j, -1.0 + 2.0j, 1.0 + 1.0j],
+            [1.0 - 1.0j, 5.0 + 0.0j, 2.0 + 3.0j],
+        ], dtype="complex128")
+
+    def test_factorize_3x3_reconstructs_PA(self):
+        # Baseline: well-conditioned 3x3, also checks output shape/piv length.
+        A = mm.SimpleArrayFloat64(array=self.A_3x3)
+        lu, piv = mm.lu_factorization(A)
+        lu_np = np.array(lu)
+        self.assertEqual(lu_np.shape, (3, 3))
+        self.assertEqual(len(piv), 3)
+        _assert_PA_equals_LU(self.A_3x3, lu_np, piv, rtol=1e-12, atol=1e-14)
+
+    def test_factorize_4x4_reconstructs_PA(self):
+        # Larger 4x4 where partial pivoting must trigger on the first column.
+        A = mm.SimpleArrayFloat64(array=self.A_4x4)
+        lu, piv = mm.lu_factorization(A)
+        lu_np = np.array(lu)
+        _assert_PA_equals_LU(self.A_4x4, lu_np, piv, rtol=1e-12, atol=1e-12)
+
+    def test_factorize_complex_3x3_reconstructs_PA(self):
+        # Complex128 path: exercises the complex template instantiation.
+        A = mm.SimpleArrayComplex128(array=self.A_complex_3x3)
+        lu, piv = mm.lu_factorization(A)
+        lu_np = np.array(lu)
+        _assert_PA_equals_LU(
+            self.A_complex_3x3, lu_np, piv, rtol=1e-12, atol=1e-12)
+
+    def test_factorize_pivots_away_from_tiny_diagonal(self):
+        # Numerical stability: A[0][0] ~ 1e-15 forces a row swap at step 0.
+        A = mm.SimpleArrayFloat64(array=self.A_tiny_pivot)
+        lu, piv = mm.lu_factorization(A)
+        # With A[0][0] ~ 1e-15 and A[1][0] = 1.0, partial pivoting must
+        # swap row 0 with a later row.
+        self.assertNotEqual(piv[0], 0)
+        lu_np = np.array(lu)
+        _assert_PA_equals_LU(
+            self.A_tiny_pivot, lu_np, piv, rtol=1e-10, atol=1e-10)
+
+    def test_factorize_float32_reconstructs_PA(self):
+        # Float32 path: same input as 3x3 case but in single precision.
+        A_np = self.A_3x3.astype(np.float32)
+        A = mm.SimpleArrayFloat32(array=A_np)
+        lu, piv = mm.lu_factorization(A)
+        lu_np = np.array(lu)
+        _assert_PA_equals_LU(A_np, lu_np, piv, rtol=1e-5, atol=1e-5)
+
+
+class TestLuSolve(unittest.TestCase):
+    """Verify lu_solve() against explicit systems with known solutions."""
+
+    def setUp(self):
+        # 2x2: [[2, 3], [4, 7]] x = [5, 11]  =>  x = [1, 1]
+        self.A_2x2 = np.array([[2.0, 3.0], [4.0, 7.0]], dtype="float64")
+        self.b_2x2 = np.array([5.0, 11.0], dtype="float64")
+        self.x_2x2_expected = np.array([1.0, 1.0], dtype="float64")
+
+        # 3x3 system with known exact solution x = [1, 1, 2].
+        self.A_3x3 = np.array([
+            [2.0, 1.0, 1.0],
+            [4.0, -6.0, 0.0],
+            [-2.0, 7.0, 2.0],
+        ], dtype="float64")
+        self.b_3x3 = np.array([5.0, -2.0, 9.0], dtype="float64")
+        self.x_3x3_expected = np.array([1.0, 1.0, 2.0], dtype="float64")
+
+        # 2x2 complex: (2 + j)x + (1 - j)y = 4 + 3j, jx + 3y = 6 + j
+        # Chosen so x = [1 + j, 2] is exact.
+        self.A_c2x2 = np.array([
+            [2.0 + 1.0j, 1.0 - 1.0j],
+            [0.0 + 1.0j, 3.0 + 0.0j],
+        ], dtype="complex128")
+        self.x_c2x2_expected = np.array([1.0 + 1.0j, 2.0], dtype="complex128")
+        self.b_c2x2 = self.A_c2x2 @ self.x_c2x2_expected
+
+    def test_solve_2x2_matches_known_solution(self):
+        # Smallest case: 2x2 with 1D rhs, also checks output shape.
+        A = mm.SimpleArrayFloat64(array=self.A_2x2)
+        b = mm.SimpleArrayFloat64(array=self.b_2x2)
+        x = mm.lu_solve(A, b)
+        self.assertEqual(x.shape, (2,))
+        np.testing.assert_allclose(
+            np.array(x), self.x_2x2_expected, rtol=1e-12, atol=1e-14)
+
+    def test_solve_3x3_matches_known_solution(self):
+        # 3x3 with 1D rhs against a precomputed exact solution.
+        A = mm.SimpleArrayFloat64(array=self.A_3x3)
+        b = mm.SimpleArrayFloat64(array=self.b_3x3)
+        x = mm.lu_solve(A, b)
+        self.assertEqual(x.shape, (3,))
+        np.testing.assert_allclose(
+            np.array(x), self.x_3x3_expected, rtol=1e-12, atol=1e-14)
+
+    def test_solve_float32(self):
+        # Float32 path: same 3x3 system in single precision.
+        A = mm.SimpleArrayFloat32(array=self.A_3x3.astype(np.float32))
+        b = mm.SimpleArrayFloat32(array=self.b_3x3.astype(np.float32))
+        x = mm.lu_solve(A, b)
+        np.testing.assert_allclose(
+            np.array(x), self.x_3x3_expected.astype(np.float32),
+            rtol=1e-5, atol=1e-5)
+
+    def test_solve_complex128_matches_known_solution(self):
+        # Complex128 path with a known exact complex solution.
+        A = mm.SimpleArrayComplex128(array=self.A_c2x2)
+        b = mm.SimpleArrayComplex128(array=self.b_c2x2)
+        x = mm.lu_solve(A, b)
+        np.testing.assert_allclose(
+            np.array(x), self.x_c2x2_expected, rtol=1e-12, atol=1e-14)
+
+    def test_solve_complex64(self):
+        # Complex64 path: same complex system in single precision.
+        A_np = self.A_c2x2.astype(np.complex64)
+        b_np = self.b_c2x2.astype(np.complex64)
+        A = mm.SimpleArrayComplex64(array=A_np)
+        b = mm.SimpleArrayComplex64(array=b_np)
+        x = mm.lu_solve(A, b)
+        np.testing.assert_allclose(
+            np.array(x), self.x_c2x2_expected.astype(np.complex64),
+            rtol=1e-5, atol=1e-5)
+
+    def test_solve_2d_multi_rhs(self):
+        # 2D rhs: each column of B yields an independent solution column in X.
+        B_np = np.array([
+            [5.0, 4.0, 6.0],
+            [-2.0, -10.0, -8.0],
+            [9.0, 3.0, 15.0],
+        ], dtype="float64")
+        A = mm.SimpleArrayFloat64(array=self.A_3x3)
+        B = mm.SimpleArrayFloat64(array=B_np)
+        X = mm.lu_solve(A, B)
+        self.assertEqual(X.shape, (3, 3))
+        # Verify A @ X == B column-by-column.
+        np.testing.assert_allclose(
+            self.A_3x3 @ np.array(X), B_np, rtol=1e-12, atol=1e-12)
+
+    def test_solve_complex_multi_rhs(self):
+        # 2D complex rhs: exercises multi-column solve on the complex path.
+        B_np = np.column_stack([
+            self.b_c2x2,
+            self.b_c2x2 * (1.0 + 0.5j),
+            self.b_c2x2.conj(),
+        ])
+        A = mm.SimpleArrayComplex128(array=self.A_c2x2)
+        B = mm.SimpleArrayComplex128(array=B_np)
+        X = mm.lu_solve(A, B)
+        self.assertEqual(X.shape, (2, 3))
+        np.testing.assert_allclose(
+            self.A_c2x2 @ np.array(X), B_np, rtol=1e-12, atol=1e-12)
+
+
+class TestLuInv(unittest.TestCase):
+    """Verify lu_inv() against matrices with known inverses."""
+
+    def setUp(self):
+        # A = [[4, 7], [2, 6]]; det = 10; A^-1 = [[0.6, -0.7], [-0.2, 0.4]].
+        self.A_2x2 = np.array([[4.0, 7.0], [2.0, 6.0]], dtype="float64")
+        self.A_2x2_inv_expected = np.array(
+            [[0.6, -0.7], [-0.2, 0.4]], dtype="float64")
+        # A 3x3 diagonal matrix whose inverse is 1/diag.
+        self.A_diag = np.diag(np.array([2.0, 4.0, 5.0], dtype="float64"))
+        self.A_diag_inv_expected = np.diag(
+            np.array([0.5, 0.25, 0.2], dtype="float64"))
+
+    def test_inv_2x2_matches_known_inverse(self):
+        # 2x2 against a hand-computed inverse, also checks output shape.
+        A = mm.SimpleArrayFloat64(array=self.A_2x2)
+        A_inv = mm.lu_inv(A)
+        self.assertEqual(A_inv.shape, (2, 2))
+        np.testing.assert_allclose(
+            np.array(A_inv), self.A_2x2_inv_expected,
+            rtol=1e-12, atol=1e-14)
+
+    def test_inv_diagonal_matches_elementwise_reciprocal(self):
+        # Diagonal matrix: inverse must be elementwise 1/diag.
+        A = mm.SimpleArrayFloat64(array=self.A_diag)
+        A_inv = np.array(mm.lu_inv(A))
+        np.testing.assert_allclose(
+            A_inv, self.A_diag_inv_expected, rtol=1e-12, atol=1e-14)
+
+    def test_inv_of_identity_is_identity(self):
+        # Identity edge case: inv(I) must be I.
+        identity = np.eye(4)
+        A = mm.SimpleArrayFloat64(array=identity)
+        A_inv = np.array(mm.lu_inv(A))
+        np.testing.assert_allclose(A_inv, identity, rtol=1e-12, atol=1e-14)
+
+    def test_inv_times_A_equals_identity(self):
+        # Round-trip identity: checks A @ A_inv and A_inv @ A both equal I.
+        A_np = np.array([
+            [2.0, 1.0, 1.0],
+            [4.0, -6.0, 0.0],
+            [-2.0, 7.0, 2.0],
+        ], dtype="float64")
+        A = mm.SimpleArrayFloat64(array=A_np)
+        A_inv = np.array(mm.lu_inv(A))
+        np.testing.assert_allclose(
+            A_np @ A_inv, np.eye(3), rtol=1e-12, atol=1e-12)
+        np.testing.assert_allclose(
+            A_inv @ A_np, np.eye(3), rtol=1e-12, atol=1e-12)
+
+    def test_inv_complex(self):
+        # Complex128 path: verifies A @ A_inv == I for a complex matrix.
+        A_np = np.array([
+            [2.0 + 1.0j, 1.0 - 1.0j],
+            [0.0 + 1.0j, 3.0 + 0.0j],
+        ], dtype="complex128")
+        A = mm.SimpleArrayComplex128(array=A_np)
+        A_inv = np.array(mm.lu_inv(A))
+        np.testing.assert_allclose(
+            A_np @ A_inv, np.eye(2, dtype="complex128"),
+            rtol=1e-12, atol=1e-12)
+
+
+class TestLuSimpleArrayMethods(unittest.TestCase):
+    """Verify .solve()/.inv() work for all floating and complex types and
+    are absent on integer types."""
+
+    # (SimpleArray class, numpy dtype, tolerance)
+    _FLOAT_CASES = [
+        (mm.SimpleArrayFloat32, np.float32, 1e-5),
+        (mm.SimpleArrayFloat64, np.float64, 1e-12),
+        (mm.SimpleArrayComplex64, np.complex64, 1e-5),
+        (mm.SimpleArrayComplex128, np.complex128, 1e-12),
+    ]
+
+    @staticmethod
+    def _build_system(np_dtype):
+        # A = [[4, 7], [2, 6]]; det = 10.  b = [11, 8]  =>  x = [1, 1].
+        A = np.array([[4.0, 7.0], [2.0, 6.0]], dtype=np_dtype)
+        b = np.array([11.0, 8.0], dtype=np_dtype)
+        return A, b
+
+    def test_solve_method_matches_free_function_for_all_dtypes(self):
+        # A.solve(b) must match mm.lu_solve(A, b) across float/complex dtypes.
+        for sa_cls, np_dtype, tol in self._FLOAT_CASES:
+            with self.subTest(cls=sa_cls.__name__):
+                A_np, b_np = self._build_system(np_dtype)
+                A = sa_cls(array=A_np)
+                b = sa_cls(array=b_np)
+                x_free = np.array(mm.lu_solve(A, b))
+                x_method = np.array(A.solve(b))
+                np.testing.assert_allclose(
+                    x_method, x_free, rtol=tol, atol=tol)
+                np.testing.assert_allclose(
+                    A_np @ x_method, b_np, rtol=tol, atol=tol)
+
+    def test_inv_method_matches_free_function_for_all_dtypes(self):
+        # A.inv() must match mm.lu_inv(A) across all float/complex dtypes.
+        for sa_cls, np_dtype, tol in self._FLOAT_CASES:
+            with self.subTest(cls=sa_cls.__name__):
+                A_np, _ = self._build_system(np_dtype)
+                A = sa_cls(array=A_np)
+                inv_free = np.array(mm.lu_inv(A))
+                inv_method = np.array(A.inv())
+                np.testing.assert_allclose(
+                    inv_method, inv_free, rtol=tol, atol=tol)
+                np.testing.assert_allclose(
+                    A_np @ inv_method, np.eye(2, dtype=np_dtype),
+                    rtol=tol, atol=tol)
+
+    def test_solve_inv_absent_on_integer_types(self):
+        # Integer/bool SimpleArrays must not expose .solve()/.inv().
+        int_classes = (
+            mm.SimpleArrayBool,
+            mm.SimpleArrayInt8, mm.SimpleArrayInt16,
+            mm.SimpleArrayInt32, mm.SimpleArrayInt64,
+            mm.SimpleArrayUint8, mm.SimpleArrayUint16,
+            mm.SimpleArrayUint32, mm.SimpleArrayUint64,
+        )
+        for cls in int_classes:
+            with self.subTest(cls=cls.__name__):
+                A = cls([2, 2])
+                self.assertFalse(hasattr(A, 'solve'))
+                self.assertFalse(hasattr(A, 'inv'))
+
+
+class TestLuErrorHandling(unittest.TestCase):
+    """Verify LU routines reject invalid inputs with clear errors."""
+
+    def test_factorize_rejects_non_square(self):
+        # Rectangular 2D input must raise a clear shape error.
+        A_rect = mm.SimpleArrayFloat64(array=np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float64"))
+        with self.assertRaisesRegex(
+                ValueError, r"must be a square 2D SimpleArray"):
+            mm.lu_factorization(A_rect)
+
+    def test_factorize_rejects_1d_input(self):
+        # 1D input must raise the same shape error (not silently reshape).
+        A_1d = mm.SimpleArrayFloat64(array=np.array(
+            [1.0, 2.0, 3.0], dtype="float64"))
+        with self.assertRaisesRegex(
+                ValueError, r"must be a square 2D SimpleArray"):
+            mm.lu_factorization(A_1d)
+
+    def test_factorize_rejects_singular_duplicate_row(self):
+        # Singular matrix (duplicate row) must raise the singular error.
+        A_sing = np.array([
+            [1.0, 2.0, 3.0],
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+        ], dtype="float64")
+        A = mm.SimpleArrayFloat64(array=A_sing)
+        with self.assertRaisesRegex(
+                RuntimeError, r"singular or near-singular"):
+            mm.lu_factorization(A)
+
+    def test_factorize_rejects_near_singular_tiny_eigenvalue(self):
+        # A = v v^T + eps * I for v = [1, 1] has eigenvalues {2 + eps, eps}.
+        # With eps = 1e-15 the smaller eigenvalue is tiny but nonzero, unlike
+        # the duplicate-row test above where an eigenvalue is exactly zero.
+        eps = 1e-15
+        A_near_sing = np.array([
+            [1.0 + eps, 1.0],
+            [1.0, 1.0 + eps],
+        ], dtype="float64")
+        A = mm.SimpleArrayFloat64(array=A_near_sing)
+        with self.assertRaisesRegex(
+                RuntimeError, r"singular or near-singular"):
+            mm.lu_factorization(A)
+
+    def test_solve_rejects_non_square_A(self):
+        # lu_solve must reject rectangular A with the same shape error.
+        A_rect = mm.SimpleArrayFloat64(array=np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float64"))
+        b = mm.SimpleArrayFloat64(array=np.array(
+            [1.0, 2.0], dtype="float64"))
+        with self.assertRaisesRegex(
+                ValueError, r"must be a square 2D SimpleArray"):
+            mm.lu_solve(A_rect, b)
+
+    def test_solve_rejects_1d_dimension_mismatch(self):
+        # 1D rhs length must match A's dimension; otherwise raise.
+        A = mm.SimpleArrayFloat64(array=np.array(
+            [[1.0, 2.0], [3.0, 4.0]], dtype="float64"))
+        b_wrong = mm.SimpleArrayFloat64(array=np.array(
+            [1.0, 2.0, 3.0], dtype="float64"))
+        with self.assertRaisesRegex(ValueError, r"dimension mismatch"):
+            mm.lu_solve(A, b_wrong)
+
+    def test_solve_rejects_2d_dimension_mismatch(self):
+        # 2D rhs row-count must match A's dimension; otherwise raise.
+        A = mm.SimpleArrayFloat64(array=np.array(
+            [[1.0, 2.0], [3.0, 4.0]], dtype="float64"))
+        B_wrong = mm.SimpleArrayFloat64(array=np.array([
+            [1.0, 2.0], [3.0, 4.0], [5.0, 6.0],
+        ], dtype="float64"))
+        with self.assertRaisesRegex(ValueError, r"dimension mismatch"):
+            mm.lu_solve(A, B_wrong)
+
+    def test_solve_rejects_3d_rhs(self):
+        # rhs must be 1D or 2D; 3D input must raise.
+        A = mm.SimpleArrayFloat64(array=np.array(
+            [[1.0, 2.0], [3.0, 4.0]], dtype="float64"))
+        b_3d = mm.SimpleArrayFloat64(array=np.array(
+            [[[1.0], [2.0]], [[3.0], [4.0]]], dtype="float64"))
+        with self.assertRaisesRegex(ValueError, r"b must be 1D or 2D"):
+            mm.lu_solve(A, b_3d)
+
+    def test_solve_rejects_singular(self):
+        # Singular A must cause lu_solve to raise rather than return garbage.
+        A_sing = np.array([
+            [1.0, 2.0, 3.0],
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+        ], dtype="float64")
+        A = mm.SimpleArrayFloat64(array=A_sing)
+        b = mm.SimpleArrayFloat64(array=np.array(
+            [1.0, 2.0, 3.0], dtype="float64"))
+        with self.assertRaises(RuntimeError):
+            mm.lu_solve(A, b)
+
+    def test_inv_rejects_non_square(self):
+        # lu_inv must reject rectangular input with the same shape error.
+        A_rect = mm.SimpleArrayFloat64(array=np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float64"))
+        with self.assertRaisesRegex(
+                ValueError, r"must be a square 2D SimpleArray"):
+            mm.lu_inv(A_rect)
+
+    def test_inv_rejects_singular(self):
+        # Singular A must cause lu_inv to raise rather than return garbage.
+        A_sing = np.array([
+            [1.0, 2.0, 3.0],
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+        ], dtype="float64")
+        A = mm.SimpleArrayFloat64(array=A_sing)
+        with self.assertRaises(RuntimeError):
+            mm.lu_inv(A)
+
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
## Summary
- Implement LU factorization with partial pivoting (PA=LU) for general (non-symmetric) matrices in `cpp/modmesh/linalg/lu_factorization.hpp`
- Add `lu_factorization()`, `lu_solve()`, and `lu_inv()` free functions with Python bindings for float32, float64, complex64, and complex128 types
- Add `.solve(b)` and `.inv()` convenience methods on `SimpleArray` for floating-point and complex types (integer arrays excluded)

## Test plan
- [x] `test_lu_solve_and_inv_dtypes`: parametric test across all 4 supported dtypes (float64, float32, complex128, complex64) verifying solve and inverse
- [x] `test_lu_solve_2d_rhs`: multi-RHS solve with 5×5 matrix and 5×4 RHS (n,m both > 3)
- [x] `test_lu_singular`: singular matrix raises `RuntimeError`
- [x] `test_lu_invalid_inputs`: non-square, 1D, dimension mismatch, wrong rank all raise `ValueError`
- [x] `test_simplearray_int_no_solve_inv`: integer SimpleArray does not expose solve/inv
- [x] All 35 tests pass (`pytest tests/test_linalg.py`)

## Document

Please also check the [Markdown file](https://gist.github.com/tigercosmos/4ff723582f5707e213ccc4d2cfe31a31) (gist) for detailed explanation of the math and code.

The PR is part of https://github.com/solvcon/modmesh/issues/719.