### PR TITLE
GitHub Action `profiling` should respect `MMGH_NIGHTLY`

### DIFF
--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -11,7 +11,7 @@ jobs:
 
     # Run profiling only on schedule or when MMGH_FORCE_PROFILE is set to 'enable'
     # You can refer to https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables to set MMGH_FORCE_PROFILE in the fork repository settings for testing purposes.
-    if: ${{ github.event_name == 'schedule' || vars.MMGH_FORCE_PROFILE == 'enable' }}
+    if: ${{ (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') || vars.MMGH_FORCE_PROFILE == 'enable' }}
 
     name: profile_${{ matrix.os }}
 


### PR DESCRIPTION
`.github/workflows/profiling.yml` did not respect `MMGH_NIGHTLY` environment variable and got executed nightly in fork, e.g., https://github.com/yungyuc/modmesh/actions/runs/25227568456 .  It is unnecessary waste of free resources.