### PR TITLE
Add 2D mesh and CE tests for quad, triangle, and mixed elements

### DIFF
--- a/cpp/modmesh/mesh/pymod/wrap_StaticMesh.cpp
+++ b/cpp/modmesh/mesh/pymod/wrap_StaticMesh.cpp
@@ -99,7 +99,7 @@ WrapStaticMesh::WrapStaticMesh(pybind11::module & mod, char const * pyname, char
         .def_property_readonly("nbcs", &wrapped_type::nbcs);
 
     (*this)
-        .def_timed("build_interior", &wrapped_type::build_interior, py::arg("_do_metric") = true, py::arg("_build_edge") = true)
+        .def_timed("build_interior", &wrapped_type::build_interior, py::arg("do_metric") = true, py::arg("build_edge") = true)
         .def_timed("build_boundary", &wrapped_type::build_boundary)
         .def_timed("build_ghost", &wrapped_type::build_ghost)
         .def_timed("build_edge", &wrapped_type::build_edge);

--- a/tests/data/mixed_tq.msh
+++ b/tests/data/mixed_tq.msh
@@ -1,0 +1,25 @@
+$MeshFormat
+2.2 0 8
+$EndMeshFormat
+$PhysicalNames
+1
+2 1 "domain"
+$EndPhysicalNames
+$Nodes
+8
+1 0 0 0
+2 1 0 0
+3 2 0 0
+4 3 0 0
+5 0 1 0
+6 1 1 0
+7 2 1 0
+8 3 1 0
+$EndNodes
+$Elements
+4
+1 3 2 1 1 1 2 6 5
+2 3 2 1 1 2 3 7 6
+3 2 2 1 1 3 4 7
+4 2 2 1 1 4 8 7
+$EndElements

--- a/tests/test_euler_multidim.py
+++ b/tests/test_euler_multidim.py
@@ -1,5 +1,7 @@
+import os
 import unittest
 
+import numpy as np
 from numpy.testing import assert_almost_equal
 
 import modmesh
@@ -11,10 +13,10 @@ class EulerCoreCETriangleTC(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         mh = modmesh.StaticMesh(ndim=2, nnode=4, nface=0, ncell=3)
-        mh.ndcrd.ndarray[:, :] = (0, 0), (-1, -1), (1, -1), (0, 1)
-        mh.cltpn.ndarray[:] = modmesh.StaticMesh.TRIANGLE
-        mh.clnds.ndarray[:, :4] = (3, 0, 1, 2), (3, 0, 2, 3), (3, 0, 3, 1)
-        mh.build_interior(True)
+        mh.ndcrd[:, :] = [(0, 0), (-1, -1), (1, -1), (0, 1)]
+        mh.cltpn.fill(modmesh.StaticMesh.TRIANGLE)
+        mh.clnds[:, :4] = (3, 0, 1, 2), (3, 0, 2, 3), (3, 0, 3, 1)
+        mh.build_interior(do_metric=True)
         mh.build_boundary()
         mh.build_ghost()
         cls.mesh = mh
@@ -82,6 +84,146 @@ class EulerCoreCETriangleTC(unittest.TestCase):
         assert_almost_equal(self.ec.cevol[0, 0], vol_before, decimal=12)
 
 
+class EulerCoreCEQuadTC(unittest.TestCase):
+    """Test CE geometry on a 2D mesh of a single unit-square quad."""
+
+    @classmethod
+    def setUpClass(cls):
+        mh = modmesh.StaticMesh(ndim=2, nnode=4, nface=0, ncell=1)
+        mh.ndcrd[:, :] = [(0, 0), (1, 0), (1, 1), (0, 1)]
+        mh.cltpn.fill(modmesh.StaticMesh.QUADRILATERAL)
+        mh.clnds[:, :5] = [(4, 0, 1, 2, 3)]
+        mh.build_interior(do_metric=True)
+        mh.build_boundary()
+        mh.build_ghost()
+        cls.mesh = mh
+        cls.ec = modmesh.EulerCore(mesh=mh, time_increment=0.01)
+
+    def test_dimensions(self):
+        self.assertEqual(2, self.ec.ndim)
+        self.assertEqual(1, self.ec.ncell)
+        self.assertEqual(4, self.ec.ngstcell)
+
+    def test_cce_volume_positive(self):
+        self.assertGreater(self.ec.cevol[0, 0], 0.0)
+
+    def test_bce_volumes_sum_to_cce(self):
+        nfc = self.mesh.clfcs[0, 0]
+        bce_sum = sum(self.ec.cevol[0, ifl] for ifl in range(1, nfc + 1))
+        assert_almost_equal(bce_sum, self.ec.cevol[0, 0], decimal=12)
+
+    def test_bce_volume_manual(self):
+        assert_almost_equal(self.ec.cevol[0, 1], 0.5, decimal=10)
+        assert_almost_equal(self.ec.cevol[0, 2], 0.5, decimal=10)
+        assert_almost_equal(self.ec.cevol[0, 3], 0.5, decimal=10)
+        assert_almost_equal(self.ec.cevol[0, 4], 0.5, decimal=10)
+        assert_almost_equal(self.ec.cevol[0, 0], 2.0, decimal=10)
+
+    def test_sfcnd_nonzero(self):
+        self.assertTrue(any(
+            self.ec.sfcnd[0, si, d] != 0
+            for si in range(modmesh.StaticMesh.CLMFC
+                            * modmesh.StaticMesh.FCMND)
+            for d in range(self.ec.ndim)))
+
+    def test_sfnml_nonzero(self):
+        self.assertTrue(any(
+            self.ec.sfnml[0, si, d] != 0
+            for si in range(modmesh.StaticMesh.CLMFC
+                            * modmesh.StaticMesh.FCMND)
+            for d in range(self.ec.ndim)))
+
+    def test_sfnml_magnitudes(self):
+        ec, ndim = self.ec, self.ec.ndim
+        for ifc in range(4):
+            for ind in range(modmesh.StaticMesh.FCMND):
+                si = ifc * modmesh.StaticMesh.FCMND + ind
+                nml = [ec.sfnml[0, si, d] for d in range(ndim)]
+                mag = np.linalg.norm(nml)
+                if mag > 1e-14:
+                    assert_almost_equal(mag, 0.5 * np.sqrt(2.0), decimal=10)
+
+
+class EulerCoreCEMixedTC(unittest.TestCase):
+    """Test CE geometry on a 2D mixed mesh (1 quad + 2 tri)."""
+
+    @classmethod
+    def setUpClass(cls):
+        mh = modmesh.StaticMesh(ndim=2, nnode=6, nface=0, ncell=3)
+        mh.ndcrd[:, :] = [
+            (0, 0), (1, 0), (2, 0),
+            (0, 1), (1, 1), (2, 1),
+        ]
+        mh.cltpn[:] = [
+            modmesh.StaticMesh.QUADRILATERAL,
+            modmesh.StaticMesh.TRIANGLE,
+            modmesh.StaticMesh.TRIANGLE,
+        ]
+        mh.clnds[:, :5] = [(4, 0, 1, 4, 3), (3, 1, 2, 4, 0), (3, 2, 5, 4, 0)]
+        mh.build_interior(do_metric=True)
+        mh.build_boundary()
+        mh.build_ghost()
+        cls.mesh = mh
+        cls.ec = modmesh.EulerCore(mesh=mh, time_increment=0.01)
+
+    def test_varying_clfcs_counts(self):
+        mh = self.mesh
+        self.assertEqual(4, mh.clfcs[0, 0])
+        self.assertEqual(3, mh.clfcs[1, 0])
+        self.assertEqual(3, mh.clfcs[2, 0])
+
+    def test_cce_volume_positive(self):
+        for icl in range(self.ec.ncell):
+            self.assertGreater(
+                self.ec.cevol[icl, 0], 0.0,
+                f"CCE volume for cell {icl} should be positive")
+
+    def test_bce_volumes_sum_to_cce(self):
+        mh = self.mesh
+        for icl in range(self.ec.ncell):
+            nfc = mh.clfcs[icl, 0]
+            bce_sum = sum(self.ec.cevol[icl, ifl] for ifl in range(1, nfc + 1))
+            assert_almost_equal(
+                bce_sum, self.ec.cevol[icl, 0], decimal=12,
+                err_msg=f"BCE sum != CCE for cell {icl}")
+
+
+class EulerCoreCERectangleTC(unittest.TestCase):
+    """Regression: rectangle.msh total CE volume."""
+
+    TESTDIR = os.path.abspath(os.path.dirname(__file__))
+    DATADIR = os.path.join(TESTDIR, "data")
+
+    @classmethod
+    def setUpClass(cls):
+        path = os.path.join(cls.DATADIR, "rectangle.msh")
+        with open(path, 'rb') as f:
+            data = f.read()
+        gmsh = modmesh.Gmsh(data)
+        cls.blk = gmsh.to_block()
+        cls.ec = modmesh.EulerCore(
+            mesh=cls.blk, time_increment=0.01)
+
+    def test_triangle_ce_total(self):
+        blk = self.blk
+        tri_ce_sum = 0.0
+        for i in range(self.ec.ncell):
+            if blk.cltpn[i] == modmesh.StaticMesh.TRIANGLE:
+                tri_ce_sum += self.ec.cevol[i, 0]
+        assert_almost_equal(tri_ce_sum, 8.0, decimal=6)
+
+    def test_triangle_bce_sum_equals_cce(self):
+        blk = self.blk
+        for i in range(self.ec.ncell):
+            if blk.cltpn[i] != modmesh.StaticMesh.TRIANGLE:
+                continue
+            nfc = blk.clfcs[i, 0]
+            bce_sum = sum(self.ec.cevol[i, ifl] for ifl in range(1, nfc + 1))
+            assert_almost_equal(
+                bce_sum, self.ec.cevol[i, 0], decimal=12,
+                err_msg=f"BCE sum != CCE for tri cell {i}")
+
+
 @unittest.skip("3D ghost cell geometry has NaN due to fill_ghost bug")
 class EulerCoreCETetrahedronTC(unittest.TestCase):
     """Test CE geometry on a 3D mesh of a single tetrahedron."""
@@ -89,11 +231,11 @@ class EulerCoreCETetrahedronTC(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         mh = modmesh.StaticMesh(ndim=3, nnode=4, nface=4, ncell=1)
-        mh.ndcrd.ndarray[:, :] = (
+        mh.ndcrd[:, :] = (
             (0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1))
-        mh.cltpn.ndarray[:] = modmesh.StaticMesh.TETRAHEDRON
-        mh.clnds.ndarray[0, :5] = (4, 0, 1, 2, 3)
-        mh.build_interior(True)
+        mh.cltpn.fill(modmesh.StaticMesh.TETRAHEDRON)
+        mh.clnds[:, :5] = [(4, 0, 1, 2, 3)]
+        mh.build_interior(do_metric=True)
         mh.build_boundary()
         mh.build_ghost()
         cls.mesh = mh

--- a/tests/test_gmsh.py
+++ b/tests/test_gmsh.py
@@ -48,23 +48,19 @@ class GmshTriangleTC(GmshTB):
 
         # Check nodes information
         self.assertEqual(blk.nnode, 4)
-
-        # Due to ghost cell and ghost node had been created, the real body
-        # had been shifted and start with index 3 (number of ghost)
-        ngst = blk.ngstcell
-        self.assertEqual(ngst, 3)
-        np.testing.assert_almost_equal(blk.ndcrd.ndarray[ngst:, :].tolist(),
-                                       [[0.0, 0.0],
-                                        [-1.0, -1.0],
-                                        [1.0, -1.0],
-                                        [0.0, 1.0]])
+        self.assertEqual(blk.ngstnode, 3)
+        np.testing.assert_almost_equal(
+            [[blk.ndcrd[i, d] for d in range(blk.ndim)]
+             for i in range(blk.nnode)],
+            [[0.0, 0.0], [-1.0, -1.0],
+             [1.0, -1.0], [0.0, 1.0]])
         # Check cells information
         self.assertEqual(blk.ncell, 3)
-        self.assertEqual(blk.cltpn.ndarray[ngst:].tolist(), [4, 4, 4])
-        self.assertEqual(blk.clnds.ndarray[ngst:, :4].tolist(),
-                         [[3, 0, 1, 2],
-                          [3, 0, 2, 3],
-                          [3, 0, 3, 1]])
+        self.assertEqual(list(blk.cltpn), [4, 4, 4])
+        self.assertEqual(
+            [[blk.clnds[i, j] for j in range(4)]
+             for i in range(blk.ncell)],
+            [[3, 0, 1, 2], [3, 0, 2, 3], [3, 0, 3, 1]])
 
 
 class GmshRectangularTC(GmshTB):

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -92,12 +92,12 @@ class StaticMeshTC(unittest.TestCase):
         self._check_metric_trivial(mh)
 
         # Test build interior data.
-        mh.build_interior(_do_metric=False, _build_edge=False)
+        mh.build_interior(do_metric=False, build_edge=False)
         self._check_shape(mh, ndim=2, nnode=4, nface=6, ncell=3,
                           nbound=0, ngstnode=0, ngstface=0, ngstcell=0,
                           nedge=0)
         self._check_metric_trivial(mh)
-        mh.build_interior()  # _do_metric=True, _build_edge=True
+        mh.build_interior()  # do_metric=True, build_edge=True
         self._check_shape(mh, ndim=2, nnode=4, nface=6, ncell=3,
                           nbound=0, ngstnode=0, ngstface=0, ngstcell=0,
                           nedge=6)
@@ -149,12 +149,12 @@ class StaticMeshTC(unittest.TestCase):
                           nedge=0)
         self._check_metric_trivial(mh)
 
-        mh.build_interior(_do_metric=False, _build_edge=False)
+        mh.build_interior(do_metric=False, build_edge=False)
         self._check_shape(mh, ndim=3, nnode=4, nface=4, ncell=1,
                           nbound=0, ngstnode=0, ngstface=0, ngstcell=0,
                           nedge=0)
         self._check_metric_trivial(mh)
-        mh.build_interior()  # _do_metric=True, _build_edge=True
+        mh.build_interior()  # do_metric=True, build_edge=True
         self._check_shape(mh, ndim=3, nnode=4, nface=4, ncell=1,
                           nbound=0, ngstnode=0, ngstface=0, ngstcell=0,
                           nedge=6)
@@ -212,18 +212,18 @@ class StaticMeshTC(unittest.TestCase):
                           nedge=0)
         self._check_metric_trivial(mh)
 
-        mh.build_interior(_do_metric=False, _build_edge=False)
+        mh.build_interior(do_metric=False, build_edge=False)
         self._check_shape(mh, ndim=1, nnode=2, nface=2, ncell=1,
                           nbound=0, ngstnode=0, ngstface=0, ngstcell=0,
                           nedge=0)
         self._check_metric_trivial(mh)
 
-        mh.build_interior()  # _do_metric=True, _build_edge=True
+        mh.build_interior()  # do_metric=True, build_edge=True
         self._check_shape(mh, ndim=1, nnode=2, nface=2, ncell=1,
                           nbound=0, ngstnode=0, ngstface=0, ngstcell=0,
                           nedge=2)
 
-        # _do_metric do nothing due to dim == 1
+        # do_metric do nothing due to dim == 1
         self._check_metric_trivial(mh)
         # TODO: Need to add build_boundary and build_ghost to make sure
         #       Line type behavior.

--- a/tests/test_mesh_2d.py
+++ b/tests/test_mesh_2d.py
@@ -1,0 +1,214 @@
+import os
+import unittest
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+
+import modmesh
+
+
+class StaticMesh2dQuadSingleTC(unittest.TestCase):
+    """Single quad (unit square): face count, normals, areas, clvol,
+    clcnd, boundary edges, ghost cells."""
+
+    @classmethod
+    def setUpClass(cls):
+        mh = modmesh.StaticMesh(ndim=2, nnode=4, nface=0, ncell=1)
+        mh.ndcrd[:, :] = [(0, 0), (1, 0), (1, 1), (0, 1)]
+        mh.cltpn.fill(modmesh.StaticMesh.QUADRILATERAL)
+        mh.clnds[:, :5] = [(4, 0, 1, 2, 3)]
+        mh.build_interior(do_metric=True)
+        mh.build_boundary()
+        mh.build_ghost()
+        cls.mesh = mh
+
+    def test_face_count(self):
+        self.assertEqual(4, self.mesh.nface)
+
+    def test_normals_unit_length(self):
+        for i in range(self.mesh.nface):
+            nml = [self.mesh.fcnml[i, d] for d in range(self.mesh.ndim)]
+            assert_almost_equal(np.linalg.norm(nml), 1.0, decimal=10)
+
+    def test_normals_values(self):
+        mh = self.mesh
+        normals = [[mh.fcnml[i, d] for d in range(mh.ndim)]
+                   for i in range(mh.nface)]
+        assert_almost_equal(
+            normals, [[0, -1], [1, 0], [0, 1], [-1, 0]], decimal=10)
+
+    def test_areas(self):
+        assert_almost_equal(list(self.mesh.fcara), [1.0] * 4, decimal=10)
+
+    def test_clvol(self):
+        assert_almost_equal(self.mesh.clvol[0], 1.0, decimal=10)
+
+    def test_clcnd(self):
+        mh = self.mesh
+        assert_almost_equal(
+            [mh.clcnd[0, 0], mh.clcnd[0, 1]], [0.5, 0.5], decimal=10)
+
+    def test_boundary_edges(self):
+        self.assertEqual(4, self.mesh.nbound)
+
+    def test_ghost_cells(self):
+        self.assertEqual(4, self.mesh.ngstcell)
+
+
+class StaticMesh2dQuadGridTC(unittest.TestCase):
+    """2x2 quad grid (9 nodes, 4 cells): interior/boundary face split,
+    fccls, all clvol = 0.25."""
+
+    @classmethod
+    def setUpClass(cls):
+        mh = modmesh.StaticMesh(ndim=2, nnode=9, nface=0, ncell=4)
+        mh.ndcrd[:, :] = [
+            (0.0, 0.0), (0.5, 0.0), (1.0, 0.0),
+            (0.0, 0.5), (0.5, 0.5), (1.0, 0.5),
+            (0.0, 1.0), (0.5, 1.0), (1.0, 1.0),
+        ]
+        mh.cltpn.fill(modmesh.StaticMesh.QUADRILATERAL)
+        mh.clnds[:, :5] = [
+            (4, 0, 1, 4, 3), (4, 1, 2, 5, 4),
+            (4, 3, 4, 7, 6), (4, 4, 5, 8, 7),
+        ]
+        mh.build_interior(do_metric=True)
+        mh.build_boundary()
+        mh.build_ghost()
+        cls.mesh = mh
+
+    def test_interior_boundary_face_split(self):
+        mh = self.mesh
+        n_boundary = sum(1 for i in range(mh.nface) if mh.fccls[i, 1] < 0)
+        n_interior = mh.nface - n_boundary
+        self.assertEqual(4, n_interior)
+        self.assertEqual(8, n_boundary)
+
+    def test_fccls_interior_faces_have_two_cells(self):
+        mh = self.mesh
+        for i in range(mh.nface):
+            if mh.fccls[i, 1] >= 0:
+                self.assertGreaterEqual(mh.fccls[i, 0], 0)
+                self.assertGreaterEqual(mh.fccls[i, 1], 0)
+
+    def test_all_clvol_quarter(self):
+        assert_almost_equal(list(self.mesh.clvol), [0.25] * 4, decimal=10)
+
+
+class StaticMesh2dMixedTC(unittest.TestCase):
+    """Mixed 2 tri + 1 quad (6 nodes): cltpn mix, face extraction,
+    clvol sum."""
+
+    @classmethod
+    def setUpClass(cls):
+        mh = modmesh.StaticMesh(ndim=2, nnode=6, nface=0, ncell=3)
+        mh.ndcrd[:, :] = [
+            (0, 0), (1, 0), (2, 0),
+            (0, 1), (1, 1), (2, 1),
+        ]
+        mh.cltpn[:] = [
+            modmesh.StaticMesh.QUADRILATERAL,
+            modmesh.StaticMesh.TRIANGLE,
+            modmesh.StaticMesh.TRIANGLE,
+        ]
+        mh.clnds[:, :5] = (
+            (4, 0, 1, 4, 3), (3, 1, 2, 4, 0), (3, 2, 5, 4, 0))
+        mh.build_interior(do_metric=True)
+        mh.build_boundary()
+        mh.build_ghost()
+        cls.mesh = mh
+
+    def test_cltpn_mix(self):
+        self.assertEqual(
+            list(self.mesh.cltpn),
+            [modmesh.StaticMesh.QUADRILATERAL,
+             modmesh.StaticMesh.TRIANGLE,
+             modmesh.StaticMesh.TRIANGLE])
+
+    def test_face_count(self):
+        self.assertEqual(8, self.mesh.nface)
+
+    def test_clvol_sum(self):
+        assert_almost_equal(sum(self.mesh.clvol), 2.0, decimal=10)
+
+    def test_individual_clvol(self):
+        assert_almost_equal(list(self.mesh.clvol), [1.0, 0.5, 0.5], decimal=10)
+
+    def test_clfcs_varying_counts(self):
+        mh = self.mesh
+        self.assertEqual(4, mh.clfcs[0, 0])
+        self.assertEqual(3, mh.clfcs[1, 0])
+        self.assertEqual(3, mh.clfcs[2, 0])
+
+
+class GmshMixedTQTC(unittest.TestCase):
+    """Gmsh import of mixed_tq.msh: counts, spot-check geometry."""
+
+    TESTDIR = os.path.abspath(os.path.dirname(__file__))
+    DATADIR = os.path.join(TESTDIR, "data")
+
+    @classmethod
+    def setUpClass(cls):
+        path = os.path.join(cls.DATADIR, "mixed_tq.msh")
+        with open(path, 'rb') as f:
+            data = f.read()
+        gmsh = modmesh.Gmsh(data)
+        cls.blk = gmsh.to_block()
+
+    def test_node_count(self):
+        self.assertEqual(8, self.blk.nnode)
+
+    def test_cell_count(self):
+        self.assertEqual(4, self.blk.ncell)
+
+    def test_mixed_cell_types(self):
+        types = set(self.blk.cltpn)
+        self.assertIn(modmesh.StaticMesh.TRIANGLE, types)
+        self.assertIn(modmesh.StaticMesh.QUADRILATERAL, types)
+
+    def test_volume_sum(self):
+        assert_almost_equal(sum(self.blk.clvol), 3.0, decimal=10)
+
+    def test_quad_clvol(self):
+        assert_almost_equal(self.blk.clvol[0], 1.0, decimal=10)
+        assert_almost_equal(self.blk.clvol[1], 1.0, decimal=10)
+
+    def test_triangle_clvol(self):
+        assert_almost_equal(self.blk.clvol[2], 0.5, decimal=10)
+        assert_almost_equal(self.blk.clvol[3], 0.5, decimal=10)
+
+
+class StaticMesh2dSingleTriEdgeTC(unittest.TestCase):
+    """Single-cell edge cases for a triangle."""
+
+    @classmethod
+    def setUpClass(cls):
+        mh = modmesh.StaticMesh(ndim=2, nnode=3, nface=0, ncell=1)
+        mh.ndcrd[:, :] = [(0, 0), (1, 0), (0, 1)]
+        mh.cltpn.fill(modmesh.StaticMesh.TRIANGLE)
+        mh.clnds[:, :4] = [(3, 0, 1, 2)]
+        mh.build_interior(do_metric=True)
+        mh.build_boundary()
+        mh.build_ghost()
+        cls.mesh = mh
+
+    def test_face_count(self):
+        self.assertEqual(3, self.mesh.nface)
+
+    def test_all_faces_are_boundary(self):
+        self.assertEqual(3, self.mesh.nbound)
+
+    def test_ghost_cells(self):
+        self.assertEqual(3, self.mesh.ngstcell)
+
+    def test_clvol(self):
+        assert_almost_equal(self.mesh.clvol[0], 0.5, decimal=10)
+
+    def test_clcnd(self):
+        mh = self.mesh
+        assert_almost_equal(
+            [mh.clcnd[0, 0], mh.clcnd[0, 1]],
+            [1.0 / 3.0, 1.0 / 3.0], decimal=10)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
This is for "Phase 1: Mesh and CE Tests for 2D Mixed Elements" in issue #66.

Add `test_mesh_2d.py` with tests for single quad, 2x2 quad grid, mixed tri/quad, Gmsh mixed import, and single triangle edge cases.  Extend `test_euler_multidim.py` with `EulerCoreCEQuadTC`, `EulerCoreCEMixedTC`, and `EulerCoreCERectangleTC` for CE volume and sub-face geometry.

Add `mixed_tq.msh` test data, which are created by Claude.

Use `SimpleArray` Python API (`__getitem__`, `fill`, slice assignment) instead of `.ndarray` across `test_mesh_2d`, `test_euler_multidim`, `test_gmsh`, and `test_mesh`.  Rename `build_interior` arguments from `_do_metric`/`_build_edge` to `do_metric`/`build_edge` in the pybind11 binding and all call sites.