### PR TITLE
Add line-economy style guideline

### DIFF
--- a/.claude/skills/cpp-style-review/SKILL.md
+++ b/.claude/skills/cpp-style-review/SKILL.md
@@ -50,6 +50,15 @@ it briefly but don't re-implement the check here.
 - Keep short accessors inline.
 - Trivial bodies (single `return`, single assignment) as one-liners.
 
+**Line economy**
+- Prefer fewer lines per STYLE.md. Flag unnecessary blank lines inside
+  short blocks and needlessly spread-out code. Do not flag structural
+  blank lines (between functions, logical sections, access specifiers).
+- Enforce STYLE.md's two hard rules: never trade line-width conformance
+  for fewer lines, and never put two consecutive executable statements
+  (separated by `;`) on one line. A single-statement inline accessor body
+  is one statement, not two, and stays the preferred form.
+
 **pybind11**
 - Split constructors from other bindings (methods, properties) into two
   distinct `(*this)` sections.

--- a/.claude/skills/python-style-review/SKILL.md
+++ b/.claude/skills/python-style-review/SKILL.md
@@ -32,6 +32,14 @@ limit, flake8) are handled by `.claude/hooks/check-source.sh`
 - Tests live in `tests/` and are named `test_*.py`.
 - Profiling scripts live in `profiling/` and are named `profile_*.py`.
 
+**Line economy**
+- Prefer fewer lines per STYLE.md. Flag unnecessary blank lines inside
+  short blocks and needlessly spread-out code. Do not flag structural
+  blank lines (between functions, logical sections).
+- Enforce STYLE.md's hard rule: never put two consecutive executable
+  statements (separated by `;`) on one line. (Line width is owned by the
+  hooks; don't re-flag it here.)
+
 **Intent (Rule 9)**
 - Tests should encode why behavior matters, not just what. If a new test
   would still pass under an obvious bug in the code it exercises,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,9 @@ owned by hooks, not skills.
 - `permissions.allow` whitelists the safe `make` targets, `cmake`, `pytest`,
   lint/format tools, and read-only git/gh. `make clean` and `make cmakeclean`
   deliberately prompt.
-- `permissions.deny` blocks force-push, `git reset --hard`, `git clean -fd`,
-  `sudo`, and `rm -rf` of root/home.
+- `permissions.deny` hard-blocks only `sudo` and `rm -rf` of root/home.
+  Destructive git operations (force-push, `git reset --hard`, `git clean -fd`)
+  are discouraged but not blocked -- use them deliberately and only when asked.
 - `hooks` wires the script above.
 - `statusLine` runs `.claude/statusline.sh` -- shows model, project, branch
   (with `*` if dirty), and context-window usage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,10 @@ See "Build, Test, Lint, Format" above for the `make` invocations.
 
 `STYLE.md` is the canonical source. At a glance:
 
+- **Line economy**: Prefer fewer lines for better human readability. Dense
+  code within the line-width limits is easier to scan. Do not add unnecessary
+  blank lines or spread simple logic across many lines. Always respect the
+  linting line-width limits -- never sacrifice them to shorten line count.
 - **C++**: 4-space indent, `m_` prefix on member vars, angle-bracket includes,
   C++23, prefer `SimpleCollector` / `small_vector` over STL for fundamentals.
 - **Python**: PEP-8, 79-char hard limit, flake8.

--- a/STYLE.md
+++ b/STYLE.md
@@ -22,6 +22,33 @@ style when adding new code and changing existing code. The rules of thumb are:
    file and follow it. Familiar with the code in the module(s) if time permits.
 3. Use the style guide.
 
+## Line Economy
+
+Prefer fewer lines for better human readability. Dense code that fits within
+the line-width limits is easier to scan than code spread across many lines.
+This applies to both C++ and Python.
+
+- Group related short declarations on one line when natural, e.g.
+  `double x, y;`.
+- Don't add blank lines inside short blocks (a 3-line function body does not
+  need internal blank lines).
+- Prefer compact forms over spread-out forms when both are equally clear.
+- Respect the linting line-width limits (below) -- never sacrifice them to
+  shorten the line count.
+- Never put two consecutive executable statements (separated by `;`) on one
+  line -- debuggers and stack traces need line granularity. A single-statement
+  inline body like `void set_flag(bool v) { m_flag = v; }` is one statement,
+  not two, and remains the preferred accessor form.
+
+Exceptions where vertical space helps:
+- Blank lines between functions and methods (required).
+- Blank lines between logical sections within a function (sparingly).
+- Blank lines around access specifiers in C++ classes.
+- Multi-line forms for genuinely complex expressions.
+
+This is a readability guideline, not a mandate to compress everything. When
+compactness hurts clarity, choose clarity.
+
 ## Indentation and file format
 
 Use 4 white spaces for indentation. Do not use a tab.


### PR DESCRIPTION
Prefer fewer lines for better human readability, always within the linting line-width limits. Document the rule in STYLE.md (canonical), summarize it in CLAUDE.md, and add reviewer-facing copies to the two style-review skills.

Also correct inconsistent deny-list description in CLAUDE.md.

[skip-ci]