### PR TITLE
Fix `QThreadStorage` warnings by deleting `QApplication` before Python finalizes

### DIFF
--- a/cpp/modmesh/pilot/RManager.cpp
+++ b/cpp/modmesh/pilot/RManager.cpp
@@ -49,13 +49,13 @@ RManager & RManager::instance()
 RManager::RManager()
     : QObject()
 {
-    m_core = QApplication::instance();
+    m_core.reset(QApplication::instance());
     static int argc = 1;
     static char exename[] = "pilot";
     static char * argv[] = {exename};
-    if (nullptr == m_core)
+    if (!m_core)
     {
-        m_core = new QApplication(argc, argv);
+        m_core.reset(new QApplication(argc, argv));
     }
 
     m_mainWindow = new QMainWindow;
@@ -77,8 +77,28 @@ RManager & RManager::setUp()
     return *this;
 }
 
+void RManager::reset()
+{
+    // Nullify all child pointers before destroying QApplication.
+    // Qt's parent-child mechanism will delete widget children; we only
+    // need to ensure our raw pointers don't dangle after the call.
+    m_already_setup = false;
+    m_core.reset();
+    m_mainWindow = nullptr;
+    m_fileMenu = nullptr;
+    m_viewMenu = nullptr;
+    m_oneMenu = nullptr;
+    m_meshMenu = nullptr;
+    m_canvasMenu = nullptr;
+    m_profilingMenu = nullptr;
+    m_windowMenu = nullptr;
+    m_pycon = nullptr;
+    m_mdiArea = nullptr;
+}
+
 RManager::~RManager()
 {
+    reset();
 }
 
 R3DWidget * RManager::add3DWidget()

--- a/cpp/modmesh/pilot/RManager.hpp
+++ b/cpp/modmesh/pilot/RManager.hpp
@@ -56,7 +56,7 @@ public:
 
     static RManager & instance();
 
-    QCoreApplication * core() { return m_core; }
+    QCoreApplication * core() { return &(*m_core); }
 
     R3DWidget * add3DWidget();
 
@@ -77,6 +77,9 @@ public:
 
     void quit() { m_core->quit(); }
 
+    /// Only call reset() when the program is to be stopped.
+    void reset();
+
     void toggleConsole();
 
 private:
@@ -94,7 +97,7 @@ private:
 
     bool m_already_setup = false;
 
-    QCoreApplication * m_core = nullptr;
+    std::unique_ptr<QCoreApplication> m_core = nullptr;
 
     QMainWindow * m_mainWindow = nullptr;
 

--- a/cpp/modmesh/pilot/RManager.hpp
+++ b/cpp/modmesh/pilot/RManager.hpp
@@ -56,7 +56,7 @@ public:
 
     static RManager & instance();
 
-    QCoreApplication * core() { return &(*m_core); }
+    QCoreApplication * core() { return m_core.get(); }
 
     R3DWidget * add3DWidget();
 

--- a/cpp/modmesh/pilot/wrap_pilot.cpp
+++ b/cpp/modmesh/pilot/wrap_pilot.cpp
@@ -575,8 +575,7 @@ void wrap_pilot(pybind11::module & mod)
     }
 
     // Register a Python atexit handler to destroy QApplication while Python
-    // is still fully alive.  If ~RManager() fires first (static destruction),
-    // reset() is a no-op because m_already_setup will already be false.
+    // is still fully alive.
     try
     {
         py::module_::import("atexit").attr("register")(

--- a/cpp/modmesh/pilot/wrap_pilot.cpp
+++ b/cpp/modmesh/pilot/wrap_pilot.cpp
@@ -573,6 +573,20 @@ void wrap_pilot(pybind11::module & mod)
     {
         std::cerr << e.what() << std::endl;
     }
+
+    // Register a Python atexit handler to destroy QApplication while Python
+    // is still fully alive.  If ~RManager() fires first (static destruction),
+    // reset() is a no-op because m_already_setup will already be false.
+    try
+    {
+        py::module_::import("atexit").attr("register")(
+            py::cpp_function([]()
+                             { RManager::instance().reset(); }));
+    }
+    catch (const pybind11::error_already_set & e)
+    {
+        std::cerr << e.what() << std::endl;
+    }
 }
 
 struct view_pymod_tag;


### PR DESCRIPTION
`RManager` created `QApplication` on the heap but never deleted it.  Qt's internal `QThreadStorage` statics were therefore destroyed at library unload while the main thread was still registered, producing:
```
  QThreadStorage: entry N destroyed before end of thread 0x...
```

Simply deleting m_core (`QApplication`) in `~RManager()` caused a segfault, because `~QApplication()` tears down `RPythonConsoleDockWidget`, whose `PythonStreamRedirect` owns Python `PyObject *` (through `pybind11::object` members) that need a live Python interpreter.  `~RManager()` is called during C++ static destruction, by which point Python is already finalizing.

The fix:
- Use `std::unique_ptr` for `RManager::m_core` instead of raw pointer to call `~QApplication()` automatically.
- Add `RManager::reset()` to nullify all child Qt pointers, including `m_core`, and delete m_core, making `~RManager()` a safe no-op if `reset()` already ran.
- Register a Python `atexit` callback in the C++ function `wrap_pilot()` that calls `RManager::instance().reset()` while Python is fully alive, so `PyObject *` inside `RPythonConsoleDockWidget` can be properly handled before `QApplication` is properly torn down as Qt's library-level statics are destroyed.

Modified from the prototype done by by: Claude Sonnet 4.6 <noreply@anthropic.com>