### PR TITLE
Add create-pr skill encoding the project PR protocol

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -5,9 +5,9 @@ description: Open a modmesh pull request that follows the project PR protocol (c
 
 # Create Pull Request (modmesh)
 
-Authoritative reference is issue solvcon/modmesh#811 and the "Pull Request
-Guidelines" section of `CLAUDE.md`. The rules below are a working summary;
-if those extend them, follow them and flag the drift.
+This file is the authoritative reference for the modmesh PR protocol.
+The "Pull Request Guidelines" section of `CLAUDE.md` is the project-wide
+cross-reference; flag any drift between the two.
 
 ## Protocol the PR must satisfy
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: create-pr
+description: Open a modmesh pull request that follows the project PR protocol (concise subject, clear description, "related to #xxx" wording, draft by default, ready-for-review via global comment). Use when the user asks to create, open, or draft a pull request.
+---
+
+# Create Pull Request (modmesh)
+
+Authoritative reference is issue solvcon/modmesh#811 and the "Pull Request
+Guidelines" section of `CLAUDE.md`. The rules below are a working summary;
+if those extend them, follow them and flag the drift.
+
+## Protocol the PR must satisfy
+
+1. **Subject** -- concise and informative.
+2. **Description** -- clear global description. State *what* changed and
+   *why* in prose; use bullets for enumerated changes; include benchmark
+   tables or verification notes when relevant.
+3. **Issue reference** -- end with "Related to #xxx" or "For issue #xxx".
+   **Never** use "close #xxx", "closes #xxx", "fixes #xxx", or any closing
+   keyword. We do not let PR/commit text drive issue management.
+4. **Draft by default** -- open as draft unless the user explicitly says it
+   is ready for review. Pushing the "ready for review" button alone is
+   *not* a review request in this project.
+5. **Request review with a global comment** -- when the PR is ready, the
+   author posts a global PR comment that explicitly asks for review. The
+   button push is not quotable in follow-ups, so the comment is required.
+6. **Inline annotations** -- the author is expected to add inline review
+   annotations to guide the reviewer, unless the diff is one-liner-ish.
+   The skill should remind the user; it does not write the annotations.
+7. **Human authorship** -- all PR comments are written by humans. Tool
+   assistance is OK, but the user must know what the text says. When the
+   skill drafts text, present it for the user's review and edits before
+   posting.
+
+## Workflow
+
+1. **Confirm scope with the user.** Ask directly when unclear from
+   context:
+   - Which issue does this PR relate to? (issue number)
+   - Is this ready for review, or should it be opened as draft?
+   - One-line gist of the change.
+
+2. **Verify branch state.** modmesh's main branch is `master`. Run in parallel:
+   - `git status` -- working tree must be clean (or surface uncommitted
+     work and ask before continuing).
+   - `git log --oneline origin/master..HEAD` -- list the commits the PR
+     will carry.
+   - `git diff --stat origin/master...HEAD` -- summarize the diff
+     (three-dot uses the merge base).
+   - `git rev-parse --abbrev-ref --symbolic-full-name @{u}` -- check if
+     the branch tracks a remote.
+   If the branch is not pushed, push with `-u` after confirming with the
+   user. Do not force-push.
+
+3. **Draft the subject and body.** Inspect the diff and the user's gist,
+   then propose a subject and a body. The body should follow the shape of
+   recent merged PRs:
+   - Short opening paragraph stating the change and motivation.
+   - Bulleted list of notable file/area changes when more than one.
+   - Verification notes (tests run, benchmarks, manual checks) when
+     non-trivial.
+   - Closing line: `Related to #xxx.` or `For issue #xxx.`.
+
+   Present the draft to the user (subject and body) and wait for edits or
+   approval before opening the PR. Do not post Claude-Code attribution
+   trailers in the PR body -- this project treats PR text as
+   human-authored.
+
+4. **Open the PR.** Load the approved title and body into shell
+   variables using **quoted heredocs** -- the single-quoted delimiter
+   suppresses every form of shell expansion, so the placeholder text
+   can contain backticks, `$`, `"`, or apostrophes without escaping.
+   Then pass the title as a double-quoted variable expansion (safe
+   because the value is already in memory) and the body via a temp
+   file:
+
+   ```bash
+   title=$(cat <<'TITLE'
+   <approved subject>
+   TITLE
+   )
+
+   body_file=$(mktemp)
+   trap 'rm -f "$body_file"' EXIT
+   cat >"$body_file" <<'BODY'
+   <approved body, already ending with "Related to #xxx." or
+   "For issue #xxx." from step 3>
+   BODY
+
+   gh pr create --draft \
+     --title "$title" \
+     --body-file "$body_file"
+   ```
+
+   Drop `--draft` only when the user has explicitly said the PR is
+   ready for review. Do not append a second issue-reference footer here;
+   the body from step 3 already has one. The `trap` ensures the temp
+   file is removed on any exit path. If the approved body would itself
+   contain the literal token `BODY` on its own line, swap the delimiter
+   to something unique (e.g. `BODY_EOF_811`).
+
+5. **After creation.** Report the PR URL back to the user. Then:
+   - If the PR is draft, remind the user that "ready for review" requires
+     a global comment, not just the button.
+   - If the PR is ready, the global review-request comment is **required**
+     by the protocol -- not optional. Draft a one-line review-request
+     comment, present it for approval, and only after the user approves
+     post it via `gh pr comment <num> --body-file <file>`. The comment
+     must be authored by the user; if the user declines to post, output
+     `blocked: review-request comment not posted` and stop.
+   - If the diff is more than one-liner-ish, remind the user to add inline
+     annotations to guide review. The skill does not write them.
+
+## Guardrails
+
+- **Closing keywords.** After loading `$title` and writing `$body_file`
+  in step 4, but **before** the `gh pr create` call, scan title and
+  body together with a single case-insensitive check:
+
+  ```bash
+  { printf '%s\n' "$title"; cat "$body_file"; } \
+      | grep -iEn '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+'
+  ```
+
+  Any hit means the text uses a banned closing keyword (close/closes/
+  closed/fix/fixes/fixed/resolve/resolves/resolved followed by `#nnn`).
+  Rewrite the offending line to "Related to #xxx" or "For issue #xxx"
+  and re-confirm with the user before retrying.
+- **Branch protection.** Never force-push, never push to `master`/`main`
+  directly, never `--no-verify`. If `gh pr create` fails, surface the
+  error and stop -- do not work around it.
+- **No fabricated context.** Do not invent benchmark numbers, test
+  results, or verification claims. Only include what the user has stated
+  or what is visible in the diff/commits.
+- **Trailers.** Do not append `Co-Authored-By:` or "Generated with Claude
+  Code" trailers to the PR body. Commits in this project are
+  human-authored by convention.
+
+## Output
+
+- Show the draft subject and body to the user before calling `gh pr
+  create`. Use a fenced block so it is easy to edit.
+- After creation, output a single line: `opened: <PR URL> (draft|ready)`.
+- If guardrails block the action (closing keyword, dirty tree, unpushed
+  branch), output `blocked: <reason>` and stop. Do not retry silently.
+
+<!-- vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: -->

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -12,9 +12,11 @@ if those extend them, follow them and flag the drift.
 ## Protocol the PR must satisfy
 
 1. **Subject** -- concise and informative.
-2. **Description** -- clear global description. State *what* changed and
-   *why* in prose; use bullets for enumerated changes; include benchmark
-   tables or verification notes when relevant.
+2. **Description** -- clear, short, human-readable global description.
+   Write it as prose paragraphs that a person would actually want to
+   read. Avoid bullet lists; only fall back to a short bulleted list or
+   a table when prose would genuinely be unreadable (e.g. a benchmark
+   matrix with many rows). State *what* changed and *why*.
 3. **Issue reference** -- end with "Related to #xxx" or "For issue #xxx".
    **Never** use "close #xxx", "closes #xxx", "fixes #xxx", or any closing
    keyword. We do not let PR/commit text drive issue management.
@@ -52,19 +54,18 @@ if those extend them, follow them and flag the drift.
    If the branch is not pushed, push with `-u` after confirming with the
    user. Do not force-push.
 
-3. **Draft the subject and body.** Inspect the diff and the user's gist,
-   then propose a subject and a body. The body should follow the shape of
-   recent merged PRs:
-   - Short opening paragraph stating the change and motivation.
-   - Bulleted list of notable file/area changes when more than one.
-   - Verification notes (tests run, benchmarks, manual checks) when
-     non-trivial.
-   - Closing line: `Related to #xxx.` or `For issue #xxx.`.
+3. **Draft the subject and body.** Inspect the diff and the user's
+   gist, then propose a subject and a body. The body should be **short
+   prose** -- a person reading it should understand what changed and
+   why without scanning a checklist. Prefer one to three paragraphs.
+   Reserve bullets for cases where prose would genuinely be unreadable
+   (long enumerations, benchmark matrices). End with the closing line
+   `Related to #xxx.` or `For issue #xxx.`.
 
-   Present the draft to the user (subject and body) and wait for edits or
-   approval before opening the PR. Do not post Claude-Code attribution
-   trailers in the PR body -- this project treats PR text as
-   human-authored.
+   Present the draft to the user (subject and body) and wait for edits
+   or approval before opening the PR. Do not post Claude-Code
+   attribution trailers in the PR body -- this project treats PR text
+   as human-authored.
 
 4. **Open the PR.** Load the approved title and body into shell
    variables using **quoted heredocs** -- the single-quoted delimiter

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -114,15 +114,13 @@ if those extend them, follow them and flag the drift.
    to something unique (e.g. `BODY_EOF_811`).
 
 5. **After creation.** Report the PR URL back to the user. Then:
-   - If the PR is draft, remind the user that "ready for review"
-     requires a global comment, not just the button.
-   - If the PR is ready, the global review-request comment is
-     **required** by the protocol -- not optional. Draft a one-line
-     review-request comment, present it for approval, and only after
-     the user approves post it via
-     `gh pr comment <num> --body-file <file>`. The comment must be
-     authored by the user; if the user declines to post, output
-     `blocked: review-request comment not posted` and stop.
+   - Remind the user that the global review-request comment is the
+     author's responsibility -- the skill does **not** post it. When
+     the PR is ready (now, or later after leaving draft), the author
+     must open a global PR comment that explicitly asks the
+     maintainer to review. Point the user at the PR URL and let them
+     write and post the comment themselves; do not draft text for it
+     and do not call `gh pr comment`.
    - Remind the user to add inline annotations on the diff (the skill
      does not write them). Recommend the user focus on the points
      that help the reviewer most:

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -17,6 +17,11 @@ cross-reference; flag any drift between the two.
    read. Avoid bullet lists; only fall back to a short bulleted list or
    a table when prose would genuinely be unreadable (e.g. a benchmark
    matrix with many rows). State *what* changed and *why*.
+   **Do not hard-wrap paragraphs.** Each paragraph is a single
+   unbroken line; separate paragraphs with one blank line. GitHub
+   reflows the text to the viewer's width, and mid-sentence line
+   breaks at 79/80 columns render as ragged prose in the PR view.
+   The 79-char source-code limit does not apply to PR descriptions.
 3. **Issue reference** -- end with "Related to #xxx" or "For issue #xxx".
    **Never** use "close #xxx", "closes #xxx", "fixes #xxx", or any closing
    keyword. We do not let PR/commit text drive issue management.
@@ -74,6 +79,13 @@ cross-reference; flag any drift between the two.
    Reserve bullets for cases where prose would genuinely be unreadable
    (long enumerations, benchmark matrices). End with the closing line
    `Related to #xxx.` or `For issue #xxx.`.
+
+   **Write each paragraph as one continuous line.** Do not insert
+   hard line breaks inside a paragraph -- not at 79 columns, not at
+   any column. Paragraphs are separated by exactly one blank line.
+   GitHub wraps to the viewer's width; pre-wrapped prose looks
+   ragged in the rendered PR. This applies to the draft you show
+   the user and to the text written into `$body_file` in step 4.
 
    Present the draft to the user (subject and body) and wait for edits
    or approval before opening the PR. Do not post Claude-Code

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -42,17 +42,30 @@ if those extend them, follow them and flag the drift.
    - Is this ready for review, or should it be opened as draft?
    - One-line gist of the change.
 
-2. **Verify branch state.** modmesh's main branch is `master`. Run in parallel:
-   - `git status` -- working tree must be clean (or surface uncommitted
-     work and ask before continuing).
+2. **Verify branch state.** modmesh's main branch is `master`. Run in
+   parallel:
+   - `git status --porcelain` -- check for staged or unstaged changes
+     and untracked files.
    - `git log --oneline origin/master..HEAD` -- list the commits the PR
      will carry.
    - `git diff --stat origin/master...HEAD` -- summarize the diff
      (three-dot uses the merge base).
    - `git rev-parse --abbrev-ref --symbolic-full-name @{u}` -- check if
      the branch tracks a remote.
-   If the branch is not pushed, push with `-u` after confirming with the
-   user. Do not force-push.
+
+   If `git status --porcelain` shows any output, the working tree is
+   not clean. Show the user the list (staged, unstaged, and untracked
+   separately) and ask explicitly how to proceed: stage and commit
+   selected files, stash, or abort. Never run `git add -A` or
+   `git add .` without confirmation -- pick specific paths so that
+   stray files (local settings, generated artifacts) are not pulled
+   into the PR.
+
+   If the branch has no commits ahead of `origin/master`, abort -- the
+   PR would be empty.
+
+   If the branch is not pushed (or is behind its remote), push after
+   confirming with the user.
 
 3. **Draft the subject and body.** Inspect the diff and the user's
    gist, then propose a subject and a body. The body should be **short
@@ -101,16 +114,28 @@ if those extend them, follow them and flag the drift.
    to something unique (e.g. `BODY_EOF_811`).
 
 5. **After creation.** Report the PR URL back to the user. Then:
-   - If the PR is draft, remind the user that "ready for review" requires
-     a global comment, not just the button.
-   - If the PR is ready, the global review-request comment is **required**
-     by the protocol -- not optional. Draft a one-line review-request
-     comment, present it for approval, and only after the user approves
-     post it via `gh pr comment <num> --body-file <file>`. The comment
-     must be authored by the user; if the user declines to post, output
+   - If the PR is draft, remind the user that "ready for review"
+     requires a global comment, not just the button.
+   - If the PR is ready, the global review-request comment is
+     **required** by the protocol -- not optional. Draft a one-line
+     review-request comment, present it for approval, and only after
+     the user approves post it via
+     `gh pr comment <num> --body-file <file>`. The comment must be
+     authored by the user; if the user declines to post, output
      `blocked: review-request comment not posted` and stop.
-   - If the diff is more than one-liner-ish, remind the user to add inline
-     annotations to guide review. The skill does not write them.
+   - Remind the user to add inline annotations on the diff (the skill
+     does not write them). Recommend the user focus on the points
+     that help the reviewer most:
+     - non-obvious design choices and the alternatives considered;
+     - subtle logic, invariants, or ordering constraints a reader
+       might overlook;
+     - changes that look like dead code or accidental edits but are
+       intentional, so the reviewer does not "fix" them;
+     - known limitations, follow-up work, and test-coverage gaps;
+     - tricky diffs (large reformatting next to substantive edits,
+       cross-file renames) where the reviewer needs guidance on what
+       to inspect carefully versus what is mechanical.
+     Skip the reminder when the diff is genuinely one-liner-ish.
 
 ## Guardrails
 
@@ -127,9 +152,9 @@ if those extend them, follow them and flag the drift.
   closed/fix/fixes/fixed/resolve/resolves/resolved followed by `#nnn`).
   Rewrite the offending line to "Related to #xxx" or "For issue #xxx"
   and re-confirm with the user before retrying.
-- **Branch protection.** Never force-push, never push to `master`/`main`
-  directly, never `--no-verify`. If `gh pr create` fails, surface the
-  error and stop -- do not work around it.
+- **Branch protection.** Never push directly to `master`/`main`, never
+  `--no-verify`. If `gh pr create` fails, surface the error and stop --
+  do not work around it.
 - **No fabricated context.** Do not invent benchmark numbers, test
   results, or verification claims. Only include what the user has stated
   or what is visible in the diff/commits.


### PR DESCRIPTION
This adds a Claude Code skill at `.claude/skills/create-pr/SKILL.md` that helps the author open a pull request following the modmesh PR protocol from issue #811. The skill walks through confirming scope, verifying branch state, drafting the subject and body for approval, checking title and body for banned closing keywords ("close", "fix", "resolve" forms followed by `#`), and calling `gh pr create` with text loaded from quoted heredocs so a subject containing backticks, `$`, `"`, or apostrophes does not need escaping.

PRs default to draft. Opening as ready-for-review triggers a mandatory global review-request comment step, because the "ready for review" button alone is not quotable in follow-ups. After creation the skill reminds the author to add inline annotations when the diff is more than one-liner-ish, and refuses to append attribution trailers since this project treats PR text as human-authored.

The skill also requires that PR description paragraphs are written as single unbroken lines separated by blank lines, rather than hard-wrapped at 79/80 columns. The source-code line-length limit does not belong in PR text; GitHub reflows to the viewer's width, and mid-sentence breaks render as ragged prose. This PR description itself follows the rule.

This PR is opened via the new `create-pr` skill.

For issue #811.
