### PR TITLE
build: skip CI for pull requests with skip-ci label or [skip-ci]

### DIFF
--- a/.github/workflows/check_skip_ci.yml
+++ b/.github/workflows/check_skip_ci.yml
@@ -1,0 +1,104 @@
+name: check_skip_ci
+
+# Reusable workflow that decides whether the heavy CI jobs should be skipped
+# for a pull request.  See issue solvcon/modmesh#814.
+#
+# A pull request skips CI when either of the following is true:
+#
+#   1. It carries the "skip-ci" label (only repository members can set
+#      labels, so this is the trusted, primary mechanism).  Apply it to pull
+#      requests that change documentation or AI prompts only.
+#   2. Its description or one of its comments has the control string
+#      "[skip-ci]" alone on a line by itself; the control string is ignored
+#      when it appears inline within other prose.  Only the description/
+#      comments written by a repository owner, member, or collaborator are
+#      honored, so an external contributor cannot bypass CI by commenting.
+#
+# Adding or removing the label (or pushing a new commit) re-evaluates the
+# decision, because the callers listen to the "labeled"/"unlabeled" pull
+# request activity types in addition to the defaults.
+#
+# The "skip" output is "true" only for pull_request events; it is empty for
+# push and schedule events, which keeps their existing gating untouched.
+
+on:
+  workflow_call:
+    outputs:
+      skip:
+        description: >-
+          "true" when CI should be skipped for the triggering pull request,
+          "false" or empty otherwise.
+        value: ${{ jobs.check.outputs.skip }}
+
+permissions: {}
+
+jobs:
+
+  check:
+
+    name: check_skip_ci
+
+    runs-on: ubuntu-24.04
+
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+
+    steps:
+
+      - name: scan label, description, and comments
+        id: check
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const trusted = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            // The control string is honored only when it is alone on a line
+            // by itself, so that prose mentioning it does not accidentally
+            // skip CI.
+            const control = /^\[skip-ci\]$/i;
+            const hasControlLine = text =>
+              (text || '').split(/\r?\n/)
+                .some(line => control.test(line.trim()));
+            const pr = context.payload.pull_request;
+
+            // 1. The skip-ci label, set by a repository member.
+            if (pr.labels.some(label => label.name === 'skip-ci')) {
+              core.notice('CI skipped: the "skip-ci" label is present.');
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            // 2. The control string in the pull request description.
+            if (trusted.includes(pr.author_association) &&
+                hasControlLine(pr.body)) {
+              core.notice('CI skipped: control string in the description.');
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            // 3. The control string in a comment from a member.
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+            const hit = comments.find(
+              comment => trusted.includes(comment.author_association) &&
+                         hasControlLine(comment.body));
+            if (hit) {
+              core.notice('CI skipped: control string in a comment.');
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            core.setOutput('skip', 'false');

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -3,6 +3,7 @@ name: devbuild
 on:
   push:
   pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   schedule:
     - cron: '34 17 * * *'
 
@@ -12,14 +13,24 @@ concurrency:
 
 jobs:
 
+  check_skip:
+    uses: ./.github/workflows/check_skip_ci.yml
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+
   standalone_buffer:
 
+    needs: [check_skip]
+
     if: |
+      needs.check_skip.outputs.skip != 'true' && (
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
        (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
         contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
-      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable')
+      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable'))
 
     name: standalone_buffer_${{ matrix.os }}
 
@@ -63,13 +74,16 @@ jobs:
 
   build:
 
+    needs: [check_skip]
+
     if: |
+      needs.check_skip.outputs.skip != 'true' && (
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
        (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
         contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
       (github.event_name == 'schedule' &&
-      vars.MMGH_NIGHTLY == 'enable')
+      vars.MMGH_NIGHTLY == 'enable'))
 
     name: build_${{ matrix.os }}_${{ matrix.cmake_build_type }}
 
@@ -204,13 +218,16 @@ jobs:
 
   build_windows:
 
+    needs: [check_skip]
+
     if: |
+      needs.check_skip.outputs.skip != 'true' && (
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
        (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
         contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
       (github.event_name == 'schedule' &&
-      vars.MMGH_NIGHTLY == 'enable')
+      vars.MMGH_NIGHTLY == 'enable'))
 
     name: build_${{ matrix.os }}_${{ matrix.cmake_build_type }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,7 @@ name: lint
 on:
   push:
   pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   schedule:
     - cron: '34 17 * * *'
 
@@ -12,16 +13,26 @@ concurrency:
 
 jobs:
 
+  check_skip:
+    uses: ./.github/workflows/check_skip_ci.yml
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+
   lint:
 
     name: Run make lint and pilot on ${{ matrix.os }}
 
+    needs: [check_skip]
+
     if: |
+      needs.check_skip.outputs.skip != 'true' && (
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
        (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
         contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
-      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable')
+      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable'))
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -3,6 +3,7 @@ name: nouse_install
 on:
   push:
   pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   schedule:
     - cron: '34 17 * * *'
 
@@ -12,14 +13,24 @@ concurrency:
 
 jobs:
 
+  check_skip:
+    uses: ./.github/workflows/check_skip_ci.yml
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+
   nouse_install:
 
+    needs: [check_skip]
+
     if: |
+      needs.check_skip.outputs.skip != 'true' && (
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
        (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
         contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
-      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable')
+      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable'))
 
     name: nouse_install_${{ matrix.os }}_Release
 


### PR DESCRIPTION
Add a reusable check_skip_ci workflow that gates the devbuild, lint, and nouse_install jobs.  CI is skipped when:
- a pull request carries the "skip-ci" label, or
- when its description or a repository member's comment has "[skip-ci]" alone on a line

I tested the two scenarios in a separate repository.  This PR demonstrates the label approach.

Toggling the label re-evaluates via the labeled/unlabeled triggers; push and schedule events keep their existing gating.  The "skip-ci" label must exist in the repository.

For issue #814.