### PR TITLE
Sync the README and developer docs with the current code base

### DIFF
--- a/.claude/skills/commit-code/SKILL.md
+++ b/.claude/skills/commit-code/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: commit-code
+description: Commits changes the solvcon way -- splits work into one-concern commits, lints first, stages exact paths, and writes STYLE.md-conformant messages (imperative subject, no semantic prefixes, no closing keywords, human-authored). Use when the user asks to commit, split work into commits, organize or rewrite commit history, or write a commit message.
+---
+
+# Commit Code (solvcon)
+
+The "Commit Log" section of `STYLE.md` at the repo root is canonical for
+the message format; `CLAUDE.md` summarizes it and `create-pr` covers
+pull requests. This skill adds the surrounding workflow and the project
+conventions that differ from default git habits.
+
+## Workflow
+
+1. **Survey.** Run `git status --porcelain` and `git diff` (with
+   `--stat`) to see what changed. Group the changes into one-concern
+   commits. Ask before staging when a file's grouping is unclear or it
+   looks unrelated to the task.
+2. **Lint.** Run `make lint` (or the subset for the touched language).
+   Fix every report and re-run. Never commit code that fails the
+   linters.
+3. **Commit each concern.** Stage the exact paths (`git add <path>`),
+   confirm `git diff --cached --stat` shows only that concern, draft the
+   message, present the subject (and body, when non-trivial) for review,
+   then commit with a quoted heredoc so backticks, `$`, and quotes
+   survive unescaped:
+
+   ```bash
+   git commit -F - <<'MSG'
+   <approved subject>
+
+   <approved body wrapped at 72, if any>
+   MSG
+   ```
+4. **Verify.** Run `git log --oneline` and report the commits created.
+
+## Message format
+
+Follow STYLE.md "Commit Log" -- do not restate it here. In brief:
+imperative subject (capitalized, no period, aim 50 / 72 hard limit), one
+blank line, then a body wrapped at 72 that explains what changed and
+why, not how. A one-line subject suffices for a trivial change.
+
+## Conventions that differ from default git habits
+
+These contradict common defaults, so apply them deliberately:
+
+- **Human-authored.** Do not append `Co-Authored-By:` or "Generated
+  with ..." trailers; this project keeps commits human-authored (see
+  `create-pr`).
+- **No semantic prefixes.** Never use `feat:`, `fix:`, `docs:`, etc.
+- **No closing keywords.** Never use `close`/`fixes`/`resolves #n`.
+  Reference an issue only when necessary, ending the body with "Related
+  to #xxx" or "For issue #xxx".
+- **One concern per commit.** Each commit stands on its own. Do not pad:
+  trivial, tightly-coupled edits belong together.
+- **Stage exact paths.** Never `git add -A` / `git add .`; never
+  `--no-verify`. Stray files (local settings, build artifacts) must not
+  ride along.
+- **Topic branch only.** Never commit directly on `master`/`main`;
+  branch first.
+
+## Rewriting history
+
+When asked to organize or clean up commits, recreate them rather than
+patching messages one by one:
+
+1. Soft-reset to the merge base: `git reset --soft <base>`, then
+   `git restore --staged .`.
+2. Recommit by concern as in the workflow above, in an order that reads
+   as a coherent progression.
+3. Before pushing, confirm the rewritten tree is identical to the prior
+   tip: `git diff <old-tip> HEAD` must be empty.
+4. Push with `git push --force-with-lease`, never a bare `--force`.
+
+## Guardrail: closing keywords
+
+Before each commit, scan the drafted message and rewrite any hit:
+
+```bash
+printf '%s\n' "$msg" \
+    | grep -iEn '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+'
+```
+
+<!-- vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: -->

--- a/README.md
+++ b/README.md
@@ -7,14 +7,20 @@ unstructured meshes of mixed element to solve conservation laws. It is
 developed by using C++ and Python to provide:
 
 1. Contiguous buffers and multi-dimensional arrays.
-2. One-dimensional solvers for demonstrating the CESE method.
-3. (Being ported from https://github.com/solvcon/pastsolvcon) unstructured
-   meshes of mixed elements for solving conservation laws by using the CESE
-   method in two- and three-dimensional space.
-4. (Under development) two- and three-dimensional body mesh generation.
-5. (Under development) an integrated runtime profiler.
-6. A graphical user interface (GUI) application based on Qt for the spatial data
-   and analysis.
+2. Linear algebra built on BLAS and LAPACK, including a general eigensolver,
+   LU factorization, and a Kalman filter.
+3. Integral transform (the Fourier transform).
+4. One-dimensional solvers for the Euler and linear scalar equations to
+   demonstrate the CESE method.
+5. Two- and three-dimensional solvers for the Euler equations using the
+   CESE method. (Under development.)
+6. Mesh and field file input and output for the Gmsh and Plot3D formats.
+7. A geometry processor with polygons, Bezier curves, and R-tree spatial
+   indexing.
+8. Two- and three-dimensional body mesh generation. (Under development.)
+9. An integrated runtime profiler.
+10. A graphical user interface (GUI) application based on Qt for the spatial
+    data and analysis.
 
 An experimental Windows binary (portable) can be downloaded from the [devbuild
 GitHub

--- a/doc/source/dev/style.md
+++ b/doc/source/dev/style.md
@@ -1,3 +1,4 @@
-# Code Style
+```{include} ../../../STYLE.md
+```
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->


### PR DESCRIPTION
Review the codebase and to supplement the latest development in `README.md`.

`doc/source/dev/style.md` was empty.  Now change it to include the contents in `STYLE.md`.  It will make the code style guide to be available in the project document page https://doc.solvcon.net/ .

Add a `commit-code` skill that captures this repository's commit and history-rewrite conventions.