### PR TITLE
Fix bundle missing six.py

### DIFF
--- a/contrib/bundle/bundle-with-homebrew.sh
+++ b/contrib/bundle/bundle-with-homebrew.sh
@@ -537,7 +537,8 @@ while IFS= read -r line; do
 done < <(python3 -c "
 import importlib, os, sys
 seeds = os.environ.get('BUNDLE_SEED_MODULES',
-    'PySide6.QtCore,PySide6.QtWidgets,PySide6.QtGui,numpy,matplotlib').split(',')
+    'PySide6.QtCore,PySide6.QtWidgets,PySide6.QtGui,numpy,matplotlib,'
+    'dateutil.relativedelta,dateutil.tz,dateutil.parser').split(',')
 extras = os.environ.get('BUNDLE_EXTRA_PACKAGES', '').split(',')
 for m in seeds + extras:
     m = m.strip()


### PR DESCRIPTION
Add dateutil.relativedelta,dateutil.tz,dateutil.parser into BUNDLE_SEED_MODULES to solve missing six module problem.

PR [#798](https://github.com/solvcon/modmesh/pull/798) introduced closure-based site-packages discovery, which loads dateutil via importlib.import_module("dateutil"). But dateutil's __init__.py is lazy (only sets __version__, doesn't import its own submodules), so dateutil.relativedelta / .rrule / .tz / .parser never run, six (which they import) never enters sys.modules, and six.py is left out of the bundle.PR [#798](https://github.com/solvcon/modmesh/pull/798) introduced closure-based site-packages discovery, which loads dateutil via importlib.import_module("dateutil"). But dateutil's __init__.py is lazy (only sets __version__, doesn't import its own submodules), so dateutil.relativedelta / .rrule / .tz / .parser never run, six (which they import) never enters sys.modules, and six.py is left out of the bundle.

Related to #765 