### PR TITLE
Prototype class `EigenSystem` for solving eigenvalue problems

### DIFF
--- a/cpp/modmesh/CMakeLists.txt
+++ b/cpp/modmesh/CMakeLists.txt
@@ -152,12 +152,14 @@ Checks: '-bugprone-suspicious-include,llvm-twine-local'")
 
 if (APPLE)
     find_library(APPLE_FWK_FOUNDATION Foundation REQUIRED)
+    find_library(APPLE_FWK_ACCELERATE Accelerate REQUIRED)
     find_library(APPLE_FWK_QUARTZ_CORE QuartzCore REQUIRED)
     find_library(APPLE_FWK_METAL Metal REQUIRED)
 
     target_link_libraries(
         modmesh_primary PUBLIC
         ${APPLE_FWK_FOUNDATION}
+        ${APPLE_FWK_ACCELERATE}
         ${APPLE_FWK_QUARTZ_CORE}
         ${APPLE_FWK_METAL}
     )

--- a/cpp/modmesh/linalg/CMakeLists.txt
+++ b/cpp/modmesh/linalg/CMakeLists.txt
@@ -8,6 +8,7 @@ set(MODMESH_LINALG_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/factorization.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lu_factorization.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kalman_filter.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/EigenSystem.hpp
     CACHE FILEPATH "" FORCE)
 
 set(MODMESH_LINALG_SOURCES
@@ -21,6 +22,7 @@ set(MODMESH_LINALG_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/pymod/linalg_pymod.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_factorization.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_kalman_filter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_EigenSystem.cpp
     CACHE FILEPATH "" FORCE)
 
 set(MODMESH_LINALG_FILES

--- a/cpp/modmesh/linalg/EigenSystem.hpp
+++ b/cpp/modmesh/linalg/EigenSystem.hpp
@@ -1,0 +1,242 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Eigenvalue and eigenvector computation for general (non-symmetric) real
+ * matrices using LAPACK DGEEV from Apple's vecLib (Accelerate framework).
+ *
+ * This header is only available on Apple platforms.
+ */
+
+#ifndef __APPLE__
+#error "modmesh/linalg/EigenSystem.hpp is only available on Apple platforms (Accelerate/vecLib)."
+#endif
+
+#include <algorithm>
+#include <cstdint>
+#include <format>
+#include <stdexcept>
+#include <string>
+
+#include <modmesh/buffer/buffer.hpp>
+
+// Opt in to the modern (non-deprecated) LAPACK signatures provided by
+// Accelerate.  Must be defined before including the Accelerate header.
+#ifndef ACCELERATE_NEW_LAPACK
+#define ACCELERATE_NEW_LAPACK
+#endif
+// NOLINTNEXTLINE(misc-header-include-cycle)
+#include <Accelerate/Accelerate.h>
+
+namespace modmesh
+{
+
+/**
+ * Eigenvalue solver for a real general matrix using LAPACK DGEEV.
+ *
+ * Construction validates the input shape and prepares column-major workspace
+ * buffers.  Call run() to invoke DGEEV to calculate eigenvalues and
+ * eigenvectors.
+ */
+class EigenSystem
+{
+
+public:
+
+    using value_type = double;
+    using array_type = SimpleArray<double>;
+
+    explicit EigenSystem(array_type const & matrix);
+
+    EigenSystem() = delete;
+    EigenSystem(EigenSystem const &) = delete;
+    EigenSystem(EigenSystem &&) = delete;
+    EigenSystem & operator=(EigenSystem const &) = delete;
+    EigenSystem & operator=(EigenSystem &&) = delete;
+    ~EigenSystem() = default;
+
+    /// Run DGEEV on the prepared workspace.
+    void run();
+
+    array_type const & matrix() const { return m_matrix; }
+    array_type const & wr() const { return m_wr; }
+    array_type const & wi() const { return m_wi; }
+    array_type const & vl() const { return m_vl; }
+    array_type const & vr() const { return m_vr; }
+    bool done() const { return m_done; }
+
+private:
+
+    static std::string format_shape(array_type const & arr);
+
+    SimpleArray<value_type> const & m_matrix;
+    SimpleArray<value_type> m_colmajor;
+    SimpleArray<value_type> m_wr;
+    SimpleArray<value_type> m_wi;
+    SimpleArray<value_type> m_vl;
+    SimpleArray<value_type> m_vr;
+    bool m_done = false;
+
+}; /* end class EigenSystem */
+
+inline EigenSystem::EigenSystem(array_type const & matrix)
+    : m_matrix(matrix)
+    , m_colmajor(matrix.shape())
+    , m_wr(matrix.shape(0))
+    , m_wi(matrix.shape(0))
+    , m_vl(matrix.shape())
+    , m_vr(matrix.shape())
+{
+    if (matrix.ndim() != 2 || matrix.shape(0) != matrix.shape(1))
+    {
+        throw std::invalid_argument(std::format(
+            "EigenSystem: matrix must be a square 2D SimpleArray, but got shape {}",
+            format_shape(matrix)));
+    }
+
+    // TODO: Enhance SimpleArray::transpose() to copy the contents when
+    // transposing.  The current SimpleArray::transpose() is a *view-only*
+    // operation: it reverses the shape and stride vectors but the underlying
+    // buffer is untouched.  So we have to manually copy element-wisely in the
+    // nested loops below.
+    m_colmajor.transpose();
+    ssize_t const n = matrix.shape(0);
+    for (ssize_t i = 0; i < n; ++i)
+    {
+        for (ssize_t j = 0; j < n; ++j)
+        {
+            m_colmajor(i, j) = matrix(i, j);
+        }
+    }
+    m_vl.transpose();
+    m_vr.transpose();
+}
+
+inline void EigenSystem::run()
+{
+    auto const n = static_cast<__LAPACK_int>(m_matrix.shape(0));
+    if (n == 0)
+    {
+        m_done = true;
+        return;
+    }
+
+    /*
+     * Apple Accelerate DGEEV reference:
+     *   https://developer.apple.com/documentation/accelerate/dgeev_(_:_:_:_:_:_:_:_:_:_:_:_:_:_:)
+     * LAPACK DGEEV API reference:
+     *   https://www.netlib.org/lapack/explore-html/d4/d68/group__geev_ga7d8afe93d23c5862e238626905ee145e.html
+     *   https://www.netlib.org/lapack/explore-html/d9/d28/dgeev_8f_source.html
+     */
+    char const jobvl = 'V';
+    char const jobvr = 'V';
+    __LAPACK_int const lda = n;
+    __LAPACK_int const ldvl = n;
+    __LAPACK_int const ldvr = n;
+    __LAPACK_int info = 0;
+
+    // Phase 1: workspace query.  lwork == -1 tells DGEEV to write the
+    // optimal workspace size into work[0] without performing any work.
+    double work_query = 0.0;
+    __LAPACK_int lwork = -1;
+    dgeev_(
+        &jobvl,
+        &jobvr,
+        &n,
+        m_colmajor.data(),
+        &lda,
+        m_wr.data(),
+        m_wi.data(),
+        m_vl.data(),
+        &ldvl,
+        m_vr.data(),
+        &ldvr,
+        &work_query,
+        &lwork,
+        &info);
+    if (info != 0)
+    {
+        throw std::runtime_error(std::format(
+            "EigenSystem::run: DGEEV workspace query failed with info={}",
+            static_cast<int64_t>(info)));
+    }
+
+    // Phase 2: allocate workspace and run.  Floor at 4*n per the LAPACK
+    // reference minimum when both eigenvector matrices are requested.
+    lwork = std::max<__LAPACK_int>(static_cast<__LAPACK_int>(work_query), 4 * n);
+    array_type work(static_cast<size_t>(lwork));
+    dgeev_(
+        &jobvl,
+        &jobvr,
+        &n,
+        m_colmajor.data(),
+        &lda,
+        m_wr.data(),
+        m_wi.data(),
+        m_vl.data(),
+        &ldvl,
+        m_vr.data(),
+        &ldvr,
+        work.data(),
+        &lwork,
+        &info);
+    if (info < 0)
+    {
+        throw std::runtime_error(std::format(
+            "EigenSystem::run: DGEEV illegal argument at position {}",
+            -static_cast<int>(info)));
+    }
+    if (info > 0)
+    {
+        throw std::runtime_error(std::format(
+            "EigenSystem::run: DGEEV failed to converge; {} eigenvalues did not converge",
+            static_cast<int>(info)));
+    }
+    m_done = true;
+}
+
+inline std::string EigenSystem::format_shape(array_type const & arr)
+{
+    std::string result = "(";
+    for (size_t i = 0; i < arr.ndim(); ++i)
+    {
+        if (i > 0)
+        {
+            result += ", ";
+        }
+        result += std::to_string(arr.shape(i));
+    }
+    result += ")";
+    return result;
+}
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/linalg/linalg.hpp
+++ b/cpp/modmesh/linalg/linalg.hpp
@@ -35,5 +35,8 @@
 #include <modmesh/linalg/factorization.hpp>
 #include <modmesh/linalg/lu_factorization.hpp>
 #include <modmesh/linalg/kalman_filter.hpp>
+#ifdef __APPLE__
+#include <modmesh/linalg/EigenSystem.hpp>
+#endif
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/linalg/pymod/linalg_pymod.cpp
+++ b/cpp/modmesh/linalg/pymod/linalg_pymod.cpp
@@ -50,6 +50,7 @@ void initialize_linalg(pybind11::module & mod)
         wrap_factorization(mod);
         wrap_states_info(mod);
         wrap_kalman_filter(mod);
+        wrap_EigenSystem(mod);
     };
 
     OneTimeInitializer<linalg_pymod_tag>::me()(mod, initialize_impl);

--- a/cpp/modmesh/linalg/pymod/linalg_pymod.hpp
+++ b/cpp/modmesh/linalg/pymod/linalg_pymod.hpp
@@ -45,6 +45,7 @@ void initialize_linalg(pybind11::module & mod);
 void wrap_factorization(pybind11::module & mod);
 void wrap_states_info(pybind11::module & mod);
 void wrap_kalman_filter(pybind11::module & mod);
+void wrap_EigenSystem(pybind11::module & mod);
 
 } /* end namespace python */
 

--- a/cpp/modmesh/linalg/pymod/wrap_EigenSystem.cpp
+++ b/cpp/modmesh/linalg/pymod/wrap_EigenSystem.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <memory>
+
+#include <modmesh/linalg/pymod/linalg_pymod.hpp>
+
+namespace modmesh
+{
+
+namespace python
+{
+
+#ifdef __APPLE__
+
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapEigenSystem
+    : public WrapBase<WrapEigenSystem, EigenSystem>
+{
+
+    using base_type = WrapBase<WrapEigenSystem, EigenSystem>;
+    using wrapped_type = typename base_type::wrapped_type;
+    using array_type = SimpleArray<double>;
+
+    friend base_type;
+
+    WrapEigenSystem(pybind11::module & mod, char const * pyname, char const * pydoc);
+
+}; /* end class WrapEigenSystem */
+
+WrapEigenSystem::WrapEigenSystem(pybind11::module & mod, char const * pyname, char const * pydoc)
+    : base_type(mod, pyname, pydoc)
+{
+    namespace py = pybind11;
+
+    (*this)
+        .def(
+            py::init(
+                [](array_type const & a)
+                {
+                    return std::make_unique<wrapped_type>(a);
+                }),
+            py::arg("a"),
+            // Keep the input array's Python wrapper alive while the
+            // EigenSystem lives, so m_matrix's C++ reference stays
+            // valid for the lifetime of this instance.
+            py::keep_alive<1, 2>());
+
+    (*this)
+        .def("run", &wrapped_type::run)
+        .def_property_readonly(
+            "matrix",
+            &wrapped_type::matrix,
+            pybind11::return_value_policy::reference_internal)
+        .def_property_readonly("wr", &wrapped_type::wr)
+        .def_property_readonly("wi", &wrapped_type::wi)
+        .def_property_readonly("vl", &wrapped_type::vl)
+        .def_property_readonly("vr", &wrapped_type::vr)
+        .def_property_readonly("done", &wrapped_type::done);
+}
+
+#endif /* __APPLE__ */
+
+void wrap_EigenSystem(pybind11::module & mod)
+{
+#ifdef __APPLE__
+    WrapEigenSystem::commit(mod, "EigenSystem", "Eigen problem solver");
+#else // __APPLE__
+    mod.attr("EigenSystem") = pybind11::none();
+#endif // __APPLE__
+}
+
+} /* end namespace python */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -127,6 +127,7 @@ list_of_linalg = [
     'lu_factorization',
     'lu_solve',
     'lu_inv',
+    'EigenSystem',
     'KalmanStateInfoFp32',
     'KalmanStateInfoFp64',
     'KalmanStateInfoComplex64',

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 import numpy as np
@@ -1204,5 +1205,166 @@ class TestLuErrorHandling(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             mm.lu_inv(A)
 
+
+@unittest.skipUnless(sys.platform == "darwin",
+                     "mm.EigenSystem requires Apple vecLib")
+class TestLinalgEigenSystemTC(unittest.TestCase):
+    """Verify EigenSystem against DGEEV reference outputs.
+
+    EigenSystem(A).run() populates wr/wi (real and imaginary parts of the
+    eigenvalues) and vl/vr (left/right eigenvector matrices) in DGEEV's
+    column-major layout (j-th column == j-th eigenvector).  For a complex
+    conjugate pair (wi[j] > 0, wi[j+1] = -wi[j]) the j-th and (j+1)-th
+    columns hold the real and imaginary parts of the eigenvector; the
+    (j+1)-th eigenvector is the complex conjugate of the j-th.
+    """
+
+    def _solve(self, A_np):
+        A = mm.SimpleArrayFloat64(array=A_np)
+        solver = mm.EigenSystem(A)
+        self.assertFalse(solver.done)
+        solver.run()
+        self.assertTrue(solver.done)
+        return (np.array(solver.wr), np.array(solver.wi),
+                np.array(solver.vl), np.array(solver.vr))
+
+    def test_diagonal_eigenvalues_and_basis_eigenvectors(self):
+        # diag(1, 2, 3, 4): eigenvalues are the diagonal; eigenvectors are
+        # standard basis vectors up to permutation/sign.
+        A_np = np.diag([1.0, 2.0, 3.0, 4.0])
+        wr, wi, _vl, vr = self._solve(A_np)
+        np.testing.assert_allclose(np.sort(wr), [1.0, 2.0, 3.0, 4.0],
+                                   rtol=1e-12, atol=1e-14)
+        np.testing.assert_allclose(wi, np.zeros(4), atol=1e-14)
+        # Each column must be a (signed) standard basis vector.
+        for j in range(4):
+            col = vr[:, j]
+            np.testing.assert_allclose(np.abs(col).sum(), 1.0,
+                                       rtol=1e-12, atol=1e-14)
+            self.assertEqual(np.count_nonzero(np.abs(col) > 1e-12), 1)
+
+    def test_symmetric_known_spectrum_reconstructs_eigenpairs(self):
+        # The fixture Q below is frozen (not generated at runtime) so the test
+        # is independent of the NumPy RNG / QR implementation.  To regenerate,
+        # run:
+        #   rng = np.random.default_rng(seed=20260509)
+        #   Q, _ = np.linalg.qr(rng.standard_normal((5, 5)))
+        # and paste Q.tolist() back in.
+        n = 5
+        lam = np.array([-2.0, -0.5, 1.0, 3.5, 7.0], dtype='float64')
+        Q = np.array([
+            [-0.024712873175908756, 0.6640676133514902,
+             0.5915632257468302, 0.4455230309449579,
+             -0.09982814051493692],
+            [-0.28147871622325943, -0.5692008616441233,
+             0.5886397812806473, 0.1575982019764191,
+             0.4748116742926241],
+            [-0.9139918340187755, 0.2754225371185904,
+             -0.14764410500783806, -0.2527961990356955,
+             0.05528700935747367],
+            [0.24639362994675912, 0.23505747176988095,
+             0.4022089819816873, -0.825230080044468,
+             0.2031290572268447],
+            [0.15513901083013232, 0.32235848835350017,
+             -0.34638895898623234, 0.17821737394071255,
+             0.8486873093331871],
+        ])
+        # Check the fixture is orthogonal first.
+        np.testing.assert_allclose(Q @ Q.T, np.eye(n), atol=1e-14)
+        A_np = Q @ np.diag(lam) @ Q.T
+        wr, wi, _vl, vr = self._solve(A_np)
+        np.testing.assert_allclose(np.sort(wr), np.sort(lam),
+                                   rtol=1e-10, atol=1e-12)
+        np.testing.assert_allclose(wi, np.zeros(n), atol=1e-12)
+        # Per-column eigenpair: A v_j = lambda_j v_j.
+        for j in range(n):
+            np.testing.assert_allclose(A_np @ vr[:, j], wr[j] * vr[:, j],
+                                       rtol=1e-10, atol=1e-12)
+
+    def test_2x2_rotation_complex_conjugate_pair(self):
+        # 2x2 90-degree rotation matrix has eigenvalues +/- i.  This fixture
+        # exercises DGEEV's packing of complex conjugate eigenvectors into
+        # consecutive real columns.
+        A_np = np.array([[0.0, -1.0], [1.0, 0.0]], dtype='float64')
+        wr, wi, _vl, vr = self._solve(A_np)
+        np.testing.assert_allclose(wr, np.zeros(2, dtype='float64'),
+                                   atol=1e-14)
+        np.testing.assert_allclose(np.sort(wi), [-1.0, 1.0], atol=1e-14)
+        j = int(np.argmax(wi))  # column with positive imaginary part
+        self.assertGreater(wi[j], 0.0)
+        self.assertAlmostEqual(wi[j] + wi[j + 1], 0.0, places=14)
+        v = vr[:, j] + 1j * vr[:, j + 1]
+        lam = wr[j] + 1j * wi[j]
+        np.testing.assert_allclose(A_np @ v, lam * v, rtol=1e-12, atol=1e-14)
+        # The (j+1)-th eigenvector is the conjugate of the j-th and corresponds
+        # to the conjugate eigenvalue.
+        v_conj = vr[:, j] - 1j * vr[:, j + 1]
+        lam_conj = wr[j] - 1j * wi[j]
+        np.testing.assert_allclose(A_np @ v_conj, lam_conj * v_conj,
+                                   rtol=1e-12, atol=1e-14)
+
+    def test_left_eigenvectors_satisfy_left_equation(self):
+        # Left eigenvectors u_j (column vector) satisfy u_j^T A = lambda_j
+        # u_j^T (i.e., A^T u_j = lambda_j u_j) for real eigenvalues (general
+        # case is A^H u_j = conj(lambda_j) u_j).  Use a non-symmetric matrix
+        # with all-real eigenvalues: upper-triangular -> spectrum is the
+        # diagonal.
+        A_np = np.array([
+            [2.0, 1.0, 0.5],
+            [0.0, 3.0, -1.0],
+            [0.0, 0.0, 5.0],
+        ], dtype='float64')
+        wr, wi, vl, _vr = self._solve(A_np)
+        np.testing.assert_allclose(np.sort(wr), [2.0, 3.0, 5.0],
+                                   rtol=1e-12, atol=1e-12)
+        np.testing.assert_allclose(wi, np.zeros(3, dtype='float64'),
+                                   atol=1e-12)
+        for j in range(3):
+            np.testing.assert_allclose(A_np.T @ vl[:, j],
+                                       wr[j] * vl[:, j],
+                                       rtol=1e-10, atol=1e-12)
+
+    def test_rejects_non_square_and_non_2d_inputs(self):
+        # Non-square 2D, 1D, and 3D inputs must all raise the same shape
+        # error from the EigenSystem constructor.
+        A_rect = mm.SimpleArrayFloat64(array=np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float64"))
+        with self.assertRaisesRegex(
+                ValueError, r"must be a square 2D SimpleArray"):
+            mm.EigenSystem(A_rect)
+
+        A_1d = mm.SimpleArrayFloat64(array=np.array(
+            [1.0, 2.0, 3.0], dtype="float64"))
+        with self.assertRaisesRegex(
+                ValueError, r"must be a square 2D SimpleArray"):
+            mm.EigenSystem(A_1d)
+
+        A_3d = mm.SimpleArrayFloat64(array=np.zeros((2, 2, 2),
+                                                    dtype="float64"))
+        with self.assertRaisesRegex(
+                ValueError, r"must be a square 2D SimpleArray"):
+            mm.EigenSystem(A_3d)
+
+    def test_accessors_before_run_are_inert(self):
+        # Construct but do not call run(); done must be False and wr must be
+        # finite-valued (DGEEV hasn't written), documenting that run() is
+        # required before reading results.
+        A_np = np.diag([1.0, 2.0])
+        A = mm.SimpleArrayFloat64(array=A_np)
+        solver = mm.EigenSystem(A)
+        self.assertFalse(solver.done)
+        wr = solver.wr.ndarray
+        self.assertTrue(np.all(np.isfinite(wr)))
+
+    def test_matrix_property_survives_input_gc(self):
+        # Construct solver, then drop the Python-side reference to A.
+        # solver.matrix must still equal the original array, confirming that
+        # keep_alive<1, 2>() on the constructor prevents the C++ m_matrix
+        # reference from dangling.
+        A_np = np.array([[3.0, 1.0], [0.0, 2.0]])
+        A = mm.SimpleArrayFloat64(array=A_np)
+        solver = mm.EigenSystem(A)
+        del A
+        np.testing.assert_array_equal(solver.matrix.ndarray, A_np)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Use Apple Accelerate/veclib DGEEV (LAPACK interface) to prototype an eigenvalue solver for a general linear system.  The prototype uses double-precision floating point (float64) only.

Provide Python binding using pybind11 and create basic tests in Python.  In the Python wrapper, set `EigenSystem` to `None` when it is not built.

All platforms has LAPACK, but properly set up the build system for all platforms will use some efforts.  I start with Apple because it is the most popular platform among the contributors, and Apple Silicon is the most accessible platform for GPU and other interesting accelerating instructions.

Future work:
1. Detail API control like selection of left and/or right eigenvectors.
2. More test cases.
3. Add all data types: float32, complex64, complex128.
4. Add Linux support.
5. Add Windows support.
6. Intel MKL (oneAPI MKL) support on Linux and Windows.