### PR TITLE
Expand pilot_clang_tidy_diff lint scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,23 @@ find_program(
     NAMES "clang-tidy"
     DOC "Path to clang-tidy executable"
 )
+if(CLANG_TIDY_EXE)
+    file(REAL_PATH "${CLANG_TIDY_EXE}" CLANG_TIDY_REALPATH)
+    get_filename_component(
+        CLANG_TIDY_BINDIR
+        "${CLANG_TIDY_REALPATH}"
+        DIRECTORY
+    )
+    find_program(
+        CLANG_TIDY_DIFF_EXE
+        NAMES "clang-tidy-diff.py"
+        HINTS
+            "${CLANG_TIDY_BINDIR}"
+            "${CLANG_TIDY_BINDIR}/../share/clang"
+        DOC "Path to clang-tidy-diff.py executable"
+    )
+endif()
+
 if(USE_CLANG_TIDY)
     if(CLANG_TIDY_EXE)
         set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}"
@@ -77,6 +94,22 @@ if(USE_CLANG_TIDY)
         message(STATUS "use clang-tidy with DO_CLANG_TIDY: ${DO_CLANG_TIDY}")
     else()
         message(FATAL_ERROR "USE_CLANG_TIDY is on but clang-tidy is not found")
+    endif()
+
+    if(CLANG_TIDY_DIFF_EXE)
+        set(DO_CLANG_TIDY_DIFF "${CLANG_TIDY_DIFF_EXE}"
+            "-p1"
+            "-extra-arg=-std=c++23"
+            "-allow-no-checks")
+        if(LINT_AS_ERRORS)
+            set(DO_CLANG_TIDY_DIFF
+                "${DO_CLANG_TIDY_DIFF}"
+                "-warnings-as-errors=*")
+        endif()
+        message(
+            STATUS
+            "use clang-tidy-diff.py with DO_CLANG_TIDY_DIFF: ${DO_CLANG_TIDY_DIFF}"
+        )
     endif()
 else()
     message(STATUS "not use clang-tidy")

--- a/cpp/binary/pilot/CMakeLists.txt
+++ b/cpp/binary/pilot/CMakeLists.txt
@@ -123,6 +123,12 @@ endif()
 
 add_custom_target(run_pilot_pytest $<TARGET_FILE:pilot> --mode=pytest)
 
+get_target_property(
+    MODMESH_PRIMARY_FILES
+    modmesh_primary
+    SOURCES
+)
+
 set(CLANG_TIDY_DIFF_EXE clang-tidy-diff.py)
 if(CLANG_TIDY_EXE)
     file(REAL_PATH "${CLANG_TIDY_EXE}" CLANG_TIDY_REALPATH)
@@ -151,7 +157,7 @@ string(
     "test -n \"$MODMESH_DIFF_BASE\""
     " && "
     "git diff --no-color -U0 \"$MODMESH_DIFF_BASE\" HEAD"
-    " -- $<JOIN:${MODMESH_PILOT_FILES}, >"
+    " -- $<JOIN:${MODMESH_PRIMARY_FILES};${CMAKE_CURRENT_SOURCE_DIR}, >"
     " | "
     "\"${CLANG_TIDY_DIFF_EXE}\" -p1"
     " -path \"${CMAKE_BINARY_DIR}\""

--- a/cpp/binary/pilot/CMakeLists.txt
+++ b/cpp/binary/pilot/CMakeLists.txt
@@ -123,54 +123,32 @@ endif()
 
 add_custom_target(run_pilot_pytest $<TARGET_FILE:pilot> --mode=pytest)
 
-get_target_property(
-    MODMESH_PRIMARY_FILES
-    modmesh_primary
-    SOURCES
-)
+if(DO_CLANG_TIDY_DIFF)
+    get_target_property(
+        MODMESH_PRIMARY_FILES
+        modmesh_primary
+        SOURCES
+    )
 
-set(CLANG_TIDY_DIFF_EXE clang-tidy-diff.py)
-if(CLANG_TIDY_EXE)
-    file(REAL_PATH "${CLANG_TIDY_EXE}" CLANG_TIDY_REALPATH)
-    get_filename_component(
-        CLANG_TIDY_BINDIR
-        "${CLANG_TIDY_REALPATH}"
-        DIRECTORY
+    string(
+        CONCAT
+        PILOT_CLANG_TIDY_DIFF_COMMAND
+        "test -n \"$MODMESH_DIFF_BASE\""
+        " && "
+        "git diff --no-color -U0 \"$MODMESH_DIFF_BASE\" HEAD"
+        " -- $<JOIN:${MODMESH_PRIMARY_FILES};${CMAKE_CURRENT_SOURCE_DIR}, >"
+        " | "
+        "$<JOIN:${DO_CLANG_TIDY_DIFF}, > -path \"${CMAKE_BINARY_DIR}\""
     )
-    find_program(
-        CLANG_TIDY_DIFF_FOUND
-        NAMES clang-tidy-diff.py
-        HINTS
-            "${CLANG_TIDY_BINDIR}"
-            "${CLANG_TIDY_BINDIR}/../share/clang"
-        NO_DEFAULT_PATH
-        NO_CACHE
+
+    add_custom_target(
+        pilot_clang_tidy_diff
+        COMMAND
+            bash -e -o pipefail -c "${PILOT_CLANG_TIDY_DIFF_COMMAND}"
+        WORKING_DIRECTORY ${PROJECT_ROOT_DIR}
+        VERBATIM
     )
-    if(CLANG_TIDY_DIFF_FOUND)
-        set(CLANG_TIDY_DIFF_EXE "${CLANG_TIDY_DIFF_FOUND}")
-    endif()
 endif()
-
-string(
-    CONCAT
-    PILOT_CLANG_TIDY_DIFF_COMMAND
-    "test -n \"$MODMESH_DIFF_BASE\""
-    " && "
-    "git diff --no-color -U0 \"$MODMESH_DIFF_BASE\" HEAD"
-    " -- $<JOIN:${MODMESH_PRIMARY_FILES};${CMAKE_CURRENT_SOURCE_DIR}, >"
-    " | "
-    "\"${CLANG_TIDY_DIFF_EXE}\" -p1"
-    " -path \"${CMAKE_BINARY_DIR}\""
-    " -config-file \"${PROJECT_ROOT_DIR}/.clang-tidy\""
-)
-
-add_custom_target(
-    pilot_clang_tidy_diff
-    COMMAND
-        bash -e -o pipefail -c "${PILOT_CLANG_TIDY_DIFF_COMMAND}"
-    WORKING_DIRECTORY ${PROJECT_ROOT_DIR}
-    VERBATIM
-)
 
 install(TARGETS pilot
     RUNTIME DESTINATION "${INSTALL_PILOTDIR}"


### PR DESCRIPTION
Related to #878.

This PR updates the `pilot_clang_tidy_diff` diff scope so PR linting covers
`modmesh_primary` sources used by the pilot build.

It also aligns the `clang-tidy-diff.py` command with the regular `clang-tidy`
configuration.

Tested with:

```sh
make pilot_clang_tidy_diff \
  VERBOSE=1 \
  BUILD_QT=ON \
  USE_CLANG_TIDY=ON \
  LINT_AS_ERRORS=ON \
  CMAKE_BUILD_TYPE=Debug \
  "CMAKE_ARGS=-DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON" \
  MODMESH_DIFF_BASE="3183ea5"
```

The command now reports the `SimpleArray.hpp` clang-tidy warnings.