### PR TITLE
Document Python-first testing and Numpy dtype conventions

### DIFF
--- a/.claude/skills/python-style-review/SKILL.md
+++ b/.claude/skills/python-style-review/SKILL.md
@@ -31,6 +31,10 @@ limit, flake8) are handled by `.claude/hooks/check-source.sh`
 - No venv/conda code paths (modmesh targets system Python).
 - Tests live in `tests/` and are named `test_*.py`.
 - Profiling scripts live in `profiling/` and are named `profile_*.py`.
+- NumPy arrays: always create with an explicit `dtype` spelled as a string,
+  e.g. `np.empty(10, dtype='float64')`. Flag array-creating calls (`np.empty`,
+  `np.zeros`, `np.ones`, `np.full`, `np.array`, `np.arange`, etc.) that omit
+  `dtype` or pass a type object (`dtype=np.float64`) instead of a string.
 
 **Line economy**
 - Prefer fewer lines per STYLE.md. Flag unnecessary blank lines inside

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,9 +163,16 @@ Python interface in `modmesh/`:
 
 ### Testing Structure
 
-- **Python tests** (`tests/`): pytest-based, files named `test_*.py`.
+Python tests are the default. Prefer writing tests in Python (`tests/`); reach
+for C++ gtest only when the code cannot or should not be exercised from Python
+-- for example, internals with no Python binding, or behavior that must be
+verified at the C++ level.
+
+- **Python tests** (`tests/`): pytest-based, files named `test_*.py`. The
+  preferred place for tests.
 - **C++ tests** (`gtests/`): googletest-based, files named
-  `test_nopython_*.cpp`.
+  `test_nopython_*.cpp`. Use only when Python cannot or should not reach the
+  code under test.
 - **Profiling benchmarks** (`profiling/`): files named `profile_*.py`.
 
 See "Build, Test, Lint, Format" above for the `make` invocations.
@@ -269,7 +276,8 @@ The pilot application (`cpp/binary/pilot/`) is a standalone Qt6-based viewer:
 2. Add header files with proper include guards.
 3. Update `cpp/modmesh/CMakeLists.txt` to include new sources.
 4. Add pybind11 bindings if Python access is needed.
-5. Write tests in both `gtests/` and `tests/`.
+5. Write tests. Prefer Python tests in `tests/`; add a `gtests/` test only
+   when the behavior cannot or should not be exercised from Python.
 
 ### Adding Python-Only Functionality
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -349,6 +349,42 @@ Never do implicit relative import:
 import onedim
 ```
 
+## NumPy Array Creation
+
+Always specify the `dtype` when creating a NumPy `ndarray`, and spell the
+dtype as a string. The default floating-point and integer types depend on the
+platform and the NumPy version, so an explicit dtype keeps the array layout
+deterministic and mirrors the fixed-width integer rule below.
+
+```python
+# GOOD: explicit dtype given as a string.
+a = np.empty(10, dtype='float64')
+b = np.zeros((3, 4), dtype='int32')
+c = np.array([1, 2, 3], dtype='uint8')
+
+# BAD: no dtype; the type is implicit and platform-dependent.
+a = np.empty(10)
+b = np.zeros((3, 4))
+
+# BAD: dtype given as a type object instead of a string.
+a = np.empty(10, dtype=np.float64)
+```
+
+This applies to every array-creating call (`np.empty`, `np.zeros`, `np.ones`,
+`np.full`, `np.array`, `np.arange`, etc.).
+
+## Testing
+
+Python tests are the default. Write tests in Python (`tests/`, pytest, files
+named `test_*.py`) whenever the code can be exercised through the Python
+bindings. Use C++ gtest (`gtests/`, files named `test_nopython_*.cpp`) only
+when the code cannot or should not be tested from Python -- for example,
+internals with no Python binding, or behavior that must be verified at the C++
+level. Do not duplicate the same test in both layers without a reason.
+
+A test should encode why a behavior matters, not merely what it does. A test
+that cannot fail when the logic it covers changes is not pulling its weight.
+
 ## Integer Type
 
 Use fixed-width integers (`int32_t`, `uint8_t`, etc.) Do not use the basic


### PR DESCRIPTION
Python is part of the user interface.  Testing in Python will exercise the longest code path through the architecture.  If there is not a good reason, Python tests should be preferred over C++.

Some code can only be tested in C++, then we test it in C++ using the google-test framework.

STYLE.md gains a "Testing" section, and CLAUDE.md/AGENTS.md updates "Testing Structure" for the preference of Python tests over C++ tests.

Also document how to create NumPy arrays:
- STYLE.md gains a "NumPy Array Creation" section requiring every array-creating call (np.empty, np.zeros, np.ones, np.full, np.array, np.arange, ...) to pass an explicit dtype spelled as a single-quoted string, e.g. np.empty(10, dtype='float64').
- Update python-style-review skill accordingly.

[skip-ci]