### PR TITLE
Ensure skip-ci label workable and do not trigger unexpected CI runs

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -3,7 +3,7 @@ name: devbuild
 on:
   push:
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [opened, reopened, synchronize]
   schedule:
     - cron: '34 17 * * *'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: lint
 on:
   push:
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [opened, reopened, synchronize]
   schedule:
     - cron: '34 17 * * *'
 

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -3,7 +3,7 @@ name: nouse_install
 on:
   push:
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [opened, reopened, synchronize]
   schedule:
     - cron: '34 17 * * *'
 


### PR DESCRIPTION
Simplify profiling job conditions and ensure the skip-ci label is honored for push-triggered updates so CI runs are not noisy or duplicated.

This PR removes push/pull_request triggers from the profiling workflow and updates check_skip_ci to detect and respect skip-ci on push-triggered runs so profiling jobs run only when intended.

Related to #858.