### PR TITLE
Add diff-based pilot clang-tidy check for PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,7 +60,7 @@ jobs:
 
     - uses: actions/checkout@v6
       with:
-        fetch-depth: 1
+        fetch-depth: ${{ github.event_name == 'pull_request' && 100 || 1 }}
 
     - name: event name
       run: |
@@ -101,6 +101,7 @@ jobs:
       run: make flake8
 
     - name: make pilot
+      if: github.event_name != 'pull_request'
       run: |
         make pilot \
           ${JOB_MAKE_ARGS} \
@@ -108,12 +109,32 @@ jobs:
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
 
     - name: make run_pilot_pytest
+      if: github.event_name != 'pull_request'
       run: |
         export LD_LIBRARY_PATH=$(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
         make run_pilot_pytest \
           ${JOB_MAKE_ARGS} \
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+
+    - name: make pilot_clang_tidy_diff
+      if: github.event_name == 'pull_request'
+      run: |
+        make pilot_clang_tidy_diff \
+          ${JOB_MAKE_ARGS} \
+          CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
+          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON" \
+          MODMESH_DIFF_BASE=${{ github.event.pull_request.base.sha }}
+
+    - name: make pilot_clang_tidy_diff with Python library path
+      if: github.event_name == 'pull_request'
+      run: |
+        export LD_LIBRARY_PATH=$(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
+        make pilot_clang_tidy_diff \
+          ${JOB_MAKE_ARGS} \
+          CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
+          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON" \
+          MODMESH_DIFF_BASE=${{ github.event.pull_request.base.sha }}
 
   send_email_on_failure:
     needs: [lint]

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,15 @@ pyprof: buildext $(PROFFILES)
 pilot: cmake
 	cmake --build $(BUILD_PATH) --target $@ VERBOSE=$(VERBOSE) $(MAKE_PARALLEL)
 
+.PHONY: pilot_clang_tidy_diff
+pilot_clang_tidy_diff: cmake
+	@test -n "$(MODMESH_DIFF_BASE)" || { \
+		echo "Error: MODMESH_DIFF_BASE is required."; \
+		exit 1; \
+	}
+	env MODMESH_DIFF_BASE="$(MODMESH_DIFF_BASE)" \
+		cmake --build $(BUILD_PATH) --target $@ VERBOSE=$(VERBOSE)
+
 .PHONY: gtest
 gtest: cmake
 	cmake --build $(BUILD_PATH) --target run_gtest VERBOSE=$(VERBOSE) $(MAKE_PARALLEL)

--- a/cpp/binary/pilot/CMakeLists.txt
+++ b/cpp/binary/pilot/CMakeLists.txt
@@ -110,6 +110,39 @@ endif()
 
 add_custom_target(run_pilot_pytest $<TARGET_FILE:pilot> --mode=pytest)
 
+set(CLANG_TIDY_DIFF_EXE clang-tidy-diff.py)
+if(CLANG_TIDY_EXE)
+    file(REAL_PATH "${CLANG_TIDY_EXE}" CLANG_TIDY_REALPATH)
+    get_filename_component(
+        CLANG_TIDY_BINDIR
+        "${CLANG_TIDY_REALPATH}"
+        DIRECTORY
+    )
+    find_program(
+        CLANG_TIDY_DIFF_FOUND
+        NAMES clang-tidy-diff.py
+        HINTS
+            "${CLANG_TIDY_BINDIR}"
+            "${CLANG_TIDY_BINDIR}/../share/clang"
+        NO_DEFAULT_PATH
+        NO_CACHE
+    )
+    if(CLANG_TIDY_DIFF_FOUND)
+        set(CLANG_TIDY_DIFF_EXE "${CLANG_TIDY_DIFF_FOUND}")
+    endif()
+endif()
+
+add_custom_target(
+    pilot_clang_tidy_diff
+    COMMAND
+        bash
+        -e
+        -o pipefail
+        -c "test -n \"$MODMESH_DIFF_BASE\"; git diff --no-color -U0 \"$MODMESH_DIFF_BASE\" HEAD -- $<JOIN:${MODMESH_PILOT_FILES}, > | \"${CLANG_TIDY_DIFF_EXE}\" -p1 -path \"${CMAKE_BINARY_DIR}\" -config-file \"${PROJECT_ROOT_DIR}/.clang-tidy\""
+    WORKING_DIRECTORY ${PROJECT_ROOT_DIR}
+    VERBATIM
+)
+
 install(TARGETS pilot
     RUNTIME DESTINATION "${INSTALL_PILOTDIR}"
     BUNDLE DESTINATION "${INSTALL_PILOTDIR}"

--- a/cpp/binary/pilot/CMakeLists.txt
+++ b/cpp/binary/pilot/CMakeLists.txt
@@ -132,13 +132,23 @@ if(CLANG_TIDY_EXE)
     endif()
 endif()
 
+string(
+    CONCAT
+    PILOT_CLANG_TIDY_DIFF_COMMAND
+    "test -n \"$MODMESH_DIFF_BASE\""
+    " && "
+    "git diff --no-color -U0 \"$MODMESH_DIFF_BASE\" HEAD"
+    " -- $<JOIN:${MODMESH_PILOT_FILES}, >"
+    " | "
+    "\"${CLANG_TIDY_DIFF_EXE}\" -p1"
+    " -path \"${CMAKE_BINARY_DIR}\""
+    " -config-file \"${PROJECT_ROOT_DIR}/.clang-tidy\""
+)
+
 add_custom_target(
     pilot_clang_tidy_diff
     COMMAND
-        bash
-        -e
-        -o pipefail
-        -c "test -n \"$MODMESH_DIFF_BASE\"; git diff --no-color -U0 \"$MODMESH_DIFF_BASE\" HEAD -- $<JOIN:${MODMESH_PILOT_FILES}, > | \"${CLANG_TIDY_DIFF_EXE}\" -p1 -path \"${CMAKE_BINARY_DIR}\" -config-file \"${PROJECT_ROOT_DIR}/.clang-tidy\""
+        bash -e -o pipefail -c "${PILOT_CLANG_TIDY_DIFF_COMMAND}"
     WORKING_DIRECTORY ${PROJECT_ROOT_DIR}
     VERBATIM
 )


### PR DESCRIPTION
Related to #676.

This PR introduces a diff-based `pilot_clang_tidy_diff` target for pull
request linting. The target runs clang-tidy-diff.py against pilot files
changed from `MODMESH_DIFF_BASE`.

PR lint jobs now use this target, while non-PR lint jobs continue running the
full `make pilot` and `make run_pilot_pytest`.