### PR TITLE
Initialize Sphinx-based documentation under doc/

### DIFF
--- a/contrib/dependency/macos26/build-mmdv-macos26.sh
+++ b/contrib/dependency/macos26/build-mmdv-macos26.sh
@@ -229,10 +229,11 @@ mmdv_brew_base_cmd() {
   # included for gfortran (scipy's Fortran sources); openblas is included as an
   # optional fallback BLAS even though numpy/scipy default to Apple's
   # Accelerate framework on macOS.  xz is included for Python's lzma module
-  # (Apple's Command Line Tools do not ship liblzma).
+  # (Apple's Command Line Tools do not ship liblzma).  doxygen is the system
+  # half of the documentation C++ API path (see doc/README.md).
   cat <<'EOF'
 brew install \
-  cmake ninja pkg-config xz gcc openblas
+  cmake ninja pkg-config xz gcc openblas doxygen
 EOF
 }
 
@@ -944,6 +945,10 @@ echo "Python build uses PGO; expect ~20 min"
 mmdv_time build_python python
 "${PY}" -m pip install -U flake8 autopep8 black pytest jsonschema certifi
 "${PY}" -m pip install -U nose boto paramiko
+# Documentation toolchain (Sphinx-based; see doc/README.md). doxygen, the
+# system half of the C++ API path, is in mmdv_brew_base_cmd above.
+"${PY}" -m pip install -U sphinx myst-parser pydata-sphinx-theme \
+  breathe sphinxcontrib-bibtex
 mmdv_time build_pybind11 pybind11
 
 else

--- a/contrib/dependency/ubuntu2404/build-mmdv-ubuntu24.sh
+++ b/contrib/dependency/ubuntu2404/build-mmdv-ubuntu24.sh
@@ -187,13 +187,15 @@ export PATH="${MMDV_USRDIR}/bin:${PATH}"
 
 mmdv_apt_base_cmd() {
   # Print the apt command for the BASE/PYTHON/NUMPY sections. The script
-  # never runs apt itself; copy the output, review it, and run it.
+  # never runs apt itself; copy the output, review it, and run it. doxygen
+  # is the system half of the documentation C++ API path (see doc/README.md).
   cat <<'EOF'
 sudo apt install -y \
   build-essential gcc g++ make cmake ninja-build pkg-config \
   git curl xz-utils gfortran libopenblas-dev \
   libffi-dev libbz2-dev liblzma-dev libgdbm-dev \
-  libncurses-dev uuid-dev tk-dev libedit-dev libexpat1-dev
+  libncurses-dev uuid-dev tk-dev libedit-dev libexpat1-dev \
+  doxygen
 EOF
 }
 
@@ -809,6 +811,10 @@ echo "Python build uses PGO; expect ~20 min"
 mmdv_time build_python python
 "${PY}" -m pip install -U flake8 autopep8 black pytest jsonschema certifi
 "${PY}" -m pip install -U nose boto paramiko
+# Documentation toolchain (Sphinx-based; see doc/README.md). doxygen, the
+# system half of the C++ API path, is in mmdv_apt_base_cmd above.
+"${PY}" -m pip install -U sphinx myst-parser pydata-sphinx-theme \
+  breathe sphinxcontrib-bibtex
 mmdv_time build_pybind11 pybind11
 
 else

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,4 @@
+# Built documentation artifacts.
+build/
+
+# vim: set ft=gitignore ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1,0 +1,23 @@
+# Minimal Doxygen config for the modmesh C++ API.
+#
+# Emits XML only -- breathe consumes the XML and Sphinx renders it.  HTML
+# and LaTeX output are disabled so Sphinx remains the single front end.
+
+PROJECT_NAME      = modmesh
+OUTPUT_DIRECTORY  = build/doxygen
+INPUT             = ../cpp/modmesh
+FILE_PATTERNS     = *.hpp *.cpp
+RECURSIVE         = YES
+
+GENERATE_HTML     = NO
+GENERATE_LATEX    = NO
+GENERATE_XML      = YES
+XML_OUTPUT        = xml
+
+# Document declarations even where an explicit comment is missing, and read
+# the first comment sentence as the brief description.
+EXTRACT_ALL       = YES
+JAVADOC_AUTOBRIEF = YES
+QUIET             = YES
+
+# vim: set ft=conf ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,38 @@
+# Minimal documentation build for modmesh.
+#
+# Quick start:
+#   pip install -r requirements.txt   # plus a system Doxygen for C++ docs
+#   make doxygen                      # C++ API XML (optional, run first)
+#   make html                         # site -> build/html/index.html
+
+SPHINXBUILD ?= sphinx-build
+PYTHON      ?= python3
+SOURCEDIR    = source
+BUILDDIR     = build
+PORT        ?= 8000
+BIND        ?= 127.0.0.1
+
+.PHONY: help html doxygen serve clean
+
+help:
+	@echo "make doxygen   generate C++ API XML (run before html for C++)"
+	@echo "make html      build the HTML site into $(BUILDDIR)/html"
+	@echo "make serve     build, then serve at http://localhost:$(PORT)/"
+	@echo "make clean     remove built docs and Doxygen output"
+
+doxygen:
+	mkdir -p "$(BUILDDIR)/doxygen"
+	doxygen Doxyfile
+
+html:
+	$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html"
+
+serve: html
+	@echo "Serving docs at http://$(BIND):$(PORT)/ -- Ctrl-C to stop"
+	cd "$(BUILDDIR)/html" && "$(PYTHON)" -m http.server "$(PORT)" \
+		--bind "$(BIND)"
+
+clean:
+	rm -rf "$(BUILDDIR)"
+
+# vim: set ft=make ff=unix fenc=utf8 noet sw=8 ts=8 sts=8 tw=79:

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,32 @@
+# modmesh documentation (prototype)
+
+modmesh is a *hybrid C++/Python* numerical library.  This is a minimal, working
+prototype of a documentation system for modmesh, built on **Sphinx**.
+
+## Layout
+
+```
+doc/
+  Makefile            html / doxygen / clean targets
+  Doxyfile            Doxygen config (XML only, consumed by breathe)
+  requirements.txt    Python build dependencies
+  source/
+    conf.py           Sphinx configuration (annotated)
+    index.md          landing page
+    refs.bib          bibliography
+    api/python.md     autodoc of modmesh.onedim
+    api/cpp.md         breathe of modmesh::ConcreteBuffer
+```
+
+## Build
+
+```sh
+pip install -r requirements.txt   # Python deps
+make doxygen                      # optional: C++ API XML (needs doxygen)
+make html                         # -> build/html/index.html
+```
+
+`make html` works without `make doxygen`; the C++ API page simply renders
+empty (a warning, not an error) until the XML exists.
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,11 @@
+# Python build dependencies for the modmesh documentation.
+# The C++ API path additionally needs a system Doxygen (e.g. `apt install
+# doxygen`); it is not a Python package.
+
+sphinx>=7.0
+myst-parser>=2.0
+pydata-sphinx-theme>=0.15
+breathe>=4.35
+sphinxcontrib-bibtex>=2.6
+
+# vim: set ft=requirements ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/doc/source/api/cpp.md
+++ b/doc/source/api/cpp.md
@@ -1,0 +1,20 @@
+# C++ API
+
+This page is bridged from Doxygen by ``breathe``.  Doxygen parses the existing
+``///`` and ``/**`` comments in `cpp/modmesh/` into XML; breathe turns that XML
+into the reference below.
+
+```{important}
+Run ``make doxygen`` once before ``make html`` so the Doxygen XML exists.
+Until then this directive renders empty (a warning, not an error).
+```
+
+Below is an example using `modmesh::ConcreteBuffer`.
+
+```{eval-rst}
+.. doxygenclass:: modmesh::ConcreteBuffer
+   :project: modmesh
+   :members:
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/api/python.md
+++ b/doc/source/api/python.md
@@ -1,0 +1,18 @@
+# Python API
+
+This page is generated from docstrings by ``autodoc``, so it stays in sync with
+the code automatically.  The compiled ``_modmesh`` extension is mocked during
+the build (see `conf.py`), so these pages render even on a clean checkout where
+the C++ layer has not been compiled.
+
+Below is an example that documents the one-dimensional Euler solver.  Point
+``automodule`` at any module to render its public surface.
+
+```{eval-rst}
+.. automodule:: modmesh.onedim.euler1d
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,0 +1,83 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# Minimal prototype of a hybrid C++/Python documentation toolchain for
+# modmesh.  The pieces, and why each is here:
+#
+#   myst_parser          author pages in Markdown (matches the repo
+#                        culture: README.md, STYLE.md, CLAUDE.md)
+#   autodoc + napoleon   Python API straight from docstrings
+#   breathe              C++ API bridged from Doxygen XML
+#   mathjax              CESE / conservation-law equations
+#   sphinxcontrib.bibtex academic citations (the CESE literature)
+#
+# Build with ``make html`` from the doc/ directory.  Run ``make doxygen``
+# first if you want the C++ API pages populated.
+
+import os
+import sys
+
+# Make the in-tree ``modmesh`` package importable for autodoc.  The repo
+# root is two levels up from this file (doc/source/conf.py).
+sys.path.insert(0, os.path.abspath("../.."))
+
+# -- Project information ----------------------------------------------------
+
+project = "modmesh"
+copyright = "2019-2026, Yung-Yu Chen and modmesh contributors"
+author = "Yung-Yu Chen and modmesh contributors"
+
+# -- General configuration --------------------------------------------------
+
+extensions = [
+    "myst_parser",            # Markdown authoring
+    "sphinx.ext.autodoc",     # pull Python docstrings
+    "sphinx.ext.autosummary",  # API summary tables
+    "sphinx.ext.napoleon",    # NumPy / Google docstring styles
+    "sphinx.ext.viewcode",    # link to highlighted source
+    "sphinx.ext.intersphinx",  # cross-link python / numpy docs
+    "sphinx.ext.mathjax",     # render LaTeX math
+    "breathe",                # C++ via Doxygen XML
+    "sphinxcontrib.bibtex",   # citations
+]
+
+# MyST Markdown extensions: $...$ and $$...$$ math, amsmath
+# environments, ::: fences, and definition lists.
+myst_enable_extensions = [
+    "dollarmath",
+    "amsmath",
+    "colon_fence",
+    "deflist",
+]
+
+autosummary_generate = True
+
+# The compiled _modmesh extension is a build artifact, absent on a clean
+# checkout (and on Read the Docs).  Mock it so autodoc can still import
+# the pure-Python layers that sit on top of it.
+autodoc_mock_imports = ["_modmesh"]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+}
+
+# -- Breathe (C++ bridge) ---------------------------------------------------
+
+# Points at the Doxygen XML produced by ``make doxygen`` (see Doxyfile).
+breathe_projects = {"modmesh": "../build/doxygen/xml"}
+breathe_default_project = "modmesh"
+
+# -- sphinxcontrib.bibtex ---------------------------------------------------
+
+bibtex_bibfiles = ["refs.bib"]
+
+# -- HTML output ------------------------------------------------------------
+
+# pydata-sphinx-theme is the de-facto standard across the scientific
+# Python stack (NumPy, SciPy, pandas, matplotlib).  See doc/README.md
+# for the sphinx-book-theme alternative tuned for teaching material.
+html_theme = "pydata_sphinx_theme"
+html_title = "modmesh"
+html_static_path = ["_static"]
+
+# vim: set ft=python ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -1,0 +1,27 @@
+# modmesh
+
+modmesh is a hybrid C++/Python library for solving conservation laws with the
+space-time Conservation Element and Solution Element (CESE) method using
+unstructured meshes of mixed elements.
+
+```{list-table}
+:header-rows: 1
+:widths: 30 70
+
+* - Page
+  - Demonstrates
+* - [Python API](api/python.md)
+  - Reference generated from docstrings via ``autodoc``.
+* - [C++ API](api/cpp.md)
+  - Reference bridged from Doxygen via ``breathe``.
+```
+
+```{toctree}
+:maxdepth: 2
+:hidden:
+
+api/python
+api/cpp
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/refs.bib
+++ b/doc/source/refs.bib
@@ -1,0 +1,14 @@
+@article{chang1995cese,
+  author  = {Chang, Sin-Chung},
+  title   = {The Method of Space-Time Conservation Element and Solution
+             Element---A New Approach for Solving the Navier-Stokes and
+             Euler Equations},
+  journal = {Journal of Computational Physics},
+  volume  = {119},
+  number  = {2},
+  pages   = {295--324},
+  year    = {1995},
+  doi     = {10.1006/jcph.1995.1137}
+}
+
+%% vim: set ft=bib ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79:


### PR DESCRIPTION
Set up the documentation system for modmesh on Sphinx, with MyST for Markdown authoring (matching the repo's README/STYLE), autodoc for the Python API, and breathe + Doxygen for the C++ API.

Build targets in doc/Makefile: html, doxygen, serve (preview over HTTP at localhost:$PORT), and clean.  Python build deps are pinned in doc/requirements.txt.

mmdv build scripts record the new dependencies inline with the existing dev tooling: doxygen in the apt/brew base package command, and the Sphinx pip toolchain in the PYTHON section's pip install line.