### PR TITLE
Allow `MMGH_PUSH_RUN_BRANCH=*` to enable CI on every push

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -17,7 +17,8 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' && vars.MMGH_PUSH_RUN_BRANCH != '' &&
-       contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name)) ||
+       (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
+        contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
       (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable')
 
     name: standalone_buffer_${{ matrix.os }}
@@ -64,7 +65,8 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
       vars.MMGH_PUSH_RUN_BRANCH != '' &&
-      contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name)) ||
+      (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
+      contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
       (github.event_name == 'schedule' &&
       vars.MMGH_NIGHTLY == 'enable')
 
@@ -203,7 +205,8 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
       vars.MMGH_PUSH_RUN_BRANCH != '' &&
-      contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name)) ||
+      (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
+      contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
       (github.event_name == 'schedule' &&
       vars.MMGH_NIGHTLY == 'enable')
 

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -16,7 +16,7 @@ jobs:
 
     if: |
       github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && vars.MMGH_PUSH_RUN_BRANCH != '' &&
+      (github.event_name == 'push' &&
        (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
         contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
       (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable')
@@ -64,9 +64,8 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
-      vars.MMGH_PUSH_RUN_BRANCH != '' &&
-      (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
-      contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
+       (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
+        contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
       (github.event_name == 'schedule' &&
       vars.MMGH_NIGHTLY == 'enable')
 
@@ -204,9 +203,8 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
-      vars.MMGH_PUSH_RUN_BRANCH != '' &&
-      (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
-      contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
+       (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
+        contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
       (github.event_name == 'schedule' &&
       vars.MMGH_NIGHTLY == 'enable')
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
 
     if: |
       github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && vars.MMGH_PUSH_RUN_BRANCH != '' &&
+      (github.event_name == 'push' &&
        (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
         contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
       (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable')

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,8 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' && vars.MMGH_PUSH_RUN_BRANCH != '' &&
-       contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name)) ||
+       (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
+        contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
       (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable')
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -16,7 +16,7 @@ jobs:
 
     if: |
       github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && vars.MMGH_PUSH_RUN_BRANCH != '' &&
+      (github.event_name == 'push' &&
        (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
         contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
       (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable')

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -17,7 +17,8 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' && vars.MMGH_PUSH_RUN_BRANCH != '' &&
-       contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name)) ||
+       (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
+        contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
       (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable')
 
     name: nouse_install_${{ matrix.os }}_Release


### PR DESCRIPTION
Add a wildcard short-circuit when the variable `MMGH_PUSH_RUN_BRANCH` is set to exactly `*`, the push event matches regardless of branch name.  Any other value keeps the existing substring-contains behaviour.

This is for issue #753 