### PR TITLE
Expand Sphinx documentation framework with section structure

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,22 +1,7 @@
-# modmesh documentation (prototype)
+# modmesh documentation
 
-modmesh is a *hybrid C++/Python* numerical library.  This is a minimal, working
-prototype of a documentation system for modmesh, built on **Sphinx**.
-
-## Layout
-
-```
-doc/
-  Makefile            html / doxygen / clean targets
-  Doxyfile            Doxygen config (XML only, consumed by breathe)
-  requirements.txt    Python build dependencies
-  source/
-    conf.py           Sphinx configuration (annotated)
-    index.md          landing page
-    refs.bib          bibliography
-    api/python.md     autodoc of modmesh.onedim
-    api/cpp.md         breathe of modmesh::ConcreteBuffer
-```
+modmesh is a *hybrid C++/Python* numerical library.  This directory contains
+the Sphinx-based documentation.
 
 ## Build
 

--- a/doc/source/api/index.md
+++ b/doc/source/api/index.md
@@ -1,0 +1,10 @@
+# API Reference
+
+```{toctree}
+:maxdepth: 2
+
+python
+cpp
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/cese/conservation.md
+++ b/doc/source/cese/conservation.md
@@ -1,0 +1,3 @@
+# Conservation Laws
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/cese/dual_mesh.md
+++ b/doc/source/cese/dual_mesh.md
@@ -1,0 +1,3 @@
+# CESE Dual Mesh
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/cese/euler.md
+++ b/doc/source/cese/euler.md
@@ -1,0 +1,3 @@
+# Euler Equations
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/cese/index.md
+++ b/doc/source/cese/index.md
@@ -1,0 +1,13 @@
+# The CESE Method
+
+```{toctree}
+:maxdepth: 2
+
+conservation
+scheme
+multidim
+euler
+dual_mesh
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/cese/multidim.md
+++ b/doc/source/cese/multidim.md
@@ -1,0 +1,3 @@
+# Multi-Dimensional CESE
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/cese/scheme.md
+++ b/doc/source/cese/scheme.md
@@ -1,0 +1,3 @@
+# Numerical Scheme
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/dev/contributing.md
+++ b/doc/source/dev/contributing.md
@@ -1,0 +1,3 @@
+# Contributing
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/dev/index.md
+++ b/doc/source/dev/index.md
@@ -1,0 +1,11 @@
+# Development
+
+```{toctree}
+:maxdepth: 2
+
+contributing
+testing
+style
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/dev/style.md
+++ b/doc/source/dev/style.md
@@ -1,0 +1,3 @@
+# Code Style
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/dev/testing.md
+++ b/doc/source/dev/testing.md
@@ -1,0 +1,3 @@
+# Testing
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -1,27 +1,18 @@
 # modmesh
 
-modmesh is a hybrid C++/Python library for solving conservation laws with the
-space-time Conservation Element and Solution Element (CESE) method using
-unstructured meshes of mixed elements.
-
-```{list-table}
-:header-rows: 1
-:widths: 30 70
-
-* - Page
-  - Demonstrates
-* - [Python API](api/python.md)
-  - Reference generated from docstrings via ``autodoc``.
-* - [C++ API](api/cpp.md)
-  - Reference bridged from Doxygen via ``breathe``.
-```
+modmesh is a hybrid C++/Python library for solving conservation laws with
+{doc}`the space-time Conservation Element and Solution Element (CESE) method
+<cese/index>` using unstructured meshes of mixed elements.
 
 ```{toctree}
 :maxdepth: 2
-:hidden:
 
-api/python
-api/cpp
+start/index
+system/index
+pilot/index
+cese/index
+dev/index
+api/index
 ```
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/pilot/airfoil.md
+++ b/doc/source/pilot/airfoil.md
@@ -1,0 +1,3 @@
+# Airfoil
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/pilot/index.md
+++ b/doc/source/pilot/index.md
@@ -1,0 +1,10 @@
+# Pilot GUI
+
+```{toctree}
+:maxdepth: 2
+
+viewer
+airfoil
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/pilot/viewer.md
+++ b/doc/source/pilot/viewer.md
@@ -1,0 +1,3 @@
+# 3D Viewer
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/start/build.md
+++ b/doc/source/start/build.md
@@ -1,0 +1,3 @@
+# Building from Source
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/start/index.md
+++ b/doc/source/start/index.md
@@ -1,0 +1,11 @@
+# Getting Started
+
+```{toctree}
+:maxdepth: 2
+
+install
+build
+quickstart
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/start/install.md
+++ b/doc/source/start/install.md
@@ -1,0 +1,3 @@
+# Installation
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/start/quickstart.md
+++ b/doc/source/start/quickstart.md
@@ -1,0 +1,3 @@
+# Quick Start
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/system/boundary.md
+++ b/doc/source/system/boundary.md
@@ -1,0 +1,3 @@
+# Boundary Conditions
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/system/buffer.md
+++ b/doc/source/system/buffer.md
@@ -1,0 +1,3 @@
+# Buffers and Arrays
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/system/index.md
+++ b/doc/source/system/index.md
@@ -1,0 +1,16 @@
+# System
+
+```{toctree}
+:maxdepth: 2
+
+buffer
+onedim
+linalg
+universe
+mesh
+boundary
+inout
+profiling
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/system/inout.md
+++ b/doc/source/system/inout.md
@@ -1,0 +1,3 @@
+# Input and Output
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/system/linalg.md
+++ b/doc/source/system/linalg.md
@@ -1,0 +1,3 @@
+# Linear Algebra
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/system/mesh.md
+++ b/doc/source/system/mesh.md
@@ -1,0 +1,3 @@
+# Meshes
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/system/onedim.md
+++ b/doc/source/system/onedim.md
@@ -1,0 +1,3 @@
+# One-Dimensional Solvers
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/system/profiling.md
+++ b/doc/source/system/profiling.md
@@ -1,0 +1,3 @@
+# Profiling
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/system/universe.md
+++ b/doc/source/system/universe.md
@@ -1,0 +1,3 @@
+# Geometry
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->


### PR DESCRIPTION
Add six top-level sections to the doc tree with stub pages (in the list order):

- start/: installation, build, quick-start
- system/: buffer, mesh, universe (geometry), linalg, onedim, profiling
- pilot/: 3D viewer, airfoil
- cese/: the CESE method (standalone section)
- dev/: contributing, testing, code style
- api/: Python and C++ API reference (index added for existing pages)

Update the root toctree, README layout, and Sphinx build accordingly.