### PR TITLE
Add member function `SimpleArray::trace()`

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -1346,6 +1346,18 @@ public:
         return result;
     }
 
+    value_type trace() const
+    {
+        auto athis = static_cast<A const *>(this);
+        validate_square("trace");
+        auto result = static_cast<value_type>(0);
+        for (ssize_t i = 0; i < athis->shape(0); ++i)
+        {
+            result += (*athis)(i, i);
+        }
+        return result;
+    }
+
 private:
 
     static void validate_positive(const char * operation_name, ssize_t n)

--- a/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/modmesh/buffer/pymod/wrap_SimpleArray.cpp
@@ -494,6 +494,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def_static("scaled_eye", &wrapped_type::scaled_eye, py::arg("n"), py::arg("scale"), "Create a scaled identity matrix of size n x n")
             .def("hermitian", &wrapped_type::hermitian, "Create hermitian (conjugate transpose) of the matrix")
             .def("symmetrize", &wrapped_type::symmetrize, "Create symmetric matrix by averaging with its transpose")
+            .def("trace", &wrapped_type::trace, "Compute the trace (sum of the diagonal) of a square matrix")
             //
             ;
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -3402,6 +3402,42 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         ):
             non_square.symmetrize()
 
+    def test_trace(self):
+        """Test trace() method for summing the diagonal of a matrix"""
+        ndarr = np.array([[1.0, 2.0, 3.0],
+                          [4.0, 5.0, 6.0],
+                          [7.0, 8.0, 9.0]], dtype='float64')
+        sarr = modmesh.SimpleArrayFloat64(array=ndarr)
+        self.assertEqual(sarr.trace(), 15.0)
+
+        ndarr_int = np.array([[2, 0, 1],
+                              [0, 3, 0],
+                              [4, 0, 5]], dtype='int32')
+        sarr_int = modmesh.SimpleArrayInt32(array=ndarr_int)
+        self.assertEqual(sarr_int.trace(), 10)
+
+        ndarr_cplx = np.array([[1.0 + 2.0j, 3.0 + 4.0j],
+                               [5.0 + 6.0j, 7.0 + 8.0j]],
+                              dtype='complex128')
+        sarr_cplx = modmesh.SimpleArrayComplex128(array=ndarr_cplx)
+        self.assertEqual(complex(sarr_cplx.trace()), 8.0 + 10.0j)
+
+        vector = modmesh.SimpleArrayFloat64(5)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray::trace\(\): operation requires 2D SimpleArray, "
+            r"but got 1D SimpleArray"
+        ):
+            vector.trace()
+
+        non_square = modmesh.SimpleArrayFloat64((3, 4))
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray::trace\(\): operation requires square "
+            r"SimpleArray, but got 3x4 shape"
+        ):
+            non_square.trace()
+
 
 class SimpleArraySearchTC(unittest.TestCase):
 


### PR DESCRIPTION
Add `SimpleArray::trace()` to `SimpleArrayMixinMatrix` to compute the trace (sum of the diagonal) of a square matrix, alongside the existing eye, scaled_eye, hermitian, and symmetrize operations.  It works for real, integer, and complex dtypes.

Expose it through the wrap_matrix() pybind11 section and cover it in tests/test_buffer.py with float, int, and complex cases plus the 2D and square validation error paths.

For issue #822.