### PR TITLE
Prevent duplicate CI runs when pushing with a pull request

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -6,11 +6,19 @@ on:
   schedule:
     - cron: '34 17 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   standalone_buffer:
 
-    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && vars.MMGH_PUSH_RUN_BRANCH != '' &&
+       contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name)) ||
+      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable')
 
     name: standalone_buffer_${{ matrix.os }}
 
@@ -52,7 +60,13 @@ jobs:
 
   build:
 
-    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' &&
+      vars.MMGH_PUSH_RUN_BRANCH != '' &&
+      contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name)) ||
+      (github.event_name == 'schedule' &&
+      vars.MMGH_NIGHTLY == 'enable')
 
     name: build_${{ matrix.os }}_${{ matrix.cmake_build_type }}
 
@@ -185,7 +199,13 @@ jobs:
 
   build_windows:
 
-    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' &&
+      vars.MMGH_PUSH_RUN_BRANCH != '' &&
+      contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name)) ||
+      (github.event_name == 'schedule' &&
+      vars.MMGH_NIGHTLY == 'enable')
 
     name: build_${{ matrix.os }}_${{ matrix.cmake_build_type }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,13 +6,21 @@ on:
   schedule:
     - cron: '34 17 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   lint:
 
     name: Run make lint and pilot on ${{ matrix.os }}
 
-    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && vars.MMGH_PUSH_RUN_BRANCH != '' &&
+       contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name)) ||
+      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable')
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -6,11 +6,19 @@ on:
   schedule:
     - cron: '34 17 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   nouse_install:
 
-    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') }}
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && vars.MMGH_PUSH_RUN_BRANCH != '' &&
+       contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name)) ||
+      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable')
 
     name: nouse_install_${{ matrix.os }}_Release
 


### PR DESCRIPTION
Restrict push trigger to run only on branches listed in the repository variable `MMGH_PUSH_RUN_BRANCH`.  If the variable is not set, do not trigger CI with the push events.  Pull request and schedule events are unaffected.

Add a concurrency group per workflow and PR number (or ref) so that a new push automatically cancels any still-running jobs for the same PR.

This is to save resources.