### PR TITLE
Expose raw span and strided mdspan for SimpleArray

### DIFF
--- a/cpp/modmesh/buffer/SimpleArray.hpp
+++ b/cpp/modmesh/buffer/SimpleArray.hpp
@@ -49,6 +49,7 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #ifdef _MSC_VER
 #include <BaseTsd.h>
@@ -1942,53 +1943,35 @@ public:
 
     std::span<value_type> as_span()
     {
-        if (!is_c_contiguous())
-        {
-            throw std::runtime_error("SimpleArray::as_span: array is not C-contiguous");
-        }
-        return std::span<value_type>(data(), size());
+        return std::span<value_type>(data(), buffer().nbytes() / ITEMSIZE);
     }
     std::span<value_type const> as_span() const
     {
-        if (!is_c_contiguous())
-        {
-            throw std::runtime_error("SimpleArray::as_span: array is not C-contiguous");
-        }
-        return std::span<value_type const>(data(), size());
+        return std::span<value_type const>(data(), buffer().nbytes() / ITEMSIZE);
     }
 
     template <size_t N>
-    std::mdspan<value_type, std::dextents<size_t, N>> as_mdspan()
+    std::mdspan<value_type, std::dextents<size_t, N>, std::layout_stride> as_mdspan()
     {
         if (ndim() != N)
         {
             throw std::out_of_range(
                 std::format("SimpleArray::as_mdspan: rank {} does not match ndim() {}", N, ndim()));
         }
-        if (!is_c_contiguous())
-        {
-            throw std::runtime_error("SimpleArray::as_mdspan: array is not C-contiguous");
-        }
-        std::array<size_t, N> exts;
-        for (size_t i = 0; i < N; ++i) { exts[i] = shape(i); }
-        return std::mdspan<value_type, std::dextents<size_t, N>>(data(), exts);
+        return std::mdspan<value_type, std::dextents<size_t, N>, std::layout_stride>(
+            data(), make_mdspan_mapping<N>());
     }
 
     template <size_t N>
-    std::mdspan<value_type const, std::dextents<size_t, N>> as_mdspan() const
+    std::mdspan<value_type const, std::dextents<size_t, N>, std::layout_stride> as_mdspan() const
     {
         if (ndim() != N)
         {
             throw std::out_of_range(
                 std::format("SimpleArray::as_mdspan: rank {} does not match ndim() {}", N, ndim()));
         }
-        if (!is_c_contiguous())
-        {
-            throw std::runtime_error("SimpleArray::as_mdspan: array is not C-contiguous");
-        }
-        std::array<size_t, N> exts;
-        for (size_t i = 0; i < N; ++i) { exts[i] = shape(i); }
-        return std::mdspan<value_type const, std::dextents<size_t, N>>(data(), exts);
+        return std::mdspan<value_type const, std::dextents<size_t, N>, std::layout_stride>(
+            data(), make_mdspan_mapping<N>());
     }
 
     /* Backdoor */
@@ -2008,6 +1991,21 @@ public:
 
 private:
     void copy_logical_into(SimpleArray & out) const;
+
+    template <size_t N, size_t... I>
+    std::layout_stride::mapping<std::dextents<size_t, N>> make_mdspan_mapping_impl(std::index_sequence<I...>) const
+    {
+        std::array<size_t, N> strides;
+        for (size_t i = 0; i < N; ++i) { strides[i] = stride(i); }
+        return std::layout_stride::mapping<std::dextents<size_t, N>>(
+            std::dextents<size_t, N>(shape(I)...), strides);
+    }
+
+    template <size_t N>
+    std::layout_stride::mapping<std::dextents<size_t, N>> make_mdspan_mapping() const
+    {
+        return make_mdspan_mapping_impl<N>(std::make_index_sequence<N>{});
+    }
 
     static bool is_c_contiguous(small_vector<size_t> const & shape,
                                 small_vector<size_t> const & stride)

--- a/gtests/test_nopython_mdspan.cpp
+++ b/gtests/test_nopython_mdspan.cpp
@@ -411,14 +411,43 @@ TEST(SimpleArray, mdspan_non_contiguous)
     mm::small_vector<size_t> stride{8, 1};
     auto buffer = mm::ConcreteBuffer::construct(3 * 8 * sizeof(double));
     mm::SimpleArray<double> arr(shape, stride, buffer);
+    for (size_t i = 0; i < 24; ++i) { arr.data(i) = static_cast<double>(i); }
+
     EXPECT_FALSE(arr.is_c_contiguous());
 
-    EXPECT_THROW(arr.as_span(), std::runtime_error);
-    EXPECT_THROW(arr.as_mdspan<2>(), std::runtime_error);
+    auto ms = arr.as_mdspan<2>();
+    EXPECT_EQ(ms.extent(0), 3u);
+    EXPECT_EQ(ms.extent(1), 4u);
+    EXPECT_EQ(ms.mapping().stride(0), 8u);
+    EXPECT_EQ(ms.mapping().stride(1), 1u);
+    for (size_t i = 0; i < 3; ++i)
+    {
+        for (size_t j = 0; j < 4; ++j)
+        {
+            EXPECT_EQ((ms[i, j]), arr.data(i * 8 + j));
+        }
+    }
+
+    auto sp = arr.as_span();
+    EXPECT_EQ(sp.size(), 24u);
+    for (size_t i = 0; i < sp.size(); ++i) { EXPECT_EQ(sp[i], arr.data(i)); }
+
+    ms[2, 3] = 99.0;
+    EXPECT_EQ(arr(2, 3), 99.0);
+    EXPECT_EQ(sp[2 * 8 + 3], 99.0);
+
+    sp[8] = 42.0;
+    EXPECT_EQ((ms[1, 0]), 42.0);
 
     const auto & carr = arr;
-    EXPECT_THROW(carr.as_span(), std::runtime_error);
-    EXPECT_THROW(carr.as_mdspan<2>(), std::runtime_error);
+    auto cms = carr.as_mdspan<2>();
+    static_assert(std::is_same_v<decltype(cms)::element_type, const double>);
+    EXPECT_EQ((cms[1, 0]), 42.0);
+
+    auto csp = carr.as_span();
+    static_assert(std::is_same_v<decltype(csp)::element_type, const double>);
+    EXPECT_EQ(csp.size(), 24u);
+    EXPECT_EQ(csp[2 * 8 + 3], 99.0);
 }
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
API `as_span()` and `as_mdspan()` only support for non-contiguous SimpleArray now, so this pull request expose raw span and strided mdspan for SimpleArray.

Related to #784.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
