### PR TITLE
Accelerate mean() with a dedicated fast sum() path

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -165,6 +165,115 @@ struct select_real_t<Complex<U>>
 };
 
 template <typename A, typename T>
+class SimpleArrayMixinSum
+{
+
+private:
+
+    using internal_types = detail::SimpleArrayInternalTypes<T>;
+
+public:
+
+    using value_type = typename internal_types::value_type;
+
+    value_type sum() const
+    {
+        auto athis = static_cast<A const *>(this);
+        const size_t n = athis->size();
+        if (n == 0)
+        {
+            return zero();
+        }
+        if (athis->is_c_contiguous())
+        {
+            return sum_contiguous(athis->data(), n);
+        }
+        return sum_strided(athis->data(), athis->shape(), athis->stride());
+    }
+
+private:
+
+    static constexpr value_type zero()
+    {
+        if constexpr (is_complex_v<value_type>)
+        {
+            return value_type{};
+        }
+        else
+        {
+            return value_type{0};
+        }
+    }
+
+    static void accumulate(value_type & acc, value_type v)
+    {
+        if constexpr (std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            acc |= v;
+        }
+        else
+        {
+            acc += v;
+        }
+    }
+
+    static value_type sum_contiguous(value_type const * data, size_t n)
+    {
+        value_type acc = zero();
+        for (size_t i = 0; i < n; ++i)
+        {
+            accumulate(acc, data[i]);
+        }
+        return acc;
+    }
+
+    // Walk a strided array by its innermost dimension: compute the row base
+    // offset once per outer iteration, then accumulate along the last axis.
+    // This avoids the per-element multi-dimensional index arithmetic that
+    // at(sidx) performs.
+    static value_type sum_strided(value_type const * data,
+                                  small_vector<size_t> const & shape,
+                                  small_vector<size_t> const & stride)
+    {
+        const size_t ndim = shape.size();
+        const size_t last_dim = shape[ndim - 1];
+        const size_t last_stride = stride[ndim - 1];
+
+        value_type acc = zero();
+        small_vector<size_t> prefix(ndim - 1, 0);
+        do
+        {
+            size_t offset = 0;
+            for (size_t i = 0; i + 1 < ndim; ++i)
+            {
+                offset += prefix[i] * stride[i];
+            }
+            value_type const * row = data + offset;
+            for (size_t j = 0; j < last_dim; ++j)
+            {
+                accumulate(acc, row[j * last_stride]);
+            }
+        } while (next_prefix(prefix, shape));
+        return acc;
+    }
+
+    static bool next_prefix(small_vector<size_t> & idx,
+                            small_vector<size_t> const & shape)
+    {
+        for (size_t i = idx.size(); i > 0; --i)
+        {
+            if (++idx[i - 1] < shape[i - 1])
+            {
+                return true;
+            }
+            idx[i - 1] = 0;
+        }
+        return false;
+    }
+
+}; /* end class SimpleArrayMixinSum */
+
+template <typename A, typename T>
 class SimpleArrayMixinCalculators
 {
 
@@ -365,15 +474,12 @@ public:
     value_type mean() const
     {
         auto athis = static_cast<A const *>(this);
-        auto sidx = athis->first_sidx();
-        value_type sum = 0;
-        int64_t total = 0;
-        do
+        const size_t n = athis->size();
+        if (n == 0)
         {
-            sum += athis->at(sidx);
-            ++total;
-        } while (athis->next_sidx(sidx));
-        return sum / static_cast<value_type>(total);
+            throw std::runtime_error("SimpleArray::mean(): empty array");
+        }
+        return athis->sum() / static_cast<value_type>(n);
     }
 
     real_type var_op(small_vector<value_type> & sv, size_t ddof) const
@@ -483,36 +589,6 @@ public:
             if (athis->data(i) > initial)
             {
                 initial = athis->data(i);
-            }
-        }
-        return initial;
-    }
-
-    value_type sum() const
-    {
-        value_type initial;
-        if constexpr (is_complex_v<value_type>)
-        {
-            initial = value_type();
-        }
-        else
-        {
-            initial = 0;
-        }
-
-        auto athis = static_cast<A const *>(this);
-        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
-        {
-            for (size_t i = 0; i < athis->size(); ++i)
-            {
-                initial += athis->data(i);
-            }
-        }
-        else
-        {
-            for (size_t i = 0; i < athis->size(); ++i)
-            {
-                initial |= athis->data(i);
             }
         }
         return initial;
@@ -1382,6 +1458,7 @@ struct with_alignment_t
 template <typename T>
 class SimpleArray
     : public detail::SimpleArrayMixinModifiers<SimpleArray<T>, T>
+    , public detail::SimpleArrayMixinSum<SimpleArray<T>, T>
     , public detail::SimpleArrayMixinCalculators<SimpleArray<T>, T>
     , public detail::SimpleArrayMixinSort<SimpleArray<T>, T>
     , public detail::SimpleArrayMixinSearch<SimpleArray<T>, T>
@@ -1877,20 +1954,32 @@ public:
     value_type const * body() const { return m_body; }
     value_type * body() { return m_body; }
 
+    bool is_c_contiguous() const { return is_c_contiguous(m_shape, m_stride); }
+
 private:
-    void check_c_contiguous(small_vector<size_t> const & shape,
-                            small_vector<size_t> const & stride) const
+    static bool is_c_contiguous(small_vector<size_t> const & shape,
+                                small_vector<size_t> const & stride)
     {
         if (stride[stride.size() - 1] != 1)
         {
-            throw std::runtime_error("SimpleArray: C contiguous stride must end with 1");
+            return false;
         }
         for (size_t it = 0; it < shape.size() - 1; ++it)
         {
             if (stride[it] != shape[it + 1] * stride[it + 1])
             {
-                throw std::runtime_error("SimpleArray: C contiguous stride must match shape");
+                return false;
             }
+        }
+        return true;
+    }
+
+    static void check_c_contiguous(small_vector<size_t> const & shape,
+                                   small_vector<size_t> const & stride)
+    {
+        if (!is_c_contiguous(shape, stride))
+        {
+            throw std::runtime_error("SimpleArray: C contiguous stride must match shape and end with 1");
         }
     }
 

--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -165,6 +165,118 @@ struct select_real_t<Complex<U>>
 };
 
 template <typename A, typename T>
+class SimpleArrayMixinSum
+{
+
+private:
+
+    using internal_types = detail::SimpleArrayInternalTypes<T>;
+
+public:
+
+    using value_type = typename internal_types::value_type;
+
+    value_type sum() const
+    {
+        auto athis = static_cast<A const *>(this);
+        const size_t n = athis->size();
+        if (n == 0)
+        {
+            return zero();
+        }
+        // Either C- or F-contiguous arrays occupy a single dense block in
+        // memory, so a linear buffer sweep visits every element exactly
+        // once, in C order or F order respectively.
+        if (athis->is_c_contiguous() || athis->is_f_contiguous())
+        {
+            return sum_contiguous(athis->data(), n);
+        }
+        return sum_strided(athis->data(), athis->shape(), athis->stride());
+    }
+
+private:
+
+    static constexpr value_type zero()
+    {
+        if constexpr (is_complex_v<value_type>)
+        {
+            return value_type{};
+        }
+        else
+        {
+            return value_type{0};
+        }
+    }
+
+    static void accumulate(value_type & acc, value_type v)
+    {
+        if constexpr (std::is_same_v<bool, std::remove_const_t<value_type>>)
+        {
+            acc |= v;
+        }
+        else
+        {
+            acc += v;
+        }
+    }
+
+    static value_type sum_contiguous(value_type const * data, size_t n)
+    {
+        value_type acc = zero();
+        for (size_t i = 0; i < n; ++i)
+        {
+            accumulate(acc, data[i]);
+        }
+        return acc;
+    }
+
+    // Walk a strided array by its innermost dimension: compute the row base
+    // offset once per outer iteration, then accumulate along the last axis.
+    // This avoids the per-element multi-dimensional index arithmetic that
+    // at(sidx) performs.
+    static value_type sum_strided(value_type const * data,
+                                  small_vector<size_t> const & shape,
+                                  small_vector<size_t> const & stride)
+    {
+        const size_t ndim = shape.size();
+        const size_t last_dim = shape[ndim - 1];
+        const size_t last_stride = stride[ndim - 1];
+
+        value_type acc = zero();
+        small_vector<size_t> prefix(ndim - 1, 0);
+        do
+        {
+            size_t offset = 0;
+            for (size_t i = 0; i + 1 < ndim; ++i)
+            {
+                offset += prefix[i] * stride[i];
+            }
+            value_type const * row = data + offset;
+            for (size_t j = 0; j < last_dim; ++j)
+            {
+                accumulate(acc, row[j * last_stride]);
+            }
+        } while (next_prefix(prefix, shape));
+        return acc;
+    }
+
+    static bool next_prefix(small_vector<size_t> & idx,
+                            small_vector<size_t> const & shape)
+    {
+        for (size_t i = idx.size(); i > 0; --i)
+        {
+            if (++idx[i - 1] < shape[i - 1])
+            {
+                return true;
+            }
+            idx[i - 1] = 0;
+        }
+        return false;
+    }
+
+}; /* end class SimpleArrayMixinSum */
+
+template <typename A, typename T>
 class SimpleArrayMixinCalculators
 {
 
@@ -365,15 +477,12 @@ public:
     value_type mean() const
     {
         auto athis = static_cast<A const *>(this);
-        auto sidx = athis->first_sidx();
-        value_type sum = 0;
-        int64_t total = 0;
-        do
+        const size_t n = athis->size();
+        if (n == 0)
         {
-            sum += athis->at(sidx);
-            ++total;
-        } while (athis->next_sidx(sidx));
-        return sum / static_cast<value_type>(total);
+            throw std::runtime_error("SimpleArray::mean(): empty array");
+        }
+        return athis->sum() / static_cast<value_type>(n);
     }
 
     real_type var_op(small_vector<value_type> & sv, size_t ddof) const
@@ -483,36 +592,6 @@ public:
             if (athis->data(i) > initial)
             {
                 initial = athis->data(i);
-            }
-        }
-        return initial;
-    }
-
-    value_type sum() const
-    {
-        value_type initial;
-        if constexpr (is_complex_v<value_type>)
-        {
-            initial = value_type();
-        }
-        else
-        {
-            initial = 0;
-        }
-
-        auto athis = static_cast<A const *>(this);
-        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
-        {
-            for (size_t i = 0; i < athis->size(); ++i)
-            {
-                initial += athis->data(i);
-            }
-        }
-        else
-        {
-            for (size_t i = 0; i < athis->size(); ++i)
-            {
-                initial |= athis->data(i);
             }
         }
         return initial;
@@ -1382,6 +1461,7 @@ struct with_alignment_t
 template <typename T>
 class SimpleArray
     : public detail::SimpleArrayMixinModifiers<SimpleArray<T>, T>
+    , public detail::SimpleArrayMixinSum<SimpleArray<T>, T>
     , public detail::SimpleArrayMixinCalculators<SimpleArray<T>, T>
     , public detail::SimpleArrayMixinSort<SimpleArray<T>, T>
     , public detail::SimpleArrayMixinSearch<SimpleArray<T>, T>
@@ -1877,36 +1957,59 @@ public:
     value_type const * body() const { return m_body; }
     value_type * body() { return m_body; }
 
+    bool is_c_contiguous() const { return is_c_contiguous(m_shape, m_stride); }
+    bool is_f_contiguous() const { return is_f_contiguous(m_shape, m_stride); }
+
 private:
-    void check_c_contiguous(small_vector<size_t> const & shape,
-                            small_vector<size_t> const & stride) const
+    static bool is_c_contiguous(small_vector<size_t> const & shape,
+                                small_vector<size_t> const & stride)
     {
         if (stride[stride.size() - 1] != 1)
         {
-            throw std::runtime_error("SimpleArray: C contiguous stride must end with 1");
+            return false;
         }
         for (size_t it = 0; it < shape.size() - 1; ++it)
         {
             if (stride[it] != shape[it + 1] * stride[it + 1])
             {
-                throw std::runtime_error("SimpleArray: C contiguous stride must match shape");
+                return false;
             }
+        }
+        return true;
+    }
+
+    static bool is_f_contiguous(small_vector<size_t> const & shape,
+                                small_vector<size_t> const & stride)
+    {
+        if (stride[0] != 1)
+        {
+            return false;
+        }
+        for (size_t it = 0; it < shape.size() - 1; ++it)
+        {
+            if (stride[it + 1] != shape[it] * stride[it])
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static void check_c_contiguous(small_vector<size_t> const & shape,
+                                   small_vector<size_t> const & stride)
+    {
+        if (!is_c_contiguous(shape, stride))
+        {
+            throw std::runtime_error("SimpleArray: C contiguous stride must match shape and end with 1");
         }
     }
 
     void check_f_contiguous(small_vector<size_t> const & shape,
                             small_vector<size_t> const & stride) const
     {
-        if (stride[0] != 1)
+        if (!is_f_contiguous(shape, stride))
         {
-            throw std::runtime_error("SimpleArray: Fortran contiguous stride must start with 1");
-        }
-        for (size_t it = 0; it < shape.size() - 1; ++it)
-        {
-            if (stride[it + 1] != shape[it] * stride[it])
-            {
-                throw std::runtime_error("SimpleArray: Fortran contiguous stride must match shape");
-            }
+            throw std::runtime_error("SimpleArray: F contiguous stride must match shape and start with 1");
         }
     }
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1443,6 +1443,24 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         self.assertEqual(sarr.min(), -2.3)
         self.assertEqual(sarr.max(), 9.2)
 
+    def test_sum_non_contiguous(self):
+        nparr = np.arange(625, dtype='float64').reshape((5, 5, 5, 5))
+        nparr = nparr[:3:2, 1:4:2, :3:3, 3:4:2]
+        sarr = modmesh.SimpleArrayFloat64(array=nparr)
+        self.assertEqual(sarr.sum(), np.sum(nparr))
+
+    def test_sum_empty(self):
+        # Empty array whose inner (non-last) dim is 0; strided path must
+        # not dereference the buffer.
+        sarr = modmesh.SimpleArrayFloat64(shape=(0, 3, 4), value=0.0)
+        sarr = sarr.transpose()  # shape (4, 3, 0) -> (0, 3, 4) non-contiguous
+        self.assertEqual(sarr.sum(), 0.0)
+
+    def test_mean_empty_raises(self):
+        sarr = modmesh.SimpleArrayFloat64(shape=(0, 3), value=0.0)
+        with self.assertRaisesRegex(RuntimeError, "empty array"):
+            sarr.mean()
+
     def test_abs(self):
         sarr = modmesh.SimpleArrayInt64(shape=(3, 2), value=-2)
         self.assertEqual(sarr.sum(), -2 * 3 * 2)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1443,6 +1443,50 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         self.assertEqual(sarr.min(), -2.3)
         self.assertEqual(sarr.max(), 9.2)
 
+    def test_sum_contiguous(self):
+        # 1D contiguous: exercises the straight pointer loop in
+        # sum_contiguous() with no shape/stride arithmetic involved.
+        nparr = np.arange(1, 101, dtype='float64')
+        sarr = modmesh.SimpleArrayFloat64(array=nparr)
+        self.assertEqual(sarr.sum(), np.sum(nparr))
+
+        # Multi-dim C-contiguous: still a single dense block, so sum()
+        # takes the contiguous path even though shape is multi-dim.
+        nparr = np.arange(60, dtype='float64').reshape((3, 4, 5))
+        sarr = modmesh.SimpleArrayFloat64(array=nparr)
+        self.assertEqual(sarr.sum(), np.sum(nparr))
+
+        # Multi-dim F-contiguous: dense block but with column-major
+        # strides; sum_contiguous() walks the buffer in F order, which
+        # still hits every element exactly once.
+        nparr = np.asfortranarray(
+            np.arange(60, dtype='float64').reshape((3, 4, 5)))
+        sarr = modmesh.SimpleArrayFloat64(array=nparr)
+        self.assertEqual(sarr.sum(), np.sum(nparr))
+
+    def test_sum_non_contiguous(self):
+        # Strided slice that fails both C- and F-contiguity checks, so
+        # sum() must take the sum_strided path. Distinct integer values
+        # mean any indexing bug shifts the result.
+        nparr = np.arange(625, dtype='float64').reshape((5, 5, 5, 5))
+        nparr = nparr[:3:2, 1:4:2, :3:3, 3:4:2]
+        sarr = modmesh.SimpleArrayFloat64(array=nparr)
+        self.assertEqual(sarr.sum(), np.sum(nparr))
+
+    def test_sum_empty_non_contiguous(self):
+        # Empty and non-contiguous: shape (3, 0, 4) with strides
+        # (0, 1, 0) is neither C- nor F-contiguous, so sum() must
+        # short-circuit on n == 0 instead of falling into the strided
+        # path and reading from an empty buffer.
+        sarr = modmesh.SimpleArrayFloat64(shape=(3, 4, 0), value=0.0)
+        sarr = sarr.transpose(axis=[0, 2, 1])
+        self.assertEqual(sarr.sum(), 0.0)
+
+    def test_mean_empty_raises(self):
+        sarr = modmesh.SimpleArrayFloat64(shape=(0, 3), value=0.0)
+        with self.assertRaisesRegex(RuntimeError, "empty array"):
+            sarr.mean()
+
     def test_abs(self):
         sarr = modmesh.SimpleArrayInt64(shape=(3, 2), value=-2)
         self.assertEqual(sarr.sum(), -2 * 3 * 2)


### PR DESCRIPTION
## Motivation

The existing `SimpleArray::mean()` walks every element through a multi-dimensional index iterator (`first_sidx` / `next_sidx` / `at(sidx)`). That per-element index arithmetic dominates the runtime and makes `mean()` several times slower than it needs to be, especially on large arrays. This PR continues the work started in #589 and takes another pass at the same goal: make `mean()` fast without introducing threading or guessed micro-optimizations.

## What changes

A new mixin `SimpleArrayMixinSum` provides `sum()` with two code paths. The contiguous path walks the buffer with a straight pointer loop so the compiler can auto-vectorize; the strided path walks by the innermost dimension, computing each row's base offset once per outer iteration instead of for every element. `mean()` now delegates to this `sum()` and simply divides by `size()`.

The refactor also fixes a latent correctness bug. The previous `sum()` iterated `data(i)` by a linear buffer index, so for a non-contiguous array (any slice or transpose) it happily summed the wrong elements. The new strided path respects the stride, and there is a regression test covering it.

## What is deliberately not included

This PR drops the threading and manual loop unrolling from the earlier iteration of #589, following the review feedback on that PR. Threads belong to a larger scheduling system that does not exist yet, and a hand-rolled unroll that funnels every partial into a single accumulator does not actually help the compiler vectorize. Private helpers that do not touch `this` are marked `static`, matching the reviewer's request.

## Edge cases covered

Empty arrays no longer read past the end of the buffer: `sum()` returns zero on any shape whose product is zero, and `mean()` throws on an empty input rather than producing `0/0` (NaN for floats, UB for integers). Ghost-cell behavior is unchanged — both old and new paths include ghost cells, which matches how `data()` and the old `first_sidx` iterator behaved.

## Benchmarks

Times are microseconds per call, best-of-5 runs of 10 iterations each, then averaged across two independent full runs. Machine: Apple Silicon, Python 3.14, release build. "before" = `upstream/master` at 3d73a5d; "after" = this branch HEAD.

### `mean()` — 3× to 6× faster

| case                   |    before |    after | speedup |
|------------------------|----------:|---------:|--------:|
| 1D contig N=1 000      |      3.26 |     1.00 |   3.26× |
| 1D contig N=100 000    |    311.65 |    74.23 |   4.20× |
| 1D contig N=10 000 000 | 31 105.37 | 6 939.76 |   4.48× |
| 3D contig 100³         |  3 862.07 |   684.52 |   5.64× |
| 3D strided 100³        |  4 285.14 |   873.83 |   4.90× |
| 3D F-contig 100³       |  3 890.77 |   684.21 |   5.69× |
| 1D F-contig N=1e7      | 30 999.39 | 6 898.32 |   4.49× |
| 4D strided 25⁴         |  1 552.80 |   260.47 |   5.96× |

### `sum()` — flat on contiguous, modest cost on strided

| case                   |    before |    after |  ratio |
|------------------------|----------:|---------:|-------:|
| 1D contig N=1 000      |      0.94 |     0.94 |  1.00× |
| 1D contig N=100 000    |     70.68 |    73.73 |  0.96× |
| 1D contig N=10 000 000 |  7 116.49 | 6 925.18 |  1.03× |
| 3D contig 100³         |    803.65 |   688.69 |  1.17× |
| 3D strided 100³        |    800.55 |   968.03 |  0.83× |
| 3D F-contig 100³       |    808.26 |   687.64 |  1.18× |
| 1D F-contig N=1e7      |  7 094.45 | 6 897.08 |  1.03× |
| 4D strided 25⁴         |    299.41 |   257.64 |  1.16× |

Note: the `sum()` "before" numbers on strided cases reflect the old buggy behavior (wrong data, read linearly along the buffer), so the comparison is about cost, not correctness — the new strided sum is correct, and on the 3D strided 100³ case it is somewhat slower than the old buggy linear walk (0.83×) because it now follows the stride properly. On contiguous shapes, `sum()` is unchanged or slightly faster.

## How to reproduce the benchmark

The benchmark script and raw results are not part of this PR; they live locally at `profiling/bench_mean_compare.py`. A minimal reproducer:

```python
import os, time
os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
import numpy as np
import modmesh

def bench(fn, iters=5):
    fn()  # warmup
    ts = []
    for _ in range(iters):
        t0 = time.perf_counter()
        for _ in range(10):
            fn()
        ts.append((time.perf_counter() - t0) / 10)
    return min(ts) * 1e6  # microseconds

cases = []
for N in [1_000, 100_000, 10_000_000]:
    a = np.random.rand(N).astype(np.float64)
    cases.append((f"1D contig N={N}", a, modmesh.SimpleArrayFloat64(array=a)))

a = np.random.rand(100, 100, 100).astype(np.float64)
cases.append(("3D contig 100^3", a, modmesh.SimpleArrayFloat64(array=a)))

a = np.random.rand(300, 300, 300).astype(np.float64)[::3, ::3, ::3]
cases.append(("3D strided 100^3", a, modmesh.SimpleArrayFloat64(array=a)))

a = np.asfortranarray(np.random.rand(100, 100, 100).astype(np.float64))
cases.append(("3D F-contig 100^3", a, modmesh.SimpleArrayFloat64(array=a)))

a = np.asfortranarray(np.random.rand(10_000_000).astype(np.float64))
cases.append(("1D F-contig N=1e7", a, modmesh.SimpleArrayFloat64(array=a)))

a = np.random.rand(50, 50, 50, 50).astype(np.float64)[::2, ::2, ::2, ::2]
cases.append(("4D strided 25^4", a, modmesh.SimpleArrayFloat64(array=a)))

print(f"{'case':<22} {'np.mean us':>12} {'sa.mean us':>12} {'sa.sum us':>12}")
for name, a, sa in cases:
    print(f"{name:<22} {bench(lambda: np.mean(a)):>12.2f} "
          f"{bench(lambda: sa.mean()):>12.2f} {bench(lambda: sa.sum()):>12.2f}")
```

Procedure to get before/after numbers:

1. Check out `upstream/master`, build with `make buildext`, run the script, record numbers.
2. Apply this branch on top, rebuild with `make buildext`, run the same script, record numbers.
3. Compare — `sa.mean` should drop by 3–6× on every shape; `sa.sum` stays about the same on contiguous shapes.

## Relation to #589

This is a rework of #589 based on the review there. It keeps the core idea (dedicated fast `sum()` path used by `mean()`), drops the parts the reviewer rejected (threads, unclear unroll), and adds the empty-array guards plus strided-sum correctness fix.