### PR TITLE
 Fix type typo in `TypeBroadcast.hpp`

### DIFF
--- a/cpp/modmesh/buffer/pymod/TypeBroadcast.hpp
+++ b/cpp/modmesh/buffer/pymod/TypeBroadcast.hpp
@@ -184,9 +184,9 @@ struct TypeBroadcast
         {
             TypeBroadcastImpl<T, int64_t>::broadcast(arr_out, slices, arr_in);
         }
-        else if (dtype_is_type<uint32_t>(arr_in))
+        else if (dtype_is_type<uint8_t>(arr_in))
         {
-            TypeBroadcastImpl<T, uint32_t>::broadcast(arr_out, slices, arr_in);
+            TypeBroadcastImpl<T, uint8_t>::broadcast(arr_out, slices, arr_in);
         }
         else if (dtype_is_type<uint16_t>(arr_in))
         {

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -846,6 +846,16 @@ class SimpleArrayBasicTC(unittest.TestCase):
                     v += 1
 
         sarr = modmesh.SimpleArrayFloat64((2, 3, 4))
+        ndarr = np.arange(2 * 3 * 4, dtype='uint8').reshape((2, 3, 4))
+        sarr[...] = ndarr[...]
+        v = 0
+        for i in range(2):
+            for j in range(3):
+                for k in range(4):
+                    self.assertEqual(v, sarr[i, j, k])
+                    v += 1
+
+        sarr = modmesh.SimpleArrayFloat64((2, 3, 4))
         ndarr = np.arange(2 * 3 * 4, dtype='float32').reshape((2, 3, 4))
         sarr[...] = ndarr[...]
         v = 0


### PR DESCRIPTION
As issue #852 mentioned, there is a typo in `TypeBroadcast.hpp`. 

https://github.com/solvcon/modmesh/blob/6fca1a59f459cdf6c8a26b8de573196253975db8/cpp/modmesh/buffer/pymod/TypeBroadcast.hpp#L187-L202

To fix this issue, this pull request replace one of `uint32_t` with `uint8_t`.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
