### PR TITLE
ci: remove ppa setting for ubuntu 24.04 runner

### DIFF
--- a/.github/actions/setup_linux/action.yml
+++ b/.github/actions/setup_linux/action.yml
@@ -86,7 +86,6 @@ runs:
     - name: Install and configure gcc-14
       shell: bash
       run: |
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
         sudo apt-get -qqy update
         sudo apt-get -qy install gcc-14 g++-14
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100


### PR DESCRIPTION
According to [Ubuntu available GCC versions](https://documentation.ubuntu.com/ubuntu-for-developers/reference/availability/gcc/), Ubuntu 24.04 supports gcc-14 natively without running `sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y`.

Therefore, I remove this line to avoid potential timeout failure when adding PPA.