### PR TITLE
Port the Euler solution marching code (issue #66 phase 4)

### DIFF
--- a/cpp/modmesh/multidim/CMakeLists.txt
+++ b/cpp/modmesh/multidim/CMakeLists.txt
@@ -13,6 +13,8 @@ set(MODMESH_MULTIDIM_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/GradientElement.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/euler_ce.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/euler_solution.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/euler_march.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/euler_gradient.cpp
     CACHE FILEPATH "" FORCE)
 
 set(MODMESH_MULTIDIM_PYMODHEADERS

--- a/cpp/modmesh/multidim/euler.hpp
+++ b/cpp/modmesh/multidim/euler.hpp
@@ -80,6 +80,13 @@ public:
     int_type neq() const { return m_neq; }
     real_type time_increment() const { return m_time_increment; }
 
+    real_type sigma0() const { return m_sigma0; }
+    real_type taumin() const { return m_taumin; }
+    real_type tauscale() const { return m_tauscale; }
+    void set_sigma0(real_type v) { m_sigma0 = v; }
+    void set_taumin(real_type v) { m_taumin = v; }
+    void set_tauscale(real_type v) { m_tauscale = v; }
+
     SimpleArray<real_type> & cevol() { return m_cevol; }
     SimpleArray<real_type> & cecnd() { return m_cecnd; }
     SimpleArray<real_type> & sfcnd() { return m_sfcnd; }
@@ -105,6 +112,26 @@ public:
         m_so1c.swap(m_so1n);
     }
 
+    // Solution marching: calc_solt, calc_soln, calc_dsoln.
+
+    // calc_solt fills the order-0 temporal derivative so0t from the Jacobian
+    // and so1c.
+    void calc_solt();
+    // calc_soln advances the order-0 solution so0n with the CESE flux integral
+    // over the BCEs.
+    void calc_soln();
+    // calc_dsoln reconstructs the order-1 derivative so1n from a per-cell
+    // GradientElement plus the gradient weighting
+    void calc_dsoln();
+
+    // march_substep runs one CESE substep and march runs the requested number
+    // of full steps (SUBSTEP_RUN substeps per step).
+    void march_substep();
+    void march(int_type steps);
+
+    // Number of CESE substeps per full marching step.
+    static constexpr int_type SUBSTEP_RUN = 2;
+
 private:
 
     void initialize_arrays();
@@ -120,6 +147,13 @@ private:
     int_type m_ncell = 0;
     int_type m_ngstcell = 0;
     int_type m_neq = 0;
+
+    // sigma0 caps the gradient weighting
+    real_type m_sigma0 = 3.0;
+    // tau (taumin + |cfl| * tauscale) sets the per-cell gradient-element
+    // spread.
+    real_type m_taumin = 0.0;
+    real_type m_tauscale = 1.0;
 
     // CE geometry arrays.
     SimpleArray<real_type> m_cevol; // [ncell, CLMFC+1]

--- a/cpp/modmesh/multidim/euler_gradient.cpp
+++ b/cpp/modmesh/multidim/euler_gradient.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Order-1 solution marching (gradient reconstruction) for the Euler CESE
+ * solver.  calc_dsoln it builds a per-cell GradientElement, solves a gradient
+ * on every fundamental gradient element, and reduces them with the W-1/2
+ * weighting and W-3/4 limiter into the new order-1 solution so1n.
+ */
+
+#include <modmesh/multidim/euler.hpp>
+#include <modmesh/multidim/GradientElement.hpp>
+
+#include <array>
+#include <cmath>
+
+namespace modmesh
+{
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void EulerCore::calc_dsoln()
+{
+    constexpr size_t NFGE_MAX = GradientElementType::NFGE_MAX;
+    constexpr size_t NEQ_MAX = 5;
+    // Floor that keeps the inverse weighting and the sigma_max bounds finite.
+    constexpr real_type ALMOST_ZERO = 1.e-200;
+
+    size_t const ndim = m_ndim;
+    auto const neq = static_cast<size_t>(m_neq);
+    real_type const hdt = m_time_increment * 0.5;
+    auto const & msh = *m_mesh;
+
+    for (int_type icl = 0; icl < m_ncell; ++icl)
+    {
+        // Per-cell weighting cap and gradient-element spread from the CFL.
+        real_type const acfl = std::fabs(m_cflc(icl));
+        real_type const sgm0 = m_sigma0 / acfl;
+        real_type const tau = m_taumin + acfl * m_tauscale;
+
+        GradientElement const gelem(msh, m_cecnd, icl, tau);
+        int_type const nfge = gelem.nfge();
+        real_type const ofg1 = gelem.nfge_inverse();
+
+        std::array<std::array<GradientElement::ge_vector_type, NEQ_MAX>, NFGE_MAX> grad = {};
+        std::array<std::array<real_type, NEQ_MAX>, NFGE_MAX> widv = {};
+        std::array<real_type, NEQ_MAX> wacc = {};
+        std::array<real_type, NEQ_MAX> sigma_max = {};
+
+        // Per fundamental gradient element: interpolate the solution deltas,
+        // solve the gradient, and accumulate the W-1/2 weighting.
+        for (int_type ifge = 0; ifge < nfge; ++ifge)
+        {
+            GradientElementType::face_list_type const & tface = gelem.faces(ifge);
+            // Solution deltas at the gradient evaluation points: udf[ieq][ivx].
+            std::array<GradientElement::ge_vector_type, NEQ_MAX> udf = {};
+            for (size_t ivx = 0; ivx < ndim; ++ivx)
+            {
+                int_type const ifl = tface[ivx] - 1;
+                int_type const jcl = gelem.rcl(ifl);
+                for (size_t ieq = 0; ieq < neq; ++ieq)
+                {
+                    // Taylor interpolation about the neighbor cell, relative to
+                    // the self new-step solution.
+                    real_type val = m_so0c(jcl, ieq) + hdt * m_so0t(jcl, ieq) - m_so0n(icl, ieq);
+                    for (size_t d = 0; d < ndim; ++d)
+                    {
+                        val += gelem.jdis(ifl, static_cast<int_type>(d)) * m_so1c(jcl, ieq, d);
+                    }
+                    udf[ieq][ivx] = val;
+                }
+            }
+            for (size_t ieq = 0; ieq < neq; ++ieq)
+            {
+                GradientElement::ge_vector_type const g = gelem.solve_gradient(ifge, udf[ieq]);
+                grad[ifge][ieq] = g;
+                real_type sq = 0.0;
+                for (size_t d = 0; d < ndim; ++d)
+                {
+                    sq += g[d] * g[d];
+                }
+                // W-1/2 weighting (alpha = 1): inverse gradient magnitude.
+                real_type const wgt = 1.0 / std::sqrt(sq + ALMOST_ZERO);
+                wacc[ieq] += wgt;
+                widv[ifge][ieq] = wgt;
+            }
+        }
+
+        // W-3/4 limiter delta and the per-equation sigma_max cap.
+        std::array<std::array<real_type, 2>, NEQ_MAX> wpa = {}; // {max, min}
+        for (int_type ifge = 0; ifge < nfge; ++ifge)
+        {
+            for (size_t ieq = 0; ieq < neq; ++ieq)
+            {
+                real_type const wgt = widv[ifge][ieq] / wacc[ieq] - ofg1;
+                widv[ifge][ieq] = wgt;
+                wpa[ieq][0] = std::fmax(wpa[ieq][0], wgt);
+                wpa[ieq][1] = std::fmin(wpa[ieq][1], wgt);
+            }
+        }
+        for (size_t ieq = 0; ieq < neq; ++ieq)
+        {
+            real_type const sm = std::fmin(
+                (1.0 - ofg1) / (wpa[ieq][0] + ALMOST_ZERO),
+                -ofg1 / (wpa[ieq][1] - ALMOST_ZERO));
+            sigma_max[ieq] = std::fmin(sm, sgm0);
+        }
+
+        // Weighted reduction of the per-element gradients into so1n.
+        for (size_t ieq = 0; ieq < neq; ++ieq)
+        {
+            for (size_t d = 0; d < ndim; ++d)
+            {
+                m_so1n(icl, ieq, d) = 0.0;
+            }
+        }
+        for (int_type isub = 0; isub < nfge; ++isub)
+        {
+            for (size_t ieq = 0; ieq < neq; ++ieq)
+            {
+                real_type const wgt = ofg1 + sigma_max[ieq] * widv[isub][ieq];
+                for (size_t d = 0; d < ndim; ++d)
+                {
+                    m_so1n(icl, ieq, d) += wgt * grad[isub][ieq][d];
+                }
+            }
+        }
+    }
+}
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/multidim/euler_march.cpp
+++ b/cpp/modmesh/multidim/euler_march.cpp
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Order-0 solution marching for the Euler CESE solver.
+ */
+
+#include <modmesh/multidim/euler.hpp>
+
+#include <array>
+#include <stdexcept>
+
+namespace modmesh
+{
+
+namespace detail
+{
+
+// Euler flux Jacobian and flux function for one cell statea. jacos is indexed
+// [ieq][jeq][idm] and fcn is indexed [ieq][idm].
+template <size_t NDIM>
+struct EulerJacobian;
+
+template <>
+struct EulerJacobian<2>
+{
+    static constexpr size_t NEQ = 4;
+    static constexpr double TINY = 1.e-60;
+
+    std::array<std::array<std::array<double, 2>, NEQ>, NEQ> jacos = {};
+    std::array<std::array<double, 2>, NEQ> fcn = {};
+
+    void update(double gamma, std::array<double, NEQ> const & sol)
+    {
+        double const ga = gamma;
+        double const ga1 = ga - 1;
+        double const ga3 = ga - 3;
+        double const ga1h = ga1 / 2;
+        double const u1 = sol[0] + TINY;
+        double const u2 = sol[1];
+        double const u3 = sol[2];
+        double const u4 = sol[3];
+
+        double const rho2 = u1 * u1;
+        double const v1 = u2 / u1;
+        double const v1o2 = v1 * v1;
+        double const v2 = u3 / u1;
+        double const v2o2 = v2 * v2;
+        double const ke2 = (u2 * u2 + u3 * u3) / u1;
+        double const g1ke2 = ga1 * ke2;
+        double const vs = ke2 / u1;
+        double const gretot = ga * u4;
+        double const getot = gretot / u1;
+        double const pr = ga1 * u4 - ga1h * ke2;
+
+        fcn[0] = {u2, u3};
+        fcn[1] = {pr + u2 * v1, u2 * v2};
+        fcn[2] = {u3 * v1, pr + u3 * v2};
+        fcn[3] = {(pr + u4) * v1, (pr + u4) * v2};
+
+        jacos[0][0] = {0, 0};
+        jacos[0][1] = {1, 0};
+        jacos[0][2] = {0, 1};
+        jacos[0][3] = {0, 0};
+
+        jacos[1][0] = {-v1o2 + ga1h * vs, -v1 * v2};
+        jacos[1][1] = {-ga3 * v1, v2};
+        jacos[1][2] = {-ga1 * v2, v1};
+        jacos[1][3] = {ga1, 0};
+
+        jacos[2][0] = {-v2 * v1, -v2o2 + ga1h * vs};
+        jacos[2][1] = {v2, -ga1 * v1};
+        jacos[2][2] = {v1, -ga3 * v2};
+        jacos[2][3] = {0, ga1};
+
+        jacos[3][0] = {(-gretot + g1ke2) * u2 / rho2, (-gretot + g1ke2) * u3 / rho2};
+        jacos[3][1] = {getot - ga1h * (vs + 2 * v1o2), -ga1 * v1 * v2};
+        jacos[3][2] = {-ga1 * v2 * v1, getot - ga1h * (vs + 2 * v2o2)};
+        jacos[3][3] = {ga * v1, ga * v2};
+    }
+}; /* end struct EulerJacobian<2> */
+
+template <>
+struct EulerJacobian<3>
+{
+    static constexpr size_t NEQ = 5;
+    static constexpr double TINY = 1.e-60;
+
+    std::array<std::array<std::array<double, 3>, NEQ>, NEQ> jacos = {};
+    std::array<std::array<double, 3>, NEQ> fcn = {};
+
+    void update(double gamma, std::array<double, NEQ> const & sol)
+    {
+        double const ga = gamma;
+        double const ga1 = ga - 1;
+        double const ga3 = ga - 3;
+        double const ga1h = ga1 / 2;
+        double const u1 = sol[0] + TINY;
+        double const u2 = sol[1];
+        double const u3 = sol[2];
+        double const u4 = sol[3];
+        double const u5 = sol[4];
+
+        double const rho2 = u1 * u1;
+        double const v1 = u2 / u1;
+        double const v1o2 = v1 * v1;
+        double const v2 = u3 / u1;
+        double const v2o2 = v2 * v2;
+        double const v3 = u4 / u1;
+        double const v3o2 = v3 * v3;
+        double const ke2 = (u2 * u2 + u3 * u3 + u4 * u4) / u1;
+        double const g1ke2 = ga1 * ke2;
+        double const vs = ke2 / u1;
+        double const gretot = ga * u5;
+        double const getot = gretot / u1;
+        double const pr = ga1 * u5 - ga1h * ke2;
+
+        fcn[0] = {u2, u3, u4};
+        fcn[1] = {pr + u2 * v1, u2 * v2, u2 * v3};
+        fcn[2] = {u3 * v1, pr + u3 * v2, u3 * v3};
+        fcn[3] = {u4 * v1, u4 * v2, pr + u4 * v3};
+        fcn[4] = {(pr + u5) * v1, (pr + u5) * v2, (pr + u5) * v3};
+
+        jacos[0][0] = {0, 0, 0};
+        jacos[0][1] = {1, 0, 0};
+        jacos[0][2] = {0, 1, 0};
+        jacos[0][3] = {0, 0, 1};
+        jacos[0][4] = {0, 0, 0};
+
+        jacos[1][0] = {-v1o2 + ga1h * vs, -v1 * v2, -v1 * v3};
+        jacos[1][1] = {-ga3 * v1, v2, v3};
+        jacos[1][2] = {-ga1 * v2, v1, 0};
+        jacos[1][3] = {-ga1 * v3, 0, v1};
+        jacos[1][4] = {ga1, 0, 0};
+
+        jacos[2][0] = {-v2 * v1, -v2o2 + ga1h * vs, -v2 * v3};
+        jacos[2][1] = {v2, -ga1 * v1, 0};
+        jacos[2][2] = {v1, -ga3 * v2, v3};
+        jacos[2][3] = {0, -ga1 * v3, v2};
+        jacos[2][4] = {0, ga1, 0};
+
+        jacos[3][0] = {-v3 * v1, -v3 * v2, -v3o2 + ga1h * vs};
+        jacos[3][1] = {v3, 0, -ga1 * v1};
+        jacos[3][2] = {0, v3, -ga1 * v2};
+        jacos[3][3] = {v1, v2, -ga3 * v3};
+        jacos[3][4] = {0, 0, ga1};
+
+        jacos[4][0] = {(-gretot + g1ke2) * u2 / rho2,
+                       (-gretot + g1ke2) * u3 / rho2,
+                       (-gretot + g1ke2) * u4 / rho2};
+        jacos[4][1] = {getot - ga1h * (vs + 2 * v1o2), -ga1 * v1 * v2, -ga1 * v1 * v3};
+        jacos[4][2] = {-ga1 * v2 * v1, getot - ga1h * (vs + 2 * v2o2), -ga1 * v2 * v3};
+        jacos[4][3] = {-ga1 * v3 * v1, -ga1 * v3 * v2, getot - ga1h * (vs + 2 * v3o2)};
+        jacos[4][4] = {ga * v1, ga * v2, ga * v3};
+    }
+}; /* end struct EulerJacobian<3> */
+
+// so0t = -(Jacobian . so1c), per real cell.
+template <size_t NDIM>
+void calc_solt_impl(EulerCore & ec)
+{
+    constexpr size_t neq = NDIM + 2;
+    auto const & msh = *ec.mesh();
+    SimpleArray<double> & so0c = ec.so0c();
+    SimpleArray<double> & so0t = ec.so0t();
+    SimpleArray<double> & so1c = ec.so1c();
+    SimpleArray<double> & gamma = ec.gamma();
+    EulerJacobian<NDIM> jaco;
+    for (int32_t icl = 0; icl < ec.ncell(); ++icl)
+    {
+        std::array<double, neq> sol = {};
+        for (size_t ieq = 0; ieq < neq; ++ieq)
+        {
+            sol[ieq] = so0c(icl, ieq);
+        }
+        jaco.update(gamma(icl), sol);
+        for (size_t ieq = 0; ieq < neq; ++ieq)
+        {
+            double val = 0.0;
+            for (size_t idm = 0; idm < NDIM; ++idm)
+            {
+                for (size_t jeq = 0; jeq < neq; ++jeq)
+                {
+                    val += jaco.jacos[ieq][jeq][idm] * so1c(icl, jeq, idm);
+                }
+            }
+            so0t(icl, ieq) = -val;
+        }
+    }
+}
+
+// so0n = CESE space-time flux integral over the BCEs, per real cell. Neighbor
+// CE centroids for ghost cells fall back to the mesh cell centroid
+// (mesh.clcnd), matching GradientElement; the cecnd ghost rows carry no mirror
+// image.
+template <size_t NDIM>
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void calc_soln_impl(EulerCore & ec)
+{
+    constexpr size_t neq = NDIM + 2;
+    constexpr size_t fcmnd = StaticMesh::FCMND;
+    auto const & msh = *ec.mesh();
+    SimpleArray<double> & cevol = ec.cevol();
+    SimpleArray<double> & cecnd = ec.cecnd();
+    SimpleArray<double> & sfcnd = ec.sfcnd();
+    SimpleArray<double> & sfnml = ec.sfnml();
+    SimpleArray<double> & so0c = ec.so0c();
+    SimpleArray<double> & so0n = ec.so0n();
+    SimpleArray<double> & so0t = ec.so0t();
+    SimpleArray<double> & so1c = ec.so1c();
+    SimpleArray<double> & gamma = ec.gamma();
+
+    double const dt = ec.time_increment();
+    double const qdt = dt * 0.25;
+    double const hdt = dt * 0.5;
+    EulerJacobian<NDIM> jaco;
+
+    for (int32_t icl = 0; icl < ec.ncell(); ++icl)
+    {
+        int32_t const clnfc = msh.clfcs(icl, 0);
+        std::array<double, neq> acc = {};
+
+        for (int32_t ifl = 1; ifl <= clnfc; ++ifl)
+        {
+            int32_t const ifc = msh.clfcs(icl, ifl);
+            int32_t const jcl = msh.fcrcl(ifc, icl);
+
+            // Neighbor CE centroid (cell-centroid mirror for ghost cells).
+            std::array<double, NDIM> jcecnd = {};
+            for (size_t d = 0; d < NDIM; ++d)
+            {
+                jcecnd[d] = (jcl >= 0) ? cecnd(jcl, d) : msh.clcnd(jcl, d);
+            }
+            // Self BCE geometry for this face.
+            double const bvol = cevol(icl, ifl);
+            std::array<double, NDIM> bcnd = {};
+            for (size_t d = 0; d < NDIM; ++d)
+            {
+                bcnd[d] = cecnd(icl, static_cast<size_t>(ifl) * NDIM + d);
+            }
+
+            // Spatial flux (given time): neighbor solution reconstructed at the
+            // BCE centroid, weighted by the BCE volume.
+            for (size_t ieq = 0; ieq < neq; ++ieq)
+            {
+                double fusp = so0c(jcl, ieq);
+                for (size_t d = 0; d < NDIM; ++d)
+                {
+                    fusp += (bcnd[d] - jcecnd[d]) * so1c(jcl, ieq, d);
+                }
+                acc[ieq] += fusp * bvol;
+            }
+
+            // Temporal flux (given space): Jacobian uses the self gamma and the
+            // neighbor conserved state.
+            std::array<double, neq> jsol = {};
+            for (size_t ieq = 0; ieq < neq; ++ieq)
+            {
+                jsol[ieq] = so0c(jcl, ieq);
+            }
+            jaco.update(gamma(icl), jsol);
+
+            int32_t const fcnnd = msh.fcnds(ifc, 0);
+            size_t const sf_base = static_cast<size_t>(ifl - 1) * fcmnd;
+            for (int32_t inf = 0; inf < fcnnd; ++inf)
+            {
+                size_t const sfi = sf_base + static_cast<size_t>(inf);
+                // Solution at the sub-face center.
+                std::array<double, neq> usfc = {};
+                for (size_t ieq = 0; ieq < neq; ++ieq)
+                {
+                    usfc[ieq] = qdt * so0t(jcl, ieq);
+                    for (size_t d = 0; d < NDIM; ++d)
+                    {
+                        usfc[ieq] += (sfcnd(icl, sfi, d) - jcecnd[d]) * so1c(jcl, ieq, d);
+                    }
+                }
+                // Flux derivative dotted with the sub-face normal.
+                for (size_t ieq = 0; ieq < neq; ++ieq)
+                {
+                    double dot = 0.0;
+                    for (size_t d2 = 0; d2 < NDIM; ++d2)
+                    {
+                        double dfcn = jaco.fcn[ieq][d2];
+                        for (size_t jeq = 0; jeq < neq; ++jeq)
+                        {
+                            dfcn += jaco.jacos[ieq][jeq][d2] * usfc[jeq];
+                        }
+                        dot += dfcn * sfnml(icl, sfi, d2);
+                    }
+                    acc[ieq] -= hdt * dot;
+                }
+            }
+        }
+
+        double const cvol = cevol(icl, 0);
+        for (size_t ieq = 0; ieq < neq; ++ieq)
+        {
+            so0n(icl, ieq) = acc[ieq] / cvol;
+        }
+    }
+}
+
+} /* end namespace detail */
+
+void EulerCore::calc_solt()
+{
+    if (2 == m_ndim)
+    {
+        detail::calc_solt_impl<2>(*this);
+    }
+    else if (3 == m_ndim)
+    {
+        detail::calc_solt_impl<3>(*this);
+    }
+    else
+    {
+        throw std::invalid_argument("EulerCore::calc_solt: ndim must be 2 or 3");
+    }
+}
+
+void EulerCore::calc_soln()
+{
+    if (2 == m_ndim)
+    {
+        detail::calc_soln_impl<2>(*this);
+    }
+    else if (3 == m_ndim)
+    {
+        detail::calc_soln_impl<3>(*this);
+    }
+    else
+    {
+        throw std::invalid_argument("EulerCore::calc_soln: ndim must be 2 or 3");
+    }
+}
+
+void EulerCore::march_substep()
+{
+    update();
+    calc_solt();
+    calc_soln();
+    // bc_soln();  // boundary conditions land in issue #66 phase 5.
+    calc_cfl();
+    calc_dsoln();
+    // bc_dsoln();  // boundary conditions land in issue #66 phase 5.
+}
+
+void EulerCore::march(int_type steps)
+{
+    for (int_type istep = 0; istep < steps; ++istep)
+    {
+        for (int_type isub = 0; isub < SUBSTEP_RUN; ++isub)
+        {
+            march_substep();
+        }
+    }
+}
+
+} /* end namespace modmesh */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/multidim/pymod/wrap_multidim.cpp
+++ b/cpp/modmesh/multidim/pymod/wrap_multidim.cpp
@@ -248,6 +248,7 @@ protected:
 
     WrapEulerCore & wrap_management();
     WrapEulerCore & wrap_preparation();
+    WrapEulerCore & wrap_march();
     WrapEulerCore & wrap_array();
 
 }; /* end class WrapEulerCore */
@@ -258,6 +259,7 @@ WrapEulerCore::WrapEulerCore(pybind11::module & mod, const char * pyname, const 
     (*this)
         .wrap_management()
         .wrap_preparation()
+        .wrap_march()
         .wrap_array()
         //
         ;
@@ -280,7 +282,6 @@ WrapEulerCore & WrapEulerCore::wrap_management()
         .def_property_readonly("ncell", &wrapped_type::ncell)
         .def_property_readonly("ngstcell", &wrapped_type::ngstcell)
         .def_property_readonly("neq", &wrapped_type::neq)
-        .def_property_readonly("time_increment", &wrapped_type::time_increment)
         //
         ;
 
@@ -319,8 +320,28 @@ WrapEulerCore & WrapEulerCore::wrap_preparation()
             py::arg("rho"),
             py::arg("v"),
             py::arg("p"))
-        .def_timed("calc_cfl", &wrapped_type::calc_cfl)
+        //
+        ;
+
+    return *this;
+}
+
+WrapEulerCore & WrapEulerCore::wrap_march()
+{
+    namespace py = pybind11;
+
+    (*this)
+        .def_property_readonly("time_increment", &wrapped_type::time_increment)
+        .def_property("sigma0", &wrapped_type::sigma0, &wrapped_type::set_sigma0)
+        .def_property("taumin", &wrapped_type::taumin, &wrapped_type::set_taumin)
+        .def_property("tauscale", &wrapped_type::tauscale, &wrapped_type::set_tauscale)
+        .def_timed("march", &wrapped_type::march, py::arg("steps"))
+        .def_timed("march_substep", &wrapped_type::march_substep)
         .def_timed("update", &wrapped_type::update)
+        .def_timed("calc_cfl", &wrapped_type::calc_cfl)
+        .def_timed("calc_solt", &wrapped_type::calc_solt)
+        .def_timed("calc_soln", &wrapped_type::calc_soln)
+        .def_timed("calc_dsoln", &wrapped_type::calc_dsoln)
         //
         ;
 

--- a/tests/test_multidim.py
+++ b/tests/test_multidim.py
@@ -6,6 +6,149 @@ from numpy.testing import assert_almost_equal
 import modmesh
 
 
+def _euler_flux(u, gamma):
+    """Analytic Euler conserved-variable flux f[ieq][d] for a state row u.
+
+    Used as an independent reference for the C++ flux/Jacobian under test.
+    """
+    nd = u.size - 2
+    rho = u[0]
+    mom = u[1:1 + nd]
+    energy = u[nd + 1]
+    vel = mom / rho
+    p = (gamma - 1.0) * (energy - 0.5 * rho * (vel @ vel))
+    f = np.zeros((u.size, nd), dtype="float64")
+    for d in range(nd):
+        f[0, d] = mom[d]
+        for k in range(nd):
+            f[1 + k, d] = mom[k] * vel[d] + (p if k == d else 0.0)
+        f[nd + 1, d] = (energy + p) * vel[d]
+    return f
+
+
+def _euler_jac_fd(u, gamma, h=1e-6):
+    """Euler flux Jacobian J[ieq][jeq][d] by central-differencing the analytic
+    flux.  Independent of the C++ analytic Jacobian, so it catches a wrong
+    Jacobian entry or sign in the marcher."""
+    neq = u.size
+    nd = neq - 2
+    jac = np.zeros((neq, neq, nd), dtype="float64")
+    for j in range(neq):
+        up = u.copy()
+        um = u.copy()
+        up[j] += h
+        um[j] -= h
+        fp = _euler_flux(up, gamma)
+        fm = _euler_flux(um, gamma)
+        jac[:, j, :] = (fp - fm) / (2 * h)
+    return jac
+
+
+def _fcmnd(mh, ec):
+    clmfc = mh.clfcs.ndarray.shape[1] - 1
+    return ec.sfcnd.ndarray.shape[1] // clmfc
+
+
+def _calc_soln_reference(mh, ec, gamma):
+    """Independent re-implementation of the CESE order-0 flux integral, using
+    a finite-difference Euler Jacobian.  Reads the same so0c/so0t/so1c that
+    calc_soln consumes and returns the expected so0n over the real cells."""
+    nd = mh.ndim
+    neq = nd + 2
+    dt = ec.time_increment
+    qdt, hdt = dt * 0.25, dt * 0.5
+    fcmnd = _fcmnd(mh, ec)
+    out = np.zeros((ec.ncell, neq), dtype="float64")
+    for icl in range(ec.ncell):
+        acc = np.zeros(neq, dtype="float64")
+        for ifl in range(1, mh.clfcs[icl, 0] + 1):
+            ifc = mh.clfcs[icl, ifl]
+            jcl = mh.fccls[ifc, 0] + mh.fccls[ifc, 1] - icl
+            jce = np.array([ec.cecnd[jcl, d] if jcl >= 0 else mh.clcnd[jcl, d]
+                            for d in range(nd)], dtype="float64")
+            bcnd = np.array([ec.cecnd[icl, ifl * nd + d]
+                             for d in range(nd)], dtype="float64")
+            js = np.array([ec.so0c[jcl, ieq] for ieq in range(neq)],
+                          dtype="float64")
+            jt = np.array([ec.so0t[jcl, ieq] for ieq in range(neq)],
+                          dtype="float64")
+            j1 = np.array([[ec.so1c[jcl, ieq, d] for d in range(nd)]
+                           for ieq in range(neq)], dtype="float64")
+            bvol = ec.cevol[icl, ifl]
+            for ieq in range(neq):
+                acc[ieq] += (js[ieq] + (bcnd - jce) @ j1[ieq]) * bvol
+            fcn = _euler_flux(js, gamma)
+            jac = _euler_jac_fd(js, gamma)
+            for inf in range(mh.fcnds[ifc, 0]):
+                sfi = (ifl - 1) * fcmnd + inf
+                sc = np.array([ec.sfcnd[icl, sfi, d]
+                               for d in range(nd)], dtype="float64")
+                sn = np.array([ec.sfnml[icl, sfi, d]
+                               for d in range(nd)], dtype="float64")
+                usfc = qdt * jt + np.array(
+                    [(sc - jce) @ j1[ieq] for ieq in range(neq)],
+                    dtype="float64")
+                for ieq in range(neq):
+                    acc[ieq] -= hdt * ((fcn[ieq] + jac[ieq].T @ usfc) @ sn)
+        out[icl] = acc / ec.cevol[icl, 0]
+    return out
+
+
+def _calc_dsoln_reference(mh, ec):
+    """Independent re-implementation of the order-1 gradient weighting/limiter,
+    reusing the verified GradientElement.solve_gradient primitive.  Returns the
+    expected so1n and whether the W-3/4 limiter is actually active."""
+    nd = mh.ndim
+    neq = nd + 2
+    hdt = ec.time_increment * 0.5
+    az = 1e-200
+    out = np.zeros((ec.ncell, neq, nd), dtype="float64")
+    active = False
+    for icl in range(ec.ncell):
+        acfl = abs(ec.cflc[icl])
+        sgm0 = ec.sigma0 / acfl
+        tau = ec.taumin + acfl * ec.tauscale
+        ge = modmesh.GradientElement(mesh=mh, cecnd=ec.cecnd, icl=icl, tau=tau)
+        nfge, ofg1 = ge.nfge, ge.nfge_inverse
+        grad = np.zeros((nfge, neq, nd), dtype="float64")
+        widv = np.zeros((nfge, neq), dtype="float64")
+        wacc = np.zeros(neq, dtype="float64")
+        for ifge in range(nfge):
+            faces = ge.faces(ifge)
+            for ieq in range(neq):
+                udf = np.zeros(nd, dtype="float64")
+                for ivx in range(nd):
+                    ifl = faces[ivx] - 1
+                    jcl = ge.rcl(ifl)
+                    val = ec.so0c[jcl, ieq] + hdt * ec.so0t[jcl, ieq] \
+                        - ec.so0n[icl, ieq]
+                    for d in range(nd):
+                        val += ge.jdis(ifl, d) * ec.so1c[jcl, ieq, d]
+                    udf[ivx] = val
+                g = np.array(ge.solve_gradient(ifge, udf.tolist()),
+                             dtype="float64")
+                grad[ifge, ieq] = g
+                wgt = 1.0 / np.sqrt(g @ g + az)
+                wacc[ieq] += wgt
+                widv[ifge, ieq] = wgt
+        wpa = np.zeros((neq, 2), dtype="float64")
+        for ifge in range(nfge):
+            for ieq in range(neq):
+                w = widv[ifge, ieq] / wacc[ieq] - ofg1
+                widv[ifge, ieq] = w
+                wpa[ieq, 0] = max(wpa[ieq, 0], w)
+                wpa[ieq, 1] = min(wpa[ieq, 1], w)
+        for ieq in range(neq):
+            sm = min((1.0 - ofg1) / (wpa[ieq, 0] + az),
+                     -ofg1 / (wpa[ieq, 1] - az), sgm0)
+            if np.abs(widv[:, ieq]).max() > 1e-9:
+                active = True
+            for ifge in range(nfge):
+                w = ofg1 + sm * widv[ifge, ieq]
+                out[icl, ieq] += w * grad[ifge, ieq]
+    return out, active
+
+
 class _TriangleMeshBase(unittest.TestCase):
     """3 triangles around the origin."""
 
@@ -212,7 +355,7 @@ class _GradientElementBase(_GradientElementBoundsBase):
         for icl in range(self.mesh.ncell):
             ge = self._ge(icl)
             mat = np.array([[ge.idis(ifl, d) for d in range(nd)]
-                            for ifl in range(ge.clnfc)])
+                            for ifl in range(ge.clnfc)], dtype="float64")
             # The face-displacement vectors must span R^ndim for the
             # gradient reconstruction to be well posed.  A per-simplex
             # determinant would wrongly fail for the hexahedron, whose
@@ -248,7 +391,7 @@ class _GradientElementBase(_GradientElementBoundsBase):
         for icl in range(self.mesh.ncell):
             ge = self._ge(icl)
             for ifge in range(ge.nfge):
-                mat = np.array(ge.displacement_matrix(ifge))
+                mat = np.array(ge.displacement_matrix(ifge), dtype="float64")
                 self.assertEqual((nd, nd), mat.shape)
                 self.assertGreater(
                     abs(np.linalg.det(mat)), 1e-10,
@@ -259,11 +402,11 @@ class _GradientElementBase(_GradientElementBoundsBase):
         # gradient evaluation point is exactly g . idis, so the per-FGE
         # solve must recover g exactly (up to round-off).
         nd = self.mesh.ndim
-        grad = np.array([1.5, -2.7, 0.9][:nd])
+        grad = np.array([1.5, -2.7, 0.9][:nd], dtype="float64")
         for icl in range(self.mesh.ncell):
             ge = self._ge(icl)
             for ifge in range(ge.nfge):
-                dst = np.array(ge.displacement_matrix(ifge))
+                dst = np.array(ge.displacement_matrix(ifge), dtype="float64")
                 faces = ge.faces(ifge)
                 # Matrix rows are the per-face idis vectors.
                 for ivx, ifl in enumerate(faces):
@@ -271,7 +414,8 @@ class _GradientElementBase(_GradientElementBoundsBase):
                         assert_almost_equal(
                             dst[ivx, d], ge.idis(ifl - 1, d), decimal=12)
                 udf = dst @ grad
-                got = np.array(ge.solve_gradient(ifge, udf.tolist()))
+                got = np.array(ge.solve_gradient(ifge, udf.tolist()),
+                               dtype="float64")
                 assert_almost_equal(got, grad, decimal=9)
 
 
@@ -351,7 +495,8 @@ class _EulerSolutionBase:
             assert_almost_equal(p_rec, self.PRES)
         # gamma is filled across every row, ghost cells included.
         total = ec.ngstcell + ec.ncell
-        assert_almost_equal(ec.gamma.ndarray, np.full(total, self.GAMMA))
+        assert_almost_equal(ec.gamma.ndarray,
+                            np.full(total, self.GAMMA, dtype="float64"))
         # init_solution leaves the conserved table's ghost rows untouched
         # (zero); ghost states are populated by boundary conditions later.
         for icl in range(-ec.ngstcell, 0):
@@ -419,7 +564,8 @@ class _EulerSolutionBase:
                          v=self._vel(nd), p=self.PRES)
         # Seed the new-step order-1 buffer with a recognizable pattern.
         so1n_view = ec.so1n.ndarray
-        so1n_view[...] = np.arange(so1n_view.size).reshape(so1n_view.shape)
+        so1n_view[...] = np.arange(
+            so1n_view.size, dtype="float64").reshape(so1n_view.shape)
         so0n_before = ec.so0n.ndarray.copy()
         so0c_before = ec.so0c.ndarray.copy()
         so1n_before = ec.so1n.ndarray.copy()
@@ -449,6 +595,216 @@ class EulerSolutionTetrahedronTC(_EulerSolutionBase, _TetrahedronMeshBase):
 
 class EulerSolutionHexahedronTC(_EulerSolutionBase, _HexahedronMeshBase):
     """EulerCore solution storage on a single hexahedron."""
+
+
+class _EulerMarchBase:
+    """EulerCore phase 4 solution marching."""
+
+    GAMMA = 1.4
+    RHO = 1.2
+    PRES = 0.9
+    VEL = (0.3, -0.15, 0.05)
+
+    def _ec(self):
+        # A fresh core per test keeps the shared class mesh read-only.
+        return modmesh.EulerCore(mesh=self.mesh, time_increment=0.01)
+
+    def _vel(self, nd):
+        return list(self.VEL[:nd])
+
+    def _uniform_row(self, nd):
+        v = self._vel(nd)
+        vsq = sum(c * c for c in v)
+        energy = self.PRES / (self.GAMMA - 1.0) + 0.5 * self.RHO * vsq
+        return [self.RHO] + [self.RHO * v[d] for d in range(nd)] + [energy]
+
+    def test_march_param_defaults(self):
+        ec = self._ec()
+        assert_almost_equal(ec.sigma0, 3.0)
+        assert_almost_equal(ec.taumin, 0.0)
+        assert_almost_equal(ec.tauscale, 1.0)
+        # The marching parameters are writable.
+        ec.sigma0, ec.taumin, ec.tauscale = 2.5, 0.1, 0.7
+        assert_almost_equal(ec.sigma0, 2.5)
+        assert_almost_equal(ec.taumin, 0.1)
+        assert_almost_equal(ec.tauscale, 0.7)
+
+    def test_calc_solt_euler_flux(self):
+        # calc_solt sets so0t = -(Jacobian . so1c).  Seeding so1c[:, d] with a
+        # scalar multiple coef[d] of the conserved state turns the Jacobian
+        # product in each direction into the analytic Euler flux there (the
+        # flux is homogeneous of degree one in the conserved variables), so
+        # so0t == -sum_d coef[d] * flux_d.  Distinct coef[d] exercises every
+        # Jacobian direction column, not just one.
+        ec = self._ec()
+        nd, neq = self.mesh.ndim, self.mesh.ndim + 2
+        row = np.array(self._uniform_row(nd), dtype="float64")
+        coef = [0.7, -1.3, 0.4][:nd]
+        for icl in range(ec.ncell):
+            ec.gamma[icl] = self.GAMMA
+            for ieq in range(neq):
+                ec.so0c[icl, ieq] = row[ieq]
+                for d in range(nd):
+                    ec.so1c[icl, ieq, d] = coef[d] * row[ieq]
+        ec.calc_solt()
+        flux = _euler_flux(row, self.GAMMA)  # flux[ieq][d]
+        expect = [-sum(coef[d] * flux[ieq][d] for d in range(nd))
+                  for ieq in range(neq)]
+        for icl in range(ec.ncell):
+            for ieq in range(neq):
+                assert_almost_equal(ec.so0t[icl, ieq], expect[ieq], decimal=10)
+
+    def test_calc_soln_freestream(self):
+        # A uniform conserved state with zero gradient is preserved exactly by
+        # the CESE flux integral: so0n == so0c.  Ghost rows are set to the same
+        # uniform state to stand in for the (phase 5) boundary conditions.
+        ec = self._ec()
+        nd, neq = self.mesh.ndim, self.mesh.ndim + 2
+        row = self._uniform_row(nd)
+        for cell in range(-ec.ngstcell, ec.ncell):
+            ec.gamma[cell] = self.GAMMA
+            for ieq in range(neq):
+                ec.so0c[cell, ieq] = row[ieq]
+                ec.so0t[cell, ieq] = 0.0
+                for d in range(nd):
+                    ec.so1c[cell, ieq, d] = 0.0
+        ec.calc_solt()
+        ec.calc_soln()
+        for icl in range(ec.ncell):
+            for ieq in range(neq):
+                assert_almost_equal(ec.so0n[icl, ieq], row[ieq], decimal=10)
+
+    def test_calc_dsoln_linear_field(self):
+        # For a global linear field u(x) = c + g . x sampled at every CE
+        # solution point, calc_dsoln recovers the gradient g exactly: each
+        # fundamental gradient element yields g, so the weighting/limiter
+        # reduces to g regardless of the per-cell tau and sigma0.
+        ec = self._ec()
+        mh = self.mesh
+        nd, neq = mh.ndim, mh.ndim + 2
+        g = [[0.1 * (ieq + 1) + 0.01 * (d + 1) for d in range(nd)]
+             for ieq in range(neq)]
+        c = [0.5 + 0.3 * ieq for ieq in range(neq)]
+
+        def point(cell):
+            return [ec.cecnd[cell, d] if cell >= 0 else mh.clcnd[cell, d]
+                    for d in range(nd)]
+
+        for cell in range(-ec.ngstcell, ec.ncell):
+            x = point(cell)
+            for ieq in range(neq):
+                val = c[ieq] + sum(g[ieq][d] * x[d] for d in range(nd))
+                ec.so0c[cell, ieq] = val
+                ec.so0n[cell, ieq] = val
+                ec.so0t[cell, ieq] = 0.0
+                for d in range(nd):
+                    ec.so1c[cell, ieq, d] = g[ieq][d]
+            ec.cflc[cell] = 0.5
+        ec.calc_dsoln()
+        for icl in range(ec.ncell):
+            for ieq in range(neq):
+                for d in range(nd):
+                    assert_almost_equal(ec.so1n[icl, ieq, d], g[ieq][d],
+                                        decimal=9)
+
+    def test_calc_soln_against_reference(self):
+        # Drive calc_soln with a non-uniform state (nonzero so1c and so0t and
+        # distinct ghost states) so the temporal flux and the order-1 spatial
+        # reconstruction are both active, then compare against an independent
+        # finite-difference-Jacobian reimplementation.  Unlike the free-stream
+        # case this constrains the hdt/qdt coefficients, the temporal sign, and
+        # the Jacobian -- none of which a uniform state can detect.
+        ec = self._ec()
+        nd, neq = self.mesh.ndim, self.mesh.ndim + 2
+        mh = self.mesh
+        base = [1.2, 0.3, -0.15, 0.2, 2.5]
+        for cell in range(-ec.ngstcell, ec.ncell):
+            x = [ec.cecnd[cell, d] if cell >= 0 else mh.clcnd[cell, d]
+                 for d in range(nd)]
+            ec.gamma[cell] = self.GAMMA
+            for ieq in range(neq):
+                s = 1.0 + 0.1 * x[0] + 0.03 * ieq
+                for d in range(1, nd):
+                    s += 0.07 * x[d]
+                ec.so0c[cell, ieq] = base[ieq] * s
+                ec.so0t[cell, ieq] = 0.01 * (ieq + 1)
+                for d in range(nd):
+                    ec.so1c[cell, ieq, d] = 0.02 * (ieq + 1) * (d + 1)
+        ec.calc_soln()
+        ref = _calc_soln_reference(mh, ec, self.GAMMA)
+        for icl in range(ec.ncell):
+            for ieq in range(neq):
+                assert_almost_equal(ec.so0n[icl, ieq], ref[icl, ieq],
+                                    decimal=10)
+
+    def test_calc_dsoln_against_reference(self):
+        # Drive calc_dsoln with a non-linear field so the per-FGE gradients
+        # differ and the W-1/2 / W-3/4 limiter is actually exercised (the
+        # linear-field test leaves it dead, since identical gradients zero the
+        # limiter delta).  Compare against an independent reimplementation of
+        # the weighting that reuses the verified solve_gradient primitive.
+        ec = self._ec()
+        nd, neq = self.mesh.ndim, self.mesh.ndim + 2
+        mh = self.mesh
+        for cell in range(-ec.ngstcell, ec.ncell):
+            x = [ec.cecnd[cell, d] if cell >= 0 else mh.clcnd[cell, d]
+                 for d in range(nd)]
+            for ieq in range(neq):
+                val = 1.0 + 0.5 * x[0] + 0.4 * x[0] * x[0] + 0.2 * ieq
+                for d in range(1, nd):
+                    val += 0.3 * x[d]
+                ec.so0c[cell, ieq] = val
+                ec.so0n[cell, ieq] = val
+                ec.so0t[cell, ieq] = 0.0
+                for d in range(nd):
+                    g = 0.1 * (ieq + 1) + 0.05 * x[0] * (d + 1)
+                    ec.so1c[cell, ieq, d] = g
+            ec.cflc[cell] = 0.5
+        ec.calc_dsoln()
+        ref, active = _calc_dsoln_reference(mh, ec)
+        self.assertTrue(active, "limiter delta stayed zero; field too smooth")
+        for icl in range(ec.ncell):
+            for ieq in range(neq):
+                for d in range(nd):
+                    assert_almost_equal(ec.so1n[icl, ieq, d],
+                                        ref[icl, ieq, d], decimal=10)
+
+    def test_march_bounded(self):
+        # Without boundary conditions (phase 5) marching is only well posed on
+        # meshes with interior faces; single-cell meshes are all-boundary.
+        if self.mesh.ncell < 2:
+            self.skipTest("march needs interior faces; BCs land in phase 5")
+        ec = self._ec()
+        nd = self.mesh.ndim
+        ec.init_solution(gamma=self.GAMMA, rho=self.RHO,
+                         v=self._vel(nd), p=self.PRES)
+        ec.march(steps=3)
+        so0n = ec.so0n.ndarray
+        self.assertTrue(np.all(np.isfinite(so0n)))
+        # Density stays positive and the state stays bounded.
+        for icl in range(ec.ncell):
+            self.assertGreater(ec.so0n[icl, 0], 0.0)
+        self.assertLess(np.abs(so0n).max(), 1e6)
+
+
+class EulerMarchTriangleTC(_EulerMarchBase, _TriangleMeshBase):
+    """EulerCore marching on 3 triangles."""
+
+
+class EulerMarchQuadTC(_EulerMarchBase, _QuadMeshBase):
+    """EulerCore marching on a unit-square quad."""
+
+
+class EulerMarchMixedTC(_EulerMarchBase, _MixedMeshBase):
+    """EulerCore marching on a 2D mixed mesh."""
+
+
+class EulerMarchTetrahedronTC(_EulerMarchBase, _TetrahedronMeshBase):
+    """EulerCore marching on a single tetrahedron."""
+
+
+class EulerMarchHexahedronTC(_EulerMarchBase, _HexahedronMeshBase):
+    """EulerCore marching on a single hexahedron."""
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Port the solvcon CESE order-0 and order-1 marching kernels into EulerCore.  This is a long PR.  The code ported is only superficially checked because a full check will need a concrete problem like an oblique shock.  It will be done in the future.  Treat the code added as a prototype.

- euler_march.cpp: the 2D/3D Euler flux Jacobian, calc_solt (so0t from the Jacobian and so1c), calc_soln (the space-time flux integral over the BCEs), and the march/march_substep drivers (two substeps per step).  Ghost neighbor CE centroids fall back to mesh.clcnd, matching GradientElement; boundary conditions are deferred to phase 5.
- euler_gradient.cpp: calc_dsoln, porting GradientWeigh -- the per-FGE gradient solve plus the W-1/2 weighting and W-3/4 limiter -- into the order-1 update.
- euler.hpp / wrap_multidim.cpp: the sigma0/taumin/tauscale parameters and the marching API, with the marching surface grouped in WrapEulerCore::wrap_march.

Tests (tests/test_multidim.py across triangle/quad/mixed/tetra/hexa): calc_solt vs the analytic Euler flux, calc_soln free-stream preservation plus an independent finite-difference-Jacobian reference, calc_dsoln exact linear-gradient recovery plus a weighting/limiter reference, and a bounded short march.

For issue #66 and related to issue #404.