### PR TITLE
Increase default CI timeouts

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -75,7 +75,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_BUILD || '30') }}
+    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_BUILD || '45') }}
 
     env:
       QT_DEBUG_PLUGINS: 1
@@ -216,7 +216,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_BUILD || '30') }}
+    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_BUILD || '45') }}
 
     env:
       QT_DEBUG_PLUGINS: 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_LINT || '30') }}
+    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_LINT || '45') }}
 
     env:
       JOB_MAKE_ARGS: VERBOSE=1 BUILD_QT=ON USE_CLANG_TIDY=ON LINT_AS_ERRORS=ON

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -25,7 +25,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_NOUSE_INSTALL || '15') }}
+    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_NOUSE_INSTALL || '30') }}
 
     env:
       JOB_CMAKE_ARGS: -DBUILD_QT=OFF -DUSE_CLANG_TIDY=OFF -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -17,7 +17,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_PROFILE || '20') }}
+    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_PROFILE || '30') }}
 
     env:
       QT_DEBUG_PLUGINS: 1


### PR DESCRIPTION
Bump `MMGH_TIMEOUT_BUILD` fallback from 30 to 45 minutes, `MMGH_TIMEOUT_LINT` fallback from 30 to 45 minutes, `MMGH_TIMEOUT_PROFILE` fallback from 20 to 30 minutes, `MMGH_TIMEOUT_NOUSE_INSTALL` from 15 to 30 minutes.