### PR TITLE
Parallelize make lint across processors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,11 +40,13 @@ jobs:
 
     env:
       JOB_MAKE_ARGS: VERBOSE=1 BUILD_QT=ON USE_CLANG_TIDY=ON LINT_AS_ERRORS=ON
-      # Cap build parallelism. The github-hosted runners have only 3 (macOS)
-      # / 4 (ubuntu) virtual cores shared with co-tenant VMs, so the default
-      # unbounded `make -j` oversubscribes memory and CPU; on the 7 GB arm64
-      # macOS runner clang-tidy then OOMs. -j2 is the safe bet on both.
-      MAKE_PARALLEL: -j2
+      # Cap parallelism. The github-hosted runners have only 3 (macOS) / 4
+      # (ubuntu) virtual cores shared with co-tenant VMs, so letting NPROC
+      # auto-detect oversubscribes memory and CPU; on the 7 GB arm64 macOS
+      # runner clang-tidy then OOMs. NPROC drives both MAKE_PARALLEL (build)
+      # and the lint targets (cformat xargs, flake8 --jobs), so capping it
+      # here bounds every parallel step. 2 is the safe bet on both runners.
+      NPROC: 2
       QT_DEBUG_PLUGINS: 1
       # QT_QPA_PLATFORM is set per-OS by the setup actions (xcb on Linux via
       # Xvfb, offscreen on macOS). Do not set it at the job level.
@@ -56,8 +58,8 @@ jobs:
     strategy:
       matrix:
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
-        # macos-26 is arm64 with 7 GB RAM; build parallelism is capped via
-        # MAKE_PARALLEL in the env block above so clang-tidy does not OOM.
+        # macos-26 is arm64 with 7 GB RAM; parallelism is capped via NPROC
+        # in the env block above so clang-tidy does not OOM.
         os: [ubuntu-24.04, macos-26]
         cmake_build_type: [Debug]
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,11 @@ BUILD_METAL ?= OFF
 BUILD_QT ?= ON
 USE_CLANG_TIDY ?= OFF
 CMAKE_BUILD_TYPE ?= Release
-MAKE_PARALLEL ?= -j
+# Number of online processors. Drives both build parallelism (MAKE_PARALLEL
+# below) and the lint targets. getconf works on both Linux and macOS; fall
+# back to 1 if unavailable. Override to cap parallelism, e.g. NPROC=2.
+NPROC ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
+MAKE_PARALLEL ?= -j $(NPROC)
 MODMESH_ROOT ?= $(shell pwd)
 CMAKE_INSTALL_PREFIX ?= $(MODMESH_ROOT)/build/fakeinstall
 CMAKE_LIBRARY_OUTPUT_DIRECTORY ?= $(MODMESH_ROOT)/modmesh
@@ -253,12 +257,8 @@ cformat: $(CFFILES)
 	if [ -n "$$ver" ] && [ "$$ver" != "$(CLANG_FORMAT_CI_VERSION)" ]; then \
 		echo "Warning: $(CLANG_FORMAT) major version $$ver differs from CI ($(CLANG_FORMAT_CI_VERSION)); formatting output may differ."; \
 	fi
-	@for fn in $(CFFILES) ; \
-	do \
-		echo "$(CFCMD) $${fn}:"; \
-		$(CFCMD) $${fn} ; ret=$$? ; \
-		if [ $${ret} -ne 0 ] ; then exit $${ret} ; fi ; \
-	done
+	@echo "Checking $(words $(CFFILES)) C++ files with clang-format..."
+	@printf '%s\n' $(CFFILES) | xargs -P $(NPROC) -n1 $(CFCMD)
 
 .PHONY: cinclude
 cinclude: $(CFFILES)
@@ -274,7 +274,7 @@ flake8:
 		echo "  Install: pip install flake8"; \
 		exit 1; \
 	}
-	$(FLAKE8) . --exclude thirdparty,tmp,_deps
+	$(FLAKE8) . --jobs $(NPROC) --exclude thirdparty,tmp,_deps
 
 .PHONY: checkascii
 checkascii:
@@ -284,8 +284,14 @@ checkascii:
 checktws:
 	$(WHICH_PYTHON) contrib/lint/check_ascii.py --check-tws
 
+# Run the lint targets concurrently, scaled to the processor count, and keep
+# going on failure so every check reports before make exits non-zero.
 .PHONY: lint
-lint: cformat cinclude flake8 checkascii checktws
+lint:
+	@$(MAKE) --no-print-directory -j $(NPROC) -k lint_targets
+
+.PHONY: lint_targets
+lint_targets: cformat cinclude flake8 checkascii checktws
 
 .PHONY: pyformat
 pyformat:


### PR DESCRIPTION
`make lint` ran its five checks serially, and `cformat` walked the ~180 C++ files in a serial shell loop, leaving most cores idle. This change adds an `NPROC` variable (detected via `getconf _NPROCESSORS_ONLN`, falling back to 1) and uses it to parallelize the whole lint run. Error propagation is preserved, and the knob stays overridable: `make NPROC=1 lint` restores fully serial execution.

| Target | Before | After |
| --- | --- | --- |
| `lint` | serial run of the five checks | recursive `$(MAKE) -j $(NPROC) -k lint_targets` |
| `cformat` | serial `for` loop over files | `xargs -P $(NPROC)` across cores |
| `flake8` | flake8 default `--jobs auto` | `--jobs $(NPROC)` |

On a 14-core machine `cformat` drops from ~5.4s to ~0.7s and the full lint run from ~8.7s to ~1.4s.
