### PR TITLE
Add architecture fence to Ubuntu mmdv build script

### DIFF
--- a/contrib/dependency/ubuntu2404/build-mmdv-ubuntu24.sh
+++ b/contrib/dependency/ubuntu2404/build-mmdv-ubuntu24.sh
@@ -73,6 +73,16 @@ set -e
 # so a failed build step would otherwise be silently ignored.
 set -o pipefail
 
+MMDV_ARCH="$(uname -m)"
+case "${MMDV_ARCH}" in
+    x86_64|amd64)
+        ;;
+    *)
+        echo "Unsupported architecture: ${MMDV_ARCH}. This script currently supports x86-64 only." >&2
+        exit 1
+        ;;
+esac
+
 MMDV_WRITE_ACTIVATE_ONLY=0
 MMDV_PRINT_PREFIX_ONLY=0
 MMDV_NO_CONFIRM=0


### PR DESCRIPTION
Closes solvcon/modmesh#807

This adds an early architecture check to the Ubuntu 24.04 mmdv build script. The script now allows x86_64/amd64 and fails fast with a clear error message on unsupported architectures.

Tested:
- build-mmdv-ubuntu24.sh --print-prefix on x86_64
- simulated arm64 uname output to verify the unsupported architecture error path
- git diff --check