### PR TITLE
Create new job to make cancelled jobs as failure jobs in CI runner

### DIFF
--- a/.github/actions/job_done/action.yml
+++ b/.github/actions/job_done/action.yml
@@ -1,0 +1,15 @@
+name: Job done
+description: Mark the current job as successfully completed.
+
+runs:
+  using: composite
+  steps:
+    - name: Mark Unix successful completion
+      if: runner.os != 'Windows'
+      shell: bash
+      run: touch "${RUNNER_TEMP}/modmesh_job_completed"
+
+    - name: Mark Windows successful completion
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: New-Item -ItemType File -Path "$env:RUNNER_TEMP\modmesh_job_completed" -Force | Out-Null

--- a/.github/actions/job_guard/action.yml
+++ b/.github/actions/job_guard/action.yml
@@ -1,0 +1,22 @@
+name: Job guard
+description: Fail the job when it does not reach the completion marker.
+
+runs:
+  using: composite
+  steps:
+    - name: Register Unix post-run completion check
+      if: runner.os != 'Windows'
+      uses: gacts/run-and-post-run@v1
+      with:
+        post: >-
+          test -f "${RUNNER_TEMP}/modmesh_job_completed" ||
+          { echo "::error::CI job timed out, was cancelled, or stopped before completion."; exit 2; }
+
+    - name: Register Windows post-run completion check
+      if: runner.os == 'Windows'
+      uses: gacts/run-and-post-run@v1
+      with:
+        post-shell: pwsh
+        post: >-
+          if (-not (Test-Path -LiteralPath "$env:RUNNER_TEMP\modmesh_job_completed"))
+          { Write-Host "::error::CI job timed out, was cancelled, or stopped before completion."; exit 2 }

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -40,6 +40,8 @@ jobs:
         with:
           fetch-depth: 1
 
+      - uses: ./.github/actions/job_guard
+
       - name: event name
         run: |
           echo "github.event_name: ${{ github.event_name }}"
@@ -60,6 +62,8 @@ jobs:
         run: |
           make standalone_buffer_setup
           make standalone_buffer
+
+      - uses: ./.github/actions/job_done
 
   build:
 
@@ -97,6 +101,8 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 1
+
+    - uses: ./.github/actions/job_guard
 
     - name: event name
       run: |
@@ -202,6 +208,8 @@ jobs:
         make buildext VERBOSE=1
         make pytest VERBOSE=1
 
+    - uses: ./.github/actions/job_done
+
   build_windows:
 
     if: |
@@ -237,6 +245,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
+
+      - uses: ./.github/actions/job_guard
 
       - name: event name
         run: |
@@ -373,15 +383,18 @@ jobs:
           name: modmesh-pilot-win64
           path: modmesh-pilot-win64/
 
+      - uses: ./.github/actions/job_done
+
   send_email_on_failure:
     needs: [standalone_buffer, build, build_windows]
-    # Run if any of the dependencies failed in master branch
+    # Run if any of the dependencies failed or timed out in master branch
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     uses: ./.github/workflows/send_email_on_fail.yml
     with:
       job_results: |
         - standalone_buffer: ${{ needs.standalone_buffer.result }}
         - build: ${{ needs.build.result }}
+        - build_windows: ${{ needs.build_windows.result }}
     secrets:
       EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
       EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,6 +51,8 @@ jobs:
       with:
         fetch-depth: 1
 
+    - uses: ./.github/actions/job_guard
+
     - name: event name
       run: |
         echo "github.event_name: ${{ github.event_name }}"
@@ -104,9 +106,11 @@ jobs:
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
 
+    - uses: ./.github/actions/job_done
+
   send_email_on_failure:
     needs: [lint]
-    # Run if any of the dependencies failed in master branch
+    # Run if any of the dependencies failed or timed out in master branch
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     uses: ./.github/workflows/send_email_on_fail.yml
     with:

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           fetch-depth: 1
 
+      - uses: ./.github/actions/job_guard
+
       - name: event name
         run: |
           echo "github.event_name: ${{ github.event_name }}"
@@ -85,9 +87,11 @@ jobs:
           pytest --rootdir=. -v
           cd ..
 
+      - uses: ./.github/actions/job_done
+
   send_email_on_failure:
     needs: [nouse_install]
-    # Run if any of the dependencies failed in master branch
+    # Run if any of the dependencies failed or timed out in master branch
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     uses: ./.github/workflows/send_email_on_fail.yml
     with:

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           fetch-depth: 1
 
+      - uses: ./.github/actions/job_guard
+
       - name: event name
         run: |
           echo "Event name: ${{ github.event_name }}"
@@ -74,9 +76,11 @@ jobs:
         run: |
           make pyprof
 
+      - uses: ./.github/actions/job_done
+
   send_email_on_failure:
     needs: [profile]
-    if: ${{ always() && (needs.*.result == 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     uses: ./.github/workflows/send_email_on_fail.yml
     with:
       job_results: |


### PR DESCRIPTION
In issue #772, we notice that when a job times out, it would be cancelled instead of fail.
Therefore, this pull request is to create new job, that could monitor cancelled jobs, and make cancelled jobs as failure jobs in CI runner.
