### PR TITLE
Accelerate fast_matmul with packing and tiling

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -135,6 +135,363 @@ struct SimpleArrayInternalTypes
 }; /* end class SimpleArrayInternalType */
 
 template <typename A, typename T>
+class SimpleArrayMatmulHelper
+{
+
+private:
+
+    using internal_types = detail::SimpleArrayInternalTypes<T>;
+
+public:
+
+    using value_type = typename internal_types::value_type;
+    using shape_type = typename internal_types::shape_type;
+
+    SimpleArrayMatmulHelper() = delete;
+    SimpleArrayMatmulHelper(A const & lhs, A const & rhs);
+    SimpleArrayMatmulHelper(A const & lhs,
+                            A const & rhs,
+                            size_t tile_x,
+                            size_t tile_y,
+                            size_t tile_z);
+    ~SimpleArrayMatmulHelper() = default;
+
+    SimpleArrayMatmulHelper(SimpleArrayMatmulHelper const &) = delete;
+    SimpleArrayMatmulHelper(SimpleArrayMatmulHelper &&) = delete;
+    SimpleArrayMatmulHelper & operator=(SimpleArrayMatmulHelper const &) = delete;
+    SimpleArrayMatmulHelper & operator=(SimpleArrayMatmulHelper &&) = delete;
+
+    A matmul();
+    A matmul_fast();
+
+private:
+
+    static std::string shape_str(A const & arr);
+    void check_dims() const;
+    void check_inner(size_t lhs_idx, size_t rhs_idx) const;
+    void check_tiles() const;
+    A matmul_vec_vec();
+    A matmul_vec_mat();
+    A matmul_mat_vec();
+    A matmul_mat_mat();
+    A pack_rhs(size_t n, size_t k);
+    void accumulate_tile(A const & packed_rhs,
+                         size_t row_begin,
+                         size_t row_end,
+                         size_t col_begin,
+                         size_t col_end,
+                         size_t inner_begin,
+                         size_t inner_end);
+    A matmul_mat_mat_tiled();
+
+    A const & m_lhs;
+    A const & m_rhs;
+    A m_result;
+    size_t m_tile_x;
+    size_t m_tile_y;
+    size_t m_tile_z;
+
+}; /* end class SimpleArrayMatmulHelper */
+
+template <typename A, typename T>
+SimpleArrayMatmulHelper<A, T>::SimpleArrayMatmulHelper(A const & lhs, A const & rhs)
+    : SimpleArrayMatmulHelper(lhs, rhs, 0, 0, 0)
+{
+}
+
+template <typename A, typename T>
+SimpleArrayMatmulHelper<A, T>::SimpleArrayMatmulHelper(A const & lhs,
+                                                       A const & rhs,
+                                                       size_t tile_x,
+                                                       size_t tile_y,
+                                                       size_t tile_z)
+    : m_lhs(lhs)
+    , m_rhs(rhs)
+    , m_tile_x(tile_x)
+    , m_tile_y(tile_y)
+    , m_tile_z(tile_z)
+{
+    check_dims();
+
+    size_t const lhs_ndim = m_lhs.ndim();
+    size_t const rhs_ndim = m_rhs.ndim();
+
+    if (lhs_ndim == 1 && rhs_ndim == 1)
+    {
+        check_inner(0, 0);
+        m_result = A(1);
+        return;
+    }
+
+    if (lhs_ndim == 1)
+    {
+        check_inner(0, 0);
+        m_result = A(m_rhs.shape(1));
+        return;
+    }
+
+    if (rhs_ndim == 1)
+    {
+        check_inner(1, 0);
+        m_result = A(m_lhs.shape(0));
+        return;
+    }
+
+    check_inner(1, 0);
+    shape_type const result_shape{m_lhs.shape(0), m_rhs.shape(1)};
+    m_result = A(result_shape);
+}
+
+template <typename A, typename T>
+A SimpleArrayMatmulHelper<A, T>::matmul()
+{
+    if (m_lhs.ndim() == 1 && m_rhs.ndim() == 1)
+    {
+        return matmul_vec_vec();
+    }
+    if (m_lhs.ndim() == 1)
+    {
+        return matmul_vec_mat();
+    }
+    if (m_rhs.ndim() == 1)
+    {
+        return matmul_mat_vec();
+    }
+
+    return matmul_mat_mat();
+}
+
+/**
+ * Perform fast matrix multiplication for SimpleArrays.
+ * This implementation currently uses tiling for 2D x 2D matrix multiplication.
+ * Future optimizations may add other techniques such as SIMD kernels.
+ */
+template <typename A, typename T>
+A SimpleArrayMatmulHelper<A, T>::matmul_fast()
+{
+    check_tiles();
+
+    if (m_lhs.ndim() == 1 && m_rhs.ndim() == 1)
+    {
+        return matmul_vec_vec();
+    }
+    if (m_lhs.ndim() == 1)
+    {
+        return matmul_vec_mat();
+    }
+    if (m_rhs.ndim() == 1)
+    {
+        return matmul_mat_vec();
+    }
+
+    return matmul_mat_mat_tiled();
+}
+
+/**
+ * Format shape for matrix multiplication diagnostics.
+ */
+template <typename A, typename T>
+std::string SimpleArrayMatmulHelper<A, T>::shape_str(A const & arr)
+{
+    if (arr.ndim() == 0)
+    {
+        return "()";
+    }
+
+    std::string result = "(";
+    for (size_t i = 0; i < arr.ndim(); ++i)
+    {
+        if (i > 0)
+        {
+            result += ",";
+        }
+        result += std::to_string(arr.shape(i));
+    }
+    result += ")";
+    return result;
+}
+
+template <typename A, typename T>
+void SimpleArrayMatmulHelper<A, T>::check_dims() const
+{
+    bool const lhs_is_supported = m_lhs.ndim() == 1 || m_lhs.ndim() == 2;
+    bool const rhs_is_supported = m_rhs.ndim() == 1 || m_rhs.ndim() == 2;
+    if (lhs_is_supported && rhs_is_supported)
+    {
+        return;
+    }
+
+    std::string const err = std::format("SimpleArray::matmul(): unsupported dimensions: "
+                                        "this={} other={}. SimpleArray must be 1D or 2D.",
+                                        shape_str(m_lhs),
+                                        shape_str(m_rhs));
+    throw std::out_of_range(err);
+}
+
+template <typename A, typename T>
+void SimpleArrayMatmulHelper<A, T>::check_inner(size_t lhs_idx, size_t rhs_idx) const
+{
+    if (m_lhs.shape(lhs_idx) == m_rhs.shape(rhs_idx))
+    {
+        return;
+    }
+
+    throw std::out_of_range(
+        std::format("SimpleArray::matmul(): shape mismatch: this={} other={}",
+                    shape_str(m_lhs),
+                    shape_str(m_rhs)));
+}
+
+template <typename A, typename T>
+void SimpleArrayMatmulHelper<A, T>::check_tiles() const
+{
+    if (m_tile_x != 0 && m_tile_y != 0 && m_tile_z != 0)
+    {
+        return;
+    }
+
+    throw std::out_of_range(
+        std::format("SimpleArray::fast_matmul(): tile sizes must be positive: "
+                    "tile_x={} tile_y={} tile_z={}",
+                    m_tile_x,
+                    m_tile_y,
+                    m_tile_z));
+}
+
+template <typename A, typename T>
+A SimpleArrayMatmulHelper<A, T>::matmul_vec_vec()
+{
+    size_t const k = m_lhs.shape(0);
+    value_type v = 0;
+    for (size_t i = 0; i < k; ++i)
+    {
+        v += m_lhs(i) * m_rhs.data(i);
+    }
+    m_result.data(0) = v;
+    return std::move(m_result);
+}
+
+template <typename A, typename T>
+A SimpleArrayMatmulHelper<A, T>::matmul_vec_mat()
+{
+    size_t const n = m_result.size();
+    size_t const k = m_lhs.shape(0);
+    for (size_t j = 0; j < n; ++j)
+    {
+        value_type v = 0;
+        for (size_t l = 0; l < k; ++l)
+        {
+            v += m_lhs(l) * m_rhs(l, j);
+        }
+        m_result.data(j) = v;
+    }
+    return std::move(m_result);
+}
+
+template <typename A, typename T>
+A SimpleArrayMatmulHelper<A, T>::matmul_mat_vec()
+{
+    size_t const m = m_result.size();
+    size_t const k = m_lhs.shape(1);
+    for (size_t i = 0; i < m; ++i)
+    {
+        value_type v = 0;
+        for (size_t l = 0; l < k; ++l)
+        {
+            v += m_lhs(i, l) * m_rhs(l);
+        }
+        m_result.data(i) = v;
+    }
+    return std::move(m_result);
+}
+
+template <typename A, typename T>
+A SimpleArrayMatmulHelper<A, T>::matmul_mat_mat()
+{
+    size_t const m = m_result.shape(0);
+    size_t const n = m_result.shape(1);
+    size_t const k = m_lhs.shape(1);
+    for (size_t i = 0; i < m; ++i)
+    {
+        for (size_t j = 0; j < n; ++j)
+        {
+            value_type v = 0;
+            for (size_t l = 0; l < k; ++l)
+            {
+                v += m_lhs(i, l) * m_rhs(l, j);
+            }
+            m_result(i, j) = v;
+        }
+    }
+    return std::move(m_result);
+}
+
+template <typename A, typename T>
+A SimpleArrayMatmulHelper<A, T>::pack_rhs(size_t n, size_t k)
+{
+    shape_type const packing_shape{n, k};
+    A packing(packing_shape);
+    for (size_t i = 0; i < n; ++i)
+    {
+        for (size_t j = 0; j < k; ++j)
+        {
+            packing(i, j) = m_rhs(j, i);
+        }
+    }
+    return packing;
+}
+
+template <typename A, typename T>
+void SimpleArrayMatmulHelper<A, T>::accumulate_tile(A const & packed_rhs,
+                                                    size_t row_begin,
+                                                    size_t row_end,
+                                                    size_t col_begin,
+                                                    size_t col_end,
+                                                    size_t inner_begin,
+                                                    size_t inner_end)
+{
+    for (size_t i = row_begin; i < row_end; ++i)
+    {
+        for (size_t j = col_begin; j < col_end; ++j)
+        {
+            value_type v = m_result(i, j);
+            for (size_t l = inner_begin; l < inner_end; ++l)
+            {
+                v += m_lhs(i, l) * packed_rhs(j, l);
+            }
+            m_result(i, j) = v;
+        }
+    }
+}
+
+template <typename A, typename T>
+A SimpleArrayMatmulHelper<A, T>::matmul_mat_mat_tiled()
+{
+    size_t const m = m_result.shape(0);
+    size_t const n = m_result.shape(1);
+    size_t const k = m_lhs.shape(1);
+    A packed_rhs = pack_rhs(n, k);
+    for (size_t i = 0; i < m_result.size(); ++i)
+    {
+        m_result.data(i) = value_type{0};
+    }
+    for (size_t row = 0; row < m; row += m_tile_x)
+    {
+        size_t const row_end = std::min(row + m_tile_x, m);
+        for (size_t col = 0; col < n; col += m_tile_y)
+        {
+            size_t const col_end = std::min(col + m_tile_y, n);
+            for (size_t inner = 0; inner < k; inner += m_tile_z)
+            {
+                size_t const inner_end = std::min(inner + m_tile_z, k);
+                accumulate_tile(packed_rhs, row, row_end, col, col_end, inner, inner_end);
+            }
+        }
+    }
+    return std::move(m_result);
+}
+
+template <typename A, typename T>
 class SimpleArrayMixinModifiers
 {
 
@@ -854,8 +1211,6 @@ public:
         return *athis;
     }
 
-    A & imatmul(A const & other);
-
     A add_simd(A const & other) const
     {
         A const * athis = static_cast<A const *>(this);
@@ -953,6 +1308,15 @@ public:
     }
 
     A matmul(A const & other) const;
+    A & imatmul(A const & other);
+    A fast_matmul(A const & other,
+                  size_t tile_x,
+                  size_t tile_y,
+                  size_t tile_z) const;
+    A & fast_imatmul(A const & other,
+                     size_t tile_x,
+                     size_t tile_y,
+                     size_t tile_z);
 
 private:
     static void find_two_bins(const uint32_t * freq, size_t n, int & bin1, int & bin2);
@@ -1051,145 +1415,16 @@ detail::SimpleArrayMixinCalculators<A, T>::median_freq(small_vector<value_type> 
  * This implementation supports 1D x 1D, 1D x 2D, 2D x 1D, and 2D x 2D matrix multiplication.
  */
 template <typename A, typename T>
-A SimpleArrayMixinCalculators<A, T>::matmul(A const & other) const // NOLINT(readability-function-cognitive-complexity)
+A SimpleArrayMixinCalculators<A, T>::matmul(A const & other) const
 {
-    auto athis = static_cast<A const *>(this);
-    const size_t this_ndim = athis->ndim();
-    const size_t other_ndim = other.ndim();
-
-    auto format_shape = [](A const * arr) -> std::string
-    {
-        if (arr->ndim() == 0)
-        {
-            return "()";
-        }
-        else
-        {
-            std::string result = "(";
-            for (size_t i = 0; i < arr->ndim(); ++i)
-            {
-                if (i > 0)
-                {
-                    result += ",";
-                }
-                result += std::to_string(arr->shape(i));
-            }
-            result += ")";
-            return result;
-        }
-    };
-
-    auto check_product_shape = [&](A const * athis, A const * other, ssize_t athis_idx, ssize_t other_idx) -> void
-    {
-        if (athis->shape(athis_idx) != other->shape(other_idx))
-        {
-            throw std::out_of_range(
-                std::format("SimpleArray::matmul(): shape mismatch: this={} other={}",
-                            format_shape(athis),
-                            format_shape(other)));
-        }
-    };
-
-    if ((this_ndim != 2 && this_ndim != 1) || (other_ndim != 2 && other_ndim != 1))
-    {
-        const std::string err = std::format("SimpleArray::matmul(): unsupported dimensions: "
-                                            "this={} other={}. SimpleArray must be 1D or 2D.",
-                                            format_shape(athis),
-                                            format_shape(&other));
-        throw std::out_of_range(err);
-    }
-
-    bool const this_is_1d = (this_ndim == 1);
-    bool const other_is_1d = (other_ndim == 1);
-
-    // 1D x 1D
-    if (this_is_1d && other_is_1d)
-    {
-        check_product_shape(athis, &other, 0, 0);
-        A result(1);
-        value_type v = 0;
-        for (size_t i = 0; i < athis->shape(0); ++i)
-        {
-            v += (*athis)(i)*other.data(i);
-        }
-        result.data(0) = v;
-        return result;
-    }
-    // 1D x 2D
-    else if (this_is_1d)
-    {
-        const size_t k = athis->shape(0);
-        const size_t n = other.shape(1);
-        check_product_shape(athis, &other, 0, 0);
-        A result(n);
-
-        for (size_t j = 0; j < n; ++j)
-        {
-            value_type v = 0;
-            for (size_t l = 0; l < k; ++l)
-            {
-                v += (*athis)(l)*other(l, j);
-            }
-            result.data(j) = v;
-        }
-        return result;
-    }
-    // 2D x 1D
-    else if (other_is_1d)
-    {
-        const size_t m = athis->shape(0);
-        const size_t k = athis->shape(1);
-
-        check_product_shape(athis, &other, 1, 0);
-        A result(m);
-
-        for (size_t i = 0; i < m; ++i)
-        {
-            value_type v = 0;
-            for (size_t l = 0; l < k; ++l)
-            {
-                v += (*athis)(i, l) * other(l);
-            }
-            result.data(i) = v;
-        }
-        return result;
-    }
-    // 2D x 2D
-    else
-    {
-        const size_t m = athis->shape(0);
-        const size_t k = athis->shape(1);
-        const size_t n = other.shape(1);
-        check_product_shape(athis, &other, 1, 0);
-
-        shape_type const result_shape{m, n};
-        A result(result_shape);
-
-        for (size_t i = 0; i < m; ++i)
-        {
-            for (size_t j = 0; j < n; ++j)
-            {
-                value_type v = 0;
-                for (size_t l = 0; l < k; ++l)
-                {
-                    v += (*athis)(i, l) * other(l, j);
-                }
-                result(i, j) = v;
-            }
-        }
-        return result;
-    }
-
-    throw std::out_of_range(
-        std::format("SimpleArray::matmul(): this={} other={}"
-                    " cannot perform matrix multiplication.",
-                    format_shape(athis),
-                    format_shape(&other)));
+    auto const * athis = static_cast<A const *>(this);
+    SimpleArrayMatmulHelper<A, T> helper(*athis, other);
+    return helper.matmul();
 }
 
 /**
- * Perform in-place matrix multiplication for 2D arrays.
- * This implementation supports only 2D x 2D matrix multiplication.
+ * Perform in-place matrix multiplication for SimpleArrays.
+ * This implementation supports 1D x 1D, 1D x 2D, 2D x 1D, and 2D x 2D matrix multiplication.
  * The result replaces the content of the current array.
  */
 template <typename A, typename T>
@@ -1197,6 +1432,39 @@ A & SimpleArrayMixinCalculators<A, T>::imatmul(A const & other)
 {
     auto athis = static_cast<A *>(this);
     A result = athis->matmul(other);
+    *athis = std::move(result);
+
+    return *athis;
+}
+
+/**
+ * Perform fast matrix multiplication for SimpleArrays.
+ * This implementation supports 1D x 1D, 1D x 2D, 2D x 1D, and 2D x 2D matrix multiplication.
+ */
+template <typename A, typename T>
+A SimpleArrayMixinCalculators<A, T>::fast_matmul(A const & other,
+                                                 size_t tile_x,
+                                                 size_t tile_y,
+                                                 size_t tile_z) const
+{
+    auto const * athis = static_cast<A const *>(this);
+    SimpleArrayMatmulHelper<A, T> helper(*athis, other, tile_x, tile_y, tile_z);
+    return helper.matmul_fast();
+}
+
+/**
+ * Perform in-place fast matrix multiplication for SimpleArrays.
+ * This implementation supports 1D x 1D, 1D x 2D, 2D x 1D, and 2D x 2D matrix multiplication.
+ * The result replaces the content of the current array.
+ */
+template <typename A, typename T>
+A & SimpleArrayMixinCalculators<A, T>::fast_imatmul(A const & other,
+                                                    size_t tile_x,
+                                                    size_t tile_y,
+                                                    size_t tile_z)
+{
+    auto athis = static_cast<A *>(this);
+    A result = athis->fast_matmul(other, tile_x, tile_y, tile_z);
     *athis = std::move(result);
 
     return *athis;

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -359,6 +359,18 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 { return self.div(scalar); })
             .def("matmul", &wrapped_type::matmul)
             .def("__matmul__", &wrapped_type::matmul)
+            .def(
+                "fast_matmul",
+                [](wrapped_type const & self,
+                   wrapped_type const & other,
+                   size_t tile_x,
+                   size_t tile_y,
+                   size_t tile_z)
+                { return self.fast_matmul(other, tile_x, tile_y, tile_z); },
+                py::arg("other"),
+                py::arg("tile_x") = 16,
+                py::arg("tile_y") = 16,
+                py::arg("tile_z") = 16)
             // TODO: In-place operation should return reference to self to support function chaining
             /*
              * Regular in-place methods (iadd, imul, etc.) are procedural calls and do

--- a/profiling/profile_matrix_ops.py
+++ b/profiling/profile_matrix_ops.py
@@ -54,8 +54,14 @@ def profile_matmul_np(lhs, rhs):
 
 
 @profile_function
-def profile_matmul_sa(lhs, rhs):
+def profile_matmul_naive_sa(lhs, rhs):
     return lhs.matmul(rhs)
+
+
+def profile_matmul_fast_sa(lhs, rhs, tile_x, tile_y, tile_z):
+    name = f"profile_matmul_fast_sa_{tile_x}_{tile_y}_{tile_z}"
+    _ = modmesh.CallProfilerProbe(name)
+    return lhs.fast_matmul(rhs, tile_x=tile_x, tile_y=tile_y, tile_z=tile_z)
 
 
 def make_data(dtype, shape):
@@ -63,6 +69,11 @@ def make_data(dtype, shape):
 
 
 def profile_matmul_operation(dtype, shapes, it=10):
+    tile_configs = (
+        (16, 16, 16),
+        (32, 32, 32),
+        (64, 64, 64),
+    )
     for m in shapes:
         lhs = make_data(dtype, (m, m))
         rhs = make_data(dtype, (m, m))
@@ -71,7 +82,9 @@ def profile_matmul_operation(dtype, shapes, it=10):
         modmesh.call_profiler.reset()
         for _ in range(it):
             profile_matmul_np(lhs, rhs)
-            profile_matmul_sa(lhs_sa, rhs_sa)
+            profile_matmul_naive_sa(lhs_sa, rhs_sa)
+            for tile_x, tile_y, tile_z in tile_configs:
+                profile_matmul_fast_sa(lhs_sa, rhs_sa, tile_x, tile_y, tile_z)
 
         res = modmesh.call_profiler.result()["children"]
         out = {}
@@ -79,16 +92,23 @@ def profile_matmul_operation(dtype, shapes, it=10):
             name = r["name"].replace("profile_matmul_", "")
             out[name] = r["total_time"] / r["count"]
 
-        print(f"## 2D x 2D shape: ({m}, {m}) x ({m}, {m}) dtype:"
-              f"`{np.dtype(dtype)}`\n")
+        print(
+            f"## 2D x 2D shape: ({m}, {m}) x ({m}, {m}) dtype:"
+            f"`{np.dtype(dtype)}`\n"
+        )
 
         def print_row(*cols):
-            print(str.format("| {:10s} | {:15s} | {:15s} |", *(cols[0:3])))
+            print(str.format("| {:20s} | {:15s} | {:15s} |", *(cols[0:3])))
 
         print_row("func", "per call (ms)", "cmp to np")
-        print_row("-" * 10, "-" * 15, "-" * 15)
+        print_row("-" * 20, "-" * 15, "-" * 15)
         npbase = out["np"]
-        for key in ("np", "sa"):
+        keys = ["np", "naive_sa"]
+        keys += [
+            f"fast_sa_{tile_x}_{tile_y}_{tile_z}"
+            for tile_x, tile_y, tile_z in tile_configs
+        ]
+        for key in keys:
             value = out[key]
             print_row(f"{key:8s}", f"{value:.3E}", f"{value / npbase:.3f}")
         print()

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -97,9 +97,14 @@ class MatmulTestBase(mm.testing.TestBase):
 
         # Test matrix multiplication
         result = a.matmul(b)
+        fast_result = a.fast_matmul(b)
 
         self.assertEqual(list(result.shape), [2, 2])
         np.testing.assert_array_almost_equal(result.ndarray, expected)
+        self.assertEqual(list(fast_result.shape), [2, 2])
+        np.testing.assert_array_almost_equal(fast_result.ndarray, expected)
+        np.testing.assert_array_almost_equal(fast_result.ndarray,
+                                             result.ndarray)
 
     def test_rectangular(self):
         """Test rectangular matrix multiplication"""
@@ -117,9 +122,14 @@ class MatmulTestBase(mm.testing.TestBase):
                             dtype=self.dtype)
 
         result = a.matmul(b)
+        fast_result = a.fast_matmul(b)
 
         self.assertEqual(list(result.shape), [2, 2])
         np.testing.assert_array_almost_equal(result.ndarray, expected)
+        self.assertEqual(list(fast_result.shape), [2, 2])
+        np.testing.assert_array_almost_equal(fast_result.ndarray, expected)
+        np.testing.assert_array_almost_equal(fast_result.ndarray,
+                                             result.ndarray)
 
     def test_identity(self):
         """Test multiplication with identity matrix"""
@@ -131,9 +141,14 @@ class MatmulTestBase(mm.testing.TestBase):
         identity = self.SimpleArray.eye(3)
 
         result = a.matmul(identity)
+        fast_result = a.fast_matmul(identity)
 
         self.assertEqual(list(result.shape), [3, 3])
         np.testing.assert_array_almost_equal(result.ndarray, a_data)
+        self.assertEqual(list(fast_result.shape), [3, 3])
+        np.testing.assert_array_almost_equal(fast_result.ndarray, a_data)
+        np.testing.assert_array_almost_equal(fast_result.ndarray,
+                                             result.ndarray)
 
     def test_zero(self):
         """Test multiplication with zero matrix"""
@@ -144,9 +159,14 @@ class MatmulTestBase(mm.testing.TestBase):
         zero = self.SimpleArray(array=zero_data)
 
         result = a.matmul(zero)
+        fast_result = a.fast_matmul(zero)
 
         self.assertEqual(list(result.shape), [2, 2])
         np.testing.assert_array_almost_equal(result.ndarray, zero_data)
+        self.assertEqual(list(fast_result.shape), [2, 2])
+        np.testing.assert_array_almost_equal(fast_result.ndarray, zero_data)
+        np.testing.assert_array_almost_equal(fast_result.ndarray,
+                                             result.ndarray)
 
     def test_dimension_mismatch_error(self):
         """Test error handling for incompatible dimensions"""
@@ -167,6 +187,12 @@ class MatmulTestBase(mm.testing.TestBase):
             r"\(3,3\)"
         ):
             a.matmul(b)
+        with self.assertRaisesRegex(
+            IndexError,
+            r"SimpleArray::matmul\(\): shape mismatch: this=\(2,2\) other="
+            r"\(3,3\)"
+        ):
+            a.fast_matmul(b)
 
     def test_compare_with_numpy(self):
         """Compare results with NumPy using fixed test data"""
@@ -268,6 +294,7 @@ class MatmulTestBase(mm.testing.TestBase):
 
                 # Compute with our implementation
                 result = a.matmul(b)
+                fast_result = a.fast_matmul(b)
 
                 # Verify with NumPy
                 np_result = np.matmul(a_data, b_data)
@@ -275,12 +302,20 @@ class MatmulTestBase(mm.testing.TestBase):
 
                 # Compare our result with expected
                 self.assertEqual(list(result.shape), list(expected.shape))
+                self.assertEqual(list(fast_result.shape),
+                                 list(expected.shape))
+                np.testing.assert_array_almost_equal(fast_result.ndarray,
+                                                     result.ndarray)
                 if self.dtype == np.float32:
                     np.testing.assert_array_almost_equal(
                         result.ndarray, expected, decimal=4)
+                    np.testing.assert_array_almost_equal(
+                        fast_result.ndarray, expected, decimal=4)
                 else:
                     np.testing.assert_array_almost_equal(
                         result.ndarray, expected, decimal=10)
+                    np.testing.assert_array_almost_equal(
+                        fast_result.ndarray, expected, decimal=10)
 
     def test_wrong_shape_error(self):
         """Test error handling for wrong shapes"""
@@ -298,6 +333,12 @@ class MatmulTestBase(mm.testing.TestBase):
             r"this=\(2,2,2\) other=\(2,2,2\)\. SimpleArray must be 1D or 2D."
         ):
             a_3d.matmul(b_3d)
+        with self.assertRaisesRegex(
+            IndexError,
+            r"SimpleArray::matmul\(\): unsupported dimensions: "
+            r"this=\(2,2,2\) other=\(2,2,2\)\. SimpleArray must be 1D or 2D."
+        ):
+            a_3d.fast_matmul(b_3d)
 
         a = np.zeros((3, 3), dtype=self.dtype)
         b = np.zeros((2, 3), dtype=self.dtype)
@@ -309,6 +350,12 @@ class MatmulTestBase(mm.testing.TestBase):
             r"this=\(3,3\) other=\(2,3\)"
         ):
             a.matmul(b)
+        with self.assertRaisesRegex(
+            IndexError,
+            r"SimpleArray::matmul\(\): shape mismatch: "
+            r"this=\(3,3\) other=\(2,3\)"
+        ):
+            a.fast_matmul(b)
 
         a = np.zeros((3, 3), dtype=self.dtype)
         b = np.zeros((2), dtype=self.dtype)
@@ -320,6 +367,12 @@ class MatmulTestBase(mm.testing.TestBase):
             r"this=\(3,3\) other=\(2\)"
         ):
             a.matmul(b)
+        with self.assertRaisesRegex(
+            IndexError,
+            r"SimpleArray::matmul\(\): shape mismatch: "
+            r"this=\(3,3\) other=\(2\)"
+        ):
+            a.fast_matmul(b)
 
         a = np.zeros((2), dtype=self.dtype)
         b = np.zeros((3, 3), dtype=self.dtype)
@@ -331,6 +384,12 @@ class MatmulTestBase(mm.testing.TestBase):
             r"this=\(2\) other=\(3,3\)"
         ):
             a.matmul(b)
+        with self.assertRaisesRegex(
+            IndexError,
+            r"SimpleArray::matmul\(\): shape mismatch: "
+            r"this=\(2\) other=\(3,3\)"
+        ):
+            a.fast_matmul(b)
 
         a = np.zeros((2), dtype=self.dtype)
         b = np.zeros((3), dtype=self.dtype)
@@ -342,6 +401,12 @@ class MatmulTestBase(mm.testing.TestBase):
             r"this=\(2\) other=\(3\)"
         ):
             a.matmul(b)
+        with self.assertRaisesRegex(
+            IndexError,
+            r"SimpleArray::matmul\(\): shape mismatch: "
+            r"this=\(2\) other=\(3\)"
+        ):
+            a.fast_matmul(b)
 
     def test_matmul_operator(self):
         """Test @ operator for matrix multiplication"""


### PR DESCRIPTION
This pull request is to accelerate `SimpleArray::matmul()`, see issue #715.
In order to compare with baseline `SimpleArray::matmul()`, I implement new api named `SimpleArray::fast_matmul()`, which is accelerated by packing and tiling technique.

The following chart and sheet records the measurement results. `np` corresponds to `numpy::matmul()`, `naive_sa` corresponds to  original `SimpleArray::matmul()`, and `fast_np_{tile_size_x}_{tile_size_y}_{tile_size_z}` corresponds to  `SimpleArray::fast_matmul()` with different tile size.

The observation is interesting, we notice that when SimpleArray is big, `SimpleArray::fast_matmul()` with small tile is faster. On the contrary, when SimpleArray is small, `SimpleArray::fast_matmul()` with big tile is faster.

<img width="1620" height="900" alt="image" src="https://github.com/user-attachments/assets/f9bb654a-0a74-4a7a-b9f2-5e9dab9d4c8b" />
<img width="1620" height="900" alt="image" src="https://github.com/user-attachments/assets/02f39db3-71e4-45a3-81bd-04e87663c0fc" />

## 2D x 2D shape: (4, 4) x (4, 4) dtype:`float32`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.818E-01       | 1.000           |
| naive_sa             | 2.404E-03       | 0.013           |
| fast_sa_16_16_16     | 2.296E-03       | 0.013           |
| fast_sa_32_32_32     | 1.875E-03       | 0.010           |
| fast_sa_64_64_64     | 1.821E-03       | 0.010           |

## 2D x 2D shape: (16, 16) x (16, 16) dtype:`float32`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 2.170E-01       | 1.000           |
| naive_sa             | 4.079E-03       | 0.019           |
| fast_sa_16_16_16     | 4.004E-03       | 0.018           |
| fast_sa_32_32_32     | 3.783E-03       | 0.017           |
| fast_sa_64_64_64     | 3.692E-03       | 0.017           |

## 2D x 2D shape: (64, 64) x (64, 64) dtype:`float32`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 2.241E-02       | 1.000           |
| naive_sa             | 2.438E-01       | 10.878          |
| fast_sa_16_16_16     | 8.967E-02       | 4.001           |
| fast_sa_32_32_32     | 1.058E-01       | 4.720           |
| fast_sa_64_64_64     | 1.391E-01       | 6.208           |

## 2D x 2D shape: (256, 256) x (256, 256) dtype:`float32`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 4.621E-02       | 1.000           |
| naive_sa             | 2.444E+01       | 528.759         |
| fast_sa_16_16_16     | 5.206E+00       | 112.646         |
| fast_sa_32_32_32     | 6.301E+00       | 136.342         |
| fast_sa_64_64_64     | 8.446E+00       | 182.766         |

## 2D x 2D shape: (1024, 1024) x (1024, 1024) dtype:`float32`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 3.203E+00       | 1.000           |
| naive_sa             | 2.065E+03       | 644.640         |
| fast_sa_16_16_16     | 3.308E+02       | 103.265         |
| fast_sa_32_32_32     | 4.138E+02       | 129.167         |
| fast_sa_64_64_64     | 5.546E+02       | 173.138         |

## 2D x 2D shape: (4, 4) x (4, 4) dtype:`float64`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 4.696E-03       | 1.000           |
| naive_sa             | 1.654E-03       | 0.352           |
| fast_sa_16_16_16     | 2.396E-03       | 0.510           |
| fast_sa_32_32_32     | 1.837E-03       | 0.391           |
| fast_sa_64_64_64     | 1.763E-03       | 0.375           |

## 2D x 2D shape: (16, 16) x (16, 16) dtype:`float64`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.889E-01       | 1.000           |
| naive_sa             | 4.654E-03       | 0.025           |
| fast_sa_16_16_16     | 4.771E-03       | 0.025           |
| fast_sa_32_32_32     | 4.017E-03       | 0.021           |
| fast_sa_64_64_64     | 3.825E-03       | 0.020           |

## 2D x 2D shape: (64, 64) x (64, 64) dtype:`float64`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 6.288E-03       | 1.000           |
| naive_sa             | 2.476E-01       | 39.384          |
| fast_sa_16_16_16     | 9.311E-02       | 14.809          |
| fast_sa_32_32_32     | 1.195E-01       | 19.000          |
| fast_sa_64_64_64     | 1.641E-01       | 26.106          |

## 2D x 2D shape: (256, 256) x (256, 256) dtype:`float64`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.621E-01       | 1.000           |
| naive_sa             | 2.486E+01       | 153.326         |
| fast_sa_16_16_16     | 5.521E+00       | 34.054          |
| fast_sa_32_32_32     | 7.124E+00       | 43.943          |
| fast_sa_64_64_64     | 1.032E+01       | 63.680          |

## 2D x 2D shape: (1024, 1024) x (1024, 1024) dtype:`float64`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.165E+01       | 1.000           |
| naive_sa             | 2.142E+03       | 183.825         |
| fast_sa_16_16_16     | 4.227E+02       | 36.281          |
| fast_sa_32_32_32     | 4.961E+02       | 42.577          |
| fast_sa_64_64_64     | 6.815E+02       | 58.492          |

## 2D x 2D shape: (9, 9) x (9, 9) dtype:`float32`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 3.254E-03       | 1.000           |
| naive_sa             | 1.842E-03       | 0.566           |
| fast_sa_16_16_16     | 2.791E-03       | 0.858           |
| fast_sa_32_32_32     | 2.450E-03       | 0.753           |
| fast_sa_64_64_64     | 2.437E-03       | 0.749           |

## 2D x 2D shape: (27, 27) x (27, 27) dtype:`float32`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.400E-01       | 1.000           |
| naive_sa             | 1.388E-02       | 0.099           |
| fast_sa_16_16_16     | 1.286E-02       | 0.092           |
| fast_sa_32_32_32     | 1.163E-02       | 0.083           |
| fast_sa_64_64_64     | 1.157E-02       | 0.083           |

## 2D x 2D shape: (81, 81) x (81, 81) dtype:`float32`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 7.596E-03       | 1.000           |
| naive_sa             | 5.659E-01       | 74.499          |
| fast_sa_16_16_16     | 1.868E-01       | 24.599          |
| fast_sa_32_32_32     | 2.133E-01       | 28.084          |
| fast_sa_64_64_64     | 2.624E-01       | 34.550          |

## 2D x 2D shape: (243, 243) x (243, 243) dtype:`float32`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 5.318E-02       | 1.000           |
| naive_sa             | 2.011E+01       | 378.090         |
| fast_sa_16_16_16     | 4.678E+00       | 87.972          |
| fast_sa_32_32_32     | 5.561E+00       | 104.579         |
| fast_sa_64_64_64     | 7.337E+00       | 137.963         |

## 2D x 2D shape: (729, 729) x (729, 729) dtype:`float32`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.196E+00       | 1.000           |
| naive_sa             | 7.124E+02       | 595.856         |
| fast_sa_16_16_16     | 1.247E+02       | 104.295         |
| fast_sa_32_32_32     | 1.486E+02       | 124.256         |
| fast_sa_64_64_64     | 1.983E+02       | 165.877         |

## 2D x 2D shape: (9, 9) x (9, 9) dtype:`float64`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 3.454E-03       | 1.000           |
| naive_sa             | 2.008E-03       | 0.581           |
| fast_sa_16_16_16     | 2.617E-03       | 0.758           |
| fast_sa_32_32_32     | 2.187E-03       | 0.633           |
| fast_sa_64_64_64     | 2.187E-03       | 0.633           |

## 2D x 2D shape: (27, 27) x (27, 27) dtype:`float64`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.416E-01       | 1.000           |
| naive_sa             | 1.424E-02       | 0.101           |
| fast_sa_16_16_16     | 1.165E-02       | 0.082           |
| fast_sa_32_32_32     | 1.119E-02       | 0.079           |
| fast_sa_64_64_64     | 1.110E-02       | 0.078           |

## 2D x 2D shape: (81, 81) x (81, 81) dtype:`float64`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.694E-02       | 1.000           |
| naive_sa             | 5.645E-01       | 33.326          |
| fast_sa_16_16_16     | 2.009E-01       | 11.864          |
| fast_sa_32_32_32     | 2.347E-01       | 13.857          |
| fast_sa_64_64_64     | 3.144E-01       | 18.562          |

## 2D x 2D shape: (243, 243) x (243, 243) dtype:`float64`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 1.535E-01       | 1.000           |
| naive_sa             | 2.021E+01       | 131.674         |
| fast_sa_16_16_16     | 4.912E+00       | 32.000          |
| fast_sa_32_32_32     | 6.214E+00       | 40.480          |
| fast_sa_64_64_64     | 8.631E+00       | 56.226          |

## 2D x 2D shape: (729, 729) x (729, 729) dtype:`float64`

| func                 | per call (ms)   | cmp to np       |
| -------------------- | --------------- | --------------- |
| np                   | 4.339E+00       | 1.000           |
| naive_sa             | 7.178E+02       | 165.433         |
| fast_sa_16_16_16     | 1.333E+02       | 30.710          |
| fast_sa_32_32_32     | 1.689E+02       | 38.931          |
| fast_sa_64_64_64     | 2.377E+02       | 54.786          |

By the way, to validate the usefulness of packing, I also profile `SimpleArray::fast_matmul()` without tiling. The following chart and sheet are data. It is clear that packing could make operation faster.
<img width="1620" height="900" alt="image" src="https://github.com/user-attachments/assets/aa457019-9a45-4303-b6b2-3674a908cb96" />
<img width="1620" height="900" alt="image" src="https://github.com/user-attachments/assets/057edaf8-e6db-402a-8ed5-78b48359219b" />

## 2D x 2D shape: (4, 4) x (4, 4) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 2.244E-01       | 1.000           |
| naive_sa   | 1.691E-03       | 0.008           |
| fast_sa    | 1.338E-03       | 0.006           |

## 2D x 2D shape: (16, 16) x (16, 16) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 2.208E-01       | 1.000           |
| naive_sa   | 4.083E-03       | 0.018           |
| fast_sa    | 2.704E-03       | 0.012           |

## 2D x 2D shape: (64, 64) x (64, 64) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 2.905E-02       | 1.000           |
| naive_sa   | 2.395E-01       | 8.245           |
| fast_sa    | 1.325E-01       | 4.559           |

## 2D x 2D shape: (256, 256) x (256, 256) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 4.985E-02       | 1.000           |
| naive_sa   | 2.443E+01       | 490.041         |
| fast_sa    | 1.485E+01       | 297.920         |

## 2D x 2D shape: (1024, 1024) x (1024, 1024) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 3.297E+00       | 1.000           |
| naive_sa   | 2.182E+03       | 661.923         |
| fast_sa    | 1.473E+03       | 446.771         |

## 2D x 2D shape: (4, 4) x (4, 4) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 5.475E-03       | 1.000           |
| naive_sa   | 2.304E-03       | 0.421           |
| fast_sa    | 1.480E-03       | 0.270           |

## 2D x 2D shape: (16, 16) x (16, 16) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 3.051E-01       | 1.000           |
| naive_sa   | 4.504E-03       | 0.015           |
| fast_sa    | 2.817E-03       | 0.009           |

## 2D x 2D shape: (64, 64) x (64, 64) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 6.013E-03       | 1.000           |
| naive_sa   | 2.360E-01       | 39.256          |
| fast_sa    | 1.577E-01       | 26.221          |

## 2D x 2D shape: (256, 256) x (256, 256) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.607E-01       | 1.000           |
| naive_sa   | 2.467E+01       | 153.484         |
| fast_sa    | 1.461E+01       | 90.939          |

## 2D x 2D shape: (1024, 1024) x (1024, 1024) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.195E+01       | 1.000           |
| naive_sa   | 2.179E+03       | 182.362         |
| fast_sa    | 1.570E+03       | 131.418         |

## 2D x 2D shape: (9, 9) x (9, 9) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 5.587E-03       | 1.000           |
| naive_sa   | 3.092E-03       | 0.553           |
| fast_sa    | 3.008E-03       | 0.538           |

## 2D x 2D shape: (27, 27) x (27, 27) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 8.550E-02       | 1.000           |
| naive_sa   | 2.400E-02       | 0.281           |
| fast_sa    | 2.574E-02       | 0.301           |

## 2D x 2D shape: (81, 81) x (81, 81) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 4.090E-02       | 1.000           |
| naive_sa   | 8.716E-01       | 21.310          |
| fast_sa    | 5.251E-01       | 12.839          |

## 2D x 2D shape: (243, 243) x (243, 243) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.098E-01       | 1.000           |
| naive_sa   | 2.485E+01       | 226.286         |
| fast_sa    | 1.503E+01       | 136.813         |

## 2D x 2D shape: (729, 729) x (729, 729) dtype:`float32`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.211E+00       | 1.000           |
| naive_sa   | 7.165E+02       | 591.653         |
| fast_sa    | 4.984E+02       | 411.572         |

## 2D x 2D shape: (9, 9) x (9, 9) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 4.358E-03       | 1.000           |
| naive_sa   | 2.167E-03       | 0.497           |
| fast_sa    | 1.546E-03       | 0.355           |

## 2D x 2D shape: (27, 27) x (27, 27) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.303E-01       | 1.000           |
| naive_sa   | 1.437E-02       | 0.110           |
| fast_sa    | 1.032E-02       | 0.079           |

## 2D x 2D shape: (81, 81) x (81, 81) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.648E-02       | 1.000           |
| naive_sa   | 5.687E-01       | 34.510          |
| fast_sa    | 3.455E-01       | 20.968          |

## 2D x 2D shape: (243, 243) x (243, 243) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 1.824E-01       | 1.000           |
| naive_sa   | 2.037E+01       | 111.698         |
| fast_sa    | 1.283E+01       | 70.352          |

## 2D x 2D shape: (729, 729) x (729, 729) dtype:`float64`

| func       | per call (ms)   | cmp to np       |
| ---------- | --------------- | --------------- |
| np         | 4.266E+00       | 1.000           |
| naive_sa   | 7.688E+02       | 180.208         |
| fast_sa    | 5.700E+02       | 133.619         |

