### PR TITLE
Build and test Qt on the xcb backend

### DIFF
--- a/.github/actions/setup_linux/action.yml
+++ b/.github/actions/setup_linux/action.yml
@@ -9,19 +9,30 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Add 12G swap
+    - name: Add swap
       # Prevent hitting runner's resource limits when running clang-tidy
       shell: bash
       run: |
-        echo "::group::Add 12G swap"
+        echo "::group::Add swap"
         # Remove /swapfile first to avoid "fallocate: Text file busy" error
         sudo swapoff -a
         sudo rm -f /swapfile
-        sudo fallocate -l 12G /swapfile
+        sudo fallocate -l 8G /swapfile
         sudo chmod 600 /swapfile
         sudo mkswap /swapfile
         sudo swapon /swapfile
         free -h
+        echo "::endgroup::"
+
+    - name: Free disk space
+      if: "${{ inputs.workflow == 'lint' || inputs.workflow == 'build' }}"
+      shell: bash
+      run: |
+        echo "::group::Free disk space"
+        df -h /
+        sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+                    /opt/hostedtoolcache/CodeQL || true
+        df -h /
         echo "::endgroup::"
 
     - name: Cache Qt download
@@ -114,6 +125,37 @@ runs:
         modules: 'qt3d'
         setup-python: 'false'
         cache: false
+
+    - name: Set up Xvfb for the xcb platform
+      if: "${{ inputs.workflow == 'lint' || inputs.workflow == 'build' }}"
+      shell: bash
+      run: |
+        echo "::group::Set up Xvfb for the xcb platform"
+        # libgl1-mesa-dri provides the llvmpipe software rasterizer so the
+        # pilot's OpenGL renders under the GPU-less Xvfb display. The X11/XCB
+        # libraries are the runtime counterparts of the -dev packages the mmdv
+        # build script installs (contrib/dependency/ubuntu2404/
+        # build-mmdv-ubuntu24.sh, mmdv_apt_qt_cmd); keep the two sets in sync.
+        sudo apt-get -qy install \
+            xvfb x11-utils \
+            libgl1 libglx-mesa0 libgl1-mesa-dri libegl1 libopengl0 \
+            libxkbcommon-x11-0 libx11-xcb1 \
+            libxcb1 libxcb-glx0 libxcb-cursor0 libxcb-icccm4 libxcb-image0 \
+            libxcb-keysyms1 libxcb-randr0 libxcb-render0 libxcb-render-util0 \
+            libxcb-shape0 libxcb-shm0 libxcb-sync1 libxcb-util1 \
+            libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1
+        Xvfb :99 -screen 0 1280x1024x24 >/tmp/xvfb.log 2>&1 &
+        for _ in $(seq 1 50) ; do
+          xdpyinfo -display :99 >/dev/null 2>&1 && break
+          sleep 0.2
+        done
+        xdpyinfo -display :99 >/dev/null 2>&1 \
+          || { echo "Xvfb failed to start" >&2 ; cat /tmp/xvfb.log >&2 ; exit 1 ; }
+        # Export DISPLAY for xcb.
+        echo "DISPLAY=:99" >> "${GITHUB_ENV}"
+        # Export QT_QPA_PLATFORM for xcb.
+        echo "QT_QPA_PLATFORM=xcb" >> "${GITHUB_ENV}"
+        echo "::endgroup::"
 
     - name: dependency by pip (common)
       shell: bash

--- a/.github/actions/setup_macos/action.yml
+++ b/.github/actions/setup_macos/action.yml
@@ -17,6 +17,17 @@ runs:
         sudo mkdir -p /usr/local/include
         echo "::endgroup::"
 
+    - name: Use the offscreen Qt platform
+      if: "${{ inputs.workflow == 'lint' || inputs.workflow == 'build' }}"
+      shell: bash
+      run: |
+        echo "::group::Use the offscreen Qt platform"
+        # macOS runners are headless and ship no xcb plugin, so keep the
+        # offscreen QPA plugin. The job-level env no longer pins
+        # QT_QPA_PLATFORM; set it here for the rest of the job.
+        echo "QT_QPA_PLATFORM=offscreen" >> "${GITHUB_ENV}"
+        echo "::endgroup::"
+
     - name: dependency by homebrew
       if: "${{ inputs.workflow == 'lint' || inputs.workflow == 'build' }}"
       shell: bash

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -101,7 +101,8 @@ jobs:
       # safe bet on both.
       MAKE_PARALLEL: -j2
       QT_DEBUG_PLUGINS: 1
-      QT_QPA_PLATFORM: offscreen # for Ubuntu runner
+      # QT_QPA_PLATFORM is set per-OS by the setup actions (xcb on Linux via
+      # Xvfb, offscreen on macOS). Do not set it at the job level.
       PIP_BREAK_SYSTEM_PACKAGES: 1 # disabling PEP668 (for MacOS runner)
       # Fix issue: https://github.com/solvcon/modmesh/issues/366
       # Use custom config for jurplel/install-qt-action@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,8 @@ jobs:
       # macOS runner clang-tidy then OOMs. -j2 is the safe bet on both.
       MAKE_PARALLEL: -j2
       QT_DEBUG_PLUGINS: 1
-      QT_QPA_PLATFORM: offscreen # for Ubuntu runner
+      # QT_QPA_PLATFORM is set per-OS by the setup actions (xcb on Linux via
+      # Xvfb, offscreen on macOS). Do not set it at the job level.
       PIP_BREAK_SYSTEM_PACKAGES: 1 # disabling PEP668 (for MacOS runner)
       # Fix issue: https://github.com/solvcon/modmesh/issues/366
       # Use custom config for jurplel/install-qt-action@v4

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -21,7 +21,8 @@ jobs:
 
     env:
       QT_DEBUG_PLUGINS: 1
-      QT_QPA_PLATFORM: offscreen # for Ubuntu runner
+      # QT_QPA_PLATFORM is set per-OS by the setup actions (xcb on Linux via
+      # Xvfb, offscreen on macOS). Do not set it at the job level.
       PIP_BREAK_SYSTEM_PACKAGES: 1 # disabling PEP668 (for MacOS runner)
       # Fix issue: https://github.com/solvcon/modmesh/issues/366
       # Use custom config for jurplel/install-qt-action@v4

--- a/contrib/dependency/ubuntu2404/build-mmdv-ubuntu24.sh
+++ b/contrib/dependency/ubuntu2404/build-mmdv-ubuntu24.sh
@@ -47,6 +47,11 @@
 #       Print MMDV_PREFIX (the path prefix that MMDV_BASE is derived from)
 #       to stdout and exit.  Nothing else is printed and no directories are
 #       created, so this is safe to capture: PREFIX=$(./script --print-prefix).
+#   ./build-mmdv-ubuntu24.sh --print-apt
+#       Print the apt prerequisite commands (the BASE/PYTHON/NUMPY section
+#       and the QT section) to stdout and exit.  Nothing is built and no
+#       directories are created.  The script never runs apt itself; copy the
+#       output, review it, and run it.
 #
 # Overridable variables (search in the script for their defaults and
 # descriptions; not repeating here):
@@ -73,6 +78,7 @@ set -o pipefail
 
 MMDV_WRITE_ACTIVATE_ONLY=0
 MMDV_PRINT_PREFIX_ONLY=0
+MMDV_PRINT_APT_ONLY=0
 MMDV_NO_CONFIRM=0
 MMDV_SKIP_LIST=""
 MMDV_KNOWN_PKGS="zlib openssl sqlite python pybind11 cython numpy scipy qt pyside6"
@@ -104,6 +110,9 @@ while [ $# -gt 0 ] ; do
       ;;
     --print-prefix)
       MMDV_PRINT_PREFIX_ONLY=1
+      ;;
+    --print-apt)
+      MMDV_PRINT_APT_ONLY=1
       ;;
     --no-confirm)
       MMDV_NO_CONFIRM=1
@@ -201,16 +210,37 @@ EOF
 
 mmdv_apt_qt_cmd() {
   # Print the apt command for the QT section (Qt + pyside6 build deps).
+  # The X11/XCB -dev packages are the full set Qt's xcb platform plugin
+  # needs at configure time. Without all of them Qt silently builds without
+  # the xcb QPA plugin, leaving only offscreen/minimal, so a real (or xvfb)
+  # X display cannot be used. build_qt force-enables FEATURE_xcb so a missing
+  # dependency fails the configure loudly instead of dropping the plugin.
+  # CI installs the runtime counterparts of these -dev packages in
+  # .github/actions/setup_linux/action.yml; keep the two sets in sync.
   cat <<'EOF'
 sudo apt install -y \
   llvm-22-dev clang-22 libclang-22-dev patchelf \
   libxkbcommon-dev libxkbcommon-x11-dev libfontconfig1-dev \
   libfreetype-dev libdbus-1-dev libgl1-mesa-dev libglu1-mesa-dev \
-  libxcb-cursor-dev libxcb-icccm4-dev libxcb-image0-dev \
-  libxcb-keysyms1-dev libxcb-randr0-dev libxcb-render-util0-dev \
-  libxcb-shape0-dev libxcb-xinerama0-dev libxcb-xkb-dev
+  libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev libxi-dev \
+  libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-cursor-dev \
+  libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev \
+  libxcb-randr0-dev libxcb-render0-dev libxcb-render-util0-dev \
+  libxcb-shape0-dev libxcb-shm0-dev libxcb-sync-dev libxcb-util-dev \
+  libxcb-xfixes0-dev libxcb-xinerama0-dev libxcb-xkb-dev
 EOF
 }
+
+# --print-apt prints both apt prerequisite commands and exits, before any
+# filesystem side effect (mkdir, activate-write, build). The apt helper
+# functions must be defined first, so this is honored here rather than
+# alongside --print-prefix above.
+if [ "${MMDV_PRINT_APT_ONLY}" = "1" ] ; then
+  mmdv_apt_base_cmd
+  echo
+  mmdv_apt_qt_cmd
+  exit 0
+fi
 
 mmdv_write_activate() {
   # Write ${MMDV_BASE}/activate. The activation script is self-locating (reads
@@ -744,6 +774,15 @@ build_qt() {
              qtquickeffectmaker qtgrpc qtmultimedia ; do
       cfgcmd+=("-DBUILD_${m}=OFF")
     done
+    # Force the xcb (X11) platform plugin on. Qt otherwise silently drops it
+    # when an XCB dev dependency is missing, leaving only the offscreen and
+    # minimal QPA plugins and making a real (or xvfb) X display unusable.
+    # Force-enabling turns a missing dependency into a configure-time failure
+    # here instead of a runtime "Could not find the Qt platform plugin xcb".
+    # xcb_xlib is the Xlib/XCB interop the plugin relies on. The required
+    # -dev packages are listed in mmdv_apt_qt_cmd above.
+    cfgcmd+=("-DFEATURE_xcb=ON")
+    cfgcmd+=("-DFEATURE_xcb_xlib=ON")
     cfgcmd+=("-DQT_ALLOW_SYMLINK_IN_PATHS=ON")
     cfgcmd+=("-DCMAKE_PREFIX_PATH=${MMDV_USRDIR}")
     cfgcmd+=("-G" "Ninja")


### PR DESCRIPTION
Use xcb instead of offscreen for Qt CI on Ubuntu Linux.

Update the mmdv build scripts accordingly.

For issue #889.