### PR TITLE
Add a postfix string for build directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ ifneq (,$(wildcard $(SETUP_FILE)))
 	include $(SETUP_FILE)
 endif
 
+# Optional extension appended to the auto-computed BUILD_PATH
+# (e.g. BUILD_PATH_EXT=_noqt).
+BUILD_PATH_EXT ?=
+
 # To workaround macos SIP: https://github.com/solvcon/modmesh/pull/16.
 # Additional configuration can be loaded from SETUP_FILE.
 RUNENV += PYTHONPATH=$(MODMESH_ROOT)
@@ -54,9 +58,9 @@ pyextsuffix := $(shell $(DIRNAME_PYTHON)/python3-config --extension-suffix)
 pyvminor := $(shell python3 -c 'import sys; print("%d%d" % sys.version_info[0:2])')
 
 ifeq ($(CMAKE_BUILD_TYPE), Debug)
-	BUILD_PATH ?= build/dbg$(pyvminor)
+	BUILD_PATH ?= build/dbg$(pyvminor)$(BUILD_PATH_EXT)
 else
-	BUILD_PATH ?= build/dev$(pyvminor)
+	BUILD_PATH ?= build/rel$(pyvminor)$(BUILD_PATH_EXT)
 endif
 export BUILD_PATH
 


### PR DESCRIPTION
* Add `BUILD_PATH_EXT` (default empty) to the end of the build path directory name (`BUILD_PATH`).
* Rename `dev*` to `rel*` for release build ("dev" was misleading).

Modified from a starting point made by [Claude Code](https://claude.com/claude-code)