### PR TITLE
Run pytest via the build interpreter to fix import failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,10 +81,9 @@ else
 endif
 export BUILD_PATH
 
-PYTEST ?= $(shell which py.test-3)
-ifeq ($(PYTEST),)
-	PYTEST := $(shell which pytest)
-endif
+# Test with the build interpreter; an ABI-tagged _modmesh cannot load under a
+# py.test-3 launcher bound to a different Python.
+PYTEST ?= $(WHICH_PYTHON) -m pytest
 ifneq ($(VERBOSE),)
 	PYTEST_OPTS ?= -v -s
 else


### PR DESCRIPTION
`make pytest` used the `py.test-3` launcher, whose shebang may bind to a different Python than the one that built the extension. Since `_modmesh` is ABI-tagged for the build interpreter, collection failed with "No module named '_modmesh'" whenever `py.test-3` resolved to another interpreter.

Default `PYTEST` to "$(WHICH_PYTHON) -m pytest" so the runner matches the build interpreter. The variable stays overridable.