### PR TITLE
ci: wrap workflow run blocks in log groups

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -53,9 +53,7 @@ jobs:
 
       - name: event name
         run: |
-          echo "::group::event name"
           echo "github.event_name: ${{ github.event_name }}"
-          echo "::endgroup::"
 
       - name: setup dependencies
         uses: ./.github/actions/setup_linux
@@ -118,9 +116,7 @@ jobs:
 
     - name: event name
       run: |
-        echo "::group::event name"
         echo "github.event_name: ${{ github.event_name }}"
-        echo "::endgroup::"
 
     - name: setup dependencies for Linux
       if: runner.os == 'Linux'
@@ -279,9 +275,7 @@ jobs:
 
       - name: event name
         run: |
-          echo "::group::event name"
           echo "github.event_name: ${{ github.event_name }}"
-          echo "::endgroup::"
 
       - uses: TheMrMilchmann/setup-msvc-dev@v4
         with:

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -53,7 +53,9 @@ jobs:
 
       - name: event name
         run: |
+          echo "::group::event name"
           echo "github.event_name: ${{ github.event_name }}"
+          echo "::endgroup::"
 
       - name: setup dependencies
         uses: ./.github/actions/setup_linux
@@ -69,8 +71,10 @@ jobs:
 
       - name: make standalone_buffer
         run: |
+          echo "::group::make standalone_buffer"
           make standalone_buffer_setup
           make standalone_buffer
+          echo "::endgroup::"
 
   build:
 
@@ -114,7 +118,9 @@ jobs:
 
     - name: event name
       run: |
+        echo "::group::event name"
         echo "github.event_name: ${{ github.event_name }}"
+        echo "::endgroup::"
 
     - name: setup dependencies for Linux
       if: runner.os == 'Linux'
@@ -137,12 +143,15 @@ jobs:
 
     - name: make gtest BUILD_QT=OFF
       run: |
+        echo "::group::make gtest BUILD_QT=OFF"
         make gtest \
           VERBOSE=1 USE_CLANG_TIDY=OFF \
           BUILD_QT=OFF
+        echo "::endgroup::"
 
     - name: make buildext BUILD_QT=OFF
       run: |
+        echo "::group::make buildext BUILD_QT=OFF"
         rm -f build/*/Makefile
         make cmake \
           VERBOSE=1 USE_CLANG_TIDY=OFF \
@@ -150,18 +159,22 @@ jobs:
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
         make buildext VERBOSE=1
+        echo "::endgroup::"
 
     - name: make pytest BUILD_QT=OFF
       run: |
+        echo "::group::make pytest BUILD_QT=OFF"
         python3 -c "import modmesh; assert modmesh.HAS_PILOT == False"
         JOB_MAKE_ARGS="${JOB_MAKE_ARGS} VERBOSE=1"
         if [ "${{ matrix.os }}" == "macos-26" ] ; then \
           JOB_MAKE_ARGS="${JOB_MAKE_ARGS} BUILD_METAL=ON" ; \
         fi
         make pytest ${JOB_MAKE_ARGS}
+        echo "::endgroup::"
 
     - name: make buildext BUILD_QT=ON
       run: |
+        echo "::group::make buildext BUILD_QT=ON"
         rm -f build/*/Makefile
         make cmake \
           VERBOSE=1 USE_CLANG_TIDY=OFF \
@@ -169,9 +182,11 @@ jobs:
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
         make buildext VERBOSE=1
+        echo "::endgroup::"
 
     - name: make pytest BUILD_QT=ON
       run: |
+        echo "::group::make pytest BUILD_QT=ON"
         python3 -c "import modmesh; assert modmesh.HAS_PILOT == True"
         JOB_MAKE_ARGS="${JOB_MAKE_ARGS} VERBOSE=1"
         if [ "${{ matrix.os }}" == "macos-26" ] ; then \
@@ -188,24 +203,30 @@ jobs:
           JOB_MAKE_ARGS="${JOB_MAKE_ARGS} BUILD_METAL=ON" ; \
         fi
         make pytest ${JOB_MAKE_ARGS}
+        echo "::endgroup::"
 
     - name: make pilot
       run: |
+        echo "::group::make pilot"
         rm -f build/*/Makefile
         make pilot \
           VERBOSE=1 USE_CLANG_TIDY=OFF \
           BUILD_QT=ON \
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+        echo "::endgroup::"
 
     - name: make run_pilot_pytest
       run: |
+        echo "::group::make run_pilot_pytest"
         export LD_LIBRARY_PATH=$(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
         make run_pilot_pytest VERBOSE=1
+        echo "::endgroup::"
 
     # FIXME: turn off until all issues resolved
     - name: make cmake USE_SANITIZER=ON & make pytest
       run: |
+        echo "::group::make cmake USE_SANITIZER=ON & make pytest"
         export ASAN_OPTIONS=verify_asan_link_order=0
         rm -f build/*/Makefile
         make cmake \
@@ -215,6 +236,7 @@ jobs:
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_SANITIZER=OFF"
         make buildext VERBOSE=1
         make pytest VERBOSE=1
+        echo "::endgroup::"
 
   build_windows:
 
@@ -257,7 +279,9 @@ jobs:
 
       - name: event name
         run: |
+          echo "::group::event name"
           echo "github.event_name: ${{ github.event_name }}"
+          echo "::endgroup::"
 
       - uses: TheMrMilchmann/setup-msvc-dev@v4
         with:
@@ -284,15 +308,18 @@ jobs:
 
       - name: install BLAS and LAPACK
         run: |
+          echo "::group::install BLAS and LAPACK"
           vcpkg install openblas:x64-windows lapack:x64-windows
           $vcpkg_bin_path = @(
             "C:\vcpkg\installed\x64-windows\bin",
             "C:\vcpkg\installed\x64-windows\debug\bin"
           ) -join ";"
           echo "$vcpkg_bin_path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "::endgroup::"
 
       - name: dependency by pip
         run: |
+          echo "::group::dependency by pip"
           pip3 install -U numpy matplotlib pytest jsonschema flake8 pybind11 pyside6==$(qmake -query QT_VERSION)
           # Add PySide6 and Shiboken6 path into system path, that allow exe file can find
           # dll during runtime
@@ -304,9 +331,11 @@ jobs:
           $pyside6_path = $(python3 -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))")
           $shiboken6_path = $(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
           echo "$pyside6_path;$shiboken6_path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "::endgroup::"
 
       - name: show dependency
         run: |
+          echo "::group::show dependency"
           Get-Command cl
           Get-Command cmake
           Get-Command python3
@@ -317,9 +346,11 @@ jobs:
           Get-Command pytest
           Get-Command clang-tidy
           Get-Command flake8
+          echo "::endgroup::"
 
       - name: cmake ALL_BUILD
         run: |
+          echo "::group::cmake ALL_BUILD"
           cmake `
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
@@ -330,22 +361,28 @@ jobs:
           cmake --build ${{ github.workspace }}/build `
             --config ${{ matrix.cmake_build_type }} `
             --target ALL_BUILD
+          echo "::endgroup::"
 
       - name: cmake run_gtest
         run: |
+          echo "::group::cmake run_gtest"
           cmake --build ${{ github.workspace }}/build `
             --config ${{ matrix.cmake_build_type }} `
             --target run_gtest
+          echo "::endgroup::"
 
       - name: cmake run_pilot_pytest
         run: |
+          echo "::group::cmake run_pilot_pytest"
           cmake --build ${{ github.workspace }}/build `
             --config ${{ matrix.cmake_build_type }} `
             --target run_pilot_pytest
+          echo "::endgroup::"
 
       - name: generate portable
         if: ${{ matrix.cmake_build_type == 'Release' }}
         run: |
+          echo "::group::generate portable"
           # Get the Python version installed and extract the major+minor version components
           $py_ver=$(python3 -V | awk '{print $2}')
           $py_main_ver=$(echo $py_ver | awk -F. '{print $1$2}')
@@ -393,6 +430,7 @@ jobs:
           Copy-Item -Path ".\modmesh" -Destination $destination -Recurse
           # Also include potential thirdparty
           Copy-Item -Path ".\thirdparty" -Destination $destination -Recurse
+          echo "::endgroup::"
 
       - name: archive portable artifacts
         if: ${{ matrix.cmake_build_type == 'Release' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,9 +64,7 @@ jobs:
 
     - name: event name
       run: |
-        echo "::group::event name"
         echo "github.event_name: ${{ github.event_name }}"
-        echo "::endgroup::"
 
     - name: setup dependencies for Linux
       if: runner.os == 'Linux'
@@ -88,19 +86,34 @@ jobs:
         create-symlink: true
 
     - name: make cformat (clang-format check)
-      run: make cformat
+      run: |
+        echo "::group::make cformat"
+        make cformat
+        echo "::endgroup::"
 
     - name: make cinclude (check_include)
-      run: make cinclude
+      run: |
+        echo "::group::make cinclude"
+        make cinclude
+        echo "::endgroup::"
 
     - name: make checkascii (check ASCII-only characters)
-      run: make checkascii
+      run: |
+        echo "::group::make checkascii"
+        make checkascii
+        echo "::endgroup::"
 
     - name: make checktws (check trailing whitespace)
-      run: make checktws
+      run: |
+        echo "::group::make checktws"
+        make checktws
+        echo "::endgroup::"
 
     - name: make flake8
-      run: make flake8
+      run: |
+        echo "::group::make flake8"
+        make flake8
+        echo "::endgroup::"
 
     - name: make pilot
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,7 +64,9 @@ jobs:
 
     - name: event name
       run: |
+        echo "::group::event name"
         echo "github.event_name: ${{ github.event_name }}"
+        echo "::endgroup::"
 
     - name: setup dependencies for Linux
       if: runner.os == 'Linux'
@@ -102,18 +104,22 @@ jobs:
 
     - name: make pilot
       run: |
+        echo "::group::make pilot"
         make pilot \
           ${JOB_MAKE_ARGS} \
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+        echo "::endgroup::"
 
     - name: make run_pilot_pytest
       run: |
+        echo "::group::make run_pilot_pytest"
         export LD_LIBRARY_PATH=$(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
         make run_pilot_pytest \
           ${JOB_MAKE_ARGS} \
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+        echo "::endgroup::"
 
   send_email_on_failure:
     needs: [lint]

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -56,7 +56,9 @@ jobs:
 
       - name: event name
         run: |
+          echo "::group::event name"
           echo "github.event_name: ${{ github.event_name }}"
+          echo "::endgroup::"
 
       - name: setup dependencies for Linux
         if: runner.os == 'Linux'
@@ -72,6 +74,7 @@ jobs:
 
       - name: setup.py install build_ext
         run: |
+          echo "::group::setup.py install build_ext"
           SUDO_CMD=""
           if [ ${{ matrix.os }} == "ubuntu-24.04" ] ; then
             SUDO_CMD="sudo"
@@ -79,9 +82,11 @@ jobs:
           $SUDO_CMD python3 setup.py install build_ext \
             --cmake-args="${JOB_CMAKE_ARGS} -DPYTHON_EXECUTABLE=$(which python3)" \
             --make-args="VERBOSE=1"
+          echo "::endgroup::"
 
       - name: pytest
         run: |
+          echo "::group::pytest"
           rm -rf tmp/
           mkdir -p tmp/
           cp -a tests tmp/
@@ -95,6 +100,7 @@ jobs:
           # The alternative command to solve the issue is ```pytest --rootdir=. -v```.
           pytest --rootdir=. -v
           cd ..
+          echo "::endgroup::"
 
   send_email_on_failure:
     needs: [nouse_install]

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -56,9 +56,7 @@ jobs:
 
       - name: event name
         run: |
-          echo "::group::event name"
           echo "github.event_name: ${{ github.event_name }}"
-          echo "::endgroup::"
 
       - name: setup dependencies for Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -40,7 +40,9 @@ jobs:
 
       - name: event name
         run: |
+          echo "::group::event name"
           echo "Event name: ${{ github.event_name }}"
+          echo "::endgroup::"
 
       - name: setup dependencies for Linux
         if: runner.os == 'Linux'
@@ -64,15 +66,19 @@ jobs:
 
       - name: make buildext BUILD_QT=ON
         run: |
+          echo "::group::make buildext BUILD_QT=ON"
           make cmake \
             VERBOSE=1 USE_CLANG_TIDY=OFF \
             BUILD_QT=ON \
             CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
           make buildext VERBOSE=1
+          echo "::endgroup::"
 
       - name: make pyprof
         run: |
+          echo "::group::make pyprof"
           make pyprof
+          echo "::endgroup::"
 
   send_email_on_failure:
     needs: [profile]

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -40,9 +40,7 @@ jobs:
 
       - name: event name
         run: |
-          echo "::group::event name"
           echo "Event name: ${{ github.event_name }}"
-          echo "::endgroup::"
 
       - name: setup dependencies for Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/send_email_on_fail.yml
+++ b/.github/workflows/send_email_on_fail.yml
@@ -20,7 +20,9 @@ jobs:
     steps:
       - name: Get current date and set to env
         run: |
+          echo "::group::Get current date and set to env"
           echo "DATE=$(date +%m/%d)" >> $GITHUB_ENV
+          echo "::endgroup::"
 
       - name: Send mail to mailing list
         uses: dawidd6/action-send-mail@v6


### PR DESCRIPTION
Related to #782

## Summary
 
 Wrap the remaining multi-line GitHub Actions `run:` blocks with
 `::group::` / `::endgroup::` so long CI logs are folded by default.
 
 ## Changes
 
 - Add log grouping to the remaining workflow steps in:
   - `.github/workflows/devbuild.yml`
   - `.github/workflows/lint.yml`
   - `.github/workflows/nouse_install.yml`
   - `.github/workflows/profiling.yml`
   - `.github/workflows/send_email_on_fail.yml`
 - Keep the workflow behavior unchanged; only improve log readability
 