### PR TITLE
Link to OpenBLAS on Linux

### DIFF
--- a/.github/actions/setup_linux/action.yml
+++ b/.github/actions/setup_linux/action.yml
@@ -54,6 +54,7 @@ runs:
         sudo apt-get -qy install kitware-archive-keyring
         sudo apt-get -qy install \
             sudo curl git build-essential make cmake libc6-dev gcc g++ \
+            libopenblas-dev \
             python3 python3-dev python3-venv
         # The path of apt-get cmake is `/usr/bin/cmake`,
         # but the path of built-in cmake of runner image is `/usr/local/bin/cmake`.

--- a/cpp/modmesh/CMakeLists.txt
+++ b/cpp/modmesh/CMakeLists.txt
@@ -163,7 +163,23 @@ if (APPLE)
         ${APPLE_FWK_QUARTZ_CORE}
         ${APPLE_FWK_METAL}
     )
+    # Accelerate/vecLib provides BLAS + LAPACK.
+    target_compile_definitions(modmesh_primary PUBLIC MM_HAS_VENDOR_LAPACK)
 endif () # APPLE
+
+if (UNIX AND NOT APPLE)
+    # OpenBLAS ships both BLAS and LAPACK symbols; treat it as the vendor
+    # LAPACK on Linux.  When it is not present, leave MM_HAS_VENDOR_LAPACK
+    # undefined so the dependent is not built.
+    find_library(OPENBLAS_LIB openblas)
+    if (OPENBLAS_LIB)
+        message(STATUS "Found OpenBLAS: ${OPENBLAS_LIB}")
+        target_link_libraries(modmesh_primary PUBLIC ${OPENBLAS_LIB})
+        target_compile_definitions(modmesh_primary PUBLIC MM_HAS_VENDOR_LAPACK)
+    else ()
+        message(STATUS "OpenBLAS not found; EigenSystem will not be built.")
+    endif ()
+endif () # UNIX AND NOT APPLE
 
 if (MSVC)
     target_compile_options(

--- a/cpp/modmesh/linalg/CMakeLists.txt
+++ b/cpp/modmesh/linalg/CMakeLists.txt
@@ -8,6 +8,7 @@ set(MODMESH_LINALG_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/factorization.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lu_factorization.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kalman_filter.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/lapack_compat.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/EigenSystem.hpp
     CACHE FILEPATH "" FORCE)
 

--- a/cpp/modmesh/linalg/EigenSystem.hpp
+++ b/cpp/modmesh/linalg/EigenSystem.hpp
@@ -30,13 +30,14 @@
 
 /**
  * Eigenvalue and eigenvector computation for general (non-symmetric) real
- * matrices using LAPACK DGEEV from Apple's vecLib (Accelerate framework).
+ * matrices using LAPACK DGEEV.
  *
- * This header is only available on Apple platforms.
+ * The LAPACK backend is selected by the build system via MM_HAS_VENDOR_LAPACK:
+ * Apple's vecLib (Accelerate framework) on macOS and OpenBLAS on Linux.
  */
 
-#ifndef __APPLE__
-#error "modmesh/linalg/EigenSystem.hpp is only available on Apple platforms (Accelerate/vecLib)."
+#ifndef MM_HAS_VENDOR_LAPACK
+#error "modmesh/linalg/EigenSystem.hpp requires a vendor LAPACK (MM_HAS_VENDOR_LAPACK)."
 #endif
 
 #include <algorithm>
@@ -46,14 +47,7 @@
 #include <string>
 
 #include <modmesh/buffer/buffer.hpp>
-
-// Opt in to the modern (non-deprecated) LAPACK signatures provided by
-// Accelerate.  Must be defined before including the Accelerate header.
-#ifndef ACCELERATE_NEW_LAPACK
-#define ACCELERATE_NEW_LAPACK
-#endif
-// NOLINTNEXTLINE(misc-header-include-cycle)
-#include <Accelerate/Accelerate.h>
+#include <modmesh/linalg/lapack_compat.hpp>
 
 namespace modmesh
 {
@@ -142,7 +136,7 @@ inline EigenSystem::EigenSystem(array_type const & matrix, bool do_vl, bool do_v
  */
 inline void EigenSystem::run()
 {
-    auto const n = static_cast<__LAPACK_int>(m_matrix.shape(0));
+    auto const n = static_cast<lapack_int_t>(m_matrix.shape(0));
     if (n == 0)
     {
         m_done = true;
@@ -158,13 +152,13 @@ inline void EigenSystem::run()
      */
     char const jobvl = m_do_vl ? 'V' : 'N';
     char const jobvr = m_do_vr ? 'V' : 'N';
-    __LAPACK_int const lda = n;
+    lapack_int_t const lda = n;
     // DGEEV requires LDVL/LDVR >= 1 and a valid (non-null) pointer even
     // when the matrix is unreferenced; route the unused side to a stack
     // scratch slot.
-    __LAPACK_int const ldvl = m_do_vl ? n : 1;
-    __LAPACK_int const ldvr = m_do_vr ? n : 1;
-    __LAPACK_int info = 0;
+    lapack_int_t const ldvl = m_do_vl ? n : 1;
+    lapack_int_t const ldvr = m_do_vr ? n : 1;
+    lapack_int_t info = 0;
     double vl_dummy = 0.0;
     double vr_dummy = 0.0;
     double * const vl_ptr = m_do_vl ? m_vl.data() : &vl_dummy;
@@ -173,7 +167,7 @@ inline void EigenSystem::run()
     // Phase 1: workspace query.  lwork == -1 tells DGEEV to write the
     // optimal workspace size into work[0] without performing any work.
     double work_query = 0.0;
-    __LAPACK_int lwork = -1;
+    lapack_int_t lwork = -1;
     dgeev_(
         &jobvl,
         &jobvr,
@@ -197,8 +191,8 @@ inline void EigenSystem::run()
     }
 
     // Phase 2: 4*n minimum when any eigenvectors requested, else 3*n.
-    __LAPACK_int const lwork_min = (m_do_vl || m_do_vr) ? 4 * n : 3 * n;
-    lwork = std::max<__LAPACK_int>(static_cast<__LAPACK_int>(work_query), lwork_min);
+    lapack_int_t const lwork_min = (m_do_vl || m_do_vr) ? 4 * n : 3 * n;
+    lwork = std::max<lapack_int_t>(static_cast<lapack_int_t>(work_query), lwork_min);
     array_type work(static_cast<size_t>(lwork));
     dgeev_(
         &jobvl,

--- a/cpp/modmesh/linalg/lapack_compat.hpp
+++ b/cpp/modmesh/linalg/lapack_compat.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * Copyright (c) 2025, Yung-Yu Chen <yyc@solvcon.net>
+ * Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -29,14 +29,58 @@
  */
 
 /**
- * The interface master header file for the linear algebraic code.
+ * Compatibility shim for the vendor LAPACK backend.
+ *
+ * On Apple, pull in Accelerate/vecLib with the modern (non-deprecated) LAPACK
+ * signatures.  On other platforms (Linux + OpenBLAS), declare the Fortran ABI
+ * symbols directly; this avoids pulling in lapacke.h, which Linux
+ * distributions package inconsistently.
+ *
+ * Consumers should include this header and use `lapack_int_t` plus the
+ * Fortran-named entry points (e.g. `dgeev_`) without conditional compilation.
+ * The header itself requires `MM_HAS_VENDOR_LAPACK` to be defined by the build
+ * system.
  */
 
-#include <modmesh/linalg/factorization.hpp>
-#include <modmesh/linalg/lu_factorization.hpp>
-#include <modmesh/linalg/kalman_filter.hpp>
-#ifdef MM_HAS_VENDOR_LAPACK
-#include <modmesh/linalg/EigenSystem.hpp>
+#ifndef MM_HAS_VENDOR_LAPACK
+#error "modmesh/linalg/lapack_compat.hpp requires a vendor LAPACK (MM_HAS_VENDOR_LAPACK)."
 #endif
+
+#ifdef __APPLE__
+// Opt in to the modern (non-deprecated) LAPACK signatures provided by
+// Accelerate.  Must be defined before including the Accelerate header.
+#ifndef ACCELERATE_NEW_LAPACK
+#define ACCELERATE_NEW_LAPACK
+#endif
+// NOLINTNEXTLINE(misc-header-include-cycle)
+#include <Accelerate/Accelerate.h>
+#else // __APPLE__
+extern "C" void dgeev_(
+    char const * jobvl,
+    char const * jobvr,
+    int const * n,
+    double * a,
+    int const * lda,
+    double * wr,
+    double * wi,
+    double * vl,
+    int const * ldvl,
+    double * vr,
+    int const * ldvr,
+    double * work,
+    int const * lwork,
+    int * info);
+#endif // __APPLE__
+
+namespace modmesh
+{
+
+#ifdef __APPLE__
+using lapack_int_t = __LAPACK_int;
+#else
+using lapack_int_t = int;
+#endif
+
+} /* end namespace modmesh */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/linalg/pymod/wrap_EigenSystem.cpp
+++ b/cpp/modmesh/linalg/pymod/wrap_EigenSystem.cpp
@@ -36,7 +36,7 @@ namespace modmesh
 namespace python
 {
 
-#ifdef __APPLE__
+#ifdef MM_HAS_VENDOR_LAPACK
 
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapEigenSystem
     : public WrapBase<WrapEigenSystem, EigenSystem>
@@ -109,15 +109,15 @@ WrapEigenSystem::WrapEigenSystem(pybind11::module & mod, char const * pyname, ch
         .def_property_readonly("done", &wrapped_type::done);
 }
 
-#endif /* __APPLE__ */
+#endif /* MM_HAS_VENDOR_LAPACK */
 
 void wrap_EigenSystem(pybind11::module & mod)
 {
-#ifdef __APPLE__
+#ifdef MM_HAS_VENDOR_LAPACK
     WrapEigenSystem::commit(mod, "EigenSystem", "Eigen problem solver");
-#else // __APPLE__
+#else // MM_HAS_VENDOR_LAPACK
     mod.attr("EigenSystem") = pybind11::none();
-#endif // __APPLE__
+#endif // MM_HAS_VENDOR_LAPACK
 }
 
 } /* end namespace python */

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 
 import numpy as np
@@ -1261,8 +1260,8 @@ class TestLuErrorHandling(unittest.TestCase):
             mm.lu_inv(A)
 
 
-@unittest.skipUnless(sys.platform == "darwin",
-                     "mm.EigenSystem requires Apple vecLib")
+@unittest.skipIf(mm.EigenSystem is None,
+                 "mm.EigenSystem is not built (no vendor LAPACK)")
 class TestLinalgEigenSystemTC(unittest.TestCase):
     """Verify EigenSystem against DGEEV reference outputs.
 


### PR DESCRIPTION
Link `EigenSystem` against OpenBLAS on Linux to mirror the Accelerate/vecLib backend on Apple (PR #768).  Changes include:

- CMake: optional `find_library(openblas)` defines `MM_HAS_VENDOR_LAPACK`; the `APPLE` branch defines the same.
- Add a new file `cpp/modmesh/linalg/lapack_compat.hpp` to abstract the compatibility layer for BLAS/LAPACK.
- Source and binding guards switch from `__APPLE__` to `MM_HAS_VENDOR_LAPACK`.
- Unit-testing skips on `mm.EigenSystem is None` instead of `sys.platform != "darwin"`.
- CI: add `libopenblas-dev` to the Linux apt-get list.

For issue #804.