### PR TITLE
Add placeholder for gradient element

### DIFF
--- a/cpp/modmesh/multidim/CMakeLists.txt
+++ b/cpp/modmesh/multidim/CMakeLists.txt
@@ -5,10 +5,12 @@ cmake_minimum_required(VERSION 4.0.1)
 
 set(MODMESH_MULTIDIM_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/multidim.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/GradientElement.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/euler.hpp
     CACHE FILEPATH "" FORCE)
 
 set(MODMESH_MULTIDIM_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/GradientElement.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/euler_ce.cpp
     CACHE FILEPATH "" FORCE)
 

--- a/cpp/modmesh/multidim/GradientElement.cpp
+++ b/cpp/modmesh/multidim/GradientElement.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <modmesh/multidim/GradientElement.hpp>
+
+#include <stdexcept>
+
+namespace modmesh
+{
+
+namespace detail
+{
+
+GradientElementTypeGroup::GradientElementTypeGroup()
+    : m_types{}
+{
+    GradientElementType & q = m_types[CellType::QUADRILATERAL];
+    q.clnfc = 4;
+    q.nfge = 4;
+    q.faces[0] = {1, 2, -1};
+    q.faces[1] = {2, 3, -1};
+    q.faces[2] = {3, 4, -1};
+    q.faces[3] = {4, 1, -1};
+
+    GradientElementType & t = m_types[CellType::TRIANGLE];
+    t.clnfc = 3;
+    t.nfge = 3;
+    t.faces[0] = {1, 2, -1};
+    t.faces[1] = {2, 3, -1};
+    t.faces[2] = {3, 1, -1};
+
+    GradientElementType & h = m_types[CellType::HEXAHEDRON];
+    h.clnfc = 6;
+    h.nfge = 8;
+    h.faces[0] = {2, 3, 5};
+    h.faces[1] = {6, 3, 2};
+    h.faces[2] = {4, 3, 6};
+    h.faces[3] = {5, 3, 4};
+    h.faces[4] = {5, 1, 2};
+    h.faces[5] = {2, 1, 6};
+    h.faces[6] = {6, 1, 4};
+    h.faces[7] = {4, 1, 5};
+
+    GradientElementType & e = m_types[CellType::TETRAHEDRON];
+    e.clnfc = 4;
+    e.nfge = 4;
+    e.faces[0] = {3, 1, 2};
+    e.faces[1] = {2, 1, 4};
+    e.faces[2] = {4, 1, 3};
+    e.faces[3] = {2, 4, 3};
+
+    GradientElementType & p = m_types[CellType::PRISM];
+    p.clnfc = 5;
+    p.nfge = 6;
+    p.faces[0] = {5, 2, 4};
+    p.faces[1] = {3, 2, 5};
+    p.faces[2] = {4, 2, 3};
+    p.faces[3] = {4, 1, 5};
+    p.faces[4] = {5, 1, 3};
+    p.faces[5] = {3, 1, 4};
+
+    GradientElementType & y = m_types[CellType::PYRAMID];
+    y.clnfc = 5;
+    y.nfge = 6;
+    y.faces[0] = {1, 5, 2};
+    y.faces[1] = {2, 5, 3};
+    y.faces[2] = {3, 5, 4};
+    y.faces[3] = {4, 5, 1};
+    y.faces[4] = {1, 3, 4};
+    y.faces[5] = {3, 1, 2};
+}
+
+std::array<double, 3> calc_gge_centroid(
+    GradientElementType const & ge,
+    std::array<double, 3> const & avg,
+    std::array<std::array<double, 3>, StaticMesh::CLMFC> const & gp,
+    size_t ndim)
+{
+    using vec3 = std::array<double, 3>;
+    vec3 cnd = {0, 0, 0};
+    double voc = 0.0;
+    for (int32_t isub = 0; isub < ge.nfge; ++isub)
+    {
+        vec3 subcnd = avg;
+        std::array<vec3, 3> dst = {};
+        for (size_t ivx = 0; ivx < ndim; ++ivx)
+        {
+            int32_t const fl = ge.faces[isub][ivx] - 1;
+            for (size_t d = 0; d < ndim; ++d)
+            {
+                subcnd[d] += gp[fl][d];
+                dst[ivx][d] = gp[fl][d] - avg[d];
+            }
+        }
+        for (size_t d = 0; d < ndim; ++d)
+        {
+            subcnd[d] /= static_cast<double>(ndim + 1);
+        }
+
+        double vob = 0.0;
+        if (2 == ndim)
+        {
+            vob = dst[0][0] * dst[1][1] - dst[0][1] * dst[1][0];
+        }
+        else
+        {
+            // clang-format off
+            vob = dst[0][0] * (dst[1][1] * dst[2][2] - dst[1][2] * dst[2][1])
+                - dst[0][1] * (dst[1][0] * dst[2][2] - dst[1][2] * dst[2][0])
+                + dst[0][2] * (dst[1][0] * dst[2][1] - dst[1][1] * dst[2][0]);
+            // clang-format on
+        }
+
+        voc += vob;
+        for (size_t d = 0; d < ndim; ++d)
+        {
+            cnd[d] += subcnd[d] * vob;
+        }
+    }
+    for (size_t d = 0; d < ndim; ++d)
+    {
+        cnd[d] /= voc;
+    }
+    return cnd;
+}
+
+} /* end namespace detail */
+
+GradientElement::GradientElement(
+    StaticMesh const & mesh,
+    SimpleArray<real_type> const & cecnd,
+    int_type icl,
+    real_type tau)
+    : m_icl(icl)
+    , m_ndim(mesh.ndim())
+    , m_clnfc(mesh.clfcs(icl, 0))
+    , m_rcls{}
+    , m_idis{}
+    , m_jdis{}
+{
+    if (m_ndim < 2 || m_ndim > 3)
+    {
+        throw std::invalid_argument("GradientElement: ndim must be 2 or 3");
+    }
+
+    size_t const ndim = m_ndim;
+
+    // Self CE centroid.
+    std::array<real_type, 3> icecnd = {0, 0, 0};
+    for (size_t d = 0; d < ndim; ++d)
+    {
+        icecnd[d] = cecnd(icl, d);
+    }
+
+    // Gradient evaluation points (absolute positions).
+    std::array<std::array<real_type, 3>, StaticMesh::CLMFC> gp = {};
+    std::array<std::array<real_type, 3>, StaticMesh::CLMFC> jd = {};
+
+    for (int_type ifl = 0; ifl < m_clnfc; ++ifl)
+    {
+        int_type const ifc = mesh.clfcs(icl, ifl + 1);
+        int_type const jcl = mesh.fcrcl(ifc, icl);
+        m_rcls[ifl] = jcl;
+
+        size_t const bce_col = static_cast<size_t>(ifl + 1) * ndim;
+        for (size_t d = 0; d < ndim; ++d)
+        {
+            real_type const mid = cecnd(icl, bce_col + d);
+            real_type const jce = (jcl >= 0) ? cecnd(jcl, d) : mesh.clcnd(jcl, d);
+            gp[ifl][d] = mid + tau * (jce - mid);
+            jd[ifl][d] = gp[ifl][d] - jce;
+        }
+    }
+
+    // Average of gradient evaluation points.
+    std::array<real_type, 3> avg = {0, 0, 0};
+    for (int_type ifl = 0; ifl < m_clnfc; ++ifl)
+    {
+        for (size_t d = 0; d < ndim; ++d)
+        {
+            avg[d] += gp[ifl][d];
+        }
+    }
+    for (size_t d = 0; d < ndim; ++d)
+    {
+        avg[d] /= m_clnfc;
+    }
+
+    // GGE centroid via sub-element triangulation.
+    GradientElementType const & ge = getype(mesh.cltpn(icl));
+    std::array<real_type, 3> const cnd = detail::calc_gge_centroid(ge, avg, gp, ndim);
+
+    // Shift so the GGE centroid coincides with the self CE
+    // centroid (solution point).
+    for (int_type ifl = 0; ifl < m_clnfc; ++ifl)
+    {
+        for (size_t d = 0; d < ndim; ++d)
+        {
+            m_idis[ifl][d] = gp[ifl][d] - cnd[d];
+            m_jdis[ifl][d] = jd[ifl][d] + icecnd[d] - cnd[d];
+        }
+    }
+}
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/multidim/GradientElement.hpp
+++ b/cpp/modmesh/multidim/GradientElement.hpp
@@ -1,0 +1,137 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Gradient element geometry for the CESE dual mesh.
+ * Port of solvcon GradientElement.hpp.
+ */
+
+#include <modmesh/mesh/mesh.hpp>
+
+#include <array>
+
+namespace modmesh
+{
+
+struct GradientElementType
+{
+
+    static constexpr size_t NFGE_MAX = 8;
+    static constexpr size_t FGENFC_MAX = 3;
+
+    using face_list_type = std::array<int32_t, FGENFC_MAX>;
+
+    int32_t clnfc = -1;
+    int32_t nfge = -1;
+    // 1-based indices into the per-cell gradient-eval-point array.
+    std::array<face_list_type, NFGE_MAX> faces = {};
+
+}; /* end struct GradientElementType */
+
+namespace detail
+{
+
+class GradientElementTypeGroup
+{
+
+public:
+
+    GradientElementType const & operator[](size_t id) const { return m_types[id]; }
+
+    static GradientElementTypeGroup const & get_instance()
+    {
+        static GradientElementTypeGroup const inst;
+        return inst;
+    }
+
+private:
+
+    GradientElementTypeGroup();
+
+    std::array<GradientElementType, CellType::NTYPE + 1> m_types;
+
+}; /* end class GradientElementTypeGroup */
+
+} /* end namespace detail */
+
+inline GradientElementType const & getype(size_t id)
+{
+    return detail::GradientElementTypeGroup::get_instance()[id];
+}
+
+class GradientElement
+{
+
+public:
+
+    using int_type = int32_t;
+    using real_type = double;
+
+    GradientElement(
+        StaticMesh const & mesh,
+        SimpleArray<real_type> const & cecnd,
+        int_type icl,
+        real_type tau);
+
+    int_type icl() const { return m_icl; }
+    uint8_t ndim() const { return m_ndim; }
+    int_type clnfc() const { return m_clnfc; }
+    int_type rcl(int_type ifl) const { return m_rcls[ifl]; }
+    real_type idis(int_type ifl, int_type d) const { return m_idis[ifl][d]; }
+    real_type jdis(int_type ifl, int_type d) const { return m_jdis[ifl][d]; }
+
+private:
+
+    // Index of the self cell that owns this gradient element.
+    int_type m_icl;
+    // Number of spatial dimensions (2 or 3).
+    uint8_t m_ndim;
+    // Number of cell faces, i.e. the number of gradient evaluation points.
+    // This is the valid extent of the per-face axis (axis 0) of the arrays
+    // below and never exceeds StaticMesh::CLMFC.
+    int_type m_clnfc;
+    // Neighbor cell across each face.  Axis 0: face index ifl, valid in [0,
+    // clnfc), capacity CLMFC.  A negative entry denotes a ghost cell.
+    std::array<int_type, StaticMesh::CLMFC> m_rcls;
+    // Displacement from the self solution point (the self cell's CE centroid)
+    // to the gradient evaluation point of each face.  Axis 0: face index ifl,
+    // valid in [0, clnfc), capacity CLMFC.  Axis 1: dimension d, valid in [0,
+    // ndim), capacity 3 (to hold up to 3D).
+    std::array<std::array<real_type, 3>, StaticMesh::CLMFC> m_idis;
+    // Displacement from the neighboring solution point (the neighbor cell's CE
+    // centroid) to the same gradient evaluation point.  Same axes and extents
+    // as m_idis.
+    std::array<std::array<real_type, 3>, StaticMesh::CLMFC> m_jdis;
+
+}; /* end class GradientElement */
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/multidim/multidim.hpp
+++ b/cpp/modmesh/multidim/multidim.hpp
@@ -33,6 +33,7 @@
  */
 
 #include <modmesh/mesh/mesh.hpp>
+#include <modmesh/multidim/GradientElement.hpp>
 #include <modmesh/multidim/euler.hpp>
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/multidim/pymod/wrap_multidim.cpp
+++ b/cpp/modmesh/multidim/pymod/wrap_multidim.cpp
@@ -36,6 +36,100 @@ namespace modmesh
 namespace python
 {
 
+class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapGradientElement
+    : public WrapBase<WrapGradientElement, GradientElement>
+{
+
+public:
+
+    using base_type = WrapBase<WrapGradientElement, GradientElement>;
+    using wrapper_type = typename base_type::wrapper_type;
+    using wrapped_type = typename base_type::wrapped_type;
+
+    friend base_type;
+
+protected:
+
+    WrapGradientElement(pybind11::module & mod, const char * pyname, const char * clsdoc);
+
+    static void check_ifl(wrapped_type const & self, wrapped_type::int_type ifl);
+    static void check_d(wrapped_type const & self, wrapped_type::int_type d);
+
+}; /* end class WrapGradientElement */
+
+void WrapGradientElement::check_ifl(wrapped_type const & self, wrapped_type::int_type ifl)
+{
+    if (ifl < 0 || ifl >= self.clnfc())
+    {
+        throw std::out_of_range(std::format(
+            "GradientElement: ifl {} out of range [0, {})", ifl, self.clnfc()));
+    }
+}
+
+void WrapGradientElement::check_d(wrapped_type const & self, wrapped_type::int_type d)
+{
+    if (d < 0 || d >= self.ndim())
+    {
+        throw std::out_of_range(std::format(
+            "GradientElement: d {} out of range [0, {})", d, self.ndim()));
+    }
+}
+
+WrapGradientElement::WrapGradientElement(pybind11::module & mod, const char * pyname, const char * clsdoc)
+    : base_type(mod, pyname, clsdoc)
+{
+    namespace py = pybind11;
+
+    (*this)
+        .def(
+            py::init(
+                [](std::shared_ptr<StaticMesh> const & mesh,
+                   SimpleArray<wrapped_type::real_type> const & cecnd,
+                   wrapped_type::int_type icl,
+                   wrapped_type::real_type tau)
+                {
+                    return wrapped_type(*mesh, cecnd, icl, tau);
+                }),
+            py::arg("mesh"),
+            py::arg("cecnd"),
+            py::arg("icl"),
+            py::arg("tau"),
+            py::keep_alive<1, 2>())
+        .def_property_readonly("icl", &wrapped_type::icl)
+        .def_property_readonly("ndim", &wrapped_type::ndim)
+        .def_property_readonly("clnfc", &wrapped_type::clnfc)
+        .def(
+            "rcl",
+            [](wrapped_type const & self, wrapped_type::int_type ifl)
+            {
+                check_ifl(self, ifl);
+                return self.rcl(ifl);
+            },
+            py::arg("ifl"))
+        .def(
+            "idis",
+            [](wrapped_type const & self, wrapped_type::int_type ifl, wrapped_type::int_type d)
+            {
+                check_ifl(self, ifl);
+                check_d(self, d);
+                return self.idis(ifl, d);
+            },
+            py::arg("ifl"),
+            py::arg("d"))
+        .def(
+            "jdis",
+            [](wrapped_type const & self, wrapped_type::int_type ifl, wrapped_type::int_type d)
+            {
+                check_ifl(self, ifl);
+                check_d(self, d);
+                return self.jdis(ifl, d);
+            },
+            py::arg("ifl"),
+            py::arg("d"))
+        //
+        ;
+}
+
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapEulerCore
     : public WrapBase<WrapEulerCore, EulerCore, std::shared_ptr<EulerCore>>
 {
@@ -124,6 +218,7 @@ WrapEulerCore & WrapEulerCore::wrap_array()
 
 void wrap_multidim(pybind11::module & mod)
 {
+    WrapGradientElement::commit(mod, "GradientElement", "Gradient element for a single cell");
     WrapEulerCore::commit(mod, "EulerCore", "Solve the Euler equation");
 }
 

--- a/modmesh/core.py
+++ b/modmesh/core.py
@@ -91,6 +91,7 @@ list_of_mesh = [
 # multidim directory symbols
 list_of_multidim = [
     'EulerCore',
+    'GradientElement',
 ]
 
 # python directory symbols

--- a/tests/test_multidim.py
+++ b/tests/test_multidim.py
@@ -1,0 +1,272 @@
+import unittest
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+
+import modmesh
+
+
+class _TriangleMeshBase(unittest.TestCase):
+    """3 triangles around the origin."""
+
+    @classmethod
+    def setUpClass(cls):
+        mh = modmesh.StaticMesh(ndim=2, nnode=4, nface=0, ncell=3)
+        mh.ndcrd[:, :] = [(0, 0), (-1, -1), (1, -1), (0, 1)]
+        mh.cltpn.fill(modmesh.StaticMesh.TRIANGLE)
+        mh.clnds[:, :4] = [(3, 0, 1, 2), (3, 0, 2, 3), (3, 0, 3, 1)]
+        mh.build_interior(do_metric=True)
+        mh.build_boundary()
+        mh.build_ghost()
+        cls.mesh = mh
+        cls.ec = modmesh.EulerCore(mesh=mh, time_increment=0.01)
+
+
+class _QuadMeshBase(unittest.TestCase):
+    """Single unit-square quadrilateral."""
+
+    @classmethod
+    def setUpClass(cls):
+        mh = modmesh.StaticMesh(ndim=2, nnode=4, nface=0, ncell=1)
+        mh.ndcrd[:, :] = [(0, 0), (1, 0), (1, 1), (0, 1)]
+        mh.cltpn.fill(modmesh.StaticMesh.QUADRILATERAL)
+        mh.clnds[:, :5] = [(4, 0, 1, 2, 3)]
+        mh.build_interior(do_metric=True)
+        mh.build_boundary()
+        mh.build_ghost()
+        cls.mesh = mh
+        cls.ec = modmesh.EulerCore(mesh=mh, time_increment=0.01)
+
+
+class _MixedMeshBase(unittest.TestCase):
+    """1 quad + 2 triangles."""
+
+    @classmethod
+    def setUpClass(cls):
+        mh = modmesh.StaticMesh(ndim=2, nnode=6, nface=0, ncell=3)
+        mh.ndcrd[:, :] = [
+            (0, 0), (1, 0), (2, 0),
+            (0, 1), (1, 1), (2, 1),
+        ]
+        mh.cltpn[:] = [
+            modmesh.StaticMesh.QUADRILATERAL,
+            modmesh.StaticMesh.TRIANGLE,
+            modmesh.StaticMesh.TRIANGLE,
+        ]
+        mh.clnds[:, :5] = [
+            (4, 0, 1, 4, 3),
+            (3, 1, 2, 4, 0),
+            (3, 2, 5, 4, 0),
+        ]
+        mh.build_interior(do_metric=True)
+        mh.build_boundary()
+        mh.build_ghost()
+        cls.mesh = mh
+        cls.ec = modmesh.EulerCore(mesh=mh, time_increment=0.01)
+
+
+class _TetrahedronMeshBase(unittest.TestCase):
+    """Single tetrahedron (4 triangular faces)."""
+
+    @classmethod
+    def setUpClass(cls):
+        mh = modmesh.StaticMesh(ndim=3, nnode=4, nface=4, ncell=1)
+        mh.ndcrd[:, :] = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1)]
+        mh.cltpn.fill(modmesh.StaticMesh.TETRAHEDRON)
+        mh.clnds[:, :5] = [(4, 0, 1, 2, 3)]
+        mh.build_interior(do_metric=True)
+        mh.build_boundary()
+        mh.build_ghost()
+        cls.mesh = mh
+        cls.ec = modmesh.EulerCore(mesh=mh, time_increment=0.01)
+
+
+class _HexahedronMeshBase(unittest.TestCase):
+    """Single unit-cube hexahedron (6 quadrilateral faces)."""
+
+    @classmethod
+    def setUpClass(cls):
+        mh = modmesh.StaticMesh(ndim=3, nnode=8, nface=6, ncell=1)
+        mh.ndcrd[:, :] = [
+            (0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0),
+            (0, 0, 1), (1, 0, 1), (1, 1, 1), (0, 1, 1),
+        ]
+        mh.cltpn.fill(modmesh.StaticMesh.HEXAHEDRON)
+        mh.clnds[:, :9] = [(8, 0, 1, 2, 3, 4, 5, 6, 7)]
+        mh.build_interior(do_metric=True)
+        mh.build_boundary()
+        mh.build_ghost()
+        cls.mesh = mh
+        cls.ec = modmesh.EulerCore(mesh=mh, time_increment=0.01)
+
+
+class _PrismMeshBase(unittest.TestCase):
+    """Single triangular prism (2 triangle + 3 quadrilateral faces)."""
+
+    @classmethod
+    def setUpClass(cls):
+        mh = modmesh.StaticMesh(ndim=3, nnode=6, nface=5, ncell=1)
+        mh.ndcrd[:, :] = [
+            (0, 0, 0), (1, 0, 0), (0, 1, 0),
+            (0, 0, 1), (1, 0, 1), (0, 1, 1),
+        ]
+        mh.cltpn.fill(modmesh.StaticMesh.PRISM)
+        mh.clnds[:, :7] = [(6, 0, 1, 2, 3, 4, 5)]
+        mh.build_interior(do_metric=True)
+        mh.build_boundary()
+        mh.build_ghost()
+        cls.mesh = mh
+        cls.ec = modmesh.EulerCore(mesh=mh, time_increment=0.01)
+
+
+class _PyramidMeshBase(unittest.TestCase):
+    """Single square pyramid (4 triangle + 1 quadrilateral faces)."""
+
+    @classmethod
+    def setUpClass(cls):
+        mh = modmesh.StaticMesh(ndim=3, nnode=5, nface=5, ncell=1)
+        mh.ndcrd[:, :] = [
+            (0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0),
+            (0.5, 0.5, 1),
+        ]
+        mh.cltpn.fill(modmesh.StaticMesh.PYRAMID)
+        mh.clnds[:, :6] = [(5, 0, 1, 2, 3, 4)]
+        mh.build_interior(do_metric=True)
+        mh.build_boundary()
+        mh.build_ghost()
+        cls.mesh = mh
+        cls.ec = modmesh.EulerCore(mesh=mh, time_increment=0.01)
+
+
+class _GradientElementBoundsBase:
+    """Checks that hold even when CE geometry is NaN (no value reads)."""
+
+    def _ge(self, icl, tau=1.0):
+        mh, cecnd = self.mesh, self.ec.cecnd
+        return modmesh.GradientElement(mesh=mh, cecnd=cecnd, icl=icl, tau=tau)
+
+    def test_basic_properties(self):
+        ge = self._ge(0)
+        self.assertEqual(0, ge.icl)
+        self.assertEqual(self.mesh.ndim, ge.ndim)
+        self.assertEqual(self.mesh.clfcs[0, 0], ge.clnfc)
+
+    def test_accessor_index_bounds(self):
+        ge = self._ge(0)
+        nfc, nd = ge.clnfc, ge.ndim
+        # In-range access does not raise across the whole valid range.
+        # The d loop reaches ndim - 1 (== 2 only in 3D), so it pins idis
+        # and jdis to accept the full dimension range, not just d <= 1.
+        for ifl in range(nfc):
+            ge.rcl(ifl)
+            for d in range(nd):
+                ge.idis(ifl, d)
+                ge.jdis(ifl, d)
+        # Out-of-range face index raises IndexError.
+        for ifl in (-1, nfc):
+            with self.assertRaises(IndexError):
+                ge.rcl(ifl)
+            with self.assertRaises(IndexError):
+                ge.idis(ifl, 0)
+            with self.assertRaises(IndexError):
+                ge.jdis(ifl, 0)
+        # Out-of-range dimension index raises IndexError.
+        for d in (-1, nd):
+            with self.assertRaises(IndexError):
+                ge.idis(0, d)
+            with self.assertRaises(IndexError):
+                ge.jdis(0, d)
+
+
+class _GradientElementBase(_GradientElementBoundsBase):
+    """Adds geometry tests that need non-NaN CE data over all cells."""
+
+    # A single 3D cell has only boundary faces, so its ghost-neighbor CE
+    # geometry (and thus its own CE centroid) is NaN until the fill_ghost
+    # bug is fixed.  Such fixtures set this False to skip the value tests;
+    # construction, basic-property and index-bound tests still run.
+    run_geometry = True
+
+    def _require_geometry(self):
+        if not self.run_geometry:
+            self.skipTest(
+                "3D single-cell ghost CE geometry is NaN (fill_ghost bug)")
+
+    def test_displacement_matrix_nonsingular(self):
+        self._require_geometry()
+        nd = self.mesh.ndim
+        for icl in range(self.mesh.ncell):
+            ge = self._ge(icl)
+            mat = np.array([[ge.idis(ifl, d) for d in range(nd)]
+                            for ifl in range(ge.clnfc)])
+            # The face-displacement vectors must span R^ndim for the
+            # gradient reconstruction to be well posed.  A per-simplex
+            # determinant would wrongly fail for the hexahedron, whose
+            # opposite faces are antiparallel.
+            self.assertEqual(nd, np.linalg.matrix_rank(mat),
+                             f"cell {icl}: idis does not span {nd}D")
+
+    def test_idis_jdis_consistency(self):
+        self._require_geometry()
+        mh, cecnd, nd = self.mesh, self.ec.cecnd, self.mesh.ndim
+        for icl in range(mh.ncell):
+            ge = self._ge(icl)
+            for ifl in range(ge.clnfc):
+                jcl = ge.rcl(ifl)
+                for d in range(nd):
+                    jce = cecnd[jcl, d] if jcl >= 0 else mh.clcnd[jcl, d]
+                    lhs = ge.idis(ifl, d) + cecnd[icl, d]
+                    assert_almost_equal(lhs, ge.jdis(ifl, d) + jce, decimal=12)
+
+    def test_tau_zero(self):
+        self._require_geometry()
+        mh, cecnd, nd = self.mesh, self.ec.cecnd, self.mesh.ndim
+        for icl in range(mh.ncell):
+            ge = self._ge(icl, tau=0.0)
+            shift = [ge.idis(0, d) + cecnd[icl, d] - cecnd[icl, nd + d]
+                     for d in range(nd)]
+            for ifl in range(1, ge.clnfc):
+                for d in range(nd):
+                    pos = ge.idis(ifl, d) + cecnd[icl, d]
+                    bce = cecnd[icl, (ifl + 1) * nd + d]
+                    assert_almost_equal(pos, bce + shift[d], decimal=12)
+
+
+class GradientElementTriangleTC(_GradientElementBase, _TriangleMeshBase):
+    """Per-cell GradientElement on 3 triangles."""
+
+
+class GradientElementQuadTC(_GradientElementBase, _QuadMeshBase):
+    """Per-cell GradientElement on a unit-square quad."""
+
+
+class GradientElementMixedTC(_GradientElementBase, _MixedMeshBase):
+    """Per-cell GradientElement on a 2D mixed mesh."""
+
+
+# 3D single-cell meshes: every face is a boundary face, so the ghost
+# neighbor CE geometry (hence the cell's own CE centroid) is NaN until the
+# fill_ghost bug is fixed.  Construction, basic properties and index bounds
+# still hold; the geometry-value tests skip via run_geometry.
+
+class GradientElementTetrahedronTC(_GradientElementBase, _TetrahedronMeshBase):
+    """Per-cell GradientElement on a single tetrahedron (4 faces)."""
+    run_geometry = False
+
+
+class GradientElementHexahedronTC(_GradientElementBase, _HexahedronMeshBase):
+    """Per-cell GradientElement on a single hexahedron (6 faces)."""
+    run_geometry = False
+
+
+class GradientElementPrismTC(_GradientElementBase, _PrismMeshBase):
+    """Per-cell GradientElement on a single prism (5 faces)."""
+    run_geometry = False
+
+
+class GradientElementPyramidTC(_GradientElementBase, _PyramidMeshBase):
+    """Per-cell GradientElement on a single pyramid (5 faces)."""
+    run_geometry = False
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`GradientElement` is solvcon's helper class for calculating the gradient at a cell in multi-dimensional space.  (Phase 2 of issue #66.)

C++ (cpp/modmesh/multidim/GradientElement.{hpp,cpp}):
- GradientElementType and GradientElementTypeGroup port solvcon's GEType sub-element face-connectivity tables for quadrilateral, triangle, hexahedron, tetrahedron, prism, and pyramid, looked up via getype().
- GradientElement reconstructs, for one cell and a per-cell tau, the gradient evaluation points and the displacement vectors from the self (idis) and neighbor (jdis) solution points.  It is dimension generic (2D and 3D).  tau varies per cell, so the element is built on the fly during marching rather than precomputed into arrays.

Python:
- Expose GradientElement(mesh, cecnd, icl, tau), keeping the input mesh alive, with bound-checked idis/jdis/rcl accessors (the inline C++ accessors stay unchecked for use in tight loops).
- Register GradientElement in modmesh.core.

Tests (tests/test_multidim.py):
- Cover GradientElement on 2D triangle, quad, and mixed meshes and on 3D tetrahedron, hexahedron, prism, and pyramid cells.
- A single 3D cell has only boundary faces, so its ghost CE geometry is NaN until the fill_ghost bug is fixed; the geometry-value tests skip while construction, basic-property, and index-bound checks run.

For issue #66.