### PR TITLE
Add a mesh information panel to the pilot

### DIFF
--- a/cpp/modmesh/pilot/RManager.cpp
+++ b/cpp/modmesh/pilot/RManager.cpp
@@ -129,6 +129,22 @@ R2DWidget * RManager::add2DWidget()
     return viewer;
 }
 
+R3DWidget * RManager::currentR3DWidget()
+{
+    if (m_mdiArea == nullptr)
+    {
+        return nullptr;
+    }
+
+    const auto * subwin = m_mdiArea->currentSubWindow();
+    if (subwin == nullptr)
+    {
+        return nullptr;
+    }
+
+    return dynamic_cast<R3DWidget *>(subwin->widget());
+}
+
 void RManager::toggleConsole()
 {
     if (m_pycon)

--- a/cpp/modmesh/pilot/RManager.hpp
+++ b/cpp/modmesh/pilot/RManager.hpp
@@ -61,6 +61,7 @@ public:
 
     R3DWidget * add3DWidget();
     R2DWidget * add2DWidget();
+    R3DWidget * currentR3DWidget();
 
     RPythonConsoleDockWidget * pycon() { return m_pycon; }
 

--- a/cpp/modmesh/pilot/wrap_pilot.cpp
+++ b/cpp/modmesh/pilot/wrap_pilot.cpp
@@ -358,6 +358,12 @@ class MODMESH_PYTHON_WRAPPER_VISIBILITY WrapRManager
                     return self.add2DWidget();
                 })
             .def(
+                "currentR3DWidget",
+                [](wrapped_type & self)
+                {
+                    return self.currentR3DWidget();
+                })
+            .def(
                 "toggleConsole",
                 [](wrapped_type & self)
                 {

--- a/modmesh/pilot/_gui.py
+++ b/modmesh/pilot/_gui.py
@@ -40,7 +40,9 @@ from . import airfoil
 
 if _pcore.enable:
     from PySide6.QtGui import QAction
+    from PySide6.QtWidgets import QMenu
     from . import _mesh
+    from . import _mesh_info
     from . import _oblique
     from . import _euler1d
     from . import _burgers1d
@@ -73,8 +75,10 @@ class _Controller(metaclass=_Singleton):
         # Do not construct any Qt member objects before calling launch(), or
         # Windows may "exited with code -1073740791."
         self._rmgr = None
+        self.panels_menu = None
         self.gmsh_dialog = None
         self.svg_dialog = None
+        self.mesh_info = None
         self.sample_mesh = None
         self.oblique_shock = None
         self.oblique_solver = None
@@ -95,9 +99,21 @@ class _Controller(metaclass=_Singleton):
         self._rmgr.setUp()
         self._rmgr.windowTitle = name
         self._rmgr.resize(w=size[0], h=size[1])
+
+        # Add the "Panels" submenu as the first item in the View menu.
+        view = self._rmgr.viewMenu
+        self.panels_menu = QMenu("Panels", self._rmgr.mainWindow)
+        actions = view.actions()
+        if actions:
+            view.insertMenu(actions[0], self.panels_menu)
+        else:
+            view.addMenu(self.panels_menu)
+
         self.gmsh_dialog = _mesh.GmshFileDialog(mgr=self._rmgr)
         self.svg_dialog = _svg_gui.SVGFileDialog(mgr=self._rmgr)
         self.sample_mesh = _mesh.SampleMesh(mgr=self._rmgr)
+        self.mesh_info = _mesh_info.MeshInfo(mgr=self._rmgr,
+                                             menu=self.panels_menu)
         self.oblique_shock = _oblique.ObliqueShockMesh(mgr=self._rmgr)
         self.oblique_solver = _oblique.ObliqueShockSolver(mgr=self._rmgr)
         self.recdom = _mesh.RectangularDomain(mgr=self._rmgr)
@@ -132,6 +148,7 @@ class _Controller(metaclass=_Singleton):
 
         self.gmsh_dialog.populate_menu()
         self.svg_dialog.populate_menu()
+        self.mesh_info.populate_menu()
         self.sample_mesh.populate_menu()
         self.oblique_shock.populate_menu()
         self.oblique_solver.populate_menu()

--- a/modmesh/pilot/_mesh_info.py
+++ b/modmesh/pilot/_mesh_info.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+"""Dock panel showing StaticMesh geometry counts in a foldable tree."""
+
+import numpy as np
+
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import (QWidget, QVBoxLayout, QDockWidget,
+                               QTreeWidget, QTreeWidgetItem, QFrame)
+
+from .. import core
+from . import _gui_common
+
+__all__ = [  # noqa: F822
+    'MeshInfo',
+]
+
+
+class MeshInfoPanel(QWidget):
+    """Widget that presents the mesh information tree inside the dock."""
+
+    # Map cell type numbers to human-readable names.
+    CELL_TYPE_NAME = {
+        core.StaticMesh.POINT: "point",
+        core.StaticMesh.LINE: "line",
+        core.StaticMesh.QUADRILATERAL: "quadrilateral",
+        core.StaticMesh.TRIANGLE: "triangle",
+        core.StaticMesh.HEXAHEDRON: "hexahedron",
+        core.StaticMesh.TETRAHEDRON: "tetrahedron",
+        core.StaticMesh.PRISM: "prism",
+        core.StaticMesh.PYRAMID: "pyramid",
+    }
+
+    def __init__(self, mh=None, parent=None):
+        super().__init__(parent)
+        self._tree = QTreeWidget()
+        self._tree.setColumnCount(1)
+        self._tree.setHeaderHidden(True)
+        # Drop the tree frame so its scroll bar sits flush in the panel.
+        self._tree.setFrameShape(QFrame.NoFrame)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._tree)
+        self.setLayout(layout)
+        self.set_mesh(mh)
+
+    @classmethod
+    def make_mesh_info(cls, mh):
+        """Build the mesh information as ``(section, rows)`` groups.
+
+        Each group pairs a heading with its ``[property, value]`` string
+        rows, so the panel renders one foldable tree node per group.
+        """
+        sections = [
+            ("Counts", [
+                ["dim", str(mh.ndim)],
+                ["node", str(mh.nnode)],
+                ["face", str(mh.nface)],
+                ["cell", str(mh.ncell)],
+                ["edge", str(mh.nedge)],
+                ["bound", str(mh.nbound)],
+                ["bcs", str(mh.nbcs)],
+            ]),
+            ("Ghost", [
+                ["node", str(mh.ngstnode)],
+                ["face", str(mh.ngstface)],
+                ["cell", str(mh.ngstcell)],
+            ]),
+        ]
+        # Ghost entities are stored first; measure only the body entities.
+        crd = mh.ndcrd.ndarray[mh.ndcrd.nghost:]
+        if crd.size:
+            lower = crd.min(axis=0)
+            upper = crd.max(axis=0)
+            bbox = [[axis, f"[{lower[it]:.4g}, {upper[it]:.4g}]"]
+                    for it, axis in zip(range(mh.ndim), "xyz")]
+            sections.append(("Bounding box", bbox))
+        # Tally the cell types over the body (non-ghost) cells.
+        tpn = mh.cltpn.ndarray[mh.cltpn.nghost:]
+        cells = []
+        for tnum, name in sorted(cls.CELL_TYPE_NAME.items()):
+            count = int(np.count_nonzero(tpn == tnum))
+            if count:
+                cells.append([name, str(count)])
+        if cells:
+            sections.append(("Cell types", cells))
+        return sections
+
+    def set_mesh(self, mh):
+        """Rebuild the tree from ``mh``, or show "No mesh loaded" when None."""
+        self._tree.clear()
+        if mh is None:
+            QTreeWidgetItem(self._tree, ["No mesh loaded"])
+            return
+        root = QTreeWidgetItem(self._tree, [f"StaticMesh ({mh.ndim}D)"])
+        for section, rows in self.make_mesh_info(mh):
+            group = QTreeWidgetItem(root, [section])
+            for prop, value in rows:
+                QTreeWidgetItem(group, [f"{prop}: {value}"])
+            group.setExpanded(True)
+        root.setExpanded(True)
+        # Widen the column so long entries are not clipped.
+        self._tree.resizeColumnToContents(0)
+
+
+class MeshInfo(_gui_common.PilotFeature):
+    """Mesh information panel, toggled from the View "Panels" submenu.
+
+    The caller supplies the ``menu`` group the toggle item is added to. When
+    on, the panel shows the active sub-window's mesh and follows the active
+    sub-window; sub-windows without a mesh show "No mesh loaded".
+    """
+
+    def __init__(self, *args, **kw):
+        self._menu = kw.pop('menu')
+        super().__init__(*args, **kw)
+        self._action = None
+        self._dock = None
+        self._panel = None
+
+    def populate_menu(self):
+        self._action = QAction("Mesh", self._mainWindow)
+        self._action.setStatusTip("Toggle the mesh information panel")
+        self._action.setCheckable(True)
+        self._action.toggled.connect(self._on_toggled)
+        self._menu.addAction(self._action)
+
+    def _on_toggled(self, checked):
+        """Show or hide the panel."""
+        if checked:
+            self._ensure_panel()
+            self._refresh()
+            self._dock.show()
+        elif self._dock is not None:
+            self._dock.hide()
+
+    def _ensure_panel(self):
+        """Build the dock lazily and follow sub-window activation."""
+        if self._panel is not None:
+            return
+        self._panel = MeshInfoPanel()
+        self._dock = QDockWidget("mesh")
+        self._dock.setWidget(self._panel)
+        self._mgr.mainWindow.addDockWidget(Qt.LeftDockWidgetArea,
+                                           self._dock)
+        # Keep the menu check in sync when the dock is closed by its button.
+        self._dock.visibilityChanged.connect(self._action.setChecked)
+        mdi = self._mdi_area()
+        if mdi is not None:
+            mdi.subWindowActivated.connect(self._on_subwindow_activated)
+
+    def _on_subwindow_activated(self, _subwin):
+        """Refresh the panel when the active sub-window changes.
+
+        The refresh is deferred to the next event-loop pass because loading
+        a mesh from a menu activates the new sub-window before ``updateMesh``
+        populates it.
+        """
+        if self._dock is not None and self._action.isChecked():
+            QTimer.singleShot(0, self._refresh)
+
+    def _refresh(self):
+        """Show the active sub-window's mesh."""
+        self._panel.set_mesh(self._active_mesh())
+
+    def _mdi_area(self):
+        return self._mainWindow.centralWidget()
+
+    def _active_mesh(self):
+        """Return the active 3D viewer's mesh, or ``None``.
+
+        ``RManager.currentR3DWidget`` is used so the pybind11 widget that
+        exposes ``mesh`` is reached; ``QMdiSubWindow.widget()`` would return
+        a bare ``QWidget``.
+        """
+        widget = self._mgr.currentR3DWidget()
+        return None if widget is None else widget.mesh
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_mesh_info.py
+++ b/tests/test_pilot_mesh_info.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026, Yung-Yu Chen <yyc@solvcon.net>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+import unittest
+
+import modmesh
+
+try:
+    from modmesh import pilot
+    from modmesh.pilot import _mesh_info
+    from PySide6.QtWidgets import QApplication, QMenu
+except ImportError:
+    pilot = None
+
+
+def _make_sample_mesh():
+    """
+    Two triangles and one quadrilateral; ``build_ghost`` adds ghost cells
+    and nodes whose presence the panel must not count.
+    """
+    core = modmesh.core
+    T = core.StaticMesh.TRIANGLE
+    Q = core.StaticMesh.QUADRILATERAL
+    mh = core.StaticMesh(ndim=2, nnode=6, nface=0, ncell=3)
+    mh.ndcrd.ndarray[:, :] = [(0, 0), (1, 0), (0, 1), (1, 1), (2, 0), (2, 1)]
+    mh.cltpn.ndarray[:] = [T, T, Q]
+    mh.clnds.ndarray[:, :5] = [(3, 0, 3, 2, -1), (3, 0, 1, 3, -1),
+                               (4, 1, 4, 5, 3)]
+    mh.build_interior()
+    mh.build_boundary()
+    mh.build_ghost()
+    return mh
+
+
+def _make_single_triangle():
+    """Return a one-cell mesh.
+
+    Its ``ncell`` of 1 differs from the sample mesh's 3, so a test cannot
+    pass on mesh state left in the shared ``RManager`` singleton.
+    """
+    core = modmesh.core
+    mh = core.StaticMesh(ndim=2, nnode=3, nface=0, ncell=1)
+    mh.ndcrd.ndarray[:, :] = [(0, 0), (1, 0), (0, 1)]
+    mh.cltpn.ndarray[:] = [core.StaticMesh.TRIANGLE]
+    mh.clnds.ndarray[:, :4] = [(3, 0, 1, 2)]
+    mh.build_interior()
+    mh.build_boundary()
+    mh.build_ghost()
+    return mh
+
+
+def _section_map(sections):
+    """Map each section name to its ``{property: value}`` dict.
+
+    Counts and Ghost share property names (node, face, cell), so the rows
+    cannot be flattened into one namespace.
+    """
+    return {name: dict(rows) for name, rows in sections}
+
+
+def _tree_sections(tree):
+    """Map each group under the mesh tree root to ``{property: value}``."""
+    result = {}
+    root = tree.topLevelItem(0)
+    for i in range(root.childCount()):
+        group = root.child(i)
+        pairs = {}
+        for j in range(group.childCount()):
+            prop, value = group.child(j).text(0).split(": ", 1)
+            pairs[prop] = value
+        result[group.text(0)] = pairs
+    return result
+
+
+@unittest.skipUnless(modmesh.HAS_PILOT, "Qt pilot is not built")
+class MakeMeshInfoTC(unittest.TestCase):
+    def test_excludes_ghost_entities(self):
+        info = _section_map(
+            _mesh_info.MeshInfoPanel.make_mesh_info(_make_sample_mesh()))
+        self.assertEqual(info["Counts"]["dim"], "2")
+        self.assertEqual(info["Counts"]["node"], "6")
+        self.assertEqual(info["Counts"]["cell"], "3")
+        # The ghost cells must not inflate the cell-type counts.
+        self.assertEqual(info["Cell types"]["triangle"], "2")
+        self.assertEqual(info["Cell types"]["quadrilateral"], "1")
+        # The bounding box must come from the body nodes only.
+        self.assertEqual(info["Bounding box"]["x"], "[0, 2]")
+        self.assertEqual(info["Bounding box"]["y"], "[0, 1]")
+
+
+@unittest.skipUnless(modmesh.HAS_PILOT, "Qt pilot is not built")
+class MeshInfoTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        # The "Panels" group is owned by the caller, not by MeshInfo.
+        self.menu = QMenu("Panels", self.mgr.mainWindow)
+
+    def test_current_r3dwidget_exposes_mesh(self):
+        # The mesh must be reached through the pybind11 R3DWidget rather than
+        # QMdiSubWindow.widget(), which returns a bare QWidget.
+        widget = self.mgr.add3DWidget()
+        widget.updateMesh(_make_sample_mesh())
+        current = self.mgr.currentR3DWidget()
+        self.assertIsNotNone(current)
+        self.assertIsNotNone(current.mesh)
+        self.assertEqual(current.mesh.ncell, 3)
+
+    def test_panel_shows_active_mesh(self):
+        widget = self.mgr.add3DWidget()
+        widget.updateMesh(_make_sample_mesh())
+        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu)
+        feature.populate_menu()
+        self.assertIn(feature._action, self.menu.actions())
+        feature._action.setChecked(True)
+        sections = _tree_sections(feature._panel._tree)
+        self.assertEqual(sections["Counts"]["cell"], "3")
+        self.assertEqual(sections["Cell types"]["triangle"], "2")
+
+    def test_panel_without_mesh(self):
+        self.mgr.add3DWidget()  # fresh viewer becomes current, no mesh
+        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu)
+        feature.populate_menu()
+        feature._action.setChecked(True)
+        root = feature._panel._tree.topLevelItem(0)
+        self.assertIn("No mesh", root.text(0))
+        self.assertEqual(root.childCount(), 0)
+
+    def test_panel_updates_on_menu_load(self):
+        # Loading from a menu creates and activates the viewer before
+        # updateMesh runs, so the refresh is deferred to the event loop.
+        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu)
+        feature.populate_menu()
+        feature._action.setChecked(True)
+        widget = self.mgr.add3DWidget()
+        widget.updateMesh(_make_single_triangle())
+        QApplication.processEvents()  # allow the deferred refresh to run
+        sections = _tree_sections(feature._panel._tree)
+        self.assertEqual(sections["Counts"]["cell"], "1")
+        self.assertEqual(sections["Cell types"]["triangle"], "1")
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_mesh_info.py
+++ b/tests/test_pilot_mesh_info.py
@@ -25,6 +25,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
+import os
 import unittest
 
 import modmesh
@@ -35,6 +36,8 @@ try:
     from PySide6.QtWidgets import QApplication, QMenu
 except ImportError:
     pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
 
 
 def _make_sample_mesh():
@@ -112,7 +115,8 @@ class MakeMeshInfoTC(unittest.TestCase):
         self.assertEqual(info["Bounding box"]["y"], "[0, 1]")
 
 
-@unittest.skipUnless(modmesh.HAS_PILOT, "Qt pilot is not built")
+@unittest.skipIf(GITHUB_ACTIONS or not modmesh.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
 class MeshInfoTC(unittest.TestCase):
     def setUp(self):
         self.mgr = pilot.RManager.instance.setUp()


### PR DESCRIPTION
Introduce `MeshInfoPanel` to display mesh metadata in the pilot GUI, wire it into the View menu under a `Panels` submenu, and expose the supporting `RManager` hook through the pybind11 bindings. Include Python tests covering the panel.

For issue #404.