### PR TITLE
Refactor pilot/canvas.py and rename tests/test_pilot_canvas.py

### DIFF
--- a/modmesh/pilot/__init__.py
+++ b/modmesh/pilot/__init__.py
@@ -48,7 +48,7 @@ if enable:
         launch,
     )
     from . import airfoil  # noqa: F401
-    from . import _canvas  # noqa: F401
+    from . import _canvas_gui  # noqa: F401
 
 # NOTE: intentionally omit __all__ for now
 

--- a/modmesh/pilot/_canvas_gui.py
+++ b/modmesh/pilot/_canvas_gui.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2026, Han-Xuan Huang <c1ydehhx@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Canvas GUI feature for pilot.
+"""
+
+from .. import core
+from ..plot import curve, plane_layer
+
+from . import _gui_common
+
+__all__ = [
+    'Canvas',
+]
+
+
+class Canvas(_gui_common.PilotFeature):
+    """
+    Canvas feature providing menu items for drawing curves and polygons.
+    """
+
+    def __init__(self, *args, **kw):
+        super(Canvas, self).__init__(*args, **kw)
+        self._world = core.WorldFp64()
+        self._widget = None
+
+    def populate_menu(self):
+        self._add_menu_item(
+            menu=self._mgr.canvasMenu,
+            text="Sample: Create ICCAD-2013",
+            tip="Create ICCAD-2013 polygon examples",
+            func=self.mesh_iccad_2013,
+        )
+
+        tip = "Draw a sample S-shaped cubic Bezier curve with control points"
+        self._add_menu_item(
+            menu=self._mgr.canvasMenu,
+            text="Sample: Bezier S-curve",
+            tip=tip,
+            func=self._bezier_s_curve,
+        )
+        self._add_menu_item(
+            menu=self._mgr.canvasMenu,
+            text="Sample: Bezier Arch",
+            tip="Draw a sample arch-shaped cubic Bezier curve with control "
+                "points",
+            func=self._bezier_arch,
+        )
+        self._add_menu_item(
+            menu=self._mgr.canvasMenu,
+            text="Sample: Bezier Loop",
+            tip="Draw a sample loop-like cubic Bezier curve with control "
+                "points",
+            func=self._bezier_loop,
+        )
+        self._add_menu_item(
+            menu=self._mgr.canvasMenu,
+            text="Sample: Ellipse",
+            tip="Draw a sample ellipse (a=2, b=1)",
+            func=self._ellipse,
+        )
+        self._add_menu_item(
+            menu=self._mgr.canvasMenu,
+            text="Sample: Parabola",
+            tip="Draw a sample parabola (y = 0.5*x^2)",
+            func=self._parabola,
+        )
+        self._add_menu_item(
+            menu=self._mgr.canvasMenu,
+            text="Sample: Hyperbola",
+            tip="Draw a sample hyperbola (both branches)",
+            func=self._hyperbola,
+        )
+
+    @staticmethod
+    def _draw_layer(world, layer):
+        point_type = core.Point3dFp64
+
+        for polygon in layer.get_polys():
+            segment_pad = core.SegmentPadFp64(ndim=2)
+
+            for coord in polygon:
+                segment_pad.append(core.Segment3dFp64(
+                    point_type(coord[0][0], coord[0][1]),
+                    point_type(coord[1][0], coord[1][1])
+                ))
+
+            world.add_segments(pad=segment_pad)
+
+    def mesh_iccad_2013(self):
+        layer = plane_layer.PlaneLayer()
+        layer.add_figure("RECT N M1 70 800 180 40")
+        layer.add_figure(
+            "PGON N M1 70 720 410 720 410 920 70 920 "
+            "70 880 370 880 370 760 70 760"
+        )
+        layer.add_figure("RECT N M1 70 1060 180 40")
+        layer.add_figure(
+            "PGON N M1 70 980 410 980 410 1180 70 1180 "
+            "70 1140 370 1140 370 1020 70 1020"
+        )
+
+        self._draw_layer(self._world, layer)
+        self._update_widget()
+
+    def _update_widget(self):
+        if self._widget is None:
+            self._widget = self._mgr.add3DWidget()
+        self._widget.updateWorld(self._world)
+        self._widget.showMark()
+
+    def _bezier_s_curve(self):
+        bezier_sample = curve.BezierSample.s_curve()
+        sampler = curve.BezierSampler(self._world, bezier_sample)
+        sampler.draw(nsample=50, fac=1.0, off_x=0.0, off_y=0.0)
+        self._update_widget()
+
+    def _bezier_arch(self):
+        bezier_sample = curve.BezierSample.arch()
+        sampler = curve.BezierSampler(self._world, bezier_sample)
+        sampler.draw(nsample=50, fac=1.0, off_x=0.0, off_y=0.0)
+        self._update_widget()
+
+    def _bezier_loop(self):
+        bezier_sample = curve.BezierSample.loop()
+        sampler = curve.BezierSampler(self._world, bezier_sample)
+        sampler.draw(nsample=50, fac=1.0, off_x=0.0, off_y=0.0)
+        self._update_widget()
+
+    def _ellipse(self):
+        ellipse = curve.Ellipse(a=2.0, b=1.0)
+        sampler = curve.CurveSampler(self._world, ellipse)
+        sampler.populate_points(npoint=100)
+        sampler.draw_cbc()
+        self._update_widget()
+
+    def _parabola(self):
+        parabola = curve.Parabola(a=0.5, t_min=-3.0, t_max=6.0)
+        sampler = curve.CurveSampler(self._world, parabola)
+        sampler.populate_points(npoint=100)
+        sampler.draw_cbc()
+        self._update_widget()
+
+    def _hyperbola(self):
+        hyperbola = curve.Hyperbola(a=1.0, b=1.0, t_min=-2.0, t_max=2.0)
+
+        right_sampler = curve.CurveSampler(self._world, hyperbola)
+        right_sampler.populate_points(npoint=100)
+        right_sampler.draw_cbc()
+
+        left_sampler = curve.CurveSampler(self._world, hyperbola)
+        left_sampler.populate_points(npoint=100)
+        left_sampler.points.x.ndarray[:] *= -1.0
+        left_sampler.draw_cbc()
+
+        self._update_widget()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/modmesh/pilot/_gui.py
+++ b/modmesh/pilot/_gui.py
@@ -45,7 +45,7 @@ if _pcore.enable:
     from . import _burgers1d
     from . import _svg_gui
     from . import _linear_wave
-    from . import _canvas
+    from . import _canvas_gui
     from . import _profiling
 
 __all__ = [  # noqa: F822
@@ -100,7 +100,7 @@ class _Controller(metaclass=_Singleton):
         self.eulerone = _euler1d.Euler1DApp(mgr=self._rmgr)
         self.burgers = _burgers1d.Burgers1DApp(mgr=self._rmgr)
         self.linear_wave = _linear_wave.LinearWave1DApp(mgr=self._rmgr)
-        self.canvas = _canvas.Canvas(mgr=self._rmgr)
+        self.canvas = _canvas_gui.Canvas(mgr=self._rmgr)
         self.openprofiledata = _profiling.Profiling(mgr=self._rmgr)
         self.runprofiling = _profiling.RunProfiling(mgr=self._rmgr)
         self.populate_menu()

--- a/modmesh/plot/__init__.py
+++ b/modmesh/plot/__init__.py
@@ -29,9 +29,10 @@
 No-GUI drawing sub-system (without GUI libraries) of modmesh.
 """
 
-from . import svg, plane_layer
+from . import curve, svg, plane_layer
 
 __all__ = [
+    'curve',
     'svg',
     'plane_layer'
 ]

--- a/modmesh/plot/curve.py
+++ b/modmesh/plot/curve.py
@@ -25,17 +25,14 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 """
-Canvas utilities and curve/conic drawing utilities for pilot GUI.
+Curve sampling helpers without GUI dependencies.
 """
 
 import numpy as np
 
-from .. import core, plot
-
-from . import _gui_common
+from .. import core
 
 __all__ = [
-    'Canvas',
     'CurveSampler',
     'Ellipse',
     'Parabola',
@@ -43,148 +40,6 @@ __all__ = [
     'BezierSample',
     'BezierSampler',
 ]
-
-
-class Canvas(_gui_common.PilotFeature):
-    """
-    Canvas feature providing menu items for drawing curves and polygons.
-    """
-
-    def __init__(self, *args, **kw):
-        super(Canvas, self).__init__(*args, **kw)
-        self._world = core.WorldFp64()
-        self._widget = None
-
-    def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
-            text="Sample: Create ICCAD-2013",
-            tip="Create ICCAD-2013 polygon examples",
-            func=self.mesh_iccad_2013,
-        )
-
-        tip = "Draw a sample S-shaped cubic Bezier curve with control points"
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
-            text="Sample: Bezier S-curve",
-            tip=tip,
-            func=self._bezier_s_curve,
-        )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
-            text="Sample: Bezier Arch",
-            tip="Draw a sample arch-shaped cubic Bezier curve with control "
-                "points",
-            func=self._bezier_arch,
-        )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
-            text="Sample: Bezier Loop",
-            tip="Draw a sample loop-like cubic Bezier curve with control "
-                "points",
-            func=self._bezier_loop,
-        )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
-            text="Sample: Ellipse",
-            tip="Draw a sample ellipse (a=2, b=1)",
-            func=self._ellipse,
-        )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
-            text="Sample: Parabola",
-            tip="Draw a sample parabola (y = 0.5*x^2)",
-            func=self._parabola,
-        )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
-            text="Sample: Hyperbola",
-            tip="Draw a sample hyperbola (both branches)",
-            func=self._hyperbola,
-        )
-
-    @staticmethod
-    def _draw_layer(world, layer):
-        point_type = core.Point3dFp64
-
-        for polygon in layer.get_polys():
-            segment_pad = core.SegmentPadFp64(ndim=2)
-
-            for coord in polygon:
-                segment_pad.append(core.Segment3dFp64(
-                    point_type(coord[0][0], coord[0][1]),
-                    point_type(coord[1][0], coord[1][1])
-                ))
-
-            world.add_segments(pad=segment_pad)
-
-    def mesh_iccad_2013(self):
-        layer = plot.plane_layer.PlaneLayer()
-        layer.add_figure("RECT N M1 70 800 180 40")
-        layer.add_figure(
-            "PGON N M1 70 720 410 720 410 920 70 920 "
-            "70 880 370 880 370 760 70 760"
-        )
-        layer.add_figure("RECT N M1 70 1060 180 40")
-        layer.add_figure(
-            "PGON N M1 70 980 410 980 410 1180 70 1180 "
-            "70 1140 370 1140 370 1020 70 1020"
-        )
-
-        self._draw_layer(self._world, layer)
-        self._update_widget()
-
-    def _update_widget(self):
-        if self._widget is None:
-            self._widget = self._mgr.add3DWidget()
-        self._widget.updateWorld(self._world)
-        self._widget.showMark()
-
-    def _bezier_s_curve(self):
-        bezier_sample = BezierSample.s_curve()
-        sampler = BezierSampler(self._world, bezier_sample)
-        sampler.draw(nsample=50, fac=1.0, off_x=0.0, off_y=0.0)
-        self._update_widget()
-
-    def _bezier_arch(self):
-        bezier_sample = BezierSample.arch()
-        sampler = BezierSampler(self._world, bezier_sample)
-        sampler.draw(nsample=50, fac=1.0, off_x=0.0, off_y=0.0)
-        self._update_widget()
-
-    def _bezier_loop(self):
-        bezier_sample = BezierSample.loop()
-        sampler = BezierSampler(self._world, bezier_sample)
-        sampler.draw(nsample=50, fac=1.0, off_x=0.0, off_y=0.0)
-        self._update_widget()
-
-    def _ellipse(self):
-        ellipse = Ellipse(a=2.0, b=1.0)
-        sampler = CurveSampler(self._world, ellipse)
-        sampler.populate_points(npoint=100)
-        sampler.draw_cbc()
-        self._update_widget()
-
-    def _parabola(self):
-        parabola = Parabola(a=0.5, t_min=-3.0, t_max=6.0)
-        sampler = CurveSampler(self._world, parabola)
-        sampler.populate_points(npoint=100)
-        sampler.draw_cbc()
-        self._update_widget()
-
-    def _hyperbola(self):
-        hyperbola = Hyperbola(a=1.0, b=1.0, t_min=-2.0, t_max=2.0)
-
-        right_sampler = CurveSampler(self._world, hyperbola)
-        right_sampler.populate_points(npoint=100)
-        right_sampler.draw_cbc()
-
-        left_sampler = CurveSampler(self._world, hyperbola)
-        left_sampler.populate_points(npoint=100)
-        left_sampler.points.x.ndarray[:] *= -1.0
-        left_sampler.draw_cbc()
-
-        self._update_widget()
 
 
 class CurveSampler:

--- a/tests/test_universe_curve.py
+++ b/tests/test_universe_curve.py
@@ -28,26 +28,28 @@
 import unittest
 
 import modmesh as mm
-import pytest
 
-pytest.importorskip("PySide6")
+from modmesh.plot import curve
 
-from modmesh.pilot import _canvas  # noqa: E402
+
+"""
+Test curve helpers that populate universe World geometry.
+"""
 
 
 class EllipseTC(unittest.TestCase):
     def test_default(self):
-        ell = _canvas.Ellipse()
+        ell = curve.Ellipse()
         self.assertEqual(ell.a, 2.0)
         self.assertEqual(ell.b, 1.0)
 
     def test_custom(self):
-        ell = _canvas.Ellipse(a=3.0, b=2.0)
+        ell = curve.Ellipse(a=3.0, b=2.0)
         self.assertEqual(ell.a, 3.0)
         self.assertEqual(ell.b, 2.0)
 
     def test_calc_points(self):
-        ell = _canvas.Ellipse(a=2.0, b=1.0)
+        ell = curve.Ellipse(a=2.0, b=1.0)
         points = ell.calc_points(10)
         self.assertEqual(points.ndim, 2)
         self.assertEqual(len(points), 11)
@@ -56,25 +58,25 @@ class EllipseTC(unittest.TestCase):
 class CurveSamplerTC(unittest.TestCase):
     def test_construction(self):
         w = mm.WorldFp64()
-        _canvas.CurveSampler(w, _canvas.Ellipse(a=2.0, b=1.0))
+        curve.CurveSampler(w, curve.Ellipse(a=2.0, b=1.0))
 
     def test_draw_ellipse(self):
         w = mm.WorldFp64()
-        sampler = _canvas.CurveSampler(w, _canvas.Ellipse(a=2.0, b=1.0))
+        sampler = curve.CurveSampler(w, curve.Ellipse(a=2.0, b=1.0))
         sampler.populate_points(npoint=20)
         sampler.draw_cbc()
         self.assertEqual(w.nbezier, 20)
 
     def test_draw_parabola(self):
         w = mm.WorldFp64()
-        sampler = _canvas.CurveSampler(w, _canvas.Parabola(a=0.5))
+        sampler = curve.CurveSampler(w, curve.Parabola(a=0.5))
         sampler.populate_points(npoint=20)
         sampler.draw_cbc()
         self.assertEqual(w.nbezier, 20)
 
     def test_draw_hyperbola(self):
         w = mm.WorldFp64()
-        sampler = _canvas.CurveSampler(w, _canvas.Hyperbola(a=1.0, b=1.0))
+        sampler = curve.CurveSampler(w, curve.Hyperbola(a=1.0, b=1.0))
         sampler.populate_points(npoint=20)
         sampler.draw_cbc()
         self.assertEqual(w.nbezier, 20)
@@ -82,54 +84,54 @@ class CurveSamplerTC(unittest.TestCase):
 
 class ParabolaTC(unittest.TestCase):
     def test_default(self):
-        par = _canvas.Parabola()
+        par = curve.Parabola()
         self.assertEqual(par.a, 0.5)
         self.assertEqual(par.t_min, -3.0)
         self.assertEqual(par.t_max, 3.0)
 
     def test_custom(self):
-        par = _canvas.Parabola(a=1.0, t_min=-2.0, t_max=2.0)
+        par = curve.Parabola(a=1.0, t_min=-2.0, t_max=2.0)
         self.assertEqual(par.a, 1.0)
         self.assertEqual(par.t_min, -2.0)
         self.assertEqual(par.t_max, 2.0)
 
     def test_calc_points(self):
-        par = _canvas.Parabola(a=0.5, t_min=-3.0, t_max=3.0)
+        par = curve.Parabola(a=0.5, t_min=-3.0, t_max=3.0)
         points = par.calc_points(20)
         self.assertEqual(len(points), 21)
 
 
 class HyperbolaTC(unittest.TestCase):
     def test_default(self):
-        hyp = _canvas.Hyperbola()
+        hyp = curve.Hyperbola()
         self.assertEqual(hyp.a, 1.0)
         self.assertEqual(hyp.b, 1.0)
         self.assertEqual(hyp.t_min, -2.0)
         self.assertEqual(hyp.t_max, 2.0)
 
     def test_custom(self):
-        hyp = _canvas.Hyperbola(a=2.0, b=1.5, t_min=-3.0, t_max=3.0)
+        hyp = curve.Hyperbola(a=2.0, b=1.5, t_min=-3.0, t_max=3.0)
         self.assertEqual(hyp.a, 2.0)
         self.assertEqual(hyp.b, 1.5)
         self.assertEqual(hyp.t_min, -3.0)
         self.assertEqual(hyp.t_max, 3.0)
 
     def test_calc_points(self):
-        hyp = _canvas.Hyperbola(a=1.0, b=1.0)
+        hyp = curve.Hyperbola(a=1.0, b=1.0)
         points = hyp.calc_points(50)
         self.assertEqual(len(points), 51)
 
 
 class BezierSampleTC(unittest.TestCase):
     def test_s_curve(self):
-        bs = _canvas.BezierSample.s_curve()
+        bs = curve.BezierSample.s_curve()
         self.assertEqual(bs.p0, (0.0, 0.0))
         self.assertEqual(bs.p1, (1.0, 3.0))
         self.assertEqual(bs.p2, (4.0, -1.0))
         self.assertEqual(bs.p3, (5.0, 2.0))
 
     def test_arch(self):
-        bs = _canvas.BezierSample.arch()
+        bs = curve.BezierSample.arch()
         # The arch preset is defined to start at the origin and end at
         # x=5, y=0 so that the curve spans a fixed 5-unit horizontal range
         self.assertEqual(bs.p0, (0.0, 0.0))
@@ -138,7 +140,7 @@ class BezierSampleTC(unittest.TestCase):
         self.assertEqual(bs.p3, (5.0, 0.0))
 
     def test_loop(self):
-        bs = _canvas.BezierSample.loop()
+        bs = curve.BezierSample.loop()
         # The loop preset shares the same endpoints as arch so that both
         # presets can be compared under identical boundary conditions;
         # the difference lies in the control points that create the loop shape
@@ -151,13 +153,13 @@ class BezierSampleTC(unittest.TestCase):
 class BezierSamplerTC(unittest.TestCase):
     def test_construction(self):
         w = mm.WorldFp64()
-        bs = _canvas.BezierSample.arch()
-        _canvas.BezierSampler(w, bs)
+        bs = curve.BezierSample.arch()
+        curve.BezierSampler(w, bs)
 
     def test_draw(self):
         w = mm.WorldFp64()
-        bs = _canvas.BezierSample.arch()
-        sampler = _canvas.BezierSampler(w, bs)
+        bs = curve.BezierSample.arch()
+        sampler = curve.BezierSampler(w, bs)
         # nsample=10 is small enough to keep the test fast but large enough
         # to exercise the loop body in draw() more than once, catching
         # off-by-one errors in the sampling range
@@ -171,8 +173,8 @@ class BezierSamplerTC(unittest.TestCase):
 
     def test_draw_no_control_polygon(self):
         w = mm.WorldFp64()
-        bs = _canvas.BezierSample.arch()
-        sampler = _canvas.BezierSampler(w, bs)
+        bs = curve.BezierSample.arch()
+        sampler = curve.BezierSampler(w, bs)
         sampler.draw(nsample=10, show_control_polygon=False)
         self.assertEqual(w.nbezier, 1)
         # Without control polygon: only 2 cross-mark segments per control
@@ -181,8 +183,8 @@ class BezierSamplerTC(unittest.TestCase):
 
     def test_draw_no_control_points(self):
         w = mm.WorldFp64()
-        bs = _canvas.BezierSample.arch()
-        sampler = _canvas.BezierSampler(w, bs)
+        bs = curve.BezierSample.arch()
+        sampler = curve.BezierSampler(w, bs)
         sampler.draw(nsample=10, show_control_points=False)
         self.assertEqual(w.nbezier, 1)
         # Without control point marks: only 3 polygon edge segments
@@ -190,8 +192,8 @@ class BezierSamplerTC(unittest.TestCase):
 
     def test_draw_curve_only(self):
         w = mm.WorldFp64()
-        bs = _canvas.BezierSample.arch()
-        sampler = _canvas.BezierSampler(w, bs)
+        bs = curve.BezierSample.arch()
+        sampler = curve.BezierSampler(w, bs)
         sampler.draw(nsample=10, show_control_polygon=False,
                      show_control_points=False)
         self.assertEqual(w.nbezier, 1)


### PR DESCRIPTION
This pull request is to make `test_pilot_canvas.py` naming better, see issue #756 . 

@yungyuc suggests that it could be renamed as `test_universe_*.py`, because the unittest checks whether `BezierSampler` in `Canvas` helper works as usual, which is more related to `modmesh.world` than `pilot`.

From my perspective, this file tests `Canvas` helper class, so I rename this file as  `test_universe_canvas.py`. I considerd the name `test_universe_pilot_helpers.py`, but this pull request doesn't deal with the other similar test file like `tests/test_pilot_airfoil.py `. Therefore, I decide to explicitly show the `Canvas` in filename.