### PR TITLE
ci: cache vcpkg on Windows to speed BLAS/LAPACK install 

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -306,6 +306,17 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Cache vcpkg (install artifacts)
+        uses: actions/cache@v4
+        with:
+          path: |
+            C:\vcpkg\installed
+            C:\vcpkg\downloads
+            C:\vcpkg\buildtrees
+            C:\vcpkg\packages
+          key: vcpkg-${{ runner.os }}-openblas-lapack
+          restore-keys: vcpkg-${{ runner.os }}-
+
       - name: install BLAS and LAPACK
         run: |
           echo "::group::install BLAS and LAPACK"


### PR DESCRIPTION
Add a vcpkg cache to the Windows build to speed repeated installation of BLAS/LAPACK.

This inserts an actions/cache step before vcpkg install that caches `C:\vcpkg\installed`, `C:\vcpkg\downloads`, `C:\vcpkg\buildtrees` and `C:\vcpkg\packages`. The cache key is `vcpkg-${{ runner.os }}-openblas-lapack` with a `vcpkg-${{ runner.os }}-` fallback. On a cache hit vcpkg reuses previously downloaded sources and build artifacts, greatly reducing the time spent by vcpkg install in CI, the result showed up with 10 minutes reduce.

Related to #860.

Reference run:
1. Before cache save: https://github.com/rockleona/modmesh/actions/runs/27013948899/job/79724126063
2. After cache save: https://github.com/rockleona/modmesh/actions/runs/27014992454/job/79727640278

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
