### PR TITLE
Add timeout-minutes with repository variable control to all CI jobs

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -25,6 +25,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_STANDALONE_BUFFER || '10') }}
+
     strategy:
       matrix:
         os: [ubuntu-24.04]
@@ -72,6 +74,8 @@ jobs:
     name: build_${{ matrix.os }}_${{ matrix.cmake_build_type }}
 
     runs-on: ${{ matrix.os }}
+
+    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_BUILD || '30') }}
 
     env:
       QT_DEBUG_PLUGINS: 1
@@ -211,6 +215,8 @@ jobs:
     name: build_${{ matrix.os }}_${{ matrix.cmake_build_type }}
 
     runs-on: ${{ matrix.os }}
+
+    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_BUILD || '30') }}
 
     env:
       QT_DEBUG_PLUGINS: 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_LINT || '30') }}
+
     env:
       JOB_MAKE_ARGS: VERBOSE=1 BUILD_QT=ON USE_CLANG_TIDY=ON LINT_AS_ERRORS=ON
       QT_DEBUG_PLUGINS: 1

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -25,6 +25,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_NOUSE_INSTALL || '15') }}
+
     env:
       JOB_CMAKE_ARGS: -DBUILD_QT=OFF -DUSE_CLANG_TIDY=OFF -DCMAKE_BUILD_TYPE=Release
 

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -17,6 +17,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_PROFILE || '20') }}
+
     env:
       QT_DEBUG_PLUGINS: 1
       QT_QPA_PLATFORM: offscreen # for Ubuntu runner


### PR DESCRIPTION
(For issue #760)

Add a job-level timeout for each job in devbuild, lint, nouse_install, and profiling workflows. Defaults are conservative (10-30 minutes) and can be overridden per-job via optional `MMGH_TIMEOUT_*` repository variables without editing the workflow:

* `MMGH_TIMEOUT_STANDALONE_BUFFER`: 10 minutes
* `MMGH_TIMEOUT_BUILD`: 30 minutes
* `MMGH_TIMEOUT_NOUSE_INSTALL`: 15 minutes
* `MMGH_TIMEOUT_LINT`: 30 minutes
* `MMGH_TIMEOUT_PROFILE`: 15 minutes

It has been tested with a private repository that `build_ubuntu-24.04_Release` took more than 90 minutes to finish.