### PR TITLE
Add `SimpleArray::transpose_copy()` and majoring helpers

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -2176,36 +2176,15 @@ public:
         }
     }
 
-    void transpose()
-    {
-        std::reverse(m_shape.begin(), m_shape.end());
-        std::reverse(m_stride.begin(), m_stride.end());
-    }
+    void transpose(bool copy = false);
 
-    void transpose(shape_type const & axis)
-    {
-        if (axis.size() != m_shape.size())
-        {
-            throw std::runtime_error("SimpleArray: axis size mismatch");
-        }
-        shape_type new_shape(m_shape.size(), -1);
-        shape_type new_stride(m_stride.size());
-        for (size_t it = 0; it < m_shape.size(); ++it)
-        {
-            if (axis[it] >= m_shape.size() || axis[it] < 0)
-            {
-                throw std::runtime_error("SimpleArray: axis out of range");
-            }
-            if (new_shape[it] != -1)
-            {
-                throw std::runtime_error("SimpleArray: axis already set");
-            }
-            new_shape[it] = m_shape[axis[it]];
-            new_stride[it] = m_stride[axis[it]];
-        }
-        m_shape = new_shape;
-        m_stride = new_stride;
-    }
+    void transpose(shape_type const & axis, bool copy = false);
+
+    SimpleArray transpose_copy() const;
+
+    SimpleArray to_row_major() const;
+
+    SimpleArray to_column_major() const;
 
     template <typename... Args>
     value_type const & operator()(Args... args) const { return *vptr(args...); }
@@ -2284,6 +2263,8 @@ public:
     bool is_f_contiguous() const { return is_f_contiguous(m_shape, m_stride); }
 
 private:
+    void copy_logical_into(SimpleArray & out) const;
+
     static bool is_c_contiguous(small_vector<size_t> const & shape,
                                 small_vector<size_t> const & stride)
     {
@@ -2449,6 +2430,219 @@ private:
     size_t m_nghost = 0;
     value_type * m_body = nullptr;
 }; /* end class SimpleArray */
+
+/**
+ * @brief Transpose by reversing all axes in place.
+ *
+ * @param copy
+ *      When false (default), perform a view-only flip.  When true, replace the
+ *      buffer with a freshly allocated C-contiguous one holding the physically
+ *      transposed contents.
+ */
+template <typename T>
+void SimpleArray<T>::transpose(bool copy)
+{
+    if (!copy)
+    {
+        std::reverse(m_shape.begin(), m_shape.end());
+        std::reverse(m_stride.begin(), m_stride.end());
+        return;
+    }
+    SimpleArray tc = transpose_copy();
+    swap(tc);
+}
+
+/**
+ * @brief Transpose with axes permuted by the given index vector in place.
+ *
+ * @param axis
+ *      Permutation: the i-th new axis is sourced from the `axis[i]`-th old
+ *      axis.  Must be a valid permutation of `[0, ndim)`.
+ * @param copy
+ *      When false (default), perform a view-only permutation of the metadata.
+ *      When true, physically permute contents into a freshly allocated
+ *      C-contiguous buffer.
+ */
+template <typename T>
+void SimpleArray<T>::transpose(shape_type const & axis, bool copy)
+{
+    // Build the permuted shape and stride by gathering each axis from the
+    // source.  It is needed by both view-only and with-copy transpose.
+    if (axis.size() != m_shape.size())
+    {
+        throw std::runtime_error("SimpleArray::transpose: axis size mismatch");
+    }
+    shape_type new_shape(m_shape.size(), -1);
+    shape_type new_stride(m_stride.size());
+    for (size_t it = 0; it < m_shape.size(); ++it)
+    {
+        if (axis[it] >= m_shape.size() || axis[it] < 0)
+        {
+            throw std::runtime_error("SimpleArray::transpose: axis out of range");
+        }
+        if (new_shape[it] != -1)
+        {
+            throw std::runtime_error("SimpleArray::transpose: axis already set");
+        }
+        new_shape[it] = m_shape[axis[it]];
+        new_stride[it] = m_stride[axis[it]];
+    }
+    if (!copy)
+    {
+        // View-only flip: install the permuted metadata in place.
+        m_shape = new_shape;
+        m_stride = new_stride;
+        return;
+    }
+    // Deep-copy path: 1. stage a strided view with the permuted shape/stride.
+    SimpleArray const view(new_shape, new_stride, m_buffer);
+    SimpleArray out(new_shape);
+    // 2. Use the same helper to keep the iteration logic the same as the other
+    // deep-copy variants.
+    view.copy_logical_into(out);
+    swap(out);
+}
+
+/**
+ * @brief Transpose with a fresh C-contiguous array returned.
+ *
+ * @details
+ *      The column-major byte layout against the original shape is structurally
+ *      identical to the C-contiguous byte layout of a transposed array.
+ *
+ * @return Freshly allocated C-contiguous SimpleArray with reversed axes.
+ */
+template <typename T>
+SimpleArray<T> SimpleArray<T>::transpose_copy() const
+{
+    // 0-D and 1-D arrays have no axes to reverse; a plain clone suffices.
+    if (m_shape.size() <= 1)
+    {
+        return SimpleArray(*this);
+    }
+    // Use to_column_major() to copy the array and then flip the shape and
+    // stride back.
+    SimpleArray out = to_column_major();
+    std::reverse(out.m_shape.begin(), out.m_shape.end());
+    std::reverse(out.m_stride.begin(), out.m_stride.end());
+    return out;
+}
+
+/**
+ * @brief
+ *      Return a fresh C-contiguous (row-major) array with the same logical
+ *      shape and values as `*this`.
+ *
+ * @details
+ *      Clones the buffer when the source is already C-contiguous; otherwise
+ *      allocates a fresh buffer and copies element-wise.
+ *
+ * @return Freshly allocated C-contiguous SimpleArray.
+ */
+template <typename T>
+SimpleArray<T> SimpleArray<T>::to_row_major() const
+{
+    if (is_c_contiguous())
+    {
+        return SimpleArray(*this);
+    }
+    SimpleArray out(m_shape);
+    copy_logical_into(out);
+    return out;
+}
+
+/**
+ * @brief
+ *      Return a fresh F-contiguous (column-major) array with the same logical
+ *      shape and values as `*this`.
+ *
+ * @details
+ *      Clones the buffer when the source is already F-contiguous; otherwise
+ *      allocates a fresh buffer with F-contiguous strides and copies
+ *      element-wise.
+ *
+ * @return Freshly allocated F-contiguous SimpleArray.
+ */
+template <typename T>
+SimpleArray<T> SimpleArray<T>::to_column_major() const
+{
+    // Empty shape or already-F-contiguous source: a buffer clone is enough.
+    if (m_shape.empty())
+    {
+        return SimpleArray(*this);
+    }
+    if (is_f_contiguous())
+    {
+        return SimpleArray(*this);
+    }
+    // Compute column-major strides: the fastest-varying axis is the leading
+    // one (stride[0] == 1).
+    shape_type fstride(m_shape.size());
+    fstride[0] = 1;
+    for (size_t i = 1; i < m_shape.size(); ++i)
+    {
+        fstride[i] = fstride[i - 1] * m_shape[i - 1];
+    }
+    // Calculate buffer size.
+    size_t nelem = 1;
+    for (size_t const s : m_shape)
+    {
+        nelem *= s;
+    }
+    // Create a fresh array, copy, and return.
+    auto buf = buffer_type::construct(nelem * ITEMSIZE, 0);
+    SimpleArray out(m_shape, fstride, buf);
+    copy_logical_into(out);
+    return out;
+}
+
+/**
+ * @brief Copy `*this` into `out` element-wise.
+ *
+ * @details
+ *      Heavy-lifting helper to copy data. `out` must share the same shape but
+ *      may carry a different stride.
+ *
+ * @param out Destination array; its shape must match the receiver's.
+ */
+template <typename T>
+void SimpleArray<T>::copy_logical_into(SimpleArray & out) const
+{
+    if (m_shape.empty())
+    {
+        return;
+    }
+    size_t total = 1;
+    for (size_t const s : m_shape)
+    {
+        total *= s;
+    }
+    if (total == 0)
+    {
+        return;
+    }
+    // Walk a multi-dimensional index in row-major order.  out's stride is only
+    // used to compute the destination offset to bridge row-major,
+    // column-major, and arbitrary strided layouts.
+    size_t const ndim = m_shape.size();
+    shape_type idx(ndim, 0);
+    for (size_t step = 0; step < total; ++step)
+    {
+        out.m_body[buffer_offset(out.m_stride, idx)] = m_body[buffer_offset(m_stride, idx)];
+        // Carry-propagating increment: bump the trailing axis; on overflow,
+        // wrap to 0 and carry into the next-most-significant axis.
+        for (size_t i = ndim; i-- > 0;)
+        {
+            if (++idx[i] < m_shape[i])
+            {
+                break;
+            }
+            // After the last element the carry rolls every axis back to 0, but
+            // the outer loop terminates before idx is used again.
+            idx[i] = 0;
+        }
+    }
+}
 
 template <typename A, typename T>
 SimpleArray<uint64_t> detail::SimpleArrayMixinSort<A, T>::argsort()

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -203,21 +203,42 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 { return self.reshape(make_shape(shape)); })
             .def(
                 "transpose",
-                [](wrapped_type & self, py::object const & axis, bool const & inplace)
+                [](wrapped_type & self, py::object const & axis, bool inplace, bool copy)
                 {
                     wrapped_type * ret = inplace ? &self : new wrapped_type(self);
                     if (axis.is_none())
                     {
-                        ret->transpose();
+                        ret->transpose(copy);
                     }
                     else
                     {
-                        ret->transpose(make_shape(axis));
+                        ret->transpose(make_shape(axis), copy);
                     }
                     return *ret;
                 },
                 py::arg("axis") = py::none(),
-                py::arg("inplace") = true)
+                py::arg("inplace") = true,
+                py::arg("copy") = false)
+            .def(
+                "transpose_copy",
+                [](wrapped_type const & self)
+                { return self.transpose_copy(); })
+            .def(
+                "to_row_major",
+                [](wrapped_type const & self)
+                { return self.to_row_major(); })
+            .def(
+                "to_column_major",
+                [](wrapped_type const & self)
+                { return self.to_column_major(); })
+            .def_property_readonly(
+                "is_c_contiguous",
+                [](wrapped_type const & self)
+                { return self.is_c_contiguous(); })
+            .def_property_readonly(
+                "is_f_contiguous",
+                [](wrapped_type const & self)
+                { return self.is_f_contiguous(); })
             .def_property_readonly(
                 "T",
                 [](wrapped_type & self)

--- a/cpp/modmesh/linalg/EigenSystem.hpp
+++ b/cpp/modmesh/linalg/EigenSystem.hpp
@@ -108,7 +108,8 @@ private:
 
 inline EigenSystem::EigenSystem(array_type const & matrix)
     : m_matrix(matrix)
-    , m_colmajor(matrix.shape())
+    // Stage matrix into a column-major workspace for LAPACK.
+    , m_colmajor(matrix.to_column_major())
     , m_wr(matrix.shape(0))
     , m_wi(matrix.shape(0))
     , m_vl(matrix.shape())
@@ -121,20 +122,6 @@ inline EigenSystem::EigenSystem(array_type const & matrix)
             format_shape(matrix)));
     }
 
-    // TODO: Enhance SimpleArray::transpose() to copy the contents when
-    // transposing.  The current SimpleArray::transpose() is a *view-only*
-    // operation: it reverses the shape and stride vectors but the underlying
-    // buffer is untouched.  So we have to manually copy element-wisely in the
-    // nested loops below.
-    m_colmajor.transpose();
-    ssize_t const n = matrix.shape(0);
-    for (ssize_t i = 0; i < n; ++i)
-    {
-        for (ssize_t j = 0; j < n; ++j)
-        {
-            m_colmajor(i, j) = matrix(i, j);
-        }
-    }
     m_vl.transpose();
     m_vr.transpose();
 }

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -371,6 +371,100 @@ class SimpleArrayBasicTC(unittest.TestCase):
         check_equal(sarr2, ndarrT)
         self.assertNotEqual(memoryview(sarr), memoryview(sarr2))
 
+    def test_SimpleArray_transpose_copy(self):
+        # Issue #792: physical (deep-copy) transpose variants.  Cover 1D, 2D,
+        # 3D, 4D; square / non-square; C-contiguous / F-contiguous input.
+
+        def make_sarr(ndarr):
+            return modmesh.SimpleArrayFloat64(array=ndarr.copy())
+
+        def values_equal(sarr, ref):
+            np.testing.assert_array_equal(np.array(sarr, copy=False), ref)
+
+        shapes = [
+            (7,),
+            (3, 5),
+            (4, 4),
+            (2, 3, 4),
+            (2, 3, 4, 5),
+        ]
+
+        for shape in shapes:
+            ndarr = np.arange(
+                int(np.prod(shape)), dtype="float64").reshape(shape)
+
+            # transpose_copy(): equivalent to numpy a.T then a fresh C-contig.
+            sarr = make_sarr(ndarr)
+            self.assertTrue(sarr.is_c_contiguous)
+            tc = sarr.transpose_copy()
+            self.assertEqual(tc.shape, ndarr.T.shape)
+            self.assertTrue(tc.is_c_contiguous)
+            values_equal(tc, np.ascontiguousarray(ndarr.T))
+            # Source unchanged.
+            values_equal(sarr, ndarr)
+
+            # to_row_major(): same shape and values, C-contiguous.
+            rm = sarr.to_row_major()
+            self.assertEqual(rm.shape, ndarr.shape)
+            self.assertTrue(rm.is_c_contiguous)
+            values_equal(rm, ndarr)
+
+            # to_column_major(): same shape and values, F-contiguous.
+            cm = sarr.to_column_major()
+            self.assertEqual(cm.shape, ndarr.shape)
+            self.assertTrue(cm.is_f_contiguous)
+            values_equal(cm, ndarr)
+
+            # transpose(copy=True): in-place physical transpose.
+            mutated = make_sarr(ndarr)
+            mutated.transpose(copy=True)
+            self.assertEqual(mutated.shape, ndarr.T.shape)
+            self.assertTrue(mutated.is_c_contiguous)
+            values_equal(mutated, np.ascontiguousarray(ndarr.T))
+
+            # Round trip: transpose_copy twice gives the original.
+            roundtrip = sarr.transpose_copy().transpose_copy()
+            self.assertEqual(roundtrip.shape, ndarr.shape)
+            values_equal(roundtrip, ndarr)
+
+            # Mutating the source after the copy does not affect the copy.
+            tc_before = np.array(tc, copy=True)
+            np.array(sarr, copy=False).flat[0] = -42.0
+            values_equal(tc, tc_before)
+
+        # F-contiguous source: take a transpose view to get non-C-contig
+        # storage, then verify the copy variants still produce correct output.
+        for shape in [(3, 5), (2, 3, 4), (2, 3, 4, 5)]:
+            ndarr = np.arange(
+                int(np.prod(shape)), dtype="float64").reshape(shape)
+
+            sarr = make_sarr(ndarr)
+            # transpose(inplace=False) returns a view that swaps shape/stride;
+            # the resulting array is F-contiguous w.r.t. its new shape.
+            fview = sarr.transpose(inplace=False)
+            self.assertEqual(fview.shape, ndarr.T.shape)
+            self.assertTrue(fview.is_f_contiguous)
+            self.assertFalse(fview.is_c_contiguous)
+
+            # transpose_copy on an F-contig array should yield a C-contig
+            # buffer whose contents are the (further) transpose, i.e. ndarr.
+            tc = fview.transpose_copy()
+            self.assertEqual(tc.shape, ndarr.shape)
+            self.assertTrue(tc.is_c_contiguous)
+            values_equal(tc, ndarr)
+
+            # to_row_major on an F-contig array reorders bytes.
+            rm = fview.to_row_major()
+            self.assertEqual(rm.shape, ndarr.T.shape)
+            self.assertTrue(rm.is_c_contiguous)
+            values_equal(rm, ndarr.T)
+
+            # to_column_major on an F-contig array is essentially a clone.
+            cm = fview.to_column_major()
+            self.assertEqual(cm.shape, ndarr.T.shape)
+            self.assertTrue(cm.is_f_contiguous)
+            values_equal(cm, ndarr.T)
+
     def test_SimpleArray_ghost_1d(self):
 
         sarr = modmesh.SimpleArrayFloat64(4 * 3 * 2)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -372,8 +372,8 @@ class SimpleArrayBasicTC(unittest.TestCase):
         self.assertNotEqual(memoryview(sarr), memoryview(sarr2))
 
     def test_SimpleArray_transpose_copy(self):
-        # Issue #792: physical (deep-copy) transpose variants.  Cover 1D, 2D,
-        # 3D, 4D; square / non-square; C-contiguous / F-contiguous input.
+        # Physical (deep-copy) transpose variants.  Cover 1D, 2D, 3D, 4D;
+        # square / non-square; C-contiguous / F-contiguous input.
 
         def make_sarr(ndarr):
             return modmesh.SimpleArrayFloat64(array=ndarr.copy())


### PR DESCRIPTION
The existing function `transpose(copy=false)` is augmented with the new optional argument `copy`.  Default `false` keeps the view-only flipping behavior; `copy=true` does an in-place deep-copy transpose into a fresh row-major (C-contiguous) buffer.

Add new member functions:
- `transpose_copy()` returns that deep-copy transpose without mutating `*this`.
- `to_row_major()` / `to_column_major()` materialise the same logical data in the requested contiguity, with a clone fast-path when the source already matches.
- Private `copy_logical_into()` is the heavy-lifting element-copy helper.  It currently uses naive copy.  Cache optimization may be added in the future.

The new methods are exposed with pybind11 and tested in Python.  A new test function `test_SimpleArray_transpose_copy()` is added under `SimpleArrayBasicTC` in `test_buffer.py` to cover 1D-4D, square and non-square, row- and column-major inputs.

`EigenSystem` now stages its LAPACK workspace by initializing `m_colmajor` directly from `matrix.to_column_major()` in the member initializer list.  The former TODO for removing the manual element-wise loop is addressed.

Related to issue #792.