### PR TITLE
Enable ccache for nouse_install

### DIFF
--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -70,6 +70,13 @@ jobs:
         with:
           workflow: 'nouse_install'
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          key: ${{ runner.os }}-Release
+          restore-keys: ${{ runner.os }}-Release
+          create-symlink: true
+
       - name: setup.py install build_ext
         run: |
           echo "::group::setup.py install build_ext"


### PR DESCRIPTION
I noticed that the `nouse_install` workflow builds the same Release buildext
path exercised by `devbuild`, so it can reuse the existing per OS ccache.