### PR TITLE
Supplement GradientElement metrics (issue #66 phase 2.2)

### DIFF
--- a/cpp/modmesh/mesh/StaticMesh_boundary.cpp
+++ b/cpp/modmesh/mesh/StaticMesh_boundary.cpp
@@ -426,15 +426,15 @@ inline void StaticMesh::fill_ghost()
                 m_fcnml(ifc, 2) += radvec[ind - 1][0] * radvec[ind][1] - radvec[ind - 1][1] * radvec[ind][0];
             }
             // compute face area.
-            m_fcara(ifc, 0) = std::sqrt(
+            m_fcara(ifc) = std::sqrt(
                 m_fcnml(ifc, 0) * m_fcnml(ifc, 0) + m_fcnml(ifc, 1) * m_fcnml(ifc, 1) + m_fcnml(ifc, 2) * m_fcnml(ifc, 2));
             // NOLINTEND(readability-math-missing-parentheses)
             // normalize normal vector.
-            m_fcnml(ifc, 0) /= m_fcnml(ifc);
-            m_fcnml(ifc, 1) /= m_fcnml(ifc);
-            m_fcnml(ifc, 2) /= m_fcnml(ifc);
+            m_fcnml(ifc, 0) /= m_fcara(ifc);
+            m_fcnml(ifc, 1) /= m_fcara(ifc);
+            m_fcnml(ifc, 2) /= m_fcara(ifc);
             // get real face area.
-            m_fcnml(ifc) /= 2.0;
+            m_fcara(ifc) /= 2.0;
         }
     }
 

--- a/cpp/modmesh/multidim/GradientElement.cpp
+++ b/cpp/modmesh/multidim/GradientElement.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
+ * Copyright (c) 2018, Yung-Yu Chen <yyc@solvcon.net>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -42,6 +42,7 @@ GradientElementTypeGroup::GradientElementTypeGroup()
     GradientElementType & q = m_types[CellType::QUADRILATERAL];
     q.clnfc = 4;
     q.nfge = 4;
+    q.nfge_inverse = 1.0 / 4;
     q.faces[0] = {1, 2, -1};
     q.faces[1] = {2, 3, -1};
     q.faces[2] = {3, 4, -1};
@@ -50,6 +51,7 @@ GradientElementTypeGroup::GradientElementTypeGroup()
     GradientElementType & t = m_types[CellType::TRIANGLE];
     t.clnfc = 3;
     t.nfge = 3;
+    t.nfge_inverse = 1.0 / 3;
     t.faces[0] = {1, 2, -1};
     t.faces[1] = {2, 3, -1};
     t.faces[2] = {3, 1, -1};
@@ -57,6 +59,7 @@ GradientElementTypeGroup::GradientElementTypeGroup()
     GradientElementType & h = m_types[CellType::HEXAHEDRON];
     h.clnfc = 6;
     h.nfge = 8;
+    h.nfge_inverse = 1.0 / 8;
     h.faces[0] = {2, 3, 5};
     h.faces[1] = {6, 3, 2};
     h.faces[2] = {4, 3, 6};
@@ -69,6 +72,7 @@ GradientElementTypeGroup::GradientElementTypeGroup()
     GradientElementType & e = m_types[CellType::TETRAHEDRON];
     e.clnfc = 4;
     e.nfge = 4;
+    e.nfge_inverse = 1.0 / 4;
     e.faces[0] = {3, 1, 2};
     e.faces[1] = {2, 1, 4};
     e.faces[2] = {4, 1, 3};
@@ -77,6 +81,7 @@ GradientElementTypeGroup::GradientElementTypeGroup()
     GradientElementType & p = m_types[CellType::PRISM];
     p.clnfc = 5;
     p.nfge = 6;
+    p.nfge_inverse = 1.0 / 6;
     p.faces[0] = {5, 2, 4};
     p.faces[1] = {3, 2, 5};
     p.faces[2] = {4, 2, 3};
@@ -87,6 +92,7 @@ GradientElementTypeGroup::GradientElementTypeGroup()
     GradientElementType & y = m_types[CellType::PYRAMID];
     y.clnfc = 5;
     y.nfge = 6;
+    y.nfge_inverse = 1.0 / 6;
     y.faces[0] = {1, 5, 2};
     y.faces[1] = {2, 5, 3};
     y.faces[2] = {3, 5, 4};
@@ -168,6 +174,8 @@ GradientElement::GradientElement(
         throw std::invalid_argument("GradientElement: ndim must be 2 or 3");
     }
 
+    m_getype = &getype(mesh.cltpn(icl));
+
     size_t const ndim = m_ndim;
 
     // Self CE centroid.
@@ -212,7 +220,7 @@ GradientElement::GradientElement(
     }
 
     // GGE centroid via sub-element triangulation.
-    GradientElementType const & ge = getype(mesh.cltpn(icl));
+    GradientElementType const & ge = *m_getype;
     std::array<real_type, 3> const cnd = detail::calc_gge_centroid(ge, avg, gp, ndim);
 
     // Shift so the GGE centroid coincides with the self CE
@@ -225,6 +233,83 @@ GradientElement::GradientElement(
             m_jdis[ifl][d] = jd[ifl][d] + icecnd[d] - cnd[d];
         }
     }
+}
+
+GradientElement::real_type GradientElement::determinant(ge_matrix_type const & a, size_t ndim)
+{
+    if (2 == ndim)
+    {
+        return a[0][0] * a[1][1] - a[0][1] * a[1][0];
+    }
+    // clang-format off
+    return a[0][0] * (a[1][1] * a[2][2] - a[1][2] * a[2][1])
+         - a[0][1] * (a[1][0] * a[2][2] - a[1][2] * a[2][0])
+         + a[0][2] * (a[1][0] * a[2][1] - a[1][1] * a[2][0]);
+    // clang-format on
+}
+
+GradientElement::ge_matrix_type GradientElement::adjugate(ge_matrix_type const & a, size_t ndim)
+{
+    ge_matrix_type r = {};
+    if (2 == ndim)
+    {
+        r[0][0] = a[1][1];
+        r[0][1] = -a[0][1];
+        r[1][0] = -a[1][0];
+        r[1][1] = a[0][0];
+        return r;
+    }
+    r[0][0] = a[1][1] * a[2][2] - a[1][2] * a[2][1];
+    r[0][1] = a[0][2] * a[2][1] - a[0][1] * a[2][2];
+    r[0][2] = a[0][1] * a[1][2] - a[0][2] * a[1][1];
+    r[1][0] = a[1][2] * a[2][0] - a[1][0] * a[2][2];
+    r[1][1] = a[0][0] * a[2][2] - a[0][2] * a[2][0];
+    r[1][2] = a[0][2] * a[1][0] - a[0][0] * a[1][2];
+    r[2][0] = a[1][0] * a[2][1] - a[1][1] * a[2][0];
+    r[2][1] = a[0][1] * a[2][0] - a[0][0] * a[2][1];
+    r[2][2] = a[0][0] * a[1][1] - a[0][1] * a[1][0];
+    return r;
+}
+
+GradientElement::ge_vector_type GradientElement::multiply(ge_matrix_type const & a, ge_vector_type const & x, size_t ndim)
+{
+    ge_vector_type r = {0, 0, 0};
+    for (size_t i = 0; i < ndim; ++i)
+    {
+        for (size_t j = 0; j < ndim; ++j)
+        {
+            r[i] += a[i][j] * x[j];
+        }
+    }
+    return r;
+}
+
+GradientElement::ge_matrix_type GradientElement::displacement_matrix(int_type ifge) const
+{
+    ge_matrix_type dst = {};
+    GradientElementType::face_list_type const & tface = m_getype->faces[ifge];
+    for (size_t ivx = 0; ivx < m_ndim; ++ivx)
+    {
+        int_type const ifl = tface[ivx] - 1;
+        for (size_t d = 0; d < m_ndim; ++d)
+        {
+            dst[ivx][d] = m_idis[ifl][d];
+        }
+    }
+    return dst;
+}
+
+GradientElement::ge_vector_type GradientElement::solve_gradient(int_type ifge, ge_vector_type const & udf) const
+{
+    ge_matrix_type const dst = displacement_matrix(ifge);
+    ge_vector_type const adjudf = multiply(adjugate(dst, m_ndim), udf, m_ndim);
+    real_type const det = determinant(dst, m_ndim);
+    ge_vector_type grad = {0, 0, 0};
+    for (size_t d = 0; d < m_ndim; ++d)
+    {
+        grad[d] = adjudf[d] / det;
+    }
+    return grad;
 }
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/multidim/GradientElement.hpp
+++ b/cpp/modmesh/multidim/GradientElement.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
+ * Copyright (c) 2018, Yung-Yu Chen <yyc@solvcon.net>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -50,6 +50,8 @@ struct GradientElementType
 
     int32_t clnfc = -1;
     int32_t nfge = -1;
+    // Reciprocal of nfge, used as the uniform gradient-weighting baseline.
+    double nfge_inverse = 0.0;
     // 1-based indices into the per-cell gradient-eval-point array.
     std::array<face_list_type, NFGE_MAX> faces = {};
 
@@ -93,6 +95,11 @@ public:
 
     using int_type = int32_t;
     using real_type = double;
+    // Fixed 3-capacity row-major matrix/vector for the leading ndim x ndim
+    // (ndim is 2 or 3) systems of the gradient reconstruction.  Distinct from
+    // the dynamic modmesh::small_vector container.
+    using ge_vector_type = std::array<real_type, 3>;
+    using ge_matrix_type = std::array<ge_vector_type, 3>;
 
     GradientElement(
         StaticMesh const & mesh,
@@ -107,8 +114,37 @@ public:
     real_type idis(int_type ifl, int_type d) const { return m_idis[ifl][d]; }
     real_type jdis(int_type ifl, int_type d) const { return m_jdis[ifl][d]; }
 
+    // Number of fundamental gradient elements (sub-simplices) of this cell.
+    int_type nfge() const { return m_getype->nfge; }
+    real_type nfge_inverse() const { return m_getype->nfge_inverse; }
+    // 1-based face indices forming the ifge-th fundamental gradient element.
+    // Only the leading ndim entries are valid; the rest are -1 sentinels.
+    GradientElementType::face_list_type const & faces(int_type ifge) const
+    {
+        return m_getype->faces[ifge];
+    }
+    // Displacement matrix of the ifge-th fundamental gradient element: row ivx
+    // is idis of the face faces(ifge)[ivx].  Only the leading ndim x ndim block
+    // is meaningful.
+    ge_matrix_type displacement_matrix(int_type ifge) const;
+    // Reconstruct the ndim-vector gradient of one fundamental gradient element
+    // from the supplied solution deltas udf by solving (displacement matrix) *
+    // grad = udf, i.e. grad = adjugate(dst) * udf / determinant(dst).
+    ge_vector_type solve_gradient(int_type ifge, ge_vector_type const & udf) const;
+
+    // Small dense linear algebra on the leading ndim x ndim block (ndim is 2 or
+    // 3); modmesh/linalg only wraps the dynamic BLAS/LAPACK routines, too heavy
+    // for these per-cell solves.  Static, as they depend solely on their
+    // arguments, which keeps them directly testable.
+    static real_type determinant(ge_matrix_type const & a, size_t ndim);
+    static ge_matrix_type adjugate(ge_matrix_type const & a, size_t ndim);
+    static ge_vector_type multiply(ge_matrix_type const & a, ge_vector_type const & x, size_t ndim);
+
 private:
 
+    // Geometry type table (sub-element face lists) for this cell's type.  Points
+    // into a process-wide singleton, so it outlives every GradientElement.
+    GradientElementType const * m_getype = nullptr;
     // Index of the self cell that owns this gradient element.
     int_type m_icl;
     // Number of spatial dimensions (2 or 3).

--- a/cpp/modmesh/multidim/pymod/wrap_multidim.cpp
+++ b/cpp/modmesh/multidim/pymod/wrap_multidim.cpp
@@ -27,6 +27,7 @@
  */
 
 #include <modmesh/python/common.hpp> // Must be the first include.
+#include <pybind11/stl.h>
 
 #include <modmesh/multidim/multidim.hpp>
 
@@ -52,8 +53,12 @@ protected:
 
     WrapGradientElement(pybind11::module & mod, const char * pyname, const char * clsdoc);
 
+    WrapGradientElement & wrap_management();
+    WrapGradientElement & wrap_gradient();
+
     static void check_ifl(wrapped_type const & self, wrapped_type::int_type ifl);
     static void check_d(wrapped_type const & self, wrapped_type::int_type d);
+    static void check_ifge(wrapped_type const & self, wrapped_type::int_type ifge);
 
 }; /* end class WrapGradientElement */
 
@@ -75,8 +80,26 @@ void WrapGradientElement::check_d(wrapped_type const & self, wrapped_type::int_t
     }
 }
 
+void WrapGradientElement::check_ifge(wrapped_type const & self, wrapped_type::int_type ifge)
+{
+    if (ifge < 0 || ifge >= self.nfge())
+    {
+        throw std::out_of_range(std::format(
+            "GradientElement: ifge {} out of range [0, {})", ifge, self.nfge()));
+    }
+}
+
 WrapGradientElement::WrapGradientElement(pybind11::module & mod, const char * pyname, const char * clsdoc)
     : base_type(mod, pyname, clsdoc)
+{
+    (*this)
+        .wrap_management()
+        .wrap_gradient()
+        //
+        ;
+}
+
+WrapGradientElement & WrapGradientElement::wrap_management()
 {
     namespace py = pybind11;
 
@@ -98,6 +121,19 @@ WrapGradientElement::WrapGradientElement(pybind11::module & mod, const char * py
         .def_property_readonly("icl", &wrapped_type::icl)
         .def_property_readonly("ndim", &wrapped_type::ndim)
         .def_property_readonly("clnfc", &wrapped_type::clnfc)
+        .def_property_readonly("nfge", &wrapped_type::nfge)
+        .def_property_readonly("nfge_inverse", &wrapped_type::nfge_inverse)
+        //
+        ;
+
+    return *this;
+}
+
+WrapGradientElement & WrapGradientElement::wrap_gradient()
+{
+    namespace py = pybind11;
+
+    (*this)
         .def(
             "rcl",
             [](wrapped_type const & self, wrapped_type::int_type ifl)
@@ -126,8 +162,72 @@ WrapGradientElement::WrapGradientElement(pybind11::module & mod, const char * py
             },
             py::arg("ifl"),
             py::arg("d"))
+        .def(
+            "faces",
+            [](wrapped_type const & self, wrapped_type::int_type ifge)
+            {
+                check_ifge(self, ifge);
+                auto const & tface = self.faces(ifge);
+                std::vector<wrapped_type::int_type> out(self.ndim());
+                for (uint8_t ivx = 0; ivx < self.ndim(); ++ivx)
+                {
+                    out[ivx] = tface[ivx];
+                }
+                return out;
+            },
+            py::arg("ifge"))
+        .def(
+            "displacement_matrix",
+            [](wrapped_type const & self, wrapped_type::int_type ifge)
+            {
+                check_ifge(self, ifge);
+                auto const dst = self.displacement_matrix(ifge);
+                size_t const nd = self.ndim();
+                std::vector<std::vector<wrapped_type::real_type>> out(
+                    nd, std::vector<wrapped_type::real_type>(nd));
+                for (size_t i = 0; i < nd; ++i)
+                {
+                    for (size_t j = 0; j < nd; ++j)
+                    {
+                        out[i][j] = dst[i][j];
+                    }
+                }
+                return out;
+            },
+            py::arg("ifge"))
+        .def(
+            "solve_gradient",
+            [](wrapped_type const & self,
+               wrapped_type::int_type ifge,
+               std::vector<wrapped_type::real_type> const & udf)
+            {
+                check_ifge(self, ifge);
+                if (udf.size() != self.ndim())
+                {
+                    throw std::invalid_argument(std::format(
+                        "GradientElement: udf size {} must equal ndim {}",
+                        udf.size(),
+                        self.ndim()));
+                }
+                wrapped_type::ge_vector_type u = {0, 0, 0};
+                for (size_t d = 0; d < self.ndim(); ++d)
+                {
+                    u[d] = udf[d];
+                }
+                wrapped_type::ge_vector_type const g = self.solve_gradient(ifge, u);
+                std::vector<wrapped_type::real_type> out(self.ndim());
+                for (size_t d = 0; d < self.ndim(); ++d)
+                {
+                    out[d] = g[d];
+                }
+                return out;
+            },
+            py::arg("ifge"),
+            py::arg("udf"))
         //
         ;
+
+    return *this;
 }
 
 class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapEulerCore

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -34,11 +34,14 @@ add_executable(
     test_nopython_rtree.cpp
     test_nopython_formatter.cpp
     test_nopython_mdspan.cpp
+    test_nopython_multidim.cpp
     ${MODMESH_TOGGLE_SOURCES}
     ${MODMESH_BUFFER_SOURCES}
     ${MODMESH_SERIALIZATION_SOURCES}
     ${MODMESH_TRANSFORM_SOURCES}
     ${MODMESH_SIMD_SOURCES}
+    ${MODMESH_MESH_SOURCES}
+    ${MODMESH_MULTIDIM_SOURCES}
 )
 
 target_link_libraries(
@@ -54,3 +57,5 @@ gtest_discover_tests(test_nopython)
 add_custom_target(run_gtest
     COMMAND $<TARGET_FILE:test_nopython>
     DEPENDS test_nopython)
+
+# vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/gtests/test_nopython_multidim.cpp
+++ b/gtests/test_nopython_multidim.cpp
@@ -1,0 +1,198 @@
+#include <modmesh/modmesh.hpp>
+#include <modmesh/multidim/multidim.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#ifdef Py_PYTHON_H
+#error "Python.h should not be included."
+#endif
+
+using namespace modmesh;
+
+namespace
+{
+
+std::shared_ptr<StaticMesh> build_mesh(
+    uint8_t ndim,
+    std::vector<std::array<double, 3>> const & coords,
+    std::vector<int32_t> const & cltpn,
+    std::vector<std::vector<int32_t>> const & clnds)
+{
+    auto const nnode = static_cast<StaticMesh::uint_type>(coords.size());
+    auto const ncell = static_cast<StaticMesh::uint_type>(cltpn.size());
+    auto mh = StaticMesh::construct(ndim, nnode, StaticMesh::uint_type(0), ncell);
+    for (StaticMesh::uint_type ind = 0; ind < nnode; ++ind)
+    {
+        for (uint8_t d = 0; d < ndim; ++d)
+        {
+            mh->ndcrd(ind, d) = coords[ind][d];
+        }
+    }
+    for (StaticMesh::uint_type icl = 0; icl < ncell; ++icl)
+    {
+        mh->cltpn(icl) = cltpn[icl];
+        for (size_t j = 0; j < clnds[icl].size(); ++j)
+        {
+            mh->clnds(static_cast<int32_t>(icl), static_cast<int32_t>(j)) = clnds[icl][j];
+        }
+    }
+    mh->build_interior(true);
+    mh->build_boundary();
+    mh->build_ghost();
+    return mh;
+}
+
+// Unit-square quadrilateral.
+std::shared_ptr<StaticMesh> make_quad()
+{
+    return build_mesh(
+        2,
+        {{0, 0, 0}, {1, 0, 0}, {1, 1, 0}, {0, 1, 0}},
+        {CellType::QUADRILATERAL},
+        {{4, 0, 1, 2, 3}});
+}
+
+// Three triangles around the origin.
+std::shared_ptr<StaticMesh> make_triangles()
+{
+    return build_mesh(
+        2,
+        {{0, 0, 0}, {-1, -1, 0}, {1, -1, 0}, {0, 1, 0}},
+        {CellType::TRIANGLE, CellType::TRIANGLE, CellType::TRIANGLE},
+        {{3, 0, 1, 2}, {3, 0, 2, 3}, {3, 0, 3, 1}});
+}
+
+// One quadrilateral and two triangles.
+std::shared_ptr<StaticMesh> make_mixed()
+{
+    return build_mesh(
+        2,
+        {{0, 0, 0}, {1, 0, 0}, {2, 0, 0}, {0, 1, 0}, {1, 1, 0}, {2, 1, 0}},
+        {CellType::QUADRILATERAL, CellType::TRIANGLE, CellType::TRIANGLE},
+        {{4, 0, 1, 4, 3}, {3, 1, 2, 4, 0}, {3, 2, 5, 4, 0}});
+}
+
+} /* end namespace */
+
+TEST(Multidim, ge_linalg_2d)
+{
+    GradientElement::ge_matrix_type a = {};
+    a[0] = {2, 1, 0};
+    a[1] = {1, 3, 0};
+
+    EXPECT_DOUBLE_EQ(5.0, GradientElement::determinant(a, 2));
+
+    GradientElement::ge_matrix_type const adj = GradientElement::adjugate(a, 2);
+    EXPECT_DOUBLE_EQ(3.0, adj[0][0]);
+    EXPECT_DOUBLE_EQ(-1.0, adj[0][1]);
+    EXPECT_DOUBLE_EQ(-1.0, adj[1][0]);
+    EXPECT_DOUBLE_EQ(2.0, adj[1][1]);
+
+    // GradientElement::adjugate(a) * a == GradientElement::determinant(a) * I.
+    for (size_t i = 0; i < 2; ++i)
+    {
+        GradientElement::ge_vector_type const col = {a[0][i], a[1][i], 0};
+        GradientElement::ge_vector_type const r = GradientElement::multiply(adj, col, 2);
+        EXPECT_NEAR((0 == i) ? 5.0 : 0.0, r[0], 1e-12);
+        EXPECT_NEAR((1 == i) ? 5.0 : 0.0, r[1], 1e-12);
+    }
+}
+
+TEST(Multidim, ge_linalg_3d)
+{
+    GradientElement::ge_matrix_type a = {};
+    a[0] = {1, 2, 3};
+    a[1] = {0, 1, 4};
+    a[2] = {5, 6, 0};
+
+    EXPECT_DOUBLE_EQ(1.0, GradientElement::determinant(a, 3));
+
+    GradientElement::ge_matrix_type const adj = GradientElement::adjugate(a, 3);
+    GradientElement::ge_matrix_type const expect = {{{-24, 18, 5}, {20, -15, -4}, {-5, 4, 1}}};
+    for (size_t i = 0; i < 3; ++i)
+    {
+        for (size_t j = 0; j < 3; ++j)
+        {
+            EXPECT_DOUBLE_EQ(expect[i][j], adj[i][j]);
+        }
+    }
+
+    // Solve a x = b via x = GradientElement::adjugate(a) b / det(a) and verify a x == b.
+    GradientElement::ge_vector_type const b = {6, -1, 2};
+    GradientElement::ge_vector_type const adjb = GradientElement::multiply(adj, b, 3);
+    double const det = GradientElement::determinant(a, 3);
+    GradientElement::ge_vector_type const x = {adjb[0] / det, adjb[1] / det, adjb[2] / det};
+    GradientElement::ge_vector_type const ax = GradientElement::multiply(a, x, 3);
+    for (size_t i = 0; i < 3; ++i)
+    {
+        EXPECT_NEAR(b[i], ax[i], 1e-12);
+    }
+}
+
+TEST(Multidim, displacement_matrix_nonsingular)
+{
+    std::vector<std::shared_ptr<StaticMesh>> const meshes = {
+        make_quad(), make_triangles(), make_mixed()};
+    for (auto const & mh : meshes)
+    {
+        auto const ec = EulerCore::construct(mh, 0.01);
+        SimpleArray<double> const & cecnd = ec->cecnd();
+        for (int32_t icl = 0; icl < static_cast<int32_t>(mh->ncell()); ++icl)
+        {
+            GradientElement const ge(*mh, cecnd, icl, 1.0);
+            for (int32_t ifge = 0; ifge < ge.nfge(); ++ifge)
+            {
+                GradientElement::ge_matrix_type const dst = ge.displacement_matrix(ifge);
+                EXPECT_GT(std::fabs(GradientElement::determinant(dst, mh->ndim())), 1e-10)
+                    << "singular FGE matrix: cell " << icl << " ifge " << ifge;
+            }
+        }
+    }
+}
+
+TEST(Multidim, solve_gradient_linear_field)
+{
+    // For a linear field u(x) = c + g . x, the solution delta at each gradient
+    // evaluation point is exactly g . idis, so the reconstructed gradient must
+    // recover g exactly (up to round-off).
+    GradientElement::ge_vector_type const g = {1.5, -2.7, 0.0};
+    std::vector<std::shared_ptr<StaticMesh>> const meshes = {
+        make_quad(), make_triangles(), make_mixed()};
+    for (auto const & mh : meshes)
+    {
+        size_t const ndim = mh->ndim();
+        auto const ec = EulerCore::construct(mh, 0.01);
+        SimpleArray<double> const & cecnd = ec->cecnd();
+        for (int32_t icl = 0; icl < static_cast<int32_t>(mh->ncell()); ++icl)
+        {
+            GradientElement const ge(*mh, cecnd, icl, 1.0);
+            for (int32_t ifge = 0; ifge < ge.nfge(); ++ifge)
+            {
+                GradientElement::ge_matrix_type const dst = ge.displacement_matrix(ifge);
+                auto const & tface = ge.faces(ifge);
+                // Displacement-matrix rows must equal the per-face idis vectors.
+                for (size_t ivx = 0; ivx < ndim; ++ivx)
+                {
+                    for (size_t d = 0; d < ndim; ++d)
+                    {
+                        EXPECT_DOUBLE_EQ(ge.idis(tface[ivx] - 1, static_cast<int32_t>(d)), dst[ivx][d]);
+                    }
+                }
+                GradientElement::ge_vector_type const udf = GradientElement::multiply(dst, g, ndim);
+                GradientElement::ge_vector_type const got = ge.solve_gradient(ifge, udf);
+                for (size_t d = 0; d < ndim; ++d)
+                {
+                    EXPECT_NEAR(g[d], got[d], 1e-9)
+                        << "cell " << icl << " ifge " << ifge << " dim " << d;
+                }
+            }
+        }
+    }
+}
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_multidim.py
+++ b/tests/test_multidim.py
@@ -139,7 +139,7 @@ class _PyramidMeshBase(unittest.TestCase):
 
 
 class _GradientElementBoundsBase:
-    """Checks that hold even when CE geometry is NaN (no value reads)."""
+    """Structural checks that do not read CE geometry values."""
 
     def _ge(self, icl, tau=1.0):
         mh, cecnd = self.mesh, self.ec.cecnd
@@ -177,23 +177,37 @@ class _GradientElementBoundsBase:
             with self.assertRaises(IndexError):
                 ge.jdis(0, d)
 
+    def test_fge_table(self):
+        # Sub-element (FGE) table is geometry-free; it holds even when the
+        # CE geometry is NaN.
+        ge = self._ge(0)
+        nfge = ge.nfge
+        self.assertGreater(nfge, 0)
+        assert_almost_equal(ge.nfge_inverse, 1.0 / nfge, decimal=12)
+        for ifge in range(nfge):
+            faces = ge.faces(ifge)
+            self.assertEqual(self.mesh.ndim, len(faces))
+            for ifl in faces:
+                # 1-based face index into the per-cell face list.
+                self.assertGreaterEqual(ifl, 1)
+                self.assertLessEqual(ifl, ge.clnfc)
+
+    def test_ifge_bounds(self):
+        ge = self._ge(0)
+        nd = self.mesh.ndim
+        for ifge in (-1, ge.nfge):
+            with self.assertRaises(IndexError):
+                ge.faces(ifge)
+            with self.assertRaises(IndexError):
+                ge.displacement_matrix(ifge)
+            with self.assertRaises(IndexError):
+                ge.solve_gradient(ifge, [0.0] * nd)
+
 
 class _GradientElementBase(_GradientElementBoundsBase):
-    """Adds geometry tests that need non-NaN CE data over all cells."""
-
-    # A single 3D cell has only boundary faces, so its ghost-neighbor CE
-    # geometry (and thus its own CE centroid) is NaN until the fill_ghost
-    # bug is fixed.  Such fixtures set this False to skip the value tests;
-    # construction, basic-property and index-bound tests still run.
-    run_geometry = True
-
-    def _require_geometry(self):
-        if not self.run_geometry:
-            self.skipTest(
-                "3D single-cell ghost CE geometry is NaN (fill_ghost bug)")
+    """Adds geometry tests that read CE data over all cells."""
 
     def test_displacement_matrix_nonsingular(self):
-        self._require_geometry()
         nd = self.mesh.ndim
         for icl in range(self.mesh.ncell):
             ge = self._ge(icl)
@@ -207,7 +221,6 @@ class _GradientElementBase(_GradientElementBoundsBase):
                              f"cell {icl}: idis does not span {nd}D")
 
     def test_idis_jdis_consistency(self):
-        self._require_geometry()
         mh, cecnd, nd = self.mesh, self.ec.cecnd, self.mesh.ndim
         for icl in range(mh.ncell):
             ge = self._ge(icl)
@@ -219,7 +232,6 @@ class _GradientElementBase(_GradientElementBoundsBase):
                     assert_almost_equal(lhs, ge.jdis(ifl, d) + jce, decimal=12)
 
     def test_tau_zero(self):
-        self._require_geometry()
         mh, cecnd, nd = self.mesh, self.ec.cecnd, self.mesh.ndim
         for icl in range(mh.ncell):
             ge = self._ge(icl, tau=0.0)
@@ -230,6 +242,37 @@ class _GradientElementBase(_GradientElementBoundsBase):
                     pos = ge.idis(ifl, d) + cecnd[icl, d]
                     bce = cecnd[icl, (ifl + 1) * nd + d]
                     assert_almost_equal(pos, bce + shift[d], decimal=12)
+
+    def test_displacement_matrix_per_fge_nonsingular(self):
+        nd = self.mesh.ndim
+        for icl in range(self.mesh.ncell):
+            ge = self._ge(icl)
+            for ifge in range(ge.nfge):
+                mat = np.array(ge.displacement_matrix(ifge))
+                self.assertEqual((nd, nd), mat.shape)
+                self.assertGreater(
+                    abs(np.linalg.det(mat)), 1e-10,
+                    f"cell {icl} ifge {ifge}: singular FGE matrix")
+
+    def test_solve_gradient_linear_field(self):
+        # For a linear field u(x) = c + g . x the solution delta at each
+        # gradient evaluation point is exactly g . idis, so the per-FGE
+        # solve must recover g exactly (up to round-off).
+        nd = self.mesh.ndim
+        grad = np.array([1.5, -2.7, 0.9][:nd])
+        for icl in range(self.mesh.ncell):
+            ge = self._ge(icl)
+            for ifge in range(ge.nfge):
+                dst = np.array(ge.displacement_matrix(ifge))
+                faces = ge.faces(ifge)
+                # Matrix rows are the per-face idis vectors.
+                for ivx, ifl in enumerate(faces):
+                    for d in range(nd):
+                        assert_almost_equal(
+                            dst[ivx, d], ge.idis(ifl - 1, d), decimal=12)
+                udf = dst @ grad
+                got = np.array(ge.solve_gradient(ifge, udf.tolist()))
+                assert_almost_equal(got, grad, decimal=9)
 
 
 class GradientElementTriangleTC(_GradientElementBase, _TriangleMeshBase):
@@ -244,29 +287,20 @@ class GradientElementMixedTC(_GradientElementBase, _MixedMeshBase):
     """Per-cell GradientElement on a 2D mixed mesh."""
 
 
-# 3D single-cell meshes: every face is a boundary face, so the ghost
-# neighbor CE geometry (hence the cell's own CE centroid) is NaN until the
-# fill_ghost bug is fixed.  Construction, basic properties and index bounds
-# still hold; the geometry-value tests skip via run_geometry.
-
 class GradientElementTetrahedronTC(_GradientElementBase, _TetrahedronMeshBase):
     """Per-cell GradientElement on a single tetrahedron (4 faces)."""
-    run_geometry = False
 
 
 class GradientElementHexahedronTC(_GradientElementBase, _HexahedronMeshBase):
     """Per-cell GradientElement on a single hexahedron (6 faces)."""
-    run_geometry = False
 
 
 class GradientElementPrismTC(_GradientElementBase, _PrismMeshBase):
     """Per-cell GradientElement on a single prism (5 faces)."""
-    run_geometry = False
 
 
 class GradientElementPyramidTC(_GradientElementBase, _PyramidMeshBase):
     """Per-cell GradientElement on a single pyramid (5 faces)."""
-    run_geometry = False
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Give `GradientElement` the geometry and linear algebra to reconstruct a gradient from supplied solution deltas, ported from solvcon's mesh/ConservationElement/GradientElement.hpp (calc_displacement_matrix, nfge, nfge_inverse, faces) and gas/derivative.hpp (grad = adjugate(dst) * udf / det(dst)).

- New GradientElement API: nfge(), nfge_inverse(), faces(ifge), displacement_matrix(ifge), solve_gradient(ifge, udf); GradientElementType gains nfge_inverse.
- Fixed-size 2x2/3x3 determinant, adjugate and matrix-vector product as static GradientElement members over the nested ge_matrix_type / ge_vector_type aliases (modmesh/linalg only wraps the dynamic BLAS/LAPACK routines, too heavy for these per-cell solves).
- pybind11 bindings split into wrap_management (construction and scalar properties) and wrap_gradient (per-face and per-FGE accessors), mirroring WrapEulerCore.
- Tests: C++ gtest suite Multidim (small-matrix math, per-FGE non-singularity, exact linear-field reconstruction) and matching Python tests in test_multidim.py, covering 2D and 3D cells (3D relies on the preceding fill_ghost fix).

Also fix the 3D ghost face metric in `StaticMesh::fill_ghost()`.  It computed 3D ghost-face normals and areas with the wrong array indexing.  (It looks like a copy-paste error from `calc_metric`.)

For issue #66.