### PR TITLE
pilot: Add 2D widget screenshot APIs and RManager 2D accessors

### DIFF
--- a/cpp/solvcon/pilot/R2DWidget.cpp
+++ b/cpp/solvcon/pilot/R2DWidget.cpp
@@ -9,11 +9,9 @@
 
 #include <cmath>
 
-#include <QColor>
 #include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
-#include <QPen>
 #include <QResizeEvent>
 #include <QWheelEvent>
 
@@ -28,15 +26,6 @@ constexpr double ZOOM_STEP_PER_DEGREE = 1.0 / 360.0;
 
 constexpr double MIN_ZOOM = 1.0e-6;
 constexpr double MAX_ZOOM = 1.0e6;
-
-constexpr double BASE_GRID_SPACING_PX = 64.0;
-constexpr double MIN_GRID_SPACING_PX = 16.0;
-constexpr double MAX_GRID_SPACING_PX = 256.0;
-
-QColor const BACKGROUND(32, 32, 36);
-QColor const MINOR_GRID(64, 64, 70);
-QColor const AXIS(200, 200, 80);
-QColor const ORIGIN(220, 80, 80);
 
 double clamp_zoom(double zoom)
 {
@@ -107,82 +96,8 @@ void R2DWidget::centerViewOnOrigin()
 void R2DWidget::paintEvent(QPaintEvent * /*event*/)
 {
     QPainter painter(this);
-    painter.setRenderHint(QPainter::Antialiasing, true);
-    painter.fillRect(rect(), BACKGROUND);
-
-    double const widget_w = static_cast<double>(width());
-    double const widget_h = static_cast<double>(height());
-
-    // Snap grid spacing to a power of ten times {1, 2, 5} for a readable band.
-    double const target_world = BASE_GRID_SPACING_PX / m_view.zoom();
-    double const exponent = std::floor(std::log10(target_world));
-    double const base = std::pow(10.0, exponent);
-    double spacing_world = base;
-    for (double mult : {1.0, 2.0, 5.0, 10.0})
-    {
-        double const candidate = base * mult;
-        double const candidate_px = m_view.zoom() * candidate;
-        if (candidate_px >= MIN_GRID_SPACING_PX && candidate_px <= MAX_GRID_SPACING_PX)
-        {
-            spacing_world = candidate;
-            break;
-        }
-        spacing_world = candidate;
-    }
-    double const spacing_px = m_view.zoom() * spacing_world;
-
-    // Draw minor grid lines in screen space directly.
-    QPen minor_pen(MINOR_GRID);
-    minor_pen.setCosmetic(true);
-    minor_pen.setWidth(1);
-    painter.setPen(minor_pen);
-
-    double const first_x = std::fmod(m_view.pan_x(), spacing_px);
-    for (double sx = first_x; sx < widget_w; sx += spacing_px)
-    {
-        painter.drawLine(QPointF(sx, 0.0), QPointF(sx, widget_h));
-    }
-    for (double sx = first_x - spacing_px; sx > 0.0; sx -= spacing_px)
-    {
-        painter.drawLine(QPointF(sx, 0.0), QPointF(sx, widget_h));
-    }
-    double const first_y = std::fmod(m_view.pan_y(), spacing_px);
-    for (double sy = first_y; sy < widget_h; sy += spacing_px)
-    {
-        painter.drawLine(QPointF(0.0, sy), QPointF(widget_w, sy));
-    }
-    for (double sy = first_y - spacing_px; sy > 0.0; sy -= spacing_px)
-    {
-        painter.drawLine(QPointF(0.0, sy), QPointF(widget_w, sy));
-    }
-
-    // Draw the world axes through the origin, if visible.
-    QPen axis_pen(AXIS);
-    axis_pen.setCosmetic(true);
-    axis_pen.setWidth(1);
-    painter.setPen(axis_pen);
-    if (m_view.pan_y() >= 0.0 && m_view.pan_y() <= widget_h)
-    {
-        painter.drawLine(QPointF(0.0, m_view.pan_y()), QPointF(widget_w, m_view.pan_y()));
-    }
-    if (m_view.pan_x() >= 0.0 && m_view.pan_x() <= widget_w)
-    {
-        painter.drawLine(QPointF(m_view.pan_x(), 0.0), QPointF(m_view.pan_x(), widget_h));
-    }
-
-    // World geometry on top of the grid, under the origin marker.
-    if (m_world)
-    {
-        RWorldRenderer2d(*m_world, m_view).paint(painter);
-    }
-
-    // Origin dot (cosmetic, fixed pixel size regardless of zoom).
-    QPen origin_pen(ORIGIN);
-    origin_pen.setCosmetic(true);
-    origin_pen.setWidth(6);
-    origin_pen.setCapStyle(Qt::RoundCap);
-    painter.setPen(origin_pen);
-    painter.drawPoint(QPointF(m_view.pan_x(), m_view.pan_y()));
+    constexpr bool full_canvas = true;
+    RWorldRenderer2d(m_world.get(), m_view).paint_canvas(painter, width(), height(), full_canvas);
 }
 
 void R2DWidget::wheelEvent(QWheelEvent * event)

--- a/cpp/solvcon/pilot/R3DWidget.hpp
+++ b/cpp/solvcon/pilot/R3DWidget.hpp
@@ -104,8 +104,6 @@ public:
 
     RCameraController * cameraController() const { return m_scene->controller(); }
 
-    QPixmap grabPixmap() const { return m_view->screen()->grabWindow(m_view->winId()); }
-
     void showMark();
     void updateMesh(std::shared_ptr<StaticMesh> const & mesh);
     void updateWorld(std::shared_ptr<WorldFp64> const & world);

--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -102,6 +102,7 @@ R2DWidget * RManager::add2DWidget()
         viewer->show();
         auto * subwin = this->addSubWindow(viewer);
         subwin->resize(400, 300);
+        viewer->resize(400, 300);
     }
     return viewer;
 }
@@ -120,6 +121,42 @@ R3DWidget * RManager::currentR3DWidget()
     }
 
     return dynamic_cast<R3DWidget *>(subwin->widget());
+}
+
+R2DWidget * RManager::currentR2DWidget()
+{
+    if (m_mdiArea == nullptr)
+    {
+        return nullptr;
+    }
+
+    const auto * subwin = m_mdiArea->currentSubWindow();
+    if (subwin == nullptr)
+    {
+        return nullptr;
+    }
+
+    return dynamic_cast<R2DWidget *>(subwin->widget());
+}
+
+std::vector<R2DWidget *> RManager::list2DWidgets()
+{
+    std::vector<R2DWidget *> widgets;
+    if (m_mdiArea == nullptr)
+    {
+        return widgets;
+    }
+
+    for (auto subwin : m_mdiArea->subWindowList())
+    {
+        auto * viewer = dynamic_cast<R2DWidget *>(subwin->widget());
+
+        if (viewer == nullptr)
+            continue;
+
+        widgets.push_back(viewer);
+    }
+    return widgets;
 }
 
 void RManager::toggleConsole()

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -12,6 +12,8 @@
 #include <solvcon/pilot/R2DWidget.hpp>
 #include <solvcon/pilot/RAction.hpp>
 
+#include <vector>
+
 #include <QMainWindow>
 #include <QMdiArea>
 #include <QMdiSubWindow>
@@ -39,6 +41,8 @@ public:
     R3DWidget * add3DWidget();
     R2DWidget * add2DWidget();
     R3DWidget * currentR3DWidget();
+    R2DWidget * currentR2DWidget();
+    std::vector<R2DWidget *> list2DWidgets();
 
     RPythonConsoleDockWidget * pycon() { return m_pycon; }
 

--- a/cpp/solvcon/pilot/RWorldRenderer2d.cpp
+++ b/cpp/solvcon/pilot/RWorldRenderer2d.cpp
@@ -5,6 +5,8 @@
 
 #include <solvcon/pilot/RWorldRenderer2d.hpp> // Must be the first include.
 
+#include <cmath>
+
 #include <QColor>
 #include <QPainter>
 #include <QPainterPath>
@@ -16,11 +18,82 @@ namespace solvcon
 namespace
 {
 
+QColor const BACKGROUND(32, 32, 36);
+QColor const MINOR_GRID(64, 64, 70);
+QColor const AXIS(200, 200, 80);
+QColor const ORIGIN(220, 80, 80);
 QColor const GEOMETRY(120, 180, 240);
+
+constexpr double BASE_GRID_SPACING_PX = 64.0;
+constexpr double MIN_GRID_SPACING_PX = 16.0;
+constexpr double MAX_GRID_SPACING_PX = 256.0;
 
 // Cosmetic (zoom-independent) screen widths for world geometry.
 constexpr double GEOMETRY_LINE_WIDTH_PX = 1.5;
 constexpr int GEOMETRY_POINT_WIDTH_PX = 5;
+
+void paint_chrome(QPainter & painter, ViewTransform2dFp64 const & view, int width, int height)
+{
+    double const widget_w = static_cast<double>(width);
+    double const widget_h = static_cast<double>(height);
+
+    // Snap grid spacing to a power of ten times {1, 2, 5} for a readable band.
+    double const target_world = BASE_GRID_SPACING_PX / view.zoom();
+    double const exponent = std::floor(std::log10(target_world));
+    double const base = std::pow(10.0, exponent);
+    double spacing_world = base;
+    for (double mult : {1.0, 2.0, 5.0, 10.0})
+    {
+        double const candidate = base * mult;
+        double const candidate_px = view.zoom() * candidate;
+        if (candidate_px >= MIN_GRID_SPACING_PX && candidate_px <= MAX_GRID_SPACING_PX)
+        {
+            spacing_world = candidate;
+            break;
+        }
+        spacing_world = candidate;
+    }
+    double const spacing_px = view.zoom() * spacing_world;
+
+    // Draw minor grid lines in screen space directly.
+    QPen minor_pen(MINOR_GRID);
+    minor_pen.setCosmetic(true);
+    minor_pen.setWidth(1);
+    painter.setPen(minor_pen);
+
+    double const first_x = std::fmod(view.pan_x(), spacing_px);
+    for (double sx = first_x; sx < widget_w; sx += spacing_px)
+    {
+        painter.drawLine(QPointF(sx, 0.0), QPointF(sx, widget_h));
+    }
+    for (double sx = first_x - spacing_px; sx > 0.0; sx -= spacing_px)
+    {
+        painter.drawLine(QPointF(sx, 0.0), QPointF(sx, widget_h));
+    }
+    double const first_y = std::fmod(view.pan_y(), spacing_px);
+    for (double sy = first_y; sy < widget_h; sy += spacing_px)
+    {
+        painter.drawLine(QPointF(0.0, sy), QPointF(widget_w, sy));
+    }
+    for (double sy = first_y - spacing_px; sy > 0.0; sy -= spacing_px)
+    {
+        painter.drawLine(QPointF(0.0, sy), QPointF(widget_w, sy));
+    }
+
+    // Draw the world axes through the origin, if visible.
+    QPen axis_pen(AXIS);
+    axis_pen.setCosmetic(true);
+    axis_pen.setWidth(1);
+    painter.setPen(axis_pen);
+    if (view.pan_y() >= 0.0 && view.pan_y() <= widget_h)
+    {
+        painter.drawLine(QPointF(0.0, view.pan_y()), QPointF(widget_w, view.pan_y()));
+    }
+    if (view.pan_x() >= 0.0 && view.pan_x() <= widget_w)
+    {
+        painter.drawLine(QPointF(view.pan_x(), 0.0), QPointF(view.pan_x(), widget_h));
+    }
+}
 
 } // anonymous namespace
 
@@ -34,6 +107,11 @@ QPointF RWorldRenderer2d::map(double world_x, double world_y) const
 
 void RWorldRenderer2d::paint(QPainter & painter) const
 {
+    if (!m_world)
+    {
+        return;
+    }
+
     // Segments and flattened curves share one cosmetic stroke pen.
     QPen geom_pen(GEOMETRY);
     geom_pen.setCosmetic(true);
@@ -41,7 +119,7 @@ void RWorldRenderer2d::paint(QPainter & painter) const
     painter.setPen(geom_pen);
 
     // 1D straight segments
-    std::shared_ptr<SegmentPadFp64> segments = m_world.collect_live_segments();
+    std::shared_ptr<SegmentPadFp64> segments = m_world->collect_live_segments();
     for (size_t i = 0; i < segments->size(); ++i)
     {
         painter.drawLine(map(segments->x0(i), segments->y0(i)),
@@ -49,7 +127,7 @@ void RWorldRenderer2d::paint(QPainter & painter) const
     }
 
     // Cubic Beziers; QPainterPath flattens them adaptively, so no sampling.
-    std::shared_ptr<CurvePadFp64> curves = m_world.collect_live_curves();
+    std::shared_ptr<CurvePadFp64> curves = m_world->collect_live_curves();
     if (curves->size() > 0)
     {
         QPainterPath path;
@@ -64,7 +142,7 @@ void RWorldRenderer2d::paint(QPainter & painter) const
     }
 
     // 0D standalone points as dots with a fixed pixel size at any zoom.
-    std::shared_ptr<PointPadFp64> const & points = m_world.points();
+    std::shared_ptr<PointPadFp64> const & points = m_world->points();
     if (points->size() > 0)
     {
         QPen point_pen(GEOMETRY);
@@ -76,6 +154,30 @@ void RWorldRenderer2d::paint(QPainter & painter) const
         {
             painter.drawPoint(map(points->x(i), points->y(i)));
         }
+    }
+}
+
+void RWorldRenderer2d::paint_canvas(QPainter & painter, int width, int height, bool full_canvas) const
+{
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.fillRect(0, 0, width, height, BACKGROUND);
+
+    if (full_canvas)
+    {
+        paint_chrome(painter, m_view, width, height);
+    }
+
+    paint(painter);
+
+    if (full_canvas)
+    {
+        // Origin dot (cosmetic, fixed pixel size regardless of zoom).
+        QPen origin_pen(ORIGIN);
+        origin_pen.setCosmetic(true);
+        origin_pen.setWidth(6);
+        origin_pen.setCapStyle(Qt::RoundCap);
+        painter.setPen(origin_pen);
+        painter.drawPoint(QPointF(m_view.pan_x(), m_view.pan_y()));
     }
 }
 

--- a/cpp/solvcon/pilot/RWorldRenderer2d.hpp
+++ b/cpp/solvcon/pilot/RWorldRenderer2d.hpp
@@ -20,28 +20,33 @@ namespace solvcon
 /**
  * Renders a world's live points, segments, and curves into a QPainter in
  * screen space, mapping math-convention world coordinates through a 2D view
- * transform. The world and view it draws are held as required construction
- * arguments, so an instance can only exist for a renderable pair. This is the
- * shared routine used by both the on-screen R2DWidget and the offscreen image
- * renderer, so neither path can drift from the other. It paints only the
- * geometry; the caller owns the background, grid, axes, and any origin marker.
+ * transform. paint() draws geometry only; paint_canvas() adds the backdrop
+ * and optional grid/axes/origin chrome.
+ * m_world is non-owning and may be null.
  */
 class RWorldRenderer2d
 {
 public:
-    RWorldRenderer2d(WorldFp64 const & world, ViewTransform2dFp64 const & view)
+    RWorldRenderer2d(WorldFp64 const * world, ViewTransform2dFp64 const & view)
         : m_world(world)
         , m_view(view)
     {
     }
 
-    void paint(QPainter & painter) const;
+    /// Paint backdrop, geometry, and optional chrome.
+    /// @param painter Target painter in screen space.
+    /// @param width Canvas width in pixels.
+    /// @param height Canvas height in pixels.
+    /// @param full_canvas If true, draw grid, axes, and the origin marker.
+    void paint_canvas(QPainter & painter, int width, int height, bool full_canvas) const;
 
 private:
+    void paint(QPainter & painter) const;
+
     // Map math-convention world (x, y) to Qt screen pixels; z is dropped.
     QPointF map(double world_x, double world_y) const;
 
-    WorldFp64 const & m_world;
+    WorldFp64 const * m_world;
     ViewTransform2dFp64 const & m_view;
 }; /* end class RWorldRenderer2d */
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -3,9 +3,9 @@
  * BSD 3-Clause License, see COPYING
  */
 
-#include <pybind11/stl.h>
+#include <pybind11/stl.h> // Must be the first include.
 
-#include <solvcon/pilot/wrap_pilot.hpp> // Must be the first include for solvcon
+#include <solvcon/pilot/wrap_pilot.hpp> // Must be the first include but give way to above.
 #include <solvcon/python/common.hpp>
 
 #include <solvcon/pilot/R2DWidget.hpp>

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -3,15 +3,18 @@
  * BSD 3-Clause License, see COPYING
  */
 
-#include <solvcon/pilot/wrap_pilot.hpp> // Must be the first include.
-#include <solvcon/python/common.hpp>
 #include <pybind11/stl.h>
 
+#include <solvcon/pilot/wrap_pilot.hpp> // Must be the first include for solvcon
+#include <solvcon/python/common.hpp>
+
+#include <solvcon/pilot/R2DWidget.hpp>
 #include <solvcon/pilot/pilot.hpp>
 
-#include <QPointer>
 #include <QClipboard>
 #include <QMenu>
+#include <QPointer>
+#include <QString>
 
 // Usually SOLVCON_PYSIDE6_FULL is not defined unless for debugging.
 #ifdef SOLVCON_PYSIDE6_FULL
@@ -146,13 +149,13 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapR3DWidget
                 [](wrapped_type & self)
                 {
                     QClipboard * clipboard = QGuiApplication::clipboard();
-                    clipboard->setPixmap(self.grabPixmap());
+                    clipboard->setPixmap(self.grab());
                 })
             .def(
                 "saveImage",
                 [](wrapped_type & self, std::string const & filename)
                 {
-                    self.grabPixmap().save(filename.c_str());
+                    self.grab().save(filename.c_str());
                 },
                 py::arg("filename"))
             .def(
@@ -201,7 +204,20 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapR2DWidget
             .def("setViewTransform", &wrapped_type::setViewTransform, py::arg("v"))
             .def("resetView", &wrapped_type::resetView)
             .def("updateWorld", &wrapped_type::updateWorld, py::arg("world"))
-            .def("requestRepaint", &wrapped_type::requestRepaint);
+            .def("requestRepaint", &wrapped_type::requestRepaint)
+            //
+            ;
+
+        (*this)
+            .def("clipImage", [](wrapped_type & self)
+                 {
+                     QClipboard * clipboard = QGuiApplication::clipboard();
+                     clipboard->setPixmap(self.grab()); })
+            .def("saveImage", [](wrapped_type & self, std::string const & filename)
+                 { self.grab().save(filename.c_str()); },
+                 py::arg("filename"))
+            //
+            ;
     }
 
 }; /* end class WrapR2DWidget */
@@ -340,6 +356,18 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 [](wrapped_type & self)
                 {
                     return self.currentR3DWidget();
+                })
+            .def(
+                "currentR2DWidget",
+                [](wrapped_type & self)
+                {
+                    return self.currentR2DWidget();
+                })
+            .def(
+                "list2DWidgets",
+                [](wrapped_type & self)
+                {
+                    return self.list2DWidgets();
                 })
             .def(
                 "toggleConsole",

--- a/solvcon/pilot/_pilot_core.py
+++ b/solvcon/pilot/_pilot_core.py
@@ -51,6 +51,7 @@ list_of_rcameracontroller = [
     'RCameraController',
 ]
 
+
 _from_impl = (  # noqa: F822
     list_of_r3dwidget +
     list_of_r2dwidget +

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -2,25 +2,29 @@
 # BSD 3-Clause License, see COPYING
 
 """
-Tests for the issue #754 PR2 2D canvas: R2DWidget rendering a World<double>.
-
-The widget paints with QPainter from the world's backend-independent
-collect_live_* surface, so these run inside the pilot binary (Qt available)
-via ``make run_pilot_pytest PYTEST_OPTS=tests/test_pilot_2d.py``. They guard
-the C++ -> Python driving path (updateWorld accepting realistic geometry
-without raising) and the view-state API; pixel-level appearance is checked
-manually in the GUI. See test_dead_shape_culling_renders_pixels (skipped) for
-the planned pixel-level coverage and what it needs first.
+Tests for R2DWidget and its on-screen screenshot APIs.
 """
 
+import os
+import tempfile
 import unittest
 
 import solvcon
 
 try:
     from solvcon import pilot
+    from PySide6.QtGui import QGuiApplication
 except ImportError:
     pilot = None
+
+_PNG_MAGIC = b'\x89PNG\r\n\x1a\n'
+
+
+def _png_size(data):
+    """Return PNG width and height from IHDR (offsets 16 and 20)."""
+    assert data[:8] == _PNG_MAGIC
+    return (int.from_bytes(data[16:20], 'big'),
+            int.from_bytes(data[20:24], 'big'))
 
 
 def _build_world():
@@ -114,22 +118,102 @@ class R2DWidgetWorldTC(unittest.TestCase):
         self.assertEqual(got.pan_y, 25.0)
         self.assertEqual(got.zoom, 3.0)
 
-    @unittest.skip("TODO: needs a synchronous-render hook on R2DWidget")
+    @unittest.skip("TODO: pixel-level DEAD-shape culling assertions")
     def test_dead_shape_culling_renders_pixels(self):
         """Assert live geometry is painted and DEAD shapes are culled.
 
-        Needs a synchronous-render hook (saveImage, parity with
-        R3DWidget) to grab the canvas headless. Skipped until then.
+        saveImage captures the widget; pixel sampling helpers are still TODO.
         """
         # w = solvcon.WorldFp64()
         # live = w.add_rectangle(-3, -3, -1, -1)   # region A (lower-left)
         # dead = w.add_rectangle(1, 1, 3, 3)       # region B (upper-right)
         # w.remove_shape(dead)
         # self.widget.setViewTransform(<fixed pan/zoom>)
-        # img = self.widget.saveImage(width=400, height=400)  # future hook
-        # self.assertGreater(foreground_pixels(img, region_A), 0)  # painted
-        # self.assertEqual(foreground_pixels(img, region_B), 0)    # culled
+        # self.widget.saveImage(path)
+        # img = read_png(path)
+        # self.assertGreater(foreground_pixels(img, region_A), 0)
+        # self.assertEqual(foreground_pixels(img, region_B), 0)
         raise NotImplementedError
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class R2DWidgetScreenshotTC(unittest.TestCase):
+    """R2DWidget on-screen screenshot APIs (saveImage/clipImage)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.widget = pilot.RManager.instance.setUp().add2DWidget()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.widget = None
+
+    def test_save_image_writes_png_file(self):
+        """saveImage writes a valid, non-empty PNG of the widget."""
+        self.widget.updateWorld(_build_world())
+        self.widget.resetView()
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "widget.png")
+            self.widget.saveImage(path)
+            with open(path, 'rb') as stream:
+                data = stream.read()
+        self.assertEqual(data[:8], _PNG_MAGIC)
+        width, height = _png_size(data)
+        self.assertGreater(width, 0)
+        self.assertGreater(height, 0)
+
+    def test_current_2d_widget_exposes_screenshot_api(self):
+        """currentR2DWidget returns the active 2D widget, API intact."""
+        mgr = pilot.RManager.instance.setUp()
+        mgr.add2DWidget()
+        current = mgr.currentR2DWidget()
+        self.assertIsNotNone(current)
+        current.updateWorld(_build_world())
+        current.resetView()
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "current.png")
+            current.saveImage(path)
+            with open(path, 'rb') as stream:
+                data = stream.read()
+        self.assertEqual(data[:8], _PNG_MAGIC)
+        width, height = _png_size(data)
+        self.assertGreater(width, 0)
+        self.assertGreater(height, 0)
+
+    def test_list_2d_widgets_returns_usable_widgets(self):
+        """list2DWidgets returns real R2DWidgets, not bare QWidgets."""
+        mgr = pilot.RManager.instance.setUp()
+        mgr.add2DWidget()
+        widgets = mgr.list2DWidgets()
+        self.assertIsInstance(widgets, list)
+        self.assertGreaterEqual(len(widgets), 1)
+        for widget in widgets:
+            self.assertTrue(hasattr(widget, "saveImage"))
+            self.assertTrue(hasattr(widget, "clipImage"))
+        listed = widgets[-1]
+        listed.updateWorld(_build_world())
+        listed.resetView()
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "listed.png")
+            listed.saveImage(path)
+            with open(path, 'rb') as stream:
+                data = stream.read()
+        self.assertEqual(data[:8], _PNG_MAGIC)
+
+    def test_clip_image_copies_pixmap_to_clipboard(self):
+        """clipImage puts a non-null widget pixmap on the clipboard."""
+        clipboard = QGuiApplication.clipboard()
+        if clipboard is None:
+            self.skipTest("no clipboard in this environment")
+        self.widget.updateWorld(_build_world())
+        self.widget.resetView()
+        clipboard.clear()
+        self.assertTrue(clipboard.pixmap().isNull())
+        self.widget.clipImage()
+        pixmap = clipboard.pixmap()
+        self.assertFalse(pixmap.isNull())
+        self.assertGreater(pixmap.width(), 0)
+        self.assertGreater(pixmap.height(), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added `saveImage` and `clipImage` for `R2DWidget`.


## Usage

### Console

```python
import solvcon
from solvcon import pilot

mgr = pilot.RManager.instance.setUp()
mgr.add2DWidget()

world = solvcon.WorldFp64()
world.add_circle(0.0, 0.0, 100.0)

# list2DWidgets() is focus-independent; it avoids the currentR2DWidget() None
w = mgr.list2DWidgets()[0]
w.updateWorld(world)
w.resetView()
w.saveImage("out.png")   # format follows the filename suffix
w.clipImage()            # copy the widget pixmap to the clipboard
```

## Canvas example

1. Select any canvas example and open it in 3D
2. Use 2D viewer to open it
3. Run the script
```
import solvcon
from solvcon import pilot
mgr = pilot.RManager.instance.setUp()
w = mgr.list2DWidgets()[0]
w.clipImage()
```
**App screenshot**
<img width="958" height="600" alt="Screenshot 2026-06-20 at 11 59 07 PM" src="https://github.com/user-attachments/assets/644ef317-3482-4898-a01f-57da5ccdcf42" />
**Clipboard**
<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/6065d0af-4005-44e5-be90-44e20ecd0e96" />


Related to #754.
