### PR TITLE
pilot: Render World in R2DWidget via QPainter (issue #754 PR2)

### DIFF
--- a/cpp/modmesh/pilot/R2DWidget.cpp
+++ b/cpp/modmesh/pilot/R2DWidget.cpp
@@ -34,6 +34,7 @@
 #include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
+#include <QPainterPath>
 #include <QPen>
 #include <QResizeEvent>
 #include <QWheelEvent>
@@ -44,9 +45,7 @@ namespace modmesh
 namespace
 {
 
-// Mouse wheels report angleDelta in 1/8-degree units. With factor =
-// exp(degrees * (1/360) * ln 2), one wheel revolution (360 degrees)
-// doubles the zoom; a typical 15-degree notch is ~2^(1/24) ~= 1.0293x.
+// One wheel revolution (360 degrees) doubles the zoom.
 constexpr double ZOOM_STEP_PER_DEGREE = 1.0 / 360.0;
 
 constexpr double MIN_ZOOM = 1.0e-6;
@@ -60,6 +59,11 @@ QColor const BACKGROUND(32, 32, 36);
 QColor const MINOR_GRID(64, 64, 70);
 QColor const AXIS(200, 200, 80);
 QColor const ORIGIN(220, 80, 80);
+QColor const GEOMETRY(120, 180, 240);
+
+// Cosmetic (zoom-independent) screen widths for world geometry.
+constexpr double GEOMETRY_LINE_WIDTH_PX = 1.5;
+constexpr int GEOMETRY_POINT_WIDTH_PX = 5;
 
 double clamp_zoom(double zoom)
 {
@@ -90,8 +94,7 @@ R2DWidget::R2DWidget(QWidget * parent, Qt::WindowFlags f)
 {
     setFocusPolicy(Qt::StrongFocus);
     setAttribute(Qt::WA_OpaquePaintEvent, true);
-    // Centering is deferred until the first resizeEvent so the widget has
-    // its real geometry; an MDI subwindow resizes us after construction.
+    // Defer centering to the first resizeEvent, when geometry is real.
 }
 
 void R2DWidget::setViewTransform(ViewTransform2dFp64 const & v)
@@ -102,8 +105,7 @@ void R2DWidget::setViewTransform(ViewTransform2dFp64 const & v)
     }
     m_view = v;
     m_view.set_zoom(clamp_zoom(m_view.zoom()));
-    // An explicit view supersedes the deferred initial centering so a later
-    // first-positive-size resize will not overwrite caller-provided pan.
+    // An explicit view disables the deferred auto-centering.
     m_view_modified = true;
     update();
 }
@@ -112,9 +114,14 @@ void R2DWidget::resetView()
 {
     m_view.reset();
     centerViewOnOrigin();
-    // Reset returns to the auto-centering state so a subsequent window
-    // resize re-pins the origin to the new widget center.
+    // Re-enable auto-centering on later resizes.
     m_view_modified = false;
+    update();
+}
+
+void R2DWidget::updateWorld(std::shared_ptr<WorldFp64> const & world)
+{
+    m_world = world;
     update();
 }
 
@@ -122,6 +129,67 @@ void R2DWidget::centerViewOnOrigin()
 {
     m_view.set_pan_x(static_cast<double>(width()) * 0.5);
     m_view.set_pan_y(static_cast<double>(height()) * 0.5);
+}
+
+void R2DWidget::paintWorld(QPainter & painter) const
+{
+    if (!m_world)
+    {
+        return;
+    }
+
+    // Map math-convention world (x, y) to Qt screen pixels; z is dropped.
+    auto map = [this](double world_x, double world_y)
+    {
+        double screen_x = 0.0;
+        double screen_y = 0.0;
+        m_view.screen_from_world(world_x, world_y, screen_x, screen_y);
+        return QPointF(screen_x, screen_y);
+    };
+
+    // Segments and flattened curves share one cosmetic stroke pen.
+    QPen geom_pen(GEOMETRY);
+    geom_pen.setCosmetic(true);
+    geom_pen.setWidthF(GEOMETRY_LINE_WIDTH_PX);
+    painter.setPen(geom_pen);
+
+    // 1D straight segments
+    std::shared_ptr<SegmentPadFp64> segments = m_world->collect_live_segments();
+    for (size_t i = 0; i < segments->size(); ++i)
+    {
+        painter.drawLine(map(segments->x0(i), segments->y0(i)),
+                         map(segments->x1(i), segments->y1(i)));
+    }
+
+    // Cubic Beziers; QPainterPath flattens them adaptively, so no sampling.
+    std::shared_ptr<CurvePadFp64> curves = m_world->collect_live_curves();
+    if (curves->size() > 0)
+    {
+        QPainterPath path;
+        for (size_t i = 0; i < curves->size(); ++i)
+        {
+            Bezier3dFp64 const c = curves->get(i);
+            path.moveTo(map(c.x0(), c.y0()));
+            path.cubicTo(map(c.x1(), c.y1()), map(c.x2(), c.y2()), map(c.x3(), c.y3()));
+        }
+        painter.setBrush(Qt::NoBrush); // stroke the outline only, never fill
+        painter.drawPath(path);
+    }
+
+    // 0D standalone points as dots with a fixed pixel size at any zoom.
+    std::shared_ptr<PointPadFp64> const & points = m_world->points();
+    if (points->size() > 0)
+    {
+        QPen point_pen(GEOMETRY);
+        point_pen.setCosmetic(true);
+        point_pen.setWidth(GEOMETRY_POINT_WIDTH_PX);
+        point_pen.setCapStyle(Qt::RoundCap);
+        painter.setPen(point_pen);
+        for (size_t i = 0; i < points->size(); ++i)
+        {
+            painter.drawPoint(map(points->x(i), points->y(i)));
+        }
+    }
 }
 
 void R2DWidget::paintEvent(QPaintEvent * /*event*/)
@@ -133,10 +201,7 @@ void R2DWidget::paintEvent(QPaintEvent * /*event*/)
     double const widget_w = static_cast<double>(width());
     double const widget_h = static_cast<double>(height());
 
-    // Choose a grid spacing that keeps screen-space spacing in a comfortable
-    // band by snapping the world spacing to the nearest power of ten times
-    // {1, 2, 5}. The spacing is reported in world units; conversion to
-    // screen pixels is `m_view.zoom() * spacing_world`.
+    // Snap grid spacing to a power of ten times {1, 2, 5} for a readable band.
     double const target_world = BASE_GRID_SPACING_PX / m_view.zoom();
     double const exponent = std::floor(std::log10(target_world));
     double const base = std::pow(10.0, exponent);
@@ -192,6 +257,9 @@ void R2DWidget::paintEvent(QPaintEvent * /*event*/)
     {
         painter.drawLine(QPointF(m_view.pan_x(), 0.0), QPointF(m_view.pan_x(), widget_h));
     }
+
+    // World geometry on top of the grid, under the origin marker.
+    paintWorld(painter);
 
     // Origin dot (cosmetic, fixed pixel size regardless of zoom).
     QPen origin_pen(ORIGIN);
@@ -263,12 +331,7 @@ void R2DWidget::mouseReleaseEvent(QMouseEvent * event)
 void R2DWidget::resizeEvent(QResizeEvent * event)
 {
     QWidget::resizeEvent(event);
-    // Auto-center the world origin on every resize until the caller or a
-    // mouse gesture sets the view explicitly; this survives the transient
-    // Qt-default-size resize that arrives before the MDI subwindow has been
-    // resized to its real geometry. Later resizes keep
-    // the user's pan/zoom; the origin may then move off-screen, which is
-    // expected behavior for a free-pan canvas.
+    // Auto-center the origin until the view is set explicitly.
     if (!m_view_modified && width() > 0 && height() > 0)
     {
         centerViewOnOrigin();

--- a/cpp/modmesh/pilot/R2DWidget.hpp
+++ b/cpp/modmesh/pilot/R2DWidget.hpp
@@ -31,11 +31,15 @@
 #include <modmesh/pilot/common_detail.hpp> // Must be the first include.
 
 #include <modmesh/universe/ViewTransform2d.hpp>
+#include <modmesh/universe/World.hpp>
+
+#include <memory>
 
 #include <QPointF>
 #include <QWidget>
 
 class QMouseEvent;
+class QPainter;
 class QPaintEvent;
 class QResizeEvent;
 class QWheelEvent;
@@ -44,12 +48,9 @@ namespace modmesh
 {
 
 /**
- * Strictly-2D drawing widget.
- *
- * Stage 1 of issue #754: a `QWidget` that provides cursor-anchored zoom and
- * mouse-drag pan over a placeholder grid. World rendering is wired up in a
- * later stage; this stage exists to nail down the view-transform and input
- * handling under a simple visual backdrop.
+ * Strictly-2D drawing widget for the pilot. Paints the geometry of the
+ * same `World<double>` that R3DWidget renders, but maps it to screen
+ * space through a 2D view transform instead of a Qt3D camera.
  */
 class R2DWidget
     : public QWidget
@@ -73,6 +74,12 @@ public:
     /// Re-center the view so the world origin sits at the widget center.
     void resetView();
 
+    /// Update the world being painted by this widget.
+    void updateWorld(std::shared_ptr<WorldFp64> const & world);
+
+    /// Get the world currently being painted.
+    std::shared_ptr<WorldFp64> const & world() const { return m_world; }
+
     /// Hook for subsequent stages; current implementation triggers a repaint.
     void requestRepaint() { update(); }
 
@@ -89,7 +96,11 @@ private:
 
     void centerViewOnOrigin();
 
+    /// Paint the world's live points, segments, and curves in screen space.
+    void paintWorld(QPainter & painter) const;
+
     ViewTransform2dFp64 m_view;
+    std::shared_ptr<WorldFp64> m_world;
     bool m_panning = false;
     bool m_view_modified = false;
     QPointF m_last_mouse_pos;

--- a/cpp/modmesh/pilot/wrap_pilot.cpp
+++ b/cpp/modmesh/pilot/wrap_pilot.cpp
@@ -223,6 +223,7 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapR2DWidget
                 py::return_value_policy::copy)
             .def("setViewTransform", &wrapped_type::setViewTransform, py::arg("v"))
             .def("resetView", &wrapped_type::resetView)
+            .def("updateWorld", &wrapped_type::updateWorld, py::arg("world"))
             .def("requestRepaint", &wrapped_type::requestRepaint);
     }
 

--- a/modmesh/pilot/_canvas_gui.py
+++ b/modmesh/pilot/_canvas_gui.py
@@ -47,6 +47,7 @@ class Canvas(_gui_common.PilotFeature):
         super(Canvas, self).__init__(*args, **kw)
         self._world = core.WorldFp64()
         self._widget = None
+        self._widget_2d = None
 
     def populate_menu(self):
         self._add_menu_item(
@@ -96,6 +97,15 @@ class Canvas(_gui_common.PilotFeature):
             func=self._hyperbola,
         )
 
+        self._mgr.canvasMenu.addSeparator()
+        self._add_menu_item(
+            menu=self._mgr.canvasMenu,
+            text="View: Open canvas in 2D",
+            tip="Show the current canvas world in a strictly-2D QPainter "
+                "widget; the same world also drives the 3D view",
+            func=self._open_2d,
+        )
+
     @staticmethod
     def _draw_layer(world, layer):
         point_type = core.Point3dFp64
@@ -132,6 +142,22 @@ class Canvas(_gui_common.PilotFeature):
             self._widget = self._mgr.add3DWidget()
         self._widget.updateWorld(self._world)
         self._widget.showMark()
+        # Keep the 2D view in sync once it has been opened. The same world
+        # drives both widgets; only the backend (Qt3D vs QPainter) differs.
+        if self._widget_2d is not None:
+            self._widget_2d.updateWorld(self._world)
+
+    def _open_2d(self):
+        """
+        Show the current canvas world in a strictly-2D QPainter widget. The
+        world is the same object the 3D view renders; the 2D widget simply
+        drops the z coordinate. Subsequent samples refresh both views via
+        ``_update_widget``.
+        """
+        if self._widget_2d is None:
+            self._widget_2d = self._mgr.add2DWidget()
+        self._widget_2d.updateWorld(self._world)
+        self._widget_2d.resetView()
 
     def _bezier_s_curve(self):
         bezier_sample = curve.BezierSample.s_curve()

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2026, An-Chi Liu <phy.tiger@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Tests for the issue #754 PR2 2D canvas: R2DWidget rendering a World<double>.
+
+The widget paints with QPainter from the world's backend-independent
+collect_live_* surface, so these run inside the pilot binary (Qt available)
+via ``make run_pilot_pytest PYTEST_OPTS=tests/test_pilot_2d.py``. They guard
+the C++ -> Python driving path (updateWorld accepting realistic geometry
+without raising) and the view-state API; pixel-level appearance is checked
+manually in the GUI. See test_dead_shape_culling_renders_pixels (skipped) for
+the planned pixel-level coverage and what it needs first.
+"""
+
+import unittest
+
+import modmesh
+
+try:
+    from modmesh import pilot
+except ImportError:
+    pilot = None
+
+
+def _build_world():
+    """A world exercising every primitive R2DWidget paints, plus the two
+    cases the 2D path must handle silently: an out-of-plane (z != 0) point
+    that gets projected, and a removed (DEAD) shape whose geometry must be
+    dropped by collect_live_*.
+    """
+    w = modmesh.WorldFp64()
+    # Bare segment (owned by no shape) and a bare cubic Bezier.
+    w.add_segment(modmesh.Point3dFp64(-3, 3, 0),
+                  modmesh.Point3dFp64(3, 3, 0))
+    w.add_bezier(modmesh.Point3dFp64(-3, 0, 0),
+                 modmesh.Point3dFp64(-1, 2, 0),
+                 modmesh.Point3dFp64(1, -2, 0),
+                 modmesh.Point3dFp64(3, 0, 0))
+    # Shapes: segment-backed and Bezier-backed.
+    w.add_triangle(0, 0, 1, 0, 0, 1)
+    w.add_rectangle(2, 2, 4, 3)
+    w.add_circle(-2, -2, 1.0)
+    # A point off the z=0 plane: the 2D widget drops z, must not error.
+    w.add_point(0.5, 0.5, 5.0)
+    # A removed shape: its segments must be culled, not painted.
+    dead = w.add_triangle(8, 8, 9, 8, 8, 9)
+    w.remove_shape(dead)
+    return w
+
+
+@unittest.skipUnless(modmesh.HAS_PILOT, "Qt pilot is not built")
+class R2DWidgetWorldTC(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.widget = pilot.RManager.instance.setUp().add2DWidget()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.widget = None
+
+    def test_add_2d_widget_created(self):
+        """The 2D widget is created and accessible via the manager.
+        """
+        self.assertIsNotNone(self.widget)
+
+    def test_update_world_accepts_mixed_geometry(self):
+        """updateWorld accepts a world with mixed geometry (segments, curves,
+        points, shapes) and a removed shape, without raising.
+        """
+        self.widget.updateWorld(_build_world())
+        self.widget.requestRepaint()
+
+    def test_update_world_none_clears(self):
+        """A null world clears the canvas to its grid backdrop instead of
+        crashing; paintWorld early-returns when no world is set.
+        """
+        self.widget.updateWorld(_build_world())
+        self.widget.updateWorld(None)
+        self.widget.requestRepaint()
+
+    def test_resync_after_mutating_world(self):
+        """Re-issuing updateWorld on the same world after adding geometry
+        (the live Canvas sample flow) repaints the new state. Guards that
+        the widget re-reads the world rather than caching a snapshot.
+        """
+        w = modmesh.WorldFp64()
+        w.add_circle(0.0, 0.0, 1.0)
+        self.widget.updateWorld(w)
+        w.add_rectangle(-2, -2, 2, 2)
+        self.widget.updateWorld(w)
+        self.widget.requestRepaint()
+
+    def test_empty_world_paints_without_error(self):
+        """A world with no geometry is valid: the loops are simply empty.
+        Catches off-by-one / null-pad assumptions in paintWorld.
+        """
+        self.widget.updateWorld(modmesh.WorldFp64())
+        self.widget.requestRepaint()
+
+    def test_view_transform_round_trip(self):
+        """The view-state API that frames the world is intact: a pan/zoom
+        set via setViewTransform reads back through the viewTransform
+        property (zoom 3.0 is well within the widget's clamp band).
+        """
+        self.widget.resetView()
+        v = modmesh.ViewTransform2dFp64()
+        v.pan(40.0, 25.0)
+        v.zoom = 3.0
+        self.widget.setViewTransform(v)
+        got = self.widget.viewTransform
+        self.assertEqual(got.pan_x, 40.0)
+        self.assertEqual(got.pan_y, 25.0)
+        self.assertEqual(got.zoom, 3.0)
+
+    @unittest.skip("TODO: needs a synchronous-render hook on R2DWidget")
+    def test_dead_shape_culling_renders_pixels(self):
+        """Assert live geometry is painted and DEAD shapes are culled.
+
+        Needs a synchronous-render hook (saveImage, parity with
+        R3DWidget) to grab the canvas headless. Skipped until then.
+        """
+        # w = modmesh.WorldFp64()
+        # live = w.add_rectangle(-3, -3, -1, -1)   # region A (lower-left)
+        # dead = w.add_rectangle(1, 1, 3, 3)       # region B (upper-right)
+        # w.remove_shape(dead)
+        # self.widget.setViewTransform(<fixed pan/zoom>)
+        # img = self.widget.saveImage(width=400, height=400)  # future hook
+        # self.assertGreater(foreground_pixels(img, region_A), 0)  # painted
+        # self.assertEqual(foreground_pixels(img, region_B), 0)    # culled
+        raise NotImplementedError
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:


### PR DESCRIPTION
Stage 2 of #754. PR1 added the R2DWidget skeleton and the Qt-free ViewTransform2d; this PR makes the widget draw a World, replacing the Qt3D-backed "2D" canvas with a real QWidget + QPainter.

R2DWidget reads the same World geometry the 3D path already uses — collect_live_segments / collect_live_curves and points() — and paints it directly: drawLine for segments, QPainterPath::cubicTo for curves (Qt flattens them), drawPoint for points, with z dropped. No new geometry layer or curve-sampling API is needed. It also gains updateWorld(world) plus a pybind binding, and the Canvas menu gains "View: Open canvas in 2D" so the same world drives both the 2D and 3D views.

Coverage is a pilot pytest (tests/test_pilot_2d.py) over updateWorld and the view API, with one skipped test marking the planned pixel-level check.

To test manually, build and launch the pilot: `make && make pilot`, then run `./build/rel<pyver>/cpp/binary/pilot/pilot.app/Contents/MacOS/pilot` from the repo root (on Linux the binary is `build/rel<pyver>/cpp/binary/pilot/pilot`). Then use either of the two ways below; in both cases confirm the segments, curves, and points render, the curves are smooth, and pan (left-drag) and wheel-zoom work.

**(1) From the Canvas menu:** Canvas → "Sample: Ellipse" (or any other Canvas sample) to populate a world and open the 3D view, then Canvas → "View: Open canvas in 2D".

<img width="1055" height="600" alt="Screenshot 2026-06-12 at 1 14 59 AM" src="https://github.com/user-attachments/assets/e1aae50c-9596-495a-b409-541dfd37b43e" />

**(2) From the Pilot Python console**, paste:

```python
import modmesh as mm
P = mm.Point3dFp64

w = mm.WorldFp64()
w.add_segment(P(-3, 3, 0), P(3, 3, 0))            # bare segment
w.add_triangle(0, 0, 1, 0, 0, 1)                  # 3 segments
w.add_rectangle(2.0, 2.0, 4.0, 3.0)               # 4 segments
w.add_circle(-2.0, -2.0, 1.0)                     # 4 cubic Beziers
w.add_bezier(P(-3, 0, 0), P(-1, 2, 0),
             P(1, -2, 0), P(3, 0, 0))             # bare cubic Bezier
w.add_point(0.5, 0.5, 0.0)                        # standalone point

wid = mm.pilot.RManager.instance.add2DWidget()
wid.updateWorld(w)
wid.resetView()
```
<img width="1042" height="597" alt="Screenshot 2026-06-12 at 1 15 32 AM" src="https://github.com/user-attachments/assets/0e692cd7-d5cd-4271-ad9f-c83b735700ea" />

Related to #754.
