### PR TITLE
Handle Python slice semantics in SimpleArray assignment

### DIFF
--- a/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
+++ b/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
@@ -16,11 +16,51 @@ namespace solvcon
 namespace python
 {
 
+namespace detail
+{
+
+inline solvcon::detail::shape_type shape_from_slices(
+    std::vector<solvcon::detail::sshape_type> const & slices)
+{
+    solvcon::detail::shape_type shape(slices.size());
+    for (size_t axis = 0; axis < slices.size(); ++axis)
+    {
+        shape[axis] = slices[axis][3];
+    }
+    return shape;
+}
+
+} /* end namespace detail */
+
 template <typename T /* original type */, typename D /* for destination type */>
 struct TypeBroadcastImpl
 {
     using shape_type = solvcon::detail::shape_type;
     using sshape_type = solvcon::detail::sshape_type;
+
+    static ssize_t input_offset(pybind11::array_t<D> const & arr_in,
+                                sshape_type const & sidx)
+    {
+        ssize_t offset = 0;
+        for (pybind11::ssize_t axis = 0; axis < arr_in.ndim(); ++axis)
+        {
+            offset += arr_in.strides(axis) / arr_in.itemsize() * sidx[axis];
+        }
+        return offset;
+    }
+
+    static ssize_t output_offset(SimpleArray<T> const & arr_out,
+                                 std::vector<sshape_type> const & slices,
+                                 sshape_type const & sidx)
+    {
+        ssize_t offset = 0;
+        for (ssize_t axis = 0; axis < arr_out.ndim(); ++axis)
+        {
+            ssize_t const index = slices[axis][0] + sidx[axis] * slices[axis][2];
+            offset += arr_out.stride(axis) * index;
+        }
+        return offset;
+    }
 
     // NOLINTNEXTLINE(misc-no-recursion)
     static void copy_idx(SimpleArray<T> & arr_out,
@@ -34,32 +74,8 @@ struct TypeBroadcastImpl
 
         if (dim < 0)
         {
-            return;
-        }
-
-        auto const axis = static_cast<size_t>(dim);
-        ssize_t const length = left_shape[axis];
-        for (ssize_t i = 0; i < length; ++i)
-        {
-            sidx[axis] = i;
-
-            ssize_t offset_in = 0;
-            pybind11::ssize_t const ndim_in = arr_in->ndim();
-            for (pybind11::ssize_t py_axis = 0; py_axis < ndim_in; ++py_axis)
-            {
-                auto const axis_in = static_cast<size_t>(py_axis);
-                offset_in += arr_in->strides(py_axis) / arr_in->itemsize() * sidx[axis_in];
-            }
-            const D * ptr_in = arr_in->data() + offset_in;
-
-            ssize_t offset_out = 0;
-            ssize_t const ndim = arr_out.ndim();
-            for (ssize_t it = 0; it < ndim; ++it)
-            {
-                auto const axis_index = static_cast<size_t>(it);
-                ssize_t const step = slices[axis_index][2];
-                offset_out += arr_out.stride(it) * sidx[axis_index] * step;
-            }
+            const D * ptr_in = arr_in->data() + input_offset(*arr_in, sidx);
+            ssize_t const offset_out = output_offset(arr_out, slices, sidx);
 
             constexpr bool valid_conversion = (!is_complex_v<T> && !is_complex_v<D>) || (is_complex_v<T> && is_complex_v<D> && std::is_same_v<T, D>);
 
@@ -73,8 +89,13 @@ struct TypeBroadcastImpl
             {
                 throw std::runtime_error("Cannot convert between complex and non-complex types");
             }
+            return;
+        }
 
-            // recursion here
+        auto const axis = static_cast<size_t>(dim);
+        for (ssize_t i = 0; i < left_shape[axis]; ++i)
+        {
+            sidx[axis] = i;
             copy_idx(arr_out, slices, arr_in, left_shape, sidx, dim - 1);
         }
     }
@@ -87,22 +108,8 @@ struct TypeBroadcastImpl
         auto * arr_new = reinterpret_cast<pybind11::array_t<D> const *>(&arr_in);
 
         ssize_t const ndim = arr_out.ndim();
-        shape_type left_shape(ndim);
-        for (ssize_t axis = 0; axis < ndim; ++axis)
-        {
-            sshape_type const & slice = slices[axis];
-            if ((slice[1] - slice[0]) % slice[2] == 0)
-            {
-                left_shape[axis] = (slice[1] - slice[0]) / slice[2];
-            }
-            else
-            {
-                left_shape[axis] = (slice[1] - slice[0]) / slice[2] + 1;
-            }
-        }
-
+        shape_type const left_shape = detail::shape_from_slices(slices);
         sshape_type const sidx_init(ndim, 0);
-
         copy_idx(arr_out, slices, arr_new, left_shape, sidx_init, ndim - 1);
     }
 }; /* end struct TypeBroadcastImpl */
@@ -125,20 +132,7 @@ struct TypeBroadcast
         }
 
         ssize_t const ndim = arr_out.ndim();
-        shape_type left_shape(ndim);
-        // TODO: range check
-        for (ssize_t axis = 0; axis < ndim; ++axis)
-        {
-            sshape_type const & slice = slices[axis];
-            if ((slice[1] - slice[0]) % slice[2] == 0)
-            {
-                left_shape[axis] = (slice[1] - slice[0]) / slice[2];
-            }
-            else
-            {
-                left_shape[axis] = (slice[1] - slice[0]) / slice[2] + 1;
-            }
-        }
+        shape_type const left_shape = detail::shape_from_slices(slices);
 
         if (arr_out.ndim() != arr_in.ndim())
         {

--- a/cpp/solvcon/buffer/pymod/array_common.hpp
+++ b/cpp/solvcon/buffer/pymod/array_common.hpp
@@ -231,7 +231,7 @@ public:
                 const auto arr_in = py_value.cast<py::array>();
 
                 auto slices = make_default_slices(arr_out);
-                copy_slice(slices[0], slice_in);
+                copy_slice(slices[0], slice_in, arr_out.shape(0));
 
                 broadcast_array_using_slice(arr_out, slices, arr_in);
                 return;
@@ -345,24 +345,33 @@ private:
         slices.reserve(shape.size());
         for (ssize_t const dim : shape)
         {
-            sshape_type default_slice(3);
+            sshape_type default_slice(4);
             default_slice[0] = 0; // start
             default_slice[1] = dim; // stop
             default_slice[2] = 1; // step
+            default_slice[3] = dim; // length
             slices.push_back(std::move(default_slice));
         }
         return slices;
     }
 
-    static void copy_slice(sshape_type & slice_out, pybind11::slice const & slice_in)
+    static void copy_slice(sshape_type & slice_out,
+                           pybind11::slice const & slice_in,
+                           ssize_t length)
     {
-        auto start = std::string(pybind11::str(slice_in.attr("start")));
-        auto stop = std::string(pybind11::str(slice_in.attr("stop")));
-        auto step = std::string(pybind11::str(slice_in.attr("step")));
+        pybind11::ssize_t start = 0;
+        pybind11::ssize_t stop = 0;
+        pybind11::ssize_t step = 0;
+        pybind11::ssize_t slicelength = 0;
+        if (!slice_in.compute(length, &start, &stop, &step, &slicelength))
+        {
+            throw pybind11::error_already_set();
+        }
 
-        slice_out[0] = start == "None" ? slice_out[0] : std::stoi(start);
-        slice_out[1] = stop == "None" ? slice_out[1] : std::stoi(stop);
-        slice_out[2] = step == "None" ? slice_out[2] : std::stoi(step);
+        slice_out[0] = start;
+        slice_out[1] = stop;
+        slice_out[2] = step;
+        slice_out[3] = slicelength;
     }
 
     static void slice_syntax_check(pybind11::tuple const & tuple, ssize_t ndim)
@@ -388,7 +397,7 @@ private:
             }
         }
 
-        if (ellipsis_cnt + slice_cnt > ndim)
+        if (slice_cnt > ndim)
         {
             throw std::runtime_error("syntax error. dimensions mismatches");
         }
@@ -405,6 +414,8 @@ private:
     {
         namespace py = pybind11;
 
+        slice_syntax_check(tuple, ndim);
+
         // copy slices from the front until an ellipsis
         bool ellipsis_flag = false;
         for (auto it = tuple.begin(); it != tuple.end(); it++)
@@ -419,7 +430,7 @@ private:
             auto & slice_out = slices[it - tuple.begin()];
             const auto slice_in = (*it).cast<py::slice>();
 
-            copy_slice(slice_out, slice_in);
+            copy_slice(slice_out, slice_in, slice_out[3]);
         }
 
         // copy slices from the back until an ellipsis
@@ -437,7 +448,7 @@ private:
                 auto & slice_out = slices[ndim - offset - 1];
                 const auto slice_in = (*it).cast<py::slice>();
 
-                copy_slice(slice_out, slice_in);
+                copy_slice(slice_out, slice_in, slice_out[3]);
             }
         }
     }

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1047,6 +1047,37 @@ class SimpleArrayBasicTC(unittest.TestCase):
         ):
             sarr[::2, ::1, ...] = ndarr[...]
 
+        sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+        sarr[:, :, :, ...] = ndarr
+        np.testing.assert_array_equal(sarr.ndarray, ndarr)
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r"syntax error\. dimensions mismatches"
+        ):
+            sarr[:, :, :, :] = np.zeros((2, 3, 4, 1), dtype='float64')
+
+    def test_SimpleArray_broadcast_slice_from_strided_ndarray(self):
+        ndarr_shape = (16, 18, 20, 22, 24)
+        ndarr = np.arange(np.prod(ndarr_shape), dtype='float64')
+        ndarr = ndarr.reshape(ndarr_shape)
+        sliced_ndarr = ndarr[15::-2, 1::2, 19::-2, 1::2, 23::-2]
+        expected = sliced_ndarr.copy()
+        sarr = solvcon.SimpleArrayFloat64(array=sliced_ndarr)
+        self.assertEqual(
+            sliced_ndarr[1, 2, 3, 4, 5],
+            sarr[1, 2, 3, 4, 5])
+
+        key = np.index_exp[::-2, 1:-1:2, -8:-1:2, 10:2:-3, ...]
+        value_shape = expected[key].shape
+        value = np.arange(np.prod(value_shape), dtype='float64')
+        value = value.reshape(value_shape) + 1000.0
+
+        sarr[key] = value
+        expected[key] = value
+
+        np.testing.assert_array_equal(sliced_ndarr, expected)
+
     def test_SimpleArray_broadcast_slice_ghost_1d(self):
         import math
         N = 13
@@ -1085,6 +1116,30 @@ class SimpleArrayBasicTC(unittest.TestCase):
             for j in range(3):
                 for k in range(4):
                     self.assertEqual(ndarr2[i, j, k], sarr[i - G, j, k])
+
+    def test_SimpleArray_broadcast_slice_negative_bounds(self):
+        ndarr_shape = (8, 9, 10, 11, 12)
+        ndarr = np.arange(np.prod(ndarr_shape), dtype='float64')
+        ndarr = ndarr.reshape(ndarr_shape)
+        expected = ndarr.copy()
+        sarr = solvcon.SimpleArrayFloat64(array=ndarr)
+
+        key = np.index_exp[-8:-1:2, 8:1:-2, 1:-1:3, ..., -2:-8:-2]
+        value_shape = expected[key].shape
+        value = np.arange(np.prod(value_shape), dtype='float64')
+        value = value.reshape(value_shape) + 1000.0
+
+        sarr[key] = value
+        expected[key] = value
+
+        np.testing.assert_array_equal(sarr.ndarray, expected)
+        np.testing.assert_array_equal(ndarr, expected)
+
+    def test_SimpleArray_broadcast_slice_zero_step(self):
+        ndarr = np.arange(4 * 5 * 6, dtype='float64').reshape((4, 5, 6))
+        sarr = solvcon.SimpleArrayFloat64(array=ndarr)
+        with self.assertRaisesRegex(ValueError, "slice step cannot be zero"):
+            sarr[::0, :, :] = np.zeros((4, 5, 6), dtype='float64')
 
     def test_SimpleArray_broadcast_from_list_list(self):
         sarr = solvcon.SimpleArrayFloat64((2, 3))


### PR DESCRIPTION
Fix `SimpleArray.__setitem__` by normalizing slices with `pybind11::slice::compute()`. The copy path now accounts for input NumPy strides, destination storage strides, slice starts, and slice steps.

## Previous failures

Negative bounds and steps could reject a valid assignment:

```python
key = np.index_exp[-8:-1:2, 8:1:-2, 1:-1:3, ..., -2:-8:-2]
sarr[key] = value
```

```text
RuntimeError: Broadcast input array from shape(4, 4, 3, 11, 3)
into shape(4, 4, 1, 11, 3)
```

A `SimpleArray` backed by a negative-strided NumPy view could produce unsigned-looking slice dimensions:

```python
view = ndarr[15::-2, 1::2, 19::-2, 1::2, 23::-2]
sarr = solvcon.SimpleArrayFloat64(array=view)
key = np.index_exp[::-2, 1:-1:2, -8:-1:2, 10:2:-3, ...]
sarr[key] = value
```

```text
RuntimeError: Broadcast input array from shape(4, 4, 4, 3, 12)
into shape(18446744073709551612, 18446744073709551615, 4, 3, 12)
```

Both assignments now update the same elements as NumPy.

Add regression coverage for negative-strided views, negative slice bounds and steps, zero steps, ellipsis handling, and excessive slices. Existing tests continue to cover assignment with ghost cells.

Related to #856.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->