### PR TITLE
ci: send mail when any profiling CI fails

### DIFF
--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -76,7 +76,7 @@ jobs:
 
   send_email_on_failure:
     needs: [profile]
-    if: ${{ always() && (needs.*.result == 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     uses: ./.github/workflows/send_email_on_fail.yml
     with:
       job_results: |


### PR DESCRIPTION


Related to https://github.com/solvcon/modmesh/issues/838.

Original condition only triggers email sending when both linux and macos fail. To fix this, I follow the way that other workflows used (`contains(needs.*.result, 'failure')`) for it.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
