### PR TITLE
Add World::describe_state for visible 2D geometry

### DIFF
--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -7,6 +7,7 @@
 
 #include <solvcon/base.hpp>
 #include <solvcon/buffer/SimpleCollector.hpp>
+#include <solvcon/serialization/SerializableItem.hpp>
 #include <solvcon/universe/bernstein.hpp>
 #include <solvcon/universe/bezier.hpp>
 #include <solvcon/universe/rtree.hpp>
@@ -28,14 +29,152 @@ enum class ShapeType : uint8_t
 
     // 1D shapes
     LINE = 2,
+    BEZIER = 3, ///< single cubic Bezier curve
 
     // 2D shapes
-    TRIANGLE = 3,
-    RECTANGLE = 4,
-    SQUARE = 5, ///< specialization of RECTANGLE with equal side lengths
-    ELLIPSE = 6,
-    CIRCLE = 7, ///< specialization of ELLIPSE with equal radii
+    TRIANGLE = 4,
+    RECTANGLE = 5,
+    SQUARE = 6, ///< specialization of RECTANGLE with equal side lengths
+    ELLIPSE = 7,
+    CIRCLE = 8, ///< specialization of ELLIPSE with equal radii
 }; /* end of enum class ShapeType */
+
+inline std::string shape_type_name(ShapeType st)
+{
+    switch (st)
+    {
+    case ShapeType::DEAD: return "DEAD";
+    case ShapeType::POINT: return "point";
+    case ShapeType::LINE: return "line";
+    case ShapeType::BEZIER: return "bezier";
+    case ShapeType::TRIANGLE: return "triangle";
+    case ShapeType::RECTANGLE: return "rectangle";
+    case ShapeType::SQUARE: return "square";
+    case ShapeType::ELLIPSE: return "ellipse";
+    case ShapeType::CIRCLE: return "circle";
+    default: return "unknown";
+    }
+}
+
+/// Level of detail for World::describe_state. C++ callers pass the enum; the
+/// Python binding accepts the equivalent lower-case string.
+enum class DescribeLevel : uint8_t
+{
+    BASIC = 0, ///< only what the 2D image draws
+}; /* end enum class DescribeLevel */
+
+inline DescribeLevel describe_level_from_string(std::string const & level)
+{
+    if (level == "basic")
+    {
+        return DescribeLevel::BASIC;
+    }
+    throw std::invalid_argument(
+        std::format("World: describe_state level '{}' not supported", level));
+}
+
+/// JSON-serializable view of one shape's rendered 2D geometry: its id, type,
+/// bounding box, segment endpoints, and curve control points. The z component
+/// is not rendered, so coordinates are 2D.
+// TODO: The shared JSON tool formats numbers with std::to_string, which keeps
+// only 6 decimal places. Coordinates that differ past the 6th decimal then
+// serialize identically and small magnitudes round to 0, which can confuse the
+// numeric oracles downstream.
+class WorldShapeState : public SerializableItem
+{
+
+public:
+
+    using coords_type = std::vector<double>;
+    using segment_list_type = std::vector<std::vector<double>>;
+    using curve_list_type = std::vector<std::vector<std::vector<double>>>;
+
+    WorldShapeState() = default;
+    WorldShapeState(WorldShapeState const &) = default;
+    WorldShapeState(WorldShapeState &&) = default;
+    WorldShapeState & operator=(WorldShapeState const &) = default;
+    WorldShapeState & operator=(WorldShapeState &&) = default;
+    ~WorldShapeState() override = default;
+
+    int32_t id() const { return m_id; }
+    int32_t & id() { return m_id; }
+
+    ShapeType type() const { return m_type; }
+    ShapeType & type() { return m_type; }
+
+    coords_type const & bbox() const { return m_bbox; }
+    coords_type & bbox() { return m_bbox; }
+
+    segment_list_type const & segments() const { return m_segments; }
+    segment_list_type & segments() { return m_segments; }
+
+    curve_list_type const & curves() const { return m_curves; }
+    curve_list_type & curves() { return m_curves; }
+
+    // The shape type serializes to its lower-case name (e.g. "triangle") so
+    // the rendered JSON stays human-readable; this is an output-only view.
+    MM_DECL_SERIALIZABLE(
+        register_member("id", m_id);
+        register_member("type", shape_type_name(m_type));
+        register_member("bbox", m_bbox);
+        register_member("segments", m_segments);
+        register_member("curves", m_curves);)
+
+private:
+
+    int32_t m_id = 0;
+    ShapeType m_type = ShapeType::DEAD;
+    coords_type m_bbox; ///< [min_x, min_y, max_x, max_y]
+    segment_list_type m_segments; ///< each [x0, y0, x1, y1]
+    curve_list_type m_curves; ///< each four [x, y]
+
+}; /* end class WorldShapeState */
+
+/// JSON view of the whole world: shapes plus the bare segments, bare curves,
+/// and free points that also render but belong to no shape.
+class WorldState : public SerializableItem
+{
+
+public:
+
+    using shape_list_type = std::vector<WorldShapeState>;
+    using segment_list_type = std::vector<std::vector<double>>;
+    using curve_list_type = std::vector<std::vector<std::vector<double>>>;
+    using point_list_type = std::vector<std::vector<double>>;
+
+    WorldState() = default;
+    WorldState(WorldState const &) = default;
+    WorldState(WorldState &&) = default;
+    WorldState & operator=(WorldState const &) = default;
+    WorldState & operator=(WorldState &&) = default;
+    ~WorldState() override = default;
+
+    shape_list_type const & shapes() const { return m_shapes; }
+    shape_list_type & shapes() { return m_shapes; }
+
+    segment_list_type const & segments() const { return m_segments; }
+    segment_list_type & segments() { return m_segments; }
+
+    curve_list_type const & curves() const { return m_curves; }
+    curve_list_type & curves() { return m_curves; }
+
+    point_list_type const & points() const { return m_points; }
+    point_list_type & points() { return m_points; }
+
+    MM_DECL_SERIALIZABLE(
+        register_member("shapes", m_shapes);
+        register_member("segments", m_segments);
+        register_member("curves", m_curves);
+        register_member("points", m_points);)
+
+private:
+
+    shape_list_type m_shapes;
+    segment_list_type m_segments; ///< bare segments
+    curve_list_type m_curves; ///< bare curves
+    point_list_type m_points; ///< free points, each [x, y]
+
+}; /* end class WorldState */
 
 /**
  * Lightweight record mapping a shape ID to the segment and curve ranges
@@ -205,6 +344,16 @@ public:
     int32_t add_circle(T cx, T cy, T r);
 
     /**
+     * Add a cubic Bezier controlled by four points.
+     */
+    int32_t add_bezier_shape(point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3);
+
+    /**
+     * Add a cubic Bezier from a bezier_type struct.
+     */
+    int32_t add_bezier_shape(bezier_type const & bezier);
+
+    /**
      * Translate all segments and curves belonging to a shape by (dx, dy).
      */
     void translate_shape(int32_t shape_id, value_type dx, value_type dy);
@@ -242,7 +391,27 @@ public:
      */
     void clear();
 
+    /**
+     * Describe the world state as a JSON-serializable object.
+     */
+    std::string describe_state(DescribeLevel level = DescribeLevel::BASIC) const;
+
 private:
+
+    /// 2D endpoints of segment i, as [x0, y0, x1, y1].
+    std::vector<double> segment_coords(size_t i) const
+    {
+        return {m_segments->x0(i), m_segments->y0(i), m_segments->x1(i), m_segments->y1(i)};
+    }
+
+    /// 2D control points of curve i, as four [x, y] pairs.
+    std::vector<std::vector<double>> curve_coords(size_t i) const
+    {
+        return {{m_curves->x0(i), m_curves->y0(i)},
+                {m_curves->x1(i), m_curves->y1(i)},
+                {m_curves->x2(i), m_curves->y2(i)},
+                {m_curves->x3(i), m_curves->y3(i)}};
+    }
 
     void check_size(size_t i, size_t s, char const * msg) const
     {
@@ -394,6 +563,22 @@ int32_t World<T>::add_circle(T cx, T cy, T r)
     int32_t const sid = add_ellipse(cx, cy, r, r);
     m_shape_registry[sid].type = ShapeType::CIRCLE;
     return sid;
+}
+
+template <typename T>
+int32_t World<T>::add_bezier_shape(point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3)
+{
+    size_t const offset = m_curves->size();
+    m_curves->append(p0, p1, p2, p3);
+    return register_shape(ShapeType::BEZIER, /*seg_off*/ 0, /*seg_cnt*/ 0, offset, 1);
+}
+
+template <typename T>
+int32_t World<T>::add_bezier_shape(bezier_type const & bezier)
+{
+    size_t const offset = m_curves->size();
+    m_curves->append(bezier);
+    return register_shape(ShapeType::BEZIER, /*seg_off*/ 0, /*seg_cnt*/ 0, offset, 1);
 }
 
 template <typename T>
@@ -560,6 +745,71 @@ void World<T>::check_shape_id(int32_t shape_id) const
         throw std::invalid_argument(
             std::format("World: shape_id {} is DEAD", shape_id));
     }
+}
+
+template <typename T>
+std::string World<T>::describe_state(DescribeLevel level) const
+{
+    (void)level; // Only BASIC exists today; richer levels are added later.
+
+    // Find the segments and curves owned by live shapes
+    small_vector<bool> segment_owned(m_segments->size(), false);
+    small_vector<bool> curve_owned(m_curves->size(), false);
+
+    WorldState state;
+    for (size_t sid = 0; sid < m_shape_registry.size(); ++sid)
+    {
+        ShapeRecord const & rec = m_shape_registry[sid];
+        for (uint32_t i = 0; i < rec.segment_count; ++i)
+        {
+            segment_owned[rec.segment_offset + i] = true;
+        }
+        for (uint32_t i = 0; i < rec.curve_count; ++i)
+        {
+            curve_owned[rec.curve_offset + i] = true;
+        }
+        if (rec.type == ShapeType::DEAD)
+        {
+            continue;
+        }
+        bbox_type const bb = compute_shape_bbox(rec);
+        WorldShapeState shape;
+        shape.id() = static_cast<int32_t>(sid);
+        shape.type() = rec.type;
+        shape.bbox() = {bb.min_x(), bb.min_y(), bb.max_x(), bb.max_y()};
+        for (uint32_t i = 0; i < rec.segment_count; ++i)
+        {
+            shape.segments().push_back(segment_coords(rec.segment_offset + i));
+        }
+        for (uint32_t i = 0; i < rec.curve_count; ++i)
+        {
+            shape.curves().push_back(curve_coords(rec.curve_offset + i));
+        }
+        state.shapes().push_back(std::move(shape));
+    }
+
+    for (size_t i = 0; i < m_segments->size(); ++i)
+    {
+        if (!segment_owned[i])
+        {
+            // already exclude DEAD shape segments, but include bare segments
+            state.segments().push_back(segment_coords(i));
+        }
+    }
+    for (size_t i = 0; i < m_curves->size(); ++i)
+    {
+        if (!curve_owned[i])
+        {
+            state.curves().push_back(curve_coords(i));
+        }
+    }
+    for (size_t i = 0; i < m_points->size(); ++i)
+    {
+        point_type const p = m_points->get(i);
+        state.points().push_back({p.x(), p.y()});
+    }
+
+    return state.to_json();
 }
 
 using WorldFp32 = World<float>;

--- a/cpp/solvcon/universe/pymod/wrap_World.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_World.cpp
@@ -82,21 +82,16 @@ WrapWorld<T> & WrapWorld<T>::wrap_management()
             "shape_type_of",
             [](wrapped_type const & self, int32_t shape_id)
             {
-                ShapeType const st = self.shape_type_of(shape_id);
-                switch (st)
-                {
-                case ShapeType::DEAD: return std::string("DEAD");
-                case ShapeType::POINT: return std::string("point");
-                case ShapeType::LINE: return std::string("line");
-                case ShapeType::TRIANGLE: return std::string("triangle");
-                case ShapeType::RECTANGLE: return std::string("rectangle");
-                case ShapeType::SQUARE: return std::string("square");
-                case ShapeType::ELLIPSE: return std::string("ellipse");
-                case ShapeType::CIRCLE: return std::string("circle");
-                default: return std::string("unknown");
-                }
+                return shape_type_name(self.shape_type_of(shape_id));
             },
             py::arg("shape_id"))
+        .def(
+            "describe_state",
+            [](wrapped_type const & self, std::string const & level)
+            {
+                return self.describe_state(describe_level_from_string(level));
+            },
+            py::arg("level") = "basic")
         .def("clear", &wrapped_type::clear)
         .def(
             "translate_shape",
@@ -310,6 +305,23 @@ WrapWorld<T> & WrapWorld<T>::wrap_shape()
             py::arg("cx"),
             py::arg("cy"),
             py::arg("r"))
+        .def(
+            "add_bezier_shape",
+            [](wrapped_type & self, point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3)
+            {
+                return self.add_bezier_shape(p0, p1, p2, p3);
+            },
+            py::arg("p0"),
+            py::arg("p1"),
+            py::arg("p2"),
+            py::arg("p3"))
+        .def(
+            "add_bezier_shape",
+            [](wrapped_type & self, bezier_type const & bezier)
+            {
+                return self.add_bezier_shape(bezier);
+            },
+            py::arg("b"))
         //
         ;
 

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -2,6 +2,7 @@
 # BSD 3-Clause License, see COPYING
 
 
+import json
 import unittest
 
 import numpy as np
@@ -522,5 +523,193 @@ class WorldEllipseTC(unittest.TestCase):
         self.w.remove_shape(sid)
         self.assertEqual(self.w.nshape, 0)
         self.assertEqual(len(self.w.query_visible(-2, -2, 2, 2)), 0)
+
+
+class WorldBezierShapeTC(unittest.TestCase):
+    """add_bezier_shape: one cubic Bezier per shape (curve counterpart of
+    add_line). The bare add_bezier leaves the curve owned by no shape."""
+
+    def setUp(self):
+        self.w = solvcon.WorldFp64()
+        self.Point = solvcon.Point3dFp64
+        self.Bezier = solvcon.Bezier3dFp64
+
+    def test_add_bezier_shape(self):
+        p = self.Point
+        sid = self.w.add_bezier_shape(p(0, 0, 0), p(1, 0, 0),
+                                      p(2, 1, 0), p(3, 1, 0))
+        self.assertEqual(self.w.nshape, 1)
+        # The shape owns one cubic Bezier and no segments.
+        self.assertEqual(self.w.nbezier, 1)
+        self.assertEqual(self.w.nsegment, 0)
+        self.assertEqual(self.w.shape_type_of(sid), "bezier")
+
+    def test_add_bezier_shape_from_bezier(self):
+        p = self.Point
+        b = self.Bezier(p0=p(0, 0, 0), p1=p(1, 0, 0),
+                        p2=p(2, 1, 0), p3=p(3, 1, 0))
+        sid = self.w.add_bezier_shape(b=b)
+        self.assertEqual(self.w.shape_type_of(sid), "bezier")
+        self.assertEqual(self.w.nbezier, 1)
+
+    def test_bare_bezier_is_not_a_shape(self):
+        p = self.Point
+        self.w.add_bezier(p(0, 0, 0), p(1, 0, 0), p(2, 1, 0), p(3, 1, 0))
+        self.assertEqual(self.w.nshape, 0)
+        self.assertEqual(self.w.nbezier, 1)
+
+    def test_translate_bezier_shape(self):
+        p = self.Point
+        sid = self.w.add_bezier_shape(p(0, 0, 0), p(1, 0, 0),
+                                      p(2, 1, 0), p(3, 1, 0))
+        self.w.translate_shape(sid, 10, 20)
+        b = self.w.bezier(0)
+        self.assertAlmostEqual(b[0][0], 10.0)
+        self.assertAlmostEqual(b[0][1], 20.0)
+        self.assertAlmostEqual(b[3][0], 13.0)
+        self.assertAlmostEqual(b[3][1], 21.0)
+
+    def test_bezier_shape_visible(self):
+        p = self.Point
+        self.w.add_bezier_shape(p(0, 0, 0), p(1, 0, 0),
+                                p(2, 1, 0), p(3, 1, 0))
+        self.w.add_bezier_shape(p(100, 100, 0), p(101, 100, 0),
+                                p(102, 101, 0), p(103, 101, 0))
+        self.assertEqual(len(self.w.query_visible(-1, -1, 5, 5)), 1)
+
+    def test_remove_bezier_shape(self):
+        p = self.Point
+        sid = self.w.add_bezier_shape(p(0, 0, 0), p(1, 0, 0),
+                                      p(2, 1, 0), p(3, 1, 0))
+        self.w.remove_shape(sid)
+        self.assertEqual(self.w.nshape, 0)
+        self.assertEqual(len(self.w.query_visible(-1, -1, 5, 5)), 0)
+
+
+class WorldDescribeStateTC(unittest.TestCase):
+    """describe_state(level="basic"): JSON serialization of visible state."""
+
+    def setUp(self):
+        self.w = solvcon.WorldFp64()
+
+    def test_empty_world(self):
+        # Locks the schema shape and the default level.
+        self.assertEqual(
+            self.w.describe_state(),
+            '{"shapes":[],"segments":[],"curves":[],"points":[]}')
+
+    def test_triangle_segments(self):
+        sid = self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        state = json.loads(self.w.describe_state(level="basic"))
+        self.assertEqual(len(state["shapes"]), 1)
+        shape = state["shapes"][0]
+        self.assertEqual(shape["id"], sid)
+        self.assertEqual(shape["type"], "triangle")
+        self.assertEqual(shape["bbox"], [0, 0, 1, 1])
+        self.assertEqual(shape["segments"],
+                         [[0, 0, 1, 0], [1, 0, 0, 1], [0, 1, 0, 0]])
+        self.assertEqual(shape["curves"], [])
+
+    def test_circle_curves(self):
+        self.w.add_circle(0, 0, 1)
+        shape = json.loads(self.w.describe_state())["shapes"][0]
+        self.assertEqual(shape["type"], "circle")
+        self.assertEqual(shape["bbox"], [-1, -1, 1, 1])
+        self.assertEqual(shape["segments"], [])
+        self.assertEqual(len(shape["curves"]), 4)
+        for curve in shape["curves"]:
+            self.assertEqual(len(curve), 4)  # four control points
+            for ctrl in curve:
+                self.assertEqual(len(ctrl), 2)  # 2D: x, y only
+        # First quadrant sweeps from (1, 0) to (0, 1).
+        self.assertEqual(shape["curves"][0][0], [1, 0])
+        self.assertEqual(shape["curves"][0][3], [0, 1])
+
+    def test_bezier_shape_curves(self):
+        p = solvcon.Point3dFp64
+        sid = self.w.add_bezier_shape(p(0, 0, 0), p(1, 0, 0),
+                                      p(2, 1, 0), p(3, 1, 0))
+        state = json.loads(self.w.describe_state())
+        shape = state["shapes"][0]
+        self.assertEqual(shape["id"], sid)
+        self.assertEqual(shape["type"], "bezier")
+        self.assertEqual(shape["segments"], [])
+        self.assertEqual(len(shape["curves"]), 1)
+        self.assertEqual(shape["curves"][0],
+                         [[0, 0], [1, 0], [2, 1], [3, 1]])
+        # The shape owns its curve, so it is not also a bare top-level curve.
+        self.assertEqual(state["curves"], [])
+
+    def test_bare_segment_and_curve(self):
+        # add_segment / add_bezier create geometry no shape owns, but it
+        # still renders, so it appears under top-level segments/curves.
+        p = solvcon.Point3dFp64
+        self.w.add_segment(p(0, 0), p(1, 2))
+        self.w.add_bezier(p(0, 0), p(1, 0), p(2, 1), p(3, 1))
+        state = json.loads(self.w.describe_state())
+        self.assertEqual(state["shapes"], [])
+        self.assertEqual(state["segments"], [[0, 0, 1, 2]])
+        self.assertEqual(len(state["curves"]), 1)
+        self.assertEqual(state["curves"][0][0], [0, 0])
+        self.assertEqual(state["curves"][0][3], [3, 1])
+
+    def test_shape_curves_are_not_double_reported(self):
+        # A circle's curves belong to the shape; they must not also appear as
+        # bare top-level curves.
+        self.w.add_circle(0, 0, 1)
+        state = json.loads(self.w.describe_state())
+        self.assertEqual(len(state["shapes"][0]["curves"]), 4)
+        self.assertEqual(state["curves"], [])
+
+    def test_coordinate_precision(self):
+        # describe_state serializes through the shared JSON tool, whose
+        # number format keeps six decimal places.
+        self.w.add_point(1.0 / 3.0, 2.5, 0)
+        pt = json.loads(self.w.describe_state())["points"][0]
+        self.assertAlmostEqual(pt[0], 0.333333, places=6)
+        self.assertEqual(pt[1], 2.5)
+
+    def test_free_points(self):
+        self.w.add_point(1, 2, 3)
+        self.w.add_point(-4, 5, 6)
+        state = json.loads(self.w.describe_state())
+        # z is not rendered, so only x, y appear.
+        self.assertEqual(state["points"], [[1, 2], [-4, 5]])
+
+    def test_dead_shapes_excluded(self):
+        keep = self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        drop = self.w.add_circle(10, 10, 1)
+        self.w.remove_shape(drop)
+        state = json.loads(self.w.describe_state())
+        ids = [s["id"] for s in state["shapes"]]
+        self.assertEqual(ids, [keep])
+        # The dead circle does not render, so its curves must not leak into
+        # the bare arrays either.
+        self.assertEqual(state["curves"], [])
+        self.assertEqual(state["segments"], [])
+
+    def test_deterministic(self):
+        def build(w):
+            w.add_circle(0, 0, 1)
+            w.add_rectangle(-2, -2, 2, 2)
+            w.add_point(1, 1, 0)
+        build(self.w)
+        other = solvcon.WorldFp64()
+        build(other)
+        # Stable across repeated calls and equal across equal worlds.
+        self.assertEqual(self.w.describe_state(), self.w.describe_state())
+        self.assertEqual(self.w.describe_state(), other.describe_state())
+
+    def test_unknown_level_raises(self):
+        self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        with self.assertRaises(ValueError):
+            self.w.describe_state(level="+diagnostics")
+
+    def test_fp32(self):
+        w = solvcon.WorldFp32()
+        w.add_line(0, 0, 1, 1)
+        shape = json.loads(w.describe_state())["shapes"][0]
+        self.assertEqual(shape["type"], "line")
+        self.assertEqual(shape["segments"], [[0, 0, 1, 1]])
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Adds World::describe_state, which serializes the world's visible 2D geometry to a deterministic JSON string. The "basic" level emits what the 2D image renders: each live shape's id, type, bounding box, and control points, the bare segments and curves owned by no shape, and the free points (z is omitted as it is not rendered). Shapes are id-ordered with fixed key order, so equal worlds produce byte-identical output that tooling can diff directly.

The shape-name switch is also extracted from the Python binding into a shared shape_type_name helper. The level is a DescribeLevel enum in C++; the binding takes the lower-case string and raises ValueError for an unknown level.

Known limitation: the shared JSON serializer keeps only six decimal places, so coordinates differing past the sixth decimal serialize identically. Flagged with a TODO for follow-up.

Related to #896.
