### PR TITLE
Add do_vl/do_vr opt-out flags to `EigenSystem`

### DIFF
--- a/cpp/modmesh/linalg/EigenSystem.hpp
+++ b/cpp/modmesh/linalg/EigenSystem.hpp
@@ -73,7 +73,7 @@ public:
     using value_type = double;
     using array_type = SimpleArray<double>;
 
-    explicit EigenSystem(array_type const & matrix);
+    explicit EigenSystem(array_type const & matrix, bool do_vl = true, bool do_vr = true);
 
     EigenSystem() = delete;
     EigenSystem(EigenSystem const &) = delete;
@@ -82,14 +82,15 @@ public:
     EigenSystem & operator=(EigenSystem &&) = delete;
     ~EigenSystem() = default;
 
-    /// Run DGEEV on the prepared workspace.
     void run();
 
     array_type const & matrix() const { return m_matrix; }
     array_type const & wr() const { return m_wr; }
     array_type const & wi() const { return m_wi; }
-    array_type const & vl() const { return m_vl; }
-    array_type const & vr() const { return m_vr; }
+    array_type const & vl(bool suppress_exception = false) const;
+    array_type const & vr(bool suppress_exception = false) const;
+    bool do_vl() const { return m_do_vl; }
+    bool do_vr() const { return m_do_vr; }
     bool done() const { return m_done; }
 
 private:
@@ -102,18 +103,22 @@ private:
     SimpleArray<value_type> m_wi;
     SimpleArray<value_type> m_vl;
     SimpleArray<value_type> m_vr;
+    bool const m_do_vl;
+    bool const m_do_vr;
     bool m_done = false;
 
 }; /* end class EigenSystem */
 
-inline EigenSystem::EigenSystem(array_type const & matrix)
+inline EigenSystem::EigenSystem(array_type const & matrix, bool do_vl, bool do_vr)
     : m_matrix(matrix)
     // Stage matrix into a column-major workspace for LAPACK.
     , m_colmajor(matrix.to_column_major())
     , m_wr(matrix.shape(0))
     , m_wi(matrix.shape(0))
-    , m_vl(matrix.shape())
-    , m_vr(matrix.shape())
+    , m_vl(do_vl ? array_type(matrix.shape()) : array_type())
+    , m_vr(do_vr ? array_type(matrix.shape()) : array_type())
+    , m_do_vl(do_vl)
+    , m_do_vr(do_vr)
 {
     if (matrix.ndim() != 2 || matrix.shape(0) != matrix.shape(1))
     {
@@ -122,10 +127,19 @@ inline EigenSystem::EigenSystem(array_type const & matrix)
             format_shape(matrix)));
     }
 
-    m_vl.transpose();
-    m_vr.transpose();
+    if (m_do_vl)
+    {
+        m_vl.transpose();
+    }
+    if (m_do_vr)
+    {
+        m_vr.transpose();
+    }
 }
 
+/**
+ * @brief Run DGEEV on the prepared workspace.
+ */
 inline void EigenSystem::run()
 {
     auto const n = static_cast<__LAPACK_int>(m_matrix.shape(0));
@@ -142,12 +156,19 @@ inline void EigenSystem::run()
      *   https://www.netlib.org/lapack/explore-html/d4/d68/group__geev_ga7d8afe93d23c5862e238626905ee145e.html
      *   https://www.netlib.org/lapack/explore-html/d9/d28/dgeev_8f_source.html
      */
-    char const jobvl = 'V';
-    char const jobvr = 'V';
+    char const jobvl = m_do_vl ? 'V' : 'N';
+    char const jobvr = m_do_vr ? 'V' : 'N';
     __LAPACK_int const lda = n;
-    __LAPACK_int const ldvl = n;
-    __LAPACK_int const ldvr = n;
+    // DGEEV requires LDVL/LDVR >= 1 and a valid (non-null) pointer even
+    // when the matrix is unreferenced; route the unused side to a stack
+    // scratch slot.
+    __LAPACK_int const ldvl = m_do_vl ? n : 1;
+    __LAPACK_int const ldvr = m_do_vr ? n : 1;
     __LAPACK_int info = 0;
+    double vl_dummy = 0.0;
+    double vr_dummy = 0.0;
+    double * const vl_ptr = m_do_vl ? m_vl.data() : &vl_dummy;
+    double * const vr_ptr = m_do_vr ? m_vr.data() : &vr_dummy;
 
     // Phase 1: workspace query.  lwork == -1 tells DGEEV to write the
     // optimal workspace size into work[0] without performing any work.
@@ -161,9 +182,9 @@ inline void EigenSystem::run()
         &lda,
         m_wr.data(),
         m_wi.data(),
-        m_vl.data(),
+        vl_ptr,
         &ldvl,
-        m_vr.data(),
+        vr_ptr,
         &ldvr,
         &work_query,
         &lwork,
@@ -175,9 +196,9 @@ inline void EigenSystem::run()
             static_cast<int64_t>(info)));
     }
 
-    // Phase 2: allocate workspace and run.  Floor at 4*n per the LAPACK
-    // reference minimum when both eigenvector matrices are requested.
-    lwork = std::max<__LAPACK_int>(static_cast<__LAPACK_int>(work_query), 4 * n);
+    // Phase 2: 4*n minimum when any eigenvectors requested, else 3*n.
+    __LAPACK_int const lwork_min = (m_do_vl || m_do_vr) ? 4 * n : 3 * n;
+    lwork = std::max<__LAPACK_int>(static_cast<__LAPACK_int>(work_query), lwork_min);
     array_type work(static_cast<size_t>(lwork));
     dgeev_(
         &jobvl,
@@ -187,9 +208,9 @@ inline void EigenSystem::run()
         &lda,
         m_wr.data(),
         m_wi.data(),
-        m_vl.data(),
+        vl_ptr,
         &ldvl,
-        m_vr.data(),
+        vr_ptr,
         &ldvr,
         work.data(),
         &lwork,
@@ -207,6 +228,50 @@ inline void EigenSystem::run()
             static_cast<int>(info)));
     }
     m_done = true;
+}
+
+/**
+ * @brief Left eigenvectors computed by DGEEV.
+ *
+ * @param suppress_exception
+ *      Return the empty placeholder instead of throwing when the matrix was
+ *      not computed.
+ * @return
+ *      Column-major n-by-n matrix; empty when do_vl=false and
+ *      suppress_exception=true.
+ * @throws std::runtime_error When do_vl=false and suppress_exception=false.
+ */
+inline EigenSystem::array_type const & EigenSystem::vl(bool suppress_exception) const
+{
+    if (!m_do_vl && !suppress_exception)
+    {
+        throw std::runtime_error(
+            "EigenSystem::vl: left eigenvectors were not computed "
+            "(do_vl=false)");
+    }
+    return m_vl;
+}
+
+/**
+ * @brief Right eigenvectors computed by DGEEV.
+ *
+ * @param suppress_exception
+ *      Return the empty placeholder instead of throwing when the matrix was
+ *      not computed.
+ * @return
+ *      Column-major n-by-n matrix; empty when do_vr=false and
+ *      suppress_exception=true.
+ * @throws std::runtime_error When do_vr=false and suppress_exception=false.
+ */
+inline EigenSystem::array_type const & EigenSystem::vr(bool suppress_exception) const
+{
+    if (!m_do_vr && !suppress_exception)
+    {
+        throw std::runtime_error(
+            "EigenSystem::vr: right eigenvectors were not computed "
+            "(do_vr=false)");
+    }
+    return m_vr;
 }
 
 inline std::string EigenSystem::format_shape(array_type const & arr)

--- a/cpp/modmesh/linalg/pymod/wrap_EigenSystem.cpp
+++ b/cpp/modmesh/linalg/pymod/wrap_EigenSystem.cpp
@@ -60,11 +60,13 @@ WrapEigenSystem::WrapEigenSystem(pybind11::module & mod, char const * pyname, ch
     (*this)
         .def(
             py::init(
-                [](array_type const & a)
+                [](array_type const & a, bool do_vl, bool do_vr)
                 {
-                    return std::make_unique<wrapped_type>(a);
+                    return std::make_unique<wrapped_type>(a, do_vl, do_vr);
                 }),
             py::arg("a"),
+            py::arg("do_vl") = true,
+            py::arg("do_vr") = true,
             // Keep the input array's Python wrapper alive while the
             // EigenSystem lives, so m_matrix's C++ reference stays
             // valid for the lifetime of this instance.
@@ -78,8 +80,32 @@ WrapEigenSystem::WrapEigenSystem(pybind11::module & mod, char const * pyname, ch
             pybind11::return_value_policy::reference_internal)
         .def_property_readonly("wr", &wrapped_type::wr)
         .def_property_readonly("wi", &wrapped_type::wi)
-        .def_property_readonly("vl", &wrapped_type::vl)
-        .def_property_readonly("vr", &wrapped_type::vr)
+        .def_property_readonly(
+            "vl",
+            [](wrapped_type const & self) -> array_type const &
+            {
+                return self.vl();
+            })
+        .def_property_readonly(
+            "vr",
+            [](wrapped_type const & self) -> array_type const &
+            {
+                return self.vr();
+            })
+        .def(
+            "get_vl",
+            &wrapped_type::vl,
+            py::arg("suppress_exception") = false,
+            "Left eigenvectors; suppress_exception=True returns empty "
+            "instead of raising when do_vl=False.")
+        .def(
+            "get_vr",
+            &wrapped_type::vr,
+            py::arg("suppress_exception") = false,
+            "Right eigenvectors; suppress_exception=True returns empty "
+            "instead of raising when do_vr=False.")
+        .def_property_readonly("do_vl", &wrapped_type::do_vl)
+        .def_property_readonly("do_vr", &wrapped_type::do_vr)
         .def_property_readonly("done", &wrapped_type::done);
 }
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1422,4 +1422,111 @@ class TestLinalgEigenSystemTC(unittest.TestCase):
         del A
         np.testing.assert_array_equal(solver.matrix.ndarray, A_np)
 
+    def test_default_constructor_flags_both_true(self):
+        # Guard against an accidental default-flag flip.
+        A = mm.SimpleArrayFloat64(array=np.diag([1.0, 2.0]))
+        solver = mm.EigenSystem(A)
+        self.assertTrue(solver.do_vl)
+        self.assertTrue(solver.do_vr)
+
+    def test_skip_vr_does_not_compute_right_eigenvectors(self):
+        # do_vr=False must keep wr/wi/vl intact and reject both vr accessors.
+        A_np = np.array([[2.0, 0.0], [0.0, 3.0]], dtype="float64")
+        A = mm.SimpleArrayFloat64(array=A_np)
+        solver = mm.EigenSystem(A, do_vr=False)
+        solver.run()
+        self.assertTrue(solver.done)
+        self.assertTrue(solver.do_vl)
+        self.assertFalse(solver.do_vr)
+        np.testing.assert_allclose(np.sort(np.array(solver.wr)),
+                                   [2.0, 3.0], atol=1e-14)
+        self.assertEqual(np.array(solver.vl).shape, (2, 2))
+        self.assertEqual(np.array(solver.get_vl()).shape, (2, 2))
+        with self.assertRaisesRegex(
+                RuntimeError, r"right eigenvectors were not computed"):
+            solver.vr  # noqa: B018
+        with self.assertRaisesRegex(
+                RuntimeError, r"right eigenvectors were not computed"):
+            solver.get_vr()
+
+    def test_skip_vl_does_not_compute_left_eigenvectors(self):
+        # Mirror of test_skip_vr_*; checks A v = lambda v stays exact.
+        A_np = np.array([[2.0, 1.0], [0.0, 3.0]], dtype="float64")
+        A = mm.SimpleArrayFloat64(array=A_np)
+        solver = mm.EigenSystem(A, do_vl=False)
+        solver.run()
+        self.assertTrue(solver.done)
+        self.assertFalse(solver.do_vl)
+        self.assertTrue(solver.do_vr)
+        wr = np.array(solver.wr)
+        vr = np.array(solver.vr)
+        for j in range(2):
+            np.testing.assert_allclose(A_np @ vr[:, j], wr[j] * vr[:, j],
+                                       rtol=1e-12, atol=1e-12)
+        with self.assertRaisesRegex(
+                RuntimeError, r"left eigenvectors were not computed"):
+            solver.vl  # noqa: B018
+        with self.assertRaisesRegex(
+                RuntimeError, r"left eigenvectors were not computed"):
+            solver.get_vl()
+
+    def test_skip_both_computes_only_eigenvalues(self):
+        # Exercises the 3*n workspace path (both jobvl=jobvr='N').
+        A_np = np.diag([1.0, 5.0, 9.0])
+        A = mm.SimpleArrayFloat64(array=A_np)
+        solver = mm.EigenSystem(A, do_vl=False, do_vr=False)
+        solver.run()
+        np.testing.assert_allclose(np.sort(np.array(solver.wr)),
+                                   [1.0, 5.0, 9.0], atol=1e-14)
+        with self.assertRaises(RuntimeError):
+            solver.vl  # noqa: B018
+        with self.assertRaises(RuntimeError):
+            solver.vr  # noqa: B018
+        with self.assertRaises(RuntimeError):
+            solver.get_vl()
+        with self.assertRaises(RuntimeError):
+            solver.get_vr()
+
+    def test_get_methods_match_property_when_computed(self):
+        # Property and get_v* must alias the same matrix; suppress flag
+        # is a no-op when the matrix exists.
+        A_np = np.diag([2.0, 4.0])
+        A = mm.SimpleArrayFloat64(array=A_np)
+        solver = mm.EigenSystem(A)
+        solver.run()
+        np.testing.assert_array_equal(np.array(solver.vl),
+                                      np.array(solver.get_vl()))
+        np.testing.assert_array_equal(np.array(solver.vr),
+                                      np.array(solver.get_vr()))
+        np.testing.assert_array_equal(
+            np.array(solver.vl),
+            np.array(solver.get_vl(suppress_exception=True)))
+        np.testing.assert_array_equal(
+            np.array(solver.vr),
+            np.array(solver.get_vr(suppress_exception=True)))
+
+    def test_get_methods_default_argument_raises(self):
+        # Only suppress_exception=True silences the exception.
+        A = mm.SimpleArrayFloat64(array=np.diag([1.0, 2.0]))
+        solver = mm.EigenSystem(A, do_vl=False, do_vr=False)
+        solver.run()
+        with self.assertRaises(RuntimeError):
+            solver.get_vl()
+        with self.assertRaises(RuntimeError):
+            solver.get_vr()
+        with self.assertRaises(RuntimeError):
+            solver.get_vl(suppress_exception=False)
+        with self.assertRaises(RuntimeError):
+            solver.get_vr(suppress_exception=False)
+
+    def test_suppress_exception_returns_empty_when_not_computed(self):
+        # suppress_exception=True returns an empty placeholder, not data.
+        A = mm.SimpleArrayFloat64(array=np.diag([1.0, 2.0]))
+        solver = mm.EigenSystem(A, do_vl=False, do_vr=False)
+        solver.run()
+        empty_vl = np.array(solver.get_vl(suppress_exception=True))
+        empty_vr = np.array(solver.get_vr(suppress_exception=True))
+        self.assertEqual(empty_vl.size, 0)
+        self.assertEqual(empty_vr.size, 0)
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Allow to construct the class `EigenSystem` with `do_vl=false` and/or `do_vr=false` to skip the corresponding eigenvector computation.

With the options to be off, the corresponding matrix stays empty.  Calling the getters `vl()` / `vr()` throw when the matrix was not computed unless called with `suppress_exception=true`, which returns the empty placeholder.

Python keeps `vl` / `vr` as read-only properties and adds `get_vl()` / `get_vr()` helpers exposing the flag.

Related to issue #791.