### PR TITLE
Add the oblique-shock Euler driver and a 2D color-field pilot view

### DIFF
--- a/cpp/modmesh/pilot/R3DWidget.cpp
+++ b/cpp/modmesh/pilot/R3DWidget.cpp
@@ -87,6 +87,28 @@ void R3DWidget::updateWorld(std::shared_ptr<WorldFp64> const & world)
     new RVertices(world, m_scene);
     new RLines(world, m_scene);
 
+    fitCameraToScene();
+}
+
+void R3DWidget::updateColorField(
+    SimpleArray<float> const & vertices,
+    SimpleArray<float> const & colors,
+    SimpleArray<uint32_t> const & indices)
+{
+    for (Qt3DCore::QNode * child : m_scene->childNodes())
+    {
+        if (typeid(*child) == typeid(RColorField))
+        {
+            child->deleteLater();
+        }
+    }
+    new RColorField(vertices, colors, indices, m_scene);
+
+    fitCameraToScene();
+}
+
+void R3DWidget::fitCameraToScene()
+{
     QVector3D box_min_pt = m_scene->minPoint(); // get the bottom-left corner of bounding box
     QVector3D box_max_pt = m_scene->maxPoint(); // get the top-right corner of bounding box
     QVector3D box_center = (box_min_pt + box_max_pt) * 0.5f; // center point of the bounding box

--- a/cpp/modmesh/pilot/R3DWidget.hpp
+++ b/cpp/modmesh/pilot/R3DWidget.hpp
@@ -124,10 +124,16 @@ public:
     void showMark();
     void updateMesh(std::shared_ptr<StaticMesh> const & mesh);
     void updateWorld(std::shared_ptr<WorldFp64> const & world);
+    void updateColorField(
+        SimpleArray<float> const & vertices,
+        SimpleArray<float> const & colors,
+        SimpleArray<uint32_t> const & indices);
 
     std::shared_ptr<StaticMesh> mesh() const { return m_mesh; }
 
 private:
+
+    void fitCameraToScene();
 
     Qt3DExtras::Qt3DWindow * m_view = nullptr;
     RScene * m_scene = nullptr;

--- a/cpp/modmesh/pilot/RWorld.cpp
+++ b/cpp/modmesh/pilot/RWorld.cpp
@@ -30,6 +30,10 @@
 
 #include <QTechnique>
 #include <QPointSize>
+#include <Qt3DExtras/QPerVertexColorMaterial>
+
+#include <limits>
+#include <stdexcept>
 
 #include <modmesh/pilot/common_detail.hpp>
 
@@ -256,6 +260,146 @@ RLines::RLines(std::shared_ptr<WorldFp64> const & world, Qt3DCore::QNode * paren
 
         addComponent(m_material);
     }
+}
+
+RColorField::RColorField(
+    SimpleArray<float> const & vertices,
+    SimpleArray<float> const & colors,
+    SimpleArray<uint32_t> const & indices,
+    Qt3DCore::QNode * parent)
+    : Qt3DCore::QEntity(parent)
+    , m_geometry(new Qt3DCore::QGeometry(this))
+    , m_renderer(new Qt3DRender::QGeometryRenderer())
+    , m_material(new Qt3DExtras::QPerVertexColorMaterial())
+{
+    // Require (nvert, 3) vertices, a matching (nvert, 3) color table, and
+    // (ntri, 3) triangle indices; mismatches would feed Qt malformed buffers.
+    if (vertices.ndim() != 2 || vertices.shape(1) != 3)
+    {
+        throw std::invalid_argument("RColorField: vertices must have shape (nvert, 3)");
+    }
+    if (colors.ndim() != 2 || colors.shape(0) != vertices.shape(0) || colors.shape(1) != 3)
+    {
+        throw std::invalid_argument("RColorField: colors must have shape (nvert, 3) matching vertices");
+    }
+    if (indices.ndim() != 2 || indices.shape(1) != 3)
+    {
+        throw std::invalid_argument("RColorField: indices must have shape (ntri, 3)");
+    }
+
+    size_t const nvert = vertices.shape(0);
+    size_t const ntri = indices.shape(0);
+
+    /*
+     * Fence the geometry building to skip empty input, mirroring RLines: Qt
+     * throws "QByteArray size disagrees with the requested shape" on a
+     * zero-sized buffer.
+     */
+    if (nvert == 0 || ntri == 0)
+    {
+        return;
+    }
+
+    {
+        // Vertex coordinate buffer; also accumulate the bounding box.
+        auto * attr = new Qt3DCore::QAttribute(m_geometry);
+        attr->setName(Qt3DCore::QAttribute::defaultPositionAttributeName());
+        attr->setAttributeType(Qt3DCore::QAttribute::VertexAttribute);
+        attr->setVertexBaseType(Qt3DCore::QAttribute::Float);
+        attr->setVertexSize(3);
+
+        QVector3D min_pt(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
+        QVector3D max_pt(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
+
+        auto * buf = new Qt3DCore::QBuffer(m_geometry);
+        {
+            QByteArray barray;
+            barray.resize(nvert * 3 * sizeof(float));
+            SimpleArray<float> sarr = makeSimpleArray<float>(barray, small_vector<size_t>{nvert, 3}, /*view*/ true);
+            for (size_t i = 0; i < nvert; ++i)
+            {
+                for (size_t d = 0; d < 3; ++d)
+                {
+                    sarr(i, d) = vertices(i, d);
+                }
+                min_pt.setX(std::min(min_pt.x(), sarr(i, 0)));
+                min_pt.setY(std::min(min_pt.y(), sarr(i, 1)));
+                min_pt.setZ(std::min(min_pt.z(), sarr(i, 2)));
+                max_pt.setX(std::max(max_pt.x(), sarr(i, 0)));
+                max_pt.setY(std::max(max_pt.y(), sarr(i, 1)));
+                max_pt.setZ(std::max(max_pt.z(), sarr(i, 2)));
+            }
+            buf->setData(barray);
+        }
+        attr->setBuffer(buf);
+        attr->setByteStride(3 * sizeof(float));
+        attr->setCount(nvert);
+        m_geometry->addAttribute(attr);
+
+        RScene * scene = qobject_cast<RScene *>(parent);
+        if (scene)
+        {
+            scene->updateBoundingBox(min_pt, max_pt);
+        }
+    }
+
+    {
+        // Per-vertex color buffer, read by the per-vertex-color material.
+        auto * attr = new Qt3DCore::QAttribute(m_geometry);
+        attr->setName(Qt3DCore::QAttribute::defaultColorAttributeName());
+        attr->setAttributeType(Qt3DCore::QAttribute::VertexAttribute);
+        attr->setVertexBaseType(Qt3DCore::QAttribute::Float);
+        attr->setVertexSize(3);
+
+        auto * buf = new Qt3DCore::QBuffer(m_geometry);
+        {
+            QByteArray barray;
+            barray.resize(nvert * 3 * sizeof(float));
+            SimpleArray<float> sarr = makeSimpleArray<float>(barray, small_vector<size_t>{nvert, 3}, /*view*/ true);
+            for (size_t i = 0; i < nvert; ++i)
+            {
+                for (size_t d = 0; d < 3; ++d)
+                {
+                    sarr(i, d) = colors(i, d);
+                }
+            }
+            buf->setData(barray);
+        }
+        attr->setBuffer(buf);
+        attr->setByteStride(3 * sizeof(float));
+        attr->setCount(nvert);
+        m_geometry->addAttribute(attr);
+    }
+
+    {
+        // Triangle index buffer.
+        auto * attr = new Qt3DCore::QAttribute(m_geometry);
+        attr->setVertexBaseType(Qt3DCore::QAttribute::UnsignedInt);
+        attr->setAttributeType(Qt3DCore::QAttribute::IndexAttribute);
+
+        auto * buf = new Qt3DCore::QBuffer(m_geometry);
+        {
+            QByteArray barray;
+            barray.resize(ntri * 3 * sizeof(uint32_t));
+            SimpleArray<uint32_t> sarr = makeSimpleArray<uint32_t>(barray, small_vector<size_t>{ntri, 3}, /*view*/ true);
+            for (size_t i = 0; i < ntri; ++i)
+            {
+                for (size_t d = 0; d < 3; ++d)
+                {
+                    sarr(i, d) = indices(i, d);
+                }
+            }
+            buf->setData(barray);
+        }
+        attr->setBuffer(buf);
+        attr->setCount(ntri * 3);
+        m_geometry->addAttribute(attr);
+    }
+
+    m_renderer->setGeometry(m_geometry);
+    m_renderer->setPrimitiveType(Qt3DRender::QGeometryRenderer::Triangles);
+    addComponent(m_renderer);
+    addComponent(m_material);
 }
 
 } /* end namespace modmesh */

--- a/cpp/modmesh/pilot/RWorld.hpp
+++ b/cpp/modmesh/pilot/RWorld.hpp
@@ -87,6 +87,27 @@ private:
 
 }; /* end class RLines */
 
+class RColorField
+    : public Qt3DCore::QEntity
+{
+    Q_OBJECT
+
+public:
+
+    RColorField(
+        SimpleArray<float> const & vertices,
+        SimpleArray<float> const & colors,
+        SimpleArray<uint32_t> const & indices,
+        Qt3DCore::QNode * parent = nullptr);
+
+private:
+
+    Qt3DCore::QGeometry * m_geometry = nullptr;
+    Qt3DRender::QGeometryRenderer * m_renderer = nullptr;
+    Qt3DRender::QMaterial * m_material = nullptr;
+
+}; /* end class RColorField */
+
 } /* end namespace modmesh */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/modmesh/pilot/wrap_pilot.cpp
+++ b/cpp/modmesh/pilot/wrap_pilot.cpp
@@ -157,6 +157,12 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapR3DWidget
             .def_property_readonly("mesh", &wrapped_type::mesh)
             .def("updateMesh", &wrapped_type::updateMesh, py::arg("mesh"))
             .def("updateWorld", &wrapped_type::updateWorld, py::arg("world"))
+            .def(
+                "updateColorField",
+                &wrapped_type::updateColorField,
+                py::arg("vertices"),
+                py::arg("colors"),
+                py::arg("indices"))
             .def("showMark", &wrapped_type::showMark)
             .def(
                 "clipImage",

--- a/modmesh/multidim/euler/oblique.py
+++ b/modmesh/multidim/euler/oblique.py
@@ -26,15 +26,16 @@
 
 
 """
-Mesh and boundary tagging for the oblique-shock reflection.
+Mesh, boundary tagging, and solver driver for the oblique-shock reflection.
 
 A uniform supersonic stream enters from the left over a slip wall whose
 bottom turns into a wedge inclined by a fixed angle.  The wedge deflects the
 flow, an oblique shock forms at the wedge tip and reflects off the flat top
 slip wall, and the flow leaves through the non-reflective outflow on the
-right.  This module owns the programmatic mesh builder and the geometric
-boundary classifier shared by the unit tests, the pilot GUI, and the
-forthcoming Euler-solver driver.
+right.  This module owns the programmatic mesh builder, the geometric
+boundary classifier, and the :class:`ObliqueShock` driver that marches the
+CESE Euler solver over the mesh; all three are shared by the unit tests and
+the pilot GUI.
 """
 
 import math
@@ -42,6 +43,7 @@ import math
 from ... import core
 
 __all__ = [
+    'ObliqueShock',
     'ObliqueShockMesher',
 ]
 
@@ -306,5 +308,67 @@ class ObliqueShockMesher(object):
             else:
                 walls.append(ifc)
         return sorted(inlet), sorted(walls), sorted(outflow)
+
+
+class ObliqueShock(object):
+    """Drive the CESE Euler solver over the oblique-shock reflection.
+    """
+
+    def __init__(self):
+        self.gamma = None
+        self.density = None
+        self.pressure = None
+        self.mach = None
+        self.speedofsound = None
+        self.velocity = None
+        self.mesher = None
+        self.mesh = None
+        # Numerical solver core (EulerCore).
+        self.svr = None
+
+    def build_constant(self, gamma=1.4, density=1.0, pressure=1.0, mach=2.0):
+        """Fix the supersonic free stream entering at the inlet.
+
+        The stream is horizontal; the bottom wedge of the phase-1 mesh
+        deflects it to form the oblique shock.  The flow speed follows from
+        the Mach number and the speed of sound of the given state.
+        """
+        self.gamma = gamma
+        self.density = density
+        self.pressure = pressure
+        self.mach = mach
+        self.speedofsound = math.sqrt(gamma * pressure / density)
+        self.velocity = mach * self.speedofsound
+
+    def build_numerical(self, cell_type='quad', time_increment=2.e-3,
+                        sigma0=3.0, taumin=0.0, tauscale=1.0, **mesher_kw):
+        """After :meth:`build_constant` is done, build the numerical solver
+        :attr:`svr` over the selected mesh flavor.
+        """
+        if None is self.gamma:
+            raise ValueError("constants are not set; call build_constant()")
+        self.mesher = ObliqueShockMesher(**mesher_kw)
+        self.mesh = self.mesher.make_mesh(cell_type=cell_type)
+        # The core prepares the CE geometry (prepare_ce) on construction.
+        svr = core.EulerCore(mesh=self.mesh, time_increment=time_increment)
+        svr.sigma0 = sigma0
+        svr.taumin = taumin
+        svr.tauscale = tauscale
+        svr.init_solution(gamma=self.gamma, rho=self.density,
+                          v=[0.0, 0.0], p=self.pressure)
+        inlet, walls, outflow = self.mesher.classify_boundary(self.mesh)
+        svr.add_inlet(inlet, value=[self.density, self.velocity, 0.0,
+                                    self.pressure, self.gamma])
+        svr.add_slipwall(walls)
+        svr.add_nonrefl(outflow)
+        # Prime the ghost rows from the initial interior state so the first
+        # substep does not read zero-filled ghosts.
+        svr.bc_soln()
+        svr.bc_dsoln()
+        self.svr = svr
+
+    def march(self, steps):
+        """March the solver the requested number of full CESE steps."""
+        self.svr.march(steps=steps)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/modmesh/pilot/_gui.py
+++ b/modmesh/pilot/_gui.py
@@ -77,6 +77,7 @@ class _Controller(metaclass=_Singleton):
         self.svg_dialog = None
         self.sample_mesh = None
         self.oblique_shock = None
+        self.oblique_solver = None
         self.recdom = None
         self.naca4airfoil = None
         self.eulerone = None
@@ -98,6 +99,7 @@ class _Controller(metaclass=_Singleton):
         self.svg_dialog = _svg_gui.SVGFileDialog(mgr=self._rmgr)
         self.sample_mesh = _mesh.SampleMesh(mgr=self._rmgr)
         self.oblique_shock = _oblique.ObliqueShockMesh(mgr=self._rmgr)
+        self.oblique_solver = _oblique.ObliqueShockSolver(mgr=self._rmgr)
         self.recdom = _mesh.RectangularDomain(mgr=self._rmgr)
         self.naca4airfoil = airfoil.Naca4Airfoil(mgr=self._rmgr)
         self.eulerone = _euler1d.Euler1DApp(mgr=self._rmgr)
@@ -132,6 +134,7 @@ class _Controller(metaclass=_Singleton):
         self.svg_dialog.populate_menu()
         self.sample_mesh.populate_menu()
         self.oblique_shock.populate_menu()
+        self.oblique_solver.populate_menu()
         self.naca4airfoil.populate_menu()
         self.recdom.populate_menu()
         self.eulerone.populate_menu()

--- a/modmesh/pilot/_oblique.py
+++ b/modmesh/pilot/_oblique.py
@@ -26,20 +26,68 @@
 
 
 """
-Example pilot app drawing the oblique-shock reflection mesh.
+Example pilot apps for the oblique-shock reflection.
 
-The mesh construction and boundary tagging live in
-:mod:`modmesh.multidim.euler.oblique`; this feature only draws the mesh in a 3D
-widget and reports the boundary classification (inlet / slip wall / outflow)
-to the console.
+The mesh construction, boundary tagging, and solver driver live in
+:mod:`modmesh.multidim.euler.oblique`.  :class:`ObliqueShockMesh` draws the
+mesh in a 3D widget and reports the boundary classification (inlet / slip wall
+/ outflow) to the console; :class:`ObliqueShockSolver` runs the Euler driver
+and animates the evolving density as a flat 2D color field, drawn with the
+native ``R3DWidget.updateColorField`` per-cell-colored triangles.
 """
 
+import numpy as np
+
+from PySide6 import QtCore
+
+from .. import core
 from ..multidim.euler import oblique
 from . import _gui_common
 
 __all__ = [  # noqa: F822
     'ObliqueShockMesh',
+    'ObliqueShockSolver',
 ]
+
+
+def _colormap(t):
+    """Map ``t`` in [0, 1] to a jet-like RGB array (``..., 3``) in [0, 1].
+
+    A four-stop blue-cyan-yellow-red ramp; the triangle-wave channels are the
+    standard compact "jet" approximation, enough to read a scalar field
+    without pulling in a plotting dependency.
+    """
+    t = np.clip(np.asarray(t, dtype='float64'), 0.0, 1.0)
+    r = np.clip(1.5 - np.abs(4.0 * t - 3.0), 0.0, 1.0)
+    g = np.clip(1.5 - np.abs(4.0 * t - 2.0), 0.0, 1.0)
+    b = np.clip(1.5 - np.abs(4.0 * t - 1.0), 0.0, 1.0)
+    return np.stack([r, g, b], axis=-1)
+
+
+def _cell_triangulation(mh):
+    """
+    Per-cell unshared triangle vertices and indices for a flat color field.
+    """
+    verts, tris, nnds = [], [], []
+    base = 0
+    for icl in range(mh.ncell):
+        nnd = mh.clnds[icl, 0]
+        nnds.append(nnd)
+        for it in range(nnd):
+            ind = mh.clnds[icl, 1 + it]
+            verts.append((mh.ndcrd[ind, 0], mh.ndcrd[ind, 1], 0.0))
+        for it in range(1, nnd - 1):
+            tris.append((base, base + it, base + it + 1))
+        base += nnd
+    return (np.array(verts, dtype='float32'),
+            np.array(tris, dtype='uint32'),
+            np.array(nnds, dtype='int64'))
+
+
+def _field_colors(field, nnds, vmin, vmax):
+    span = vmax - vmin
+    t = (field - vmin) / span if span > 0 else np.zeros_like(field)
+    return np.repeat(_colormap(t), nnds, axis=0).astype('float32')
 
 
 class ObliqueShockMesh(_gui_common.PilotFeature):
@@ -90,6 +138,72 @@ class ObliqueShockMesh(_gui_common.PilotFeature):
             f"{mh.nedge} edges\n"
             f"boundary faces: {len(inlet)} inlet, {len(walls)} slip wall, "
             f"{len(outflow)} outflow\n")
+
+
+class ObliqueShockSolver(_gui_common.PilotFeature):
+    """
+    Run the oblique-shock Euler driver and animate the density field.
+    """
+
+    #: Solver steps marched per timer frame.
+    STEPS_PER_FRAME = 5
+    #: Stop the animation after this many steps.
+    MAX_STEPS = 2000
+    #: Qt timer interval in milliseconds.
+    INTERVAL_MS = 50
+
+    def __init__(self, *args, **kw):
+        # Keep every running session (3D widget, timer, driver) referenced so
+        # Qt and the driver are not garbage-collected mid-run.
+        self._sessions = []
+        super(ObliqueShockSolver, self).__init__(*args, **kw)
+
+    def populate_menu(self):
+        self._add_menu_item(
+            menu=self._mgr.meshMenu,
+            text="Sample: oblique-shock solution (density)",
+            tip="March the oblique-shock Euler solver and draw the density "
+                "as a 2D color field",
+            func=self._run,
+        )
+
+    def _run(self):
+        shock = oblique.ObliqueShock()
+        shock.build_constant()
+        shock.build_numerical(cell_type='quad')
+
+        # The cell geometry is fixed across the run; only the colors change,
+        # so triangulate once and cache the vertex/index arrays.
+        verts, indices, nnds = _cell_triangulation(shock.mesh)
+        widget = self._mgr.add3DWidget()
+        widget.showMark()
+        timer = QtCore.QTimer()
+        session = dict(shock=shock, widget=widget, timer=timer, nnds=nnds,
+                       verts=core.SimpleArrayFloat32(array=verts),
+                       indices=core.SimpleArrayUint32(array=indices), step=0)
+        self._draw_frame(session)
+        timer.timeout.connect(lambda: self._advance(session))
+        timer.start(self.INTERVAL_MS)
+        self._sessions.append(session)
+
+    def _advance(self, session):
+        if session['step'] >= self.MAX_STEPS:
+            session['timer'].stop()
+            return
+        session['shock'].march(self.STEPS_PER_FRAME)
+        session['step'] += self.STEPS_PER_FRAME
+        self._draw_frame(session)
+
+    def _draw_frame(self, session):
+        svr = session['shock'].svr
+        # Density is the first conserved variable; the raw .ndarray view
+        # prepends the ghost rows, so colour only the body cells.
+        field = svr.so0n.ndarray[svr.ngstcell:, 0]
+        colors = _field_colors(field, session['nnds'],
+                               field.min(), field.max())
+        session['widget'].updateColorField(
+            session['verts'], core.SimpleArrayFloat32(array=colors),
+            session['indices'])
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_multidim_euler_oblique.py
+++ b/tests/test_multidim_euler_oblique.py
@@ -25,9 +25,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
-"""Phase 1 of porting the 2/3D Euler solver: the oblique-shock
-reflection mesh and its boundary tagging, implemented in
-``modmesh.multidim.euler.oblique`` and shared with the pilot GUI.
+"""The oblique-shock reflection test.
 
 A uniform supersonic stream enters from the left over a slip wall whose bottom
 turns into a wedge inclined by a fixed angle.  The wedge deflects the flow, an
@@ -42,7 +40,7 @@ import unittest
 from numpy.testing import assert_almost_equal
 
 import modmesh
-from modmesh.multidim.euler.oblique import ObliqueShockMesher
+from modmesh.multidim.euler.oblique import ObliqueShock, ObliqueShockMesher
 
 
 class _ObliqueMeshBase:
@@ -282,6 +280,54 @@ class ObliqueShockMesherTC(unittest.TestCase):
         with self.assertRaises(ValueError):
             ObliqueShockMesher(nx=2, ny=2, ll=(0.0, 0.0), ur=(3.0, 1.0),
                                x_ramp=0.5, wedge_angle=30.0)
+
+
+class _ObliqueShockDriverBase:
+    """Base class to test for solver over each mesh flavor and marches a few
+    steps; subclasses select the flavor.
+    """
+
+    CELL_TYPE = None
+    # A coarse mesh keeps the driver tests fast.
+    MESHER_KW = dict(nx=24, ny=8, x_ramp=1.0)
+
+    def test_build_and_march(self):
+        shock = ObliqueShock()
+        shock.build_constant()
+        shock.build_numerical(cell_type=self.CELL_TYPE, **self.MESHER_KW)
+        # The core is built over the mesh with the right shape.
+        self.assertEqual(shock.mesh.ncell, shock.svr.ncell)
+        self.assertEqual(2, shock.svr.ndim)
+        # The solution is not yet validated. Only make sure the solver runs
+        # through.
+        shock.march(10)
+
+
+class ObliqueShockDriverQuadTC(_ObliqueShockDriverBase, unittest.TestCase):
+    """The driver over the structured quadrilateral mesh."""
+
+    CELL_TYPE = 'quad'
+
+
+class ObliqueShockDriverTriangleTC(_ObliqueShockDriverBase,
+                                   unittest.TestCase):
+    """The driver over the structured triangular mesh."""
+
+    CELL_TYPE = 'triangle'
+
+
+class ObliqueShockDriverUnstructuredTC(_ObliqueShockDriverBase,
+                                       unittest.TestCase):
+    """The driver over the unstructured (Delaunay) triangular mesh."""
+
+    CELL_TYPE = 'unstructured'
+
+
+class ObliqueShockDriverTC(unittest.TestCase):
+
+    def test_numerical_requires_constants(self):
+        with self.assertRaises(ValueError):
+            ObliqueShock().build_numerical()
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Phase 2 of porting the multidimensional Euler solver (issue #404): a Python driver over the phase-1 oblique-shock mesh, plus a native pilot visualization of the evolving solution.

Driver (modmesh/multidim/euler/oblique.py):
- `ObliqueShock` class has a simple time-marcher. We only test that it can run through at this point.

RWorld per-cell color field (cpp/modmesh/pilot):
- Add `RColorField`, a Qt3D entity that renders filled triangles with a `QPerVertexColorMaterial` from plain arrays.  `R3DWidget::updateColorField()` swaps one in and frames it; the camera fit is factored out of `updateWorld()` into `fitCameraToScene()`.

The drawing is basic.  The solution does not look right.  I cannot be sure about the correctness of the drawing.  The code is experimental.
<img width="1004" height="637" alt="image" src="https://github.com/user-attachments/assets/cca4a57c-70f9-4e7b-95c6-e7fb4b6d9eea" />

Pilot view (modmesh/pilot/_oblique.py, _gui.py):
- ObliqueShockSolver runs the driver over the quad mesh and draws the density as a flat 2D color field.