### PR TITLE
Forward `PYTEST_OPTS` through Python testing targets (in make)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,11 @@ buildext: cmake
 install: cmake
 	cmake --build $(BUILD_PATH) --target $@ VERBOSE=$(VERBOSE) $(MAKE_PARALLEL)
 
+# Pass PYTEST_OPTS to forward arguments to the pytest harness. Examples:
+# Example for one file:
+#   make pytest PYTEST_OPTS='-k test_buffer.py'
+# Example for one class:
+#   make pytest PYTEST_OPTS='-v -k SimpleArrayBasicTC'
 .PHONY: pytest
 pytest: buildext
 	env $(RUNENV) \
@@ -146,9 +151,16 @@ pilot: cmake
 gtest: cmake
 	cmake --build $(BUILD_PATH) --target run_gtest VERBOSE=$(VERBOSE) $(MAKE_PARALLEL)
 
+# Pass PYTEST_OPTS to forward arguments to the pytest harness running
+# inside the pilot binary.
+# Example for one file:
+#   make run_pilot_pytest PYTEST_OPTS='-k test_buffer.py'
+# Example for one class:
+#   make run_pilot_pytest PYTEST_OPTS='-v -k SimpleArrayBasicTC'
 .PHONY: run_pilot_pytest
 run_pilot_pytest: pilot
-	cmake --build $(BUILD_PATH) --target $@ VERBOSE=$(VERBOSE)
+	env $(RUNENV) PYTEST_OPTS="$(PYTEST_OPTS)" \
+		cmake --build $(BUILD_PATH) --target $@ VERBOSE=$(VERBOSE)
 
 .PHONY: standalone_buffer_setup
 standalone_buffer_setup:

--- a/modmesh/system.py
+++ b/modmesh/system.py
@@ -68,7 +68,10 @@ def _parse_command_line(argv):
                         default='pilot',
                         choices=['pilot', 'python', 'pytest'],
                         help='mode selection (default = %(default)s)')
-    args = parser.parse_args(argv[1:])
+    # Unknown args (e.g., pytest flags after --mode=pytest) are forwarded to
+    # the mode handler instead of erroring out.
+    args, extra = parser.parse_known_args(argv[1:])
+    args.extra = extra
     if parser.exited:
         args.exit = (parser.exited_status, parser.exited_message)
     else:
@@ -85,13 +88,29 @@ def _run_pilot(argv=None):
     return pilot.launch()
 
 
-def _run_pytest():
+def _run_pytest(extra_args=None):
+    """Run the pytest harness against modmesh's tests directory.
+
+    :param extra_args: Pytest options passed on the pilot command line
+        (after ``--mode=pytest``). When non-empty, takes precedence over
+        the ``PYTEST_OPTS`` environment variable, which is the path used
+        by ``make run_pilot_pytest PYTEST_OPTS=...``.
+    :type extra_args: list[str] or None
+    :returns: Pytest exit code.
+    :rtype: int
+    """
     # Import pytest locally to avoid making it a dependency to the whole
     # modmesh.
     import pytest
+    import shlex
     mmpath = os.path.join(os.path.dirname(modmesh.__file__), '..', 'tests')
     mmpath = os.path.abspath(mmpath)
-    return pytest.main(['-v', '-x', mmpath])
+    if extra_args:
+        opts = list(extra_args)
+    else:
+        env_opts = os.environ.get('PYTEST_OPTS', '')
+        opts = shlex.split(env_opts) if env_opts else ['-v', '-x']
+    return pytest.main(opts + [mmpath])
 
 
 def setup_process(argv):
@@ -106,10 +125,17 @@ def enter_main(argv):
     ret = 0
     if args.exit:
         ret = args.exit[0]
+    elif args.extra and args.mode != 'pytest':
+        # Extra args are only meaningful in pytest mode (forwarded to the
+        # pytest runner). Reject them in other modes to surface typos.
+        sys.stderr.write(
+            'mode "{}" does not accept extra arguments: {}\n'.format(
+                args.mode, ' '.join(args.extra)))
+        ret = 2
     elif 'pilot' == args.mode:
         ret = _run_pilot(argv)
     elif 'pytest' == args.mode:
-        ret = _run_pytest()
+        ret = _run_pytest(args.extra)
     elif 'python' == args.mode:
         sys.stderr.write('mode "python" should not run in Python main')
         ret = 1


### PR DESCRIPTION
It is difficult to select tests for the two make targets for Python testing: `run_pilot_pytest` and `pytest`. For `run_pilot_pytest`, it was not possible, because the options to `pytest` was hard-coded in `_run_pytest()`.

This change fixed the hard-coding issue in `_run_pytest()`, and add examples in `Makefile` to show how to select tests using `PYTEST_OPTS`.

This PR is for issue #763.