### PR TITLE
Add the oblique-shock 2D mesh for the multidimensional Euler solver

### DIFF
--- a/modmesh/multidim/__init__.py
+++ b/modmesh/multidim/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
+# Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -26,25 +26,14 @@
 
 
 """
-modmesh: the description of the package is intentionally left blank
+Multi-dimensional solvers for conservation laws, grouped by equation set;
+currently the Euler-equation utilities.
 """
 
+from . import euler
 
-# Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
-
-
-from . import core
-from .core import *  # noqa: F401, F403
-from . import apputil  # noqa: F401
-from . import spacetime  # noqa: F401
-from . import onedim  # noqa: F401
-from . import multidim  # noqa: F401
-from . import system  # noqa: F401
-from . import testing  # noqa: F401
-from . import toggle  # noqa: F401
-from . import track  # noqa: F401
-
-clinfo = core.ProcessInfo.instance.command_line
-
+__all__ = [
+    'euler',
+]
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/multidim/euler/__init__.py
+++ b/modmesh/multidim/euler/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, Yung-Yu Chen <yyc@solvcon.net>
+# Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -26,25 +26,14 @@
 
 
 """
-modmesh: the description of the package is intentionally left blank
+Multi-dimensional Euler-equation solver; currently the mesh builder and
+boundary tagging for the oblique-shock reflection.
 """
 
+from . import oblique
 
-# Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
-
-
-from . import core
-from .core import *  # noqa: F401, F403
-from . import apputil  # noqa: F401
-from . import spacetime  # noqa: F401
-from . import onedim  # noqa: F401
-from . import multidim  # noqa: F401
-from . import system  # noqa: F401
-from . import testing  # noqa: F401
-from . import toggle  # noqa: F401
-from . import track  # noqa: F401
-
-clinfo = core.ProcessInfo.instance.command_line
-
+__all__ = [
+    'oblique',
+]
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/multidim/euler/oblique.py
+++ b/modmesh/multidim/euler/oblique.py
@@ -1,0 +1,310 @@
+# Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+Mesh and boundary tagging for the oblique-shock reflection.
+
+A uniform supersonic stream enters from the left over a slip wall whose
+bottom turns into a wedge inclined by a fixed angle.  The wedge deflects the
+flow, an oblique shock forms at the wedge tip and reflects off the flat top
+slip wall, and the flow leaves through the non-reflective outflow on the
+right.  This module owns the programmatic mesh builder and the geometric
+boundary classifier shared by the unit tests, the pilot GUI, and the
+forthcoming Euler-solver driver.
+"""
+
+import math
+
+from ... import core
+
+__all__ = [
+    'ObliqueShockMesher',
+]
+
+
+class ObliqueShockMesher(object):
+    """Generate the mesh for the oblique-shock reflection.
+
+    The rectangular-like domain runs from the lower-left corner ``ll`` to
+    the upper-right corner ``ur``.  The bottom edge is flat up to ``x_ramp``
+    and then ramps up at ``wedge_angle`` degrees.  The wedge top must stay
+    below the domain height (``ur[1] - ll[1]``); otherwise the grid columns
+    would invert and the mesh silently self-overlap, so the constructor
+    raises :class:`ValueError` instead.
+    """
+
+    def __init__(self, nx=48, ny=16, ll=(0.0, 0.0), ur=(3.0, 1.0),
+                 x_ramp=1.5, wedge_angle=15.0):
+        self.nx = nx
+        self.ny = ny
+        (self.x0, self.y0), (self.x1, self.y1) = ll, ur
+        self.x_ramp = x_ramp
+        self.tan_theta = math.tan(math.radians(wedge_angle))
+        wedge_top = (self.x1 - x_ramp) * self.tan_theta
+        if wedge_top >= self.y1 - self.y0:
+            raise ValueError(
+                f"wedge top (ur[0] - x_ramp) * tan(wedge_angle) = "
+                f"{wedge_top:g} must stay below the domain height "
+                f"{self.y1 - self.y0:g}")
+
+    def _node(self, it, jt):
+        x = self.x0 + it * (self.x1 - self.x0) / self.nx
+        yb = (self.y0 if x <= self.x_ramp
+              else self.y0 + (x - self.x_ramp) * self.tan_theta)
+        return x, yb + (self.y1 - yb) * jt / self.ny
+
+    def _nid(self, it, jt):
+        return jt * (self.nx + 1) + it
+
+    def _box(self, it, jt):
+        return (self._nid(it, jt), self._nid(it + 1, jt),
+                self._nid(it + 1, jt + 1), self._nid(it, jt + 1))
+
+    def make_mesh(self, cell_type='quad'):
+        """Build a :class:`~modmesh.core.StaticMesh` of the selected flavor.
+
+        ``cell_type`` selects the element shape:
+        - ``'quad'`` keeps one quadrilateral per grid box,
+        - ``'triangle'`` cuts each box along its lower-left-to-upper-right
+          diagonal into two triangles (flipping the diagonal at two corners
+          so no triangle carries two boundary faces), and
+        - ``'unstructured'`` Delaunay-triangulates the same boundary nodes
+          plus jittered interior points into an irregular (but deterministic)
+          triangulation, refined to the same one-boundary-face-per-cell rule.
+
+        Both triangular flavors keep at most one boundary face per cell,
+        which the corner ``'quad'`` cells cannot.  All flavors share the
+        boundary layout (nx segments on the bottom and top, ny on the left
+        and right) and produce counter-clockwise cells.  The returned mesh
+        has ``ndcrd``/``cltpn``/``clnds`` filled and ``build_interior`` /
+        ``build_boundary`` / ``build_ghost`` run.
+        """
+        nx, ny = self.nx, self.ny
+        if cell_type in ('quad', 'triangle'):
+            nodes = core.PointPadFp64(ndim=2)
+            for jt in range(ny + 1):
+                for it in range(nx + 1):
+                    nodes.append(*self._node(it, jt))
+            if cell_type == 'quad':
+                tpn = core.StaticMesh.QUADRILATERAL
+                cells = [(4,) + self._box(it, jt)
+                         for jt in range(ny) for it in range(nx)]
+            else:
+                tpn = core.StaticMesh.TRIANGLE
+                cells = []
+                for jt in range(ny):
+                    for it in range(nx):
+                        ll, lr, ur, ul = self._box(it, jt)
+                        # Split along the lower-left-to-upper-right diagonal,
+                        # except at the upper-left and lower-right domain
+                        # corners, whose corner cell would otherwise carry
+                        # the two boundary edges meeting there.
+                        if (it, jt) in ((0, ny - 1), (nx - 1, 0)):
+                            cells += [(3, ll, lr, ul), (3, lr, ur, ul)]
+                        else:
+                            cells += [(3, ll, lr, ur), (3, ll, ur, ul)]
+        elif cell_type == 'unstructured':
+            tpn = core.StaticMesh.TRIANGLE
+            nodes = self._jitter_points()
+            cells = [(3,) + tri
+                     for tri in self._split_double_boundary(nodes)]
+        else:
+            raise ValueError(f"unknown cell_type '{cell_type}'")
+        mh = core.StaticMesh(ndim=2, nnode=len(nodes), nface=0,
+                             ncell=len(cells))
+        mh.ndcrd[:, :] = nodes.pack_array().ndarray
+        mh.cltpn.fill(tpn)
+        mh.clnds[:, :len(cells[0])] = cells
+        mh.build_interior(do_metric=True)
+        mh.build_boundary()
+        mh.build_ghost()
+        return mh
+
+    def _jitter_points(self):
+        """Collect the unstructured point cloud in a :class:`PointPad`.
+
+        The boundary keeps the structured node layout (a counter-clockwise
+        outline walk), so classification is identical across flavors.
+        Interior nodes are displaced in logical (it, jt) space by an
+        RNG-free phase -- deterministic, yet irregular -- bounded by 0.3
+        logical units per axis to stay well inside the domain.
+        """
+        nx, ny = self.nx, self.ny
+        pad = core.PointPadFp64(ndim=2)
+        for it in range(nx + 1):
+            pad.append(*self._node(it, 0))
+        for jt in range(1, ny + 1):
+            pad.append(*self._node(nx, jt))
+        for it in range(nx - 1, -1, -1):
+            pad.append(*self._node(it, ny))
+        for jt in range(ny - 1, 0, -1):
+            pad.append(*self._node(0, jt))
+        for jt in range(1, ny):
+            for it in range(1, nx):
+                pad.append(*self._node(
+                    it + 0.3 * math.sin(12.9898 * it + 78.233 * jt),
+                    jt + 0.3 * math.cos(26.651 * it + 41.347 * jt)))
+        return pad
+
+    @staticmethod
+    def _circumcircle(pts, ia, ib, ic):
+        """Circumcenter and squared circumradius of triangle (ia, ib, ic)."""
+        ax, ay = pts[ia]
+        bx, by = pts[ib]
+        cx, cy = pts[ic]
+        dd = 2.0 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by))
+        a2, b2, c2 = ax * ax + ay * ay, bx * bx + by * by, cx * cx + cy * cy
+        ux = (a2 * (by - cy) + b2 * (cy - ay) + c2 * (ay - by)) / dd
+        uy = (a2 * (cx - bx) + b2 * (ax - cx) + c2 * (bx - ax)) / dd
+        return ux, uy, (ax - ux) ** 2 + (ay - uy) ** 2
+
+    @classmethod
+    def _triangulate(cls, pad):
+        """Bowyer-Watson Delaunay triangulation of the :class:`PointPad`
+        ``pad``; returns CCW index triples.
+
+        Seed a far-away super-triangle, insert one point at a time (carve
+        the triangles whose circumcircle strictly contains it, fan the
+        cavity rim to the point), then drop the triangles touching a super
+        vertex.  On-circle points count as outside, keeping the cavity well
+        defined under the cocircular ties of the regular boundary layout.
+        Naive O(n^2).
+
+        References:
+        - A. Bowyer, "Computing Dirichlet tessellations", The Computer
+          Journal 24(2):162-166, 1981.
+          https://doi.org/10.1093/comjnl/24.2.162
+        - D. F. Watson, "Computing the n-dimensional Delaunay tessellation
+          with application to Voronoi polytopes", The Computer Journal
+          24(2):167-172, 1981.  https://doi.org/10.1093/comjnl/24.2.167
+        - https://en.wikipedia.org/wiki/Bowyer%E2%80%93Watson_algorithm
+        """
+        npt = len(pad)
+        pts = [(pad.x_at(ip), pad.y_at(ip)) for ip in range(npt)]
+        xs = [px for px, py in pts]
+        ys = [py for px, py in pts]
+        xmid = (min(xs) + max(xs)) / 2.0
+        ymid = (min(ys) + max(ys)) / 2.0
+        span = max(max(xs) - min(xs), max(ys) - min(ys), 1.0)
+        pts += [(xmid - 64.0 * span, ymid - 32.0 * span),
+                (xmid + 64.0 * span, ymid - 32.0 * span),
+                (xmid, ymid + 64.0 * span)]
+        # Triangles keyed by CCW vertex triple, valued by circumcircle.
+        cc = {(npt, npt + 1, npt + 2):
+              cls._circumcircle(pts, npt, npt + 1, npt + 2)}
+        for ip in range(npt):
+            px, py = pts[ip]
+            bad = [tri for tri, (ux, uy, rr) in cc.items()
+                   if (px - ux) ** 2 + (py - uy) ** 2 < rr * (1.0 - 1e-12)]
+            dedges = set()
+            for tri in bad:
+                ta, tb, tc = tri
+                dedges.update(((ta, tb), (tb, tc), (tc, ta)))
+                del cc[tri]
+            # The cavity rim is the directed edges whose reverse was not
+            # carved; they run CCW, so fanning them to the point keeps the
+            # triangles CCW.
+            for ea, eb in dedges:
+                if (eb, ea) not in dedges:
+                    cc[(ea, eb, ip)] = cls._circumcircle(pts, ea, eb, ip)
+        tris = []
+        for tri in cc:
+            if max(tri) >= npt:
+                continue
+            (ax, ay), (bx, by), (cx, cy) = (pts[iv] for iv in tri)
+            if (bx - ax) * (cy - ay) - (cx - ax) * (by - ay) < 0.0:
+                tri = (tri[0], tri[2], tri[1])
+            tris.append(tri)
+        return tris
+
+    @classmethod
+    def _split_double_boundary(cls, pad):
+        """Triangulate the :class:`PointPad` ``pad``, appending Steiner
+        points into it until no cell touches the boundary with more than
+        one face; returns the triangles.
+
+        A cell with two single-shared (boundary) edges is a corner ear with
+        a single interior neighbour, which the CESE solver dislikes.  A
+        Steiner point at the ear's centroid keeps the next Delaunay pass
+        from rebuilding it; the boundary nodes never move, so the
+        classification is unchanged.  One pass suffices here; the cap only
+        bounds pathological input.
+        """
+        for _ in range(16):
+            tris = cls._triangulate(pad)
+            shared = {}
+            for tri in tris:
+                for it in range(3):
+                    edge = frozenset((tri[it], tri[(it + 1) % 3]))
+                    shared[edge] = shared.get(edge, 0) + 1
+            extra = []
+            for tri in tris:
+                on_boundary = sum(
+                    1 for it in range(3)
+                    if shared[frozenset((tri[it], tri[(it + 1) % 3]))] == 1)
+                if on_boundary >= 2:
+                    extra.append((sum(pad.x_at(iv) for iv in tri) / 3.0,
+                                  sum(pad.y_at(iv) for iv in tri) / 3.0))
+            if not extra:
+                return tris
+            for xc, yc in extra:
+                pad.append(xc, yc)
+        raise RuntimeError("boundary-cell refinement did not converge")
+
+    @staticmethod
+    def classify_boundary(mh, tol=1e-9):
+        """Bucket the boundary faces of ``mh`` by physical role.
+
+        A boundary face has no neighbour cell, i.e. ``fccls(ifc, 1) < 0``.
+        Each is classified by its face-centre ``fccnd`` x position and
+        outward ``fcnml`` direction: the left edge (``x == xmin``, normal
+        pointing in -x) is the supersonic inlet, the right edge
+        (``x == xmax``, normal in +x) is the non-reflective outflow, and
+        every remaining face -- the deflecting bottom wedge and the
+        reflecting top -- is a slip wall.  ``xmin``/``xmax`` come from the
+        boundary face centres because ``ndcrd`` also carries extrapolated
+        ghost-node coordinates that overshoot the real edges.
+
+        Returns ``(inlet, walls, outflow)`` as sorted face-index lists
+        ready to feed ``add_inlet`` / ``add_slipwall`` / ``add_nonrefl``.
+        """
+        bfaces = [ifc for ifc in range(mh.nface) if mh.fccls[ifc, 1] < 0]
+        xcs = [mh.fccnd[ifc, 0] for ifc in bfaces]
+        xmin, xmax = min(xcs), max(xcs)
+        inlet, walls, outflow = [], [], []
+        for ifc in bfaces:
+            xc = mh.fccnd[ifc, 0]
+            nx = mh.fcnml[ifc, 0]
+            if abs(xc - xmin) <= tol and nx < 0.0:
+                inlet.append(ifc)
+            elif abs(xc - xmax) <= tol and nx > 0.0:
+                outflow.append(ifc)
+            else:
+                walls.append(ifc)
+        return sorted(inlet), sorted(walls), sorted(outflow)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/pilot/_gui.py
+++ b/modmesh/pilot/_gui.py
@@ -41,6 +41,7 @@ from . import airfoil
 if _pcore.enable:
     from PySide6.QtGui import QAction
     from . import _mesh
+    from . import _oblique
     from . import _euler1d
     from . import _burgers1d
     from . import _svg_gui
@@ -75,6 +76,7 @@ class _Controller(metaclass=_Singleton):
         self.gmsh_dialog = None
         self.svg_dialog = None
         self.sample_mesh = None
+        self.oblique_shock = None
         self.recdom = None
         self.naca4airfoil = None
         self.eulerone = None
@@ -95,6 +97,7 @@ class _Controller(metaclass=_Singleton):
         self.gmsh_dialog = _mesh.GmshFileDialog(mgr=self._rmgr)
         self.svg_dialog = _svg_gui.SVGFileDialog(mgr=self._rmgr)
         self.sample_mesh = _mesh.SampleMesh(mgr=self._rmgr)
+        self.oblique_shock = _oblique.ObliqueShockMesh(mgr=self._rmgr)
         self.recdom = _mesh.RectangularDomain(mgr=self._rmgr)
         self.naca4airfoil = airfoil.Naca4Airfoil(mgr=self._rmgr)
         self.eulerone = _euler1d.Euler1DApp(mgr=self._rmgr)
@@ -128,6 +131,7 @@ class _Controller(metaclass=_Singleton):
         self.gmsh_dialog.populate_menu()
         self.svg_dialog.populate_menu()
         self.sample_mesh.populate_menu()
+        self.oblique_shock.populate_menu()
         self.naca4airfoil.populate_menu()
         self.recdom.populate_menu()
         self.eulerone.populate_menu()

--- a/modmesh/pilot/_oblique.py
+++ b/modmesh/pilot/_oblique.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+Example pilot app drawing the oblique-shock reflection mesh.
+
+The mesh construction and boundary tagging live in
+:mod:`modmesh.multidim.euler.oblique`; this feature only draws the mesh in a 3D
+widget and reports the boundary classification (inlet / slip wall / outflow)
+to the console.
+"""
+
+from ..multidim.euler import oblique
+from . import _gui_common
+
+__all__ = [  # noqa: F822
+    'ObliqueShockMesh',
+]
+
+
+class ObliqueShockMesh(_gui_common.PilotFeature):
+    """
+    Draw the oblique-shock reflection mesh and tag its boundary.
+    """
+
+    def populate_menu(self):
+        self._add_menu_item(
+            menu=self._mgr.meshMenu,
+            text="Sample: oblique-shock reflection mesh (2D quad)",
+            tip="Draw the quad wedge mesh for the oblique-shock reflection",
+            func=self.draw_quad_mesh,
+        )
+        self._add_menu_item(
+            menu=self._mgr.meshMenu,
+            text="Sample: oblique-shock reflection mesh (2D triangle)",
+            tip="Draw the triangle wedge mesh for the oblique-shock "
+                "reflection",
+            func=self.draw_triangle_mesh,
+        )
+        self._add_menu_item(
+            menu=self._mgr.meshMenu,
+            text="Sample: oblique-shock reflection mesh (2D unstructured)",
+            tip="Draw the unstructured (Delaunay) triangle wedge mesh for "
+                "the oblique-shock reflection",
+            func=self.draw_unstructured_mesh,
+        )
+
+    def draw_quad_mesh(self):
+        self._draw_mesh('quad')
+
+    def draw_triangle_mesh(self):
+        self._draw_mesh('triangle')
+
+    def draw_unstructured_mesh(self):
+        self._draw_mesh('unstructured')
+
+    def _draw_mesh(self, cell_type):
+        mesher = oblique.ObliqueShockMesher()
+        mh = mesher.make_mesh(cell_type=cell_type)
+        inlet, walls, outflow = mesher.classify_boundary(mh)
+        w = self._mgr.add3DWidget()
+        w.updateMesh(mh)
+        w.showMark()
+        self._pycon.writeToHistory(
+            f"oblique-shock {cell_type} mesh: {mh.ncell} cells, "
+            f"{mh.nedge} edges\n"
+            f"boundary faces: {len(inlet)} inlet, {len(walls)} slip wall, "
+            f"{len(outflow)} outflow\n")
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,8 @@ def main():
         version="0.0",
         packages=[
             'modmesh',
+            'modmesh.multidim',
+            'modmesh.multidim.euler',
             'modmesh.onedim',
             'modmesh.pilot',
             'modmesh.pilot.airfoil',

--- a/tests/test_multidim_euler_oblique.py
+++ b/tests/test_multidim_euler_oblique.py
@@ -1,0 +1,287 @@
+# Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+"""Phase 1 of porting the 2/3D Euler solver: the oblique-shock
+reflection mesh and its boundary tagging, implemented in
+``modmesh.multidim.euler.oblique`` and shared with the pilot GUI.
+
+A uniform supersonic stream enters from the left over a slip wall whose bottom
+turns into a wedge inclined by a fixed angle.  The wedge deflects the flow, an
+oblique shock forms at the wedge tip and reflects off the flat top slip wall,
+and the flow leaves through the non-reflective outflow on the right.  The mesh
+comes in three element flavors: one quadrilateral per grid box, each box cut
+into two triangles, or a Delaunay triangulation of jittered interior points.
+"""
+
+import unittest
+
+from numpy.testing import assert_almost_equal
+
+import modmesh
+from modmesh.multidim.euler.oblique import ObliqueShockMesher
+
+
+class _ObliqueMeshBase:
+    """The oblique-shock mesh builds and its boundary classifies cleanly.
+
+    The boundary checks are identical for all three element flavors because
+    every flavor shares the same boundary node layout (interior-only changes
+    in cell shape never touch the boundary faces); subclasses set the flavor,
+    and the box-based flavors also set the cell count per grid box.
+    """
+
+    NX = 24
+    NY = 8
+    LL = (0.0, 0.0)
+    UR = (3.0, 1.0)
+    CELL_TYPE = None
+    CELLS_PER_BOX = None
+    CLTPN = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mesher = ObliqueShockMesher(nx=cls.NX, ny=cls.NY, ll=cls.LL,
+                                        ur=cls.UR, x_ramp=0.5,
+                                        wedge_angle=15.0)
+        cls.mesh = cls.mesher.make_mesh(cell_type=cls.CELL_TYPE)
+
+    def _boundary_faces(self):
+        return {ifc for ifc in range(self.mesh.nface)
+                if self.mesh.fccls[ifc, 1] < 0}
+
+    def _signed_area2(self, icl):
+        # Twice the signed shoelace area of cell icl, straight from
+        # ndcrd/clnds via element access (the .ndarray views carry
+        # prepended ghost rows).
+        mh = self.mesh
+        nnd = mh.clnds[icl, 0]
+        xy = [(mh.ndcrd[mh.clnds[icl, 1 + it], 0],
+               mh.ndcrd[mh.clnds[icl, 1 + it], 1])
+              for it in range(nnd)]
+        return sum(xy[it][0] * xy[(it + 1) % nnd][1]
+                   - xy[(it + 1) % nnd][0] * xy[it][1]
+                   for it in range(nnd))
+
+    def test_mesh_shape(self):
+        mh = self.mesh
+        nbox = self.NX * self.NY
+        self.assertEqual(2, mh.ndim)
+        self.assertEqual(self.CELLS_PER_BOX * nbox, mh.ncell)
+        # Element access reads the body cells; the .ndarray views also
+        # carry the ghost cells that build_ghost prepends.
+        self.assertTrue(all(mh.cltpn[icl] == self.CLTPN
+                            for icl in range(mh.ncell)))
+        # A structured quad grid has 2*nx*ny + nx + ny faces; each box split
+        # adds one cell and one (diagonal, interior) face.
+        self.assertEqual((self.CELLS_PER_BOX + 1) * nbox + self.NX + self.NY,
+                         mh.nface)
+        # The boundary is the four edges of the logical grid either way.
+        self.assertEqual(2 * (self.NX + self.NY), len(self._boundary_faces()))
+
+    def test_classification_partitions_boundary(self):
+        inlet, walls, outflow = self.mesher.classify_boundary(self.mesh)
+        # Every role is present.
+        self.assertTrue(inlet)
+        self.assertTrue(walls)
+        self.assertTrue(outflow)
+        si, sw, so = set(inlet), set(walls), set(outflow)
+        # The three roles are pairwise disjoint.
+        self.assertEqual(set(), si & sw)
+        self.assertEqual(set(), si & so)
+        self.assertEqual(set(), sw & so)
+        # Together they cover every boundary face and nothing else.
+        self.assertEqual(self._boundary_faces(), si | sw | so)
+
+    def test_classification_counts(self):
+        inlet, walls, outflow = self.mesher.classify_boundary(self.mesh)
+        # The left and right edges carry one face per cell row; the top and
+        # bottom edges carry one per cell column.
+        self.assertEqual(self.NY, len(inlet))
+        self.assertEqual(self.NY, len(outflow))
+        self.assertEqual(2 * self.NX, len(walls))
+
+    def test_inlet_outflow_geometry(self):
+        mh = self.mesh
+        inlet, walls, outflow = self.mesher.classify_boundary(mh)
+        # The real domain spans [LL[0], UR[0]]; ndcrd would include ghost-node
+        # coordinates that overshoot the edges, so use the construction
+        # bounds.
+        xmin, xmax = self.LL[0], self.UR[0]
+        # Inlet faces sit on x == xmin with the outward normal pointing in -x.
+        for ifc in inlet:
+            assert_almost_equal(mh.fccnd[ifc, 0], xmin, decimal=12)
+            assert_almost_equal(
+                [mh.fcnml[ifc, 0], mh.fcnml[ifc, 1]], [-1.0, 0.0], decimal=12)
+        # Outflow faces sit on x == xmax with the normal pointing in +x.
+        for ifc in outflow:
+            assert_almost_equal(mh.fccnd[ifc, 0], xmax, decimal=12)
+            assert_almost_equal(
+                [mh.fcnml[ifc, 0], mh.fcnml[ifc, 1]], [1.0, 0.0], decimal=12)
+        # Wall faces are the top and bottom edges: their centres are strictly
+        # interior in x and their outward normals are vertical-dominant.
+        for ifc in walls:
+            xc = mh.fccnd[ifc, 0]
+            self.assertGreater(xc, xmin)
+            self.assertLess(xc, xmax)
+            self.assertGreater(abs(mh.fcnml[ifc, 1]), abs(mh.fcnml[ifc, 0]))
+
+    def test_wedge_is_present(self):
+        # The defining feature versus a plain channel: some slip-wall faces
+        # are inclined, so their outward normal has a non-zero x component.
+        mh = self.mesh
+        _, walls, _ = self.mesher.classify_boundary(mh)
+        inclined = [ifc for ifc in walls if abs(mh.fcnml[ifc, 0]) > 1e-6]
+        self.assertTrue(inclined)
+
+    def test_cell_winding_and_volume(self):
+        # clvol alone cannot pin the winding: build_interior repairs
+        # inverted faces and accumulates absolute values, so it stays
+        # positive even for clockwise connectivity.  Check the signed
+        # shoelace area instead, and keep the clvol check for degeneracy
+        # (zero or NaN volume).
+        mh = self.mesh
+        for icl in range(mh.ncell):
+            self.assertGreater(self._signed_area2(icl), 0.0)
+            self.assertGreater(mh.clvol[icl], 0.0)
+
+    def test_cells_tile_the_domain(self):
+        # The cells tile the domain exactly (no overlap, no gap): the
+        # signed cell areas must sum to the area enclosed by the boundary
+        # faces, computed independently through the divergence theorem
+        # (area = 1/2 * sum of fcara * (fccnd . fcnml) over the boundary).
+        mh = self.mesh
+        total = sum(self._signed_area2(icl) for icl in range(mh.ncell)) / 2.0
+        enclosed = sum(mh.fcara[ifc] * (mh.fccnd[ifc, 0] * mh.fcnml[ifc, 0]
+                                        + mh.fccnd[ifc, 1] * mh.fcnml[ifc, 1])
+                       for ifc in self._boundary_faces()) / 2.0
+        assert_almost_equal(total, enclosed, decimal=10)
+
+
+class _SingleBoundaryFaceTB:
+    """No cell touches the domain boundary with more than one face.
+
+    Mixed into the triangular flavors only: a corner ``'quad'`` cell always
+    owns its two adjacent boundary edges, so quads are exempt.
+    """
+
+    def test_at_most_one_boundary_face_per_cell(self):
+        # Each cell keeps at least two interior neighbours for the CESE
+        # solver.  fccls(ifc, 0) is the interior cell of boundary face ifc,
+        # so tallying it counts the boundary faces each cell owns.
+        mh = self.mesh
+        per_cell = {}
+        for ifc in self._boundary_faces():
+            icl = mh.fccls[ifc, 0]
+            per_cell[icl] = per_cell.get(icl, 0) + 1
+        self.assertTrue(per_cell)
+        self.assertLessEqual(max(per_cell.values()), 1)
+
+
+class ObliqueShockQuadMeshTC(_ObliqueMeshBase, unittest.TestCase):
+    """One quadrilateral per grid box."""
+
+    CELL_TYPE = 'quad'
+    CELLS_PER_BOX = 1
+    CLTPN = modmesh.StaticMesh.QUADRILATERAL
+
+
+class ObliqueShockTriangleMeshTC(_ObliqueMeshBase, _SingleBoundaryFaceTB,
+                                 unittest.TestCase):
+    """Each grid box cut along its diagonal into two triangles."""
+
+    CELL_TYPE = 'triangle'
+    CELLS_PER_BOX = 2
+    CLTPN = modmesh.StaticMesh.TRIANGLE
+
+
+class ObliqueShockUnstructuredMeshTC(_ObliqueMeshBase, _SingleBoundaryFaceTB,
+                                     unittest.TestCase):
+    """Delaunay triangulation of the wedge: the structured boundary layout
+    with jittered interior points.  The boundary tests of the base apply
+    unchanged because all flavors share the boundary node layout.
+    """
+
+    CELL_TYPE = 'unstructured'
+    CELLS_PER_BOX = None  # not box-based; test_mesh_shape is overridden
+    CLTPN = modmesh.StaticMesh.TRIANGLE
+
+    def _body_connectivity(self, mh):
+        # The body cells as (type, node-id tuple) pairs, plus the node
+        # coordinates, via element access -- the canonical identity of a
+        # mesh, free of the ghost rows and uninitialised trailing clnds
+        # columns that the raw .ndarray views carry.
+        cells = [(mh.cltpn[icl],
+                  tuple(mh.clnds[icl, 1 + it]
+                        for it in range(mh.clnds[icl, 0])))
+                 for icl in range(mh.ncell)]
+        nodes = [(mh.ndcrd[ind, 0], mh.ndcrd[ind, 1])
+                 for ind in range(mh.nnode)]
+        return cells, nodes
+
+    def test_mesh_shape(self):
+        # The counts are not box-based, but any triangulation using every
+        # vertex of a convex region obeys exact combinatorics: with nb
+        # boundary and ni interior vertices it has 2*ni + nb - 2 cells,
+        # and the Euler characteristic of a disk (V - E + F = 1) pins the
+        # face count.
+        mh = self.mesh
+        nbnd = 2 * (self.NX + self.NY)
+        self.assertEqual(2, mh.ndim)
+        self.assertTrue(all(mh.cltpn[icl] == self.CLTPN
+                            for icl in range(mh.ncell)))
+        self.assertEqual(nbnd, len(self._boundary_faces()))
+        self.assertEqual(2 * (mh.nnode - nbnd) + nbnd - 2, mh.ncell)
+        self.assertEqual(1, mh.nnode - mh.nface + mh.ncell)
+
+    def test_triangulation_is_deterministic(self):
+        # The flavor advertises a reproducible mesh (RNG-free jitter): a
+        # second build of the same parameters must reproduce the node
+        # coordinates and the triangle connectivity exactly.  Guards against
+        # a future switch to an unseeded RNG, which the count/Euler/tiling
+        # invariants would not catch.
+        again = self.mesher.make_mesh(cell_type=self.CELL_TYPE)
+        self.assertEqual(self._body_connectivity(self.mesh),
+                         self._body_connectivity(again))
+
+
+class ObliqueShockMesherTC(unittest.TestCase):
+
+    def test_unknown_cell_type(self):
+        with self.assertRaises(ValueError):
+            ObliqueShockMesher(nx=2, ny=2).make_mesh(cell_type='hexagon')
+
+    def test_wedge_top_must_stay_below_ly(self):
+        # Past atan(height / (ur[0] - x_ramp)) the grid columns invert and
+        # the mesh would silently self-overlap; the constructor refuses
+        # instead.  Here the limit is atan(1.0 / 2.5) ~ 21.8 degrees, so 30
+        # degrees overflows.
+        with self.assertRaises(ValueError):
+            ObliqueShockMesher(nx=2, ny=2, ll=(0.0, 0.0), ur=(3.0, 1.0),
+                               x_ramp=0.5, wedge_angle=30.0)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Set up the mesh for the classic oblique-shock reflection: a supersonic inflow over a rectangular domain whose bottom slip wall ramps into a wedge, with the reflecting top wall and a non-reflective outflow on the right.

- `modmesh/multidim/euler/oblique.py`: `ObliqueShockMesher` takes the domain geometry (`nx`, `ny`, `ll`, `ur`, `x_ramp`, `wedge_angle`) and `make_mesh(cell_type)` builds the domain in three element flavors: `'quad'` (one quadrilateral per grid box), `'triangle'` (each box split along its lower-left-to-upper-right diagonal), and `'unstructured'` (Bowyer-Watson Delaunay triangulation of the boundary nodes plus deterministically jittered interior points).
  - Every flavor collects its nodes in a `PointPadFp64` through the `SimpleArray` API.
  - In either triangular flavor, No cell touches the boundary with more than one face.
  - `classify_boundary` buckets the boundary faces into inlet, slip-wall, and outflow lists ready for the boundary-condition registration.
- `modmesh/pilot/_oblique.py`: pilot menu items drawing the three flavors.
- `tests/test_multidim_euler_oblique.py`: mesh shape and combinatorics, boundary classification, cell winding, domain tiling, determinism, and the one-boundary-face-per-cell rule.

For phase 1 of issue #404.