### PR TITLE
fix: add missing windows part in email when devbuild CI failure

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -448,6 +448,7 @@ jobs:
       job_results: |
         - standalone_buffer: ${{ needs.standalone_buffer.result }}
         - build: ${{ needs.build.result }}
+        - build_windows: ${{ needs.build_windows.result }}
     secrets:
       EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
       EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}


### PR DESCRIPTION
<!--
modmesh pull request guidelines.

- Subject: concise and informative.
- Description: clear prose.  Write single-line paragraphs separated by blank
  lines; GitHub reflows text to the viewer's width, so hard-wrapping at 79/80
  columns renders as ragged mid-sentence breaks.
- Draft until ready: open the PR as a draft while work is in progress.  When
  the PR is ready for review, post a global PR comment that explicitly asks for
  review.  Pushing the "ready for review" button alone is not a review request,
  because the push cannot be quoted in follow-ups.
- Inline annotations: as the author, add inline annotations on the diff to
  guide the reviewer, unless the diff is one-liner-ish.
- Issue reference: end the description with "Related to #xxx" or "For issue
  #xxx".  Do not use closing keywords (close, closes, closed, fix, fixes,
  fixed, resolve, resolves, resolved) followed by an issue number.  We do not
  let PR or commit text drive issue management.
- Authorship: PR text is treated as human-authored.  Tool assistance is OK, but
  you need to know what you wrote.

Delete this comment block before submitting.
-->

I noticed that when the devbuild CI fails, it sometimes still triggers an email where the entire content indicates success.

After reviewing the workflow, I found that the current email content forgot to include the Windows part. Therefore, I made this PR to fix it.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
