### PR TITLE
Add GitHub pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!--
+modmesh pull request guidelines.
+
+- Subject: concise and informative.
+- Description: clear prose.  Write single-line paragraphs separated by blank
+  lines; GitHub reflows text to the viewer's width, so hard-wrapping at 79/80
+  columns renders as ragged mid-sentence breaks.
+- Draft until ready: open the PR as a draft while work is in progress.  When
+  the PR is ready for review, post a global PR comment that explicitly asks for
+  review.  Pushing the "ready for review" button alone is not a review request,
+  because the push cannot be quoted in follow-ups.
+- Inline annotations: as the author, add inline annotations on the diff to
+  guide the reviewer, unless the diff is one-liner-ish.
+- Issue reference: end the description with "Related to #xxx" or "For issue
+  #xxx".  Do not use closing keywords (close, closes, closed, fix, fixes,
+  fixed, resolve, resolves, resolved) followed by an issue number.  We do not
+  let PR or commit text drive issue management.
+- Authorship: PR text is treated as human-authored.  Tool assistance is OK, but
+  you need to know what you wrote.
+
+Delete this comment block before submitting.
+-->
+
+Replace this paragraph with a clear prose description of what this
+PR changes and why.
+
+Related to #xxx.
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->


### PR DESCRIPTION
Add .github/pull_request_template.md so the modmesh PR protocol is surfaced at the moment of opening a PR rather than only in issue text.  The template carries the review protocol described in issue #811 and used in PR #812.