### PR TITLE
Mesh information panel to highlight boundary sets

### DIFF
--- a/cpp/solvcon/pilot/R3DWidget.cpp
+++ b/cpp/solvcon/pilot/R3DWidget.cpp
@@ -161,13 +161,41 @@ void R3DWidget::updateMesh(std::shared_ptr<StaticMesh> const & mesh)
 {
     for (Qt3DCore::QNode * child : m_scene->childNodes())
     {
-        if (typeid(*child) == typeid(RStaticMesh))
+        if (typeid(*child) == typeid(RStaticMesh) || typeid(*child) == typeid(RBoundary))
         {
             child->deleteLater();
         }
     }
     new RStaticMesh(mesh, m_scene);
     m_mesh = mesh;
+}
+
+void R3DWidget::showMesh(bool show)
+{
+    for (Qt3DCore::QNode * child : m_scene->childNodes())
+    {
+        if (typeid(*child) == typeid(RStaticMesh))
+        {
+            child->setEnabled(show);
+        }
+    }
+}
+
+void R3DWidget::showBoundary(int ibc, bool show)
+{
+    // Remove an existing boundary highlight for this set so a re-show stays
+    // single and a hide simply leaves none behind.
+    for (Qt3DCore::QNode * child : m_scene->childNodes())
+    {
+        if (typeid(*child) == typeid(RBoundary) && static_cast<RBoundary *>(child)->ibc() == ibc)
+        {
+            child->deleteLater();
+        }
+    }
+    if (show && nullptr != m_mesh)
+    {
+        new RBoundary(m_mesh, ibc, m_scene);
+    }
 }
 
 void R3DWidget::updateWorld(std::shared_ptr<WorldFp64> const & world)

--- a/cpp/solvcon/pilot/R3DWidget.hpp
+++ b/cpp/solvcon/pilot/R3DWidget.hpp
@@ -108,6 +108,8 @@ public:
 
     void showMark();
     void updateMesh(std::shared_ptr<StaticMesh> const & mesh);
+    void showMesh(bool show);
+    void showBoundary(int ibc, bool show);
     void updateWorld(std::shared_ptr<WorldFp64> const & world);
     void updateColorField(
         SimpleArray<float> const & vertices,

--- a/cpp/solvcon/pilot/RStaticMesh.cpp
+++ b/cpp/solvcon/pilot/RStaticMesh.cpp
@@ -7,6 +7,17 @@
 
 #include <solvcon/pilot/common_detail.hpp>
 
+#include <Qt3DExtras/QPerVertexColorMaterial>
+
+#include <QCullFace>
+#include <QEffect>
+#include <QRenderPass>
+#include <QTechnique>
+
+#include <array>
+#include <cmath>
+#include <limits>
+
 namespace solvcon
 {
 
@@ -66,6 +77,214 @@ void RStaticMesh::update_geometry_impl(StaticMesh const & mh, Qt3DCore::QGeometr
         indices->setCount(mh.nedge() * 2);
 
         geom->addAttribute(indices);
+    }
+}
+
+namespace
+{
+
+/// Pick a distinct, saturated color for a boundary set so neighboring sets
+/// stay tellable apart; the palette repeats for meshes with many sets.
+std::array<float, 3> boundary_color(int ibc)
+{
+    static const std::array<std::array<float, 3>, 6> palette{{
+        {1.0f, 0.20f, 0.20f}, // red
+        {0.20f, 0.60f, 1.0f}, // blue
+        {0.20f, 0.80f, 0.30f}, // green
+        {1.0f, 0.70f, 0.10f}, // amber
+        {0.80f, 0.30f, 0.90f}, // purple
+        {0.10f, 0.80f, 0.80f}, // teal
+    }};
+    return palette.at(static_cast<size_t>(ibc < 0 ? 0 : ibc) % palette.size());
+}
+
+} /* end namespace */
+
+RBoundary::RBoundary(std::shared_ptr<StaticMesh> const & mesh, int ibc, Qt3DCore::QNode * parent)
+    : Qt3DCore::QEntity(parent)
+    , m_ibc(ibc)
+    , m_geometry(new Qt3DCore::QGeometry(this))
+    , m_renderer(new Qt3DRender::QGeometryRenderer())
+    , m_material(new Qt3DExtras::QPerVertexColorMaterial())
+{
+    build_geometry(*mesh, ibc, m_geometry);
+    // build_geometry leaves no attribute when the set has no face; an empty
+    // buffer would make Qt throw. addComponent would otherwise adopt these, so
+    // free them here before bailing out.
+    if (m_geometry->attributes().isEmpty())
+    {
+        delete m_renderer;
+        m_renderer = nullptr;
+        delete m_material;
+        m_material = nullptr;
+        return;
+    }
+    m_renderer->setGeometry(m_geometry);
+    m_renderer->setPrimitiveType(Qt3DRender::QGeometryRenderer::Triangles);
+    addComponent(m_renderer);
+    // The ribbon is a flat two-sided strip whose quads are wound either way,
+    // so disable face culling to keep every edge visible.
+    for (Qt3DRender::QTechnique * tech : m_material->effect()->techniques())
+    {
+        for (Qt3DRender::QRenderPass * pass : tech->renderPasses())
+        {
+            auto * cull = new Qt3DRender::QCullFace(m_material);
+            cull->setMode(Qt3DRender::QCullFace::NoCulling);
+            pass->addRenderState(cull);
+        }
+    }
+    addComponent(m_material);
+}
+
+void RBoundary::build_geometry(StaticMesh const & mh, int ibc, Qt3DCore::QGeometry * geom)
+{
+    // Gather the boundary-set edges as node-index pairs; with none there is
+    // nothing to draw and the geometry is left empty.
+    SimpleCollector<uint32_t> ends;
+    SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
+    for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+    {
+        if (bndfcs(ibnd, 1) != ibc)
+        {
+            continue;
+        }
+        int32_t const ifc = bndfcs(ibnd, 0);
+        int32_t const nnd = mh.fcnds(ifc, 0);
+        // A 2D face is a single edge; a 3D face is a polygon whose rim edges
+        // close back to the first node.
+        for (int32_t ind = 1; ind <= nnd; ++ind)
+        {
+            ends.push_back(static_cast<uint32_t>(mh.fcnds(ifc, ind)));
+            int32_t const next = (ind == nnd) ? 1 : ind + 1;
+            ends.push_back(static_cast<uint32_t>(mh.fcnds(ifc, next)));
+            if (2 == nnd)
+            {
+                break; // avoid drawing the same segment twice.
+            }
+        }
+    }
+    size_t const nedge = ends.size() / 2;
+    if (0 == nedge)
+    {
+        return;
+    }
+
+    // glLineWidth is unreliable (clamped to 1 in the OpenGL core profile), so
+    // the thickness is built from triangles instead. The half-width is a small
+    // fraction of the mesh extent, so the ribbon reads about twice the
+    // hairline wireframe and stays sensible at any zoom.
+    float lo[3] = {std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max()};
+    float hi[3] = {std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest()};
+    auto node = [&mh](uint32_t ind, size_t dim) -> float
+    { return (dim < mh.ndim()) ? static_cast<float>(mh.ndcrd(ind, dim)) : 0.0f; };
+    for (uint32_t ind = 0; ind < mh.nnode(); ++ind)
+    {
+        for (size_t dim = 0; dim < 3; ++dim)
+        {
+            lo[dim] = std::min(lo[dim], node(ind, dim));
+            hi[dim] = std::max(hi[dim], node(ind, dim));
+        }
+    }
+    float const diag = std::sqrt(
+        (hi[0] - lo[0]) * (hi[0] - lo[0]) + (hi[1] - lo[1]) * (hi[1] - lo[1]) + (hi[2] - lo[2]) * (hi[2] - lo[2]));
+    float const half = (diag > 0.0f ? diag : 1.0f) * 0.0035f;
+    // Lift the ribbon toward the viewer (the meshes are 2D, so +z) so it wins
+    // the depth test against the coplanar wireframe instead of z-fighting it.
+    float const lift = half;
+
+    // Expand each edge into a flat quad (two triangles) offset perpendicular to
+    // the edge in the view plane; the meshes are 2D, so the cross product with
+    // the z axis gives the in-plane normal.
+    std::array<float, 3> const color = boundary_color(ibc);
+    QByteArray vbuf;
+    QByteArray cbuf;
+    QByteArray ibuf;
+    vbuf.resize(nedge * 4 * 3 * sizeof(float));
+    cbuf.resize(nedge * 4 * 3 * sizeof(float));
+    ibuf.resize(nedge * 6 * sizeof(uint32_t));
+    SimpleArray<float> verts = makeSimpleArray<float>(vbuf, small_vector<size_t>{nedge * 4, 3}, /*view*/ true);
+    SimpleArray<float> colors = makeSimpleArray<float>(cbuf, small_vector<size_t>{nedge * 4, 3}, /*view*/ true);
+    SimpleArray<uint32_t> idx = makeSimpleArray<uint32_t>(ibuf, small_vector<size_t>{nedge * 6}, /*view*/ true);
+    for (size_t ie = 0; ie < nedge; ++ie)
+    {
+        uint32_t const i0 = ends[ie * 2];
+        uint32_t const i1 = ends[ie * 2 + 1];
+        float const dx = node(i1, 0) - node(i0, 0);
+        float const dy = node(i1, 1) - node(i0, 1);
+        float nx = dy;
+        float ny = -dx;
+        float len = std::sqrt(nx * nx + ny * ny);
+        if (len < std::numeric_limits<float>::epsilon())
+        {
+            nx = 1.0f;
+            ny = 0.0f;
+            len = 1.0f;
+        }
+        float const ox = nx / len * half;
+        float const oy = ny / len * half;
+        // Corner order p0+o, p0-o, p1-o, p1+o makes the two triangles below.
+        float const px[4] = {node(i0, 0) + ox, node(i0, 0) - ox, node(i1, 0) - ox, node(i1, 0) + ox};
+        float const py[4] = {node(i0, 1) + oy, node(i0, 1) - oy, node(i1, 1) - oy, node(i1, 1) + oy};
+        float const pz[4] = {node(i0, 2) + lift, node(i0, 2) + lift, node(i1, 2) + lift, node(i1, 2) + lift};
+        size_t const base = ie * 4;
+        for (size_t ic = 0; ic < 4; ++ic)
+        {
+            verts(base + ic, 0) = px[ic];
+            verts(base + ic, 1) = py[ic];
+            verts(base + ic, 2) = pz[ic];
+            colors(base + ic, 0) = color[0];
+            colors(base + ic, 1) = color[1];
+            colors(base + ic, 2) = color[2];
+        }
+        size_t const iib = ie * 6;
+        idx(iib + 0) = static_cast<uint32_t>(base + 0);
+        idx(iib + 1) = static_cast<uint32_t>(base + 1);
+        idx(iib + 2) = static_cast<uint32_t>(base + 2);
+        idx(iib + 3) = static_cast<uint32_t>(base + 0);
+        idx(iib + 4) = static_cast<uint32_t>(base + 2);
+        idx(iib + 5) = static_cast<uint32_t>(base + 3);
+    }
+
+    {
+        // Ribbon vertex coordinates.
+        auto * attr = new Qt3DCore::QAttribute(geom);
+        attr->setName(Qt3DCore::QAttribute::defaultPositionAttributeName());
+        attr->setAttributeType(Qt3DCore::QAttribute::VertexAttribute);
+        attr->setVertexBaseType(Qt3DCore::QAttribute::Float);
+        attr->setVertexSize(3);
+        auto * buf = new Qt3DCore::QBuffer(geom);
+        buf->setData(vbuf);
+        attr->setBuffer(buf);
+        attr->setByteStride(3 * sizeof(float));
+        attr->setCount(nedge * 4);
+        geom->addAttribute(attr);
+    }
+
+    {
+        // A flat color per vertex feeds the per-vertex-color material.
+        auto * attr = new Qt3DCore::QAttribute(geom);
+        attr->setName(Qt3DCore::QAttribute::defaultColorAttributeName());
+        attr->setAttributeType(Qt3DCore::QAttribute::VertexAttribute);
+        attr->setVertexBaseType(Qt3DCore::QAttribute::Float);
+        attr->setVertexSize(3);
+        auto * buf = new Qt3DCore::QBuffer(geom);
+        buf->setData(cbuf);
+        attr->setBuffer(buf);
+        attr->setByteStride(3 * sizeof(float));
+        attr->setCount(nedge * 4);
+        geom->addAttribute(attr);
+    }
+
+    {
+        // Triangle index buffer, two triangles per edge.
+        auto * attr = new Qt3DCore::QAttribute(geom);
+        attr->setVertexBaseType(Qt3DCore::QAttribute::UnsignedInt);
+        attr->setAttributeType(Qt3DCore::QAttribute::IndexAttribute);
+        auto * buf = new Qt3DCore::QBuffer(geom);
+        buf->setData(ibuf);
+        attr->setBuffer(buf);
+        attr->setCount(static_cast<uint32_t>(nedge * 6));
+        geom->addAttribute(attr);
     }
 }
 

--- a/cpp/solvcon/pilot/RStaticMesh.hpp
+++ b/cpp/solvcon/pilot/RStaticMesh.hpp
@@ -50,6 +50,34 @@ private:
 
 }; /* end class RStaticMesh */
 
+/**
+ * Render the faces of a single boundary set as thick colored ribbons so the
+ * set stands out over the wireframe mesh.  Each edge is widened into two
+ * triangles because glLineWidth is clamped to 1 in the OpenGL core profile.
+ * One entity is created per highlighted boundary set; @ref ibc identifies
+ * which set it draws.
+ */
+class RBoundary
+    : public Qt3DCore::QEntity
+{
+
+public:
+
+    RBoundary(std::shared_ptr<StaticMesh> const & mesh, int ibc, Qt3DCore::QNode * parent = nullptr);
+
+    int ibc() const { return m_ibc; }
+
+private:
+
+    static void build_geometry(StaticMesh const & mh, int ibc, Qt3DCore::QGeometry * geom);
+
+    int m_ibc = -1;
+    Qt3DCore::QGeometry * m_geometry = nullptr;
+    Qt3DRender::QGeometryRenderer * m_renderer = nullptr;
+    Qt3DRender::QMaterial * m_material = nullptr;
+
+}; /* end class RBoundary */
+
 } /* end namespace solvcon */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -133,6 +133,8 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapR3DWidget
         (*this)
             .def_property_readonly("mesh", &wrapped_type::mesh)
             .def("updateMesh", &wrapped_type::updateMesh, py::arg("mesh"))
+            .def("showMesh", &wrapped_type::showMesh, py::arg("show"))
+            .def("showBoundary", &wrapped_type::showBoundary, py::arg("ibc"), py::arg("show"))
             .def("updateWorld", &wrapped_type::updateWorld, py::arg("world"))
             .def(
                 "updateColorField",

--- a/solvcon/pilot/_mesh_info.py
+++ b/solvcon/pilot/_mesh_info.py
@@ -19,8 +19,13 @@ __all__ = [  # noqa: F822
 ]
 
 
-class MeshInfoPanel(QWidget):
+class MeshInfoTree(QWidget):
     """Widget that presents the mesh information tree inside the dock."""
+
+    # Data roles that route a tree item's check-box toggle; the boundary
+    # index rides in the role after the kind.
+    _ROLE_KIND = Qt.UserRole
+    _ROLE_IBC = Qt.UserRole + 1
 
     # Map cell type numbers to human-readable names.
     CELL_TYPE_NAME = {
@@ -45,6 +50,14 @@ class MeshInfoPanel(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self._tree)
         self.setLayout(layout)
+        # Called when a check box flips; the owner wires these to the viewer.
+        # ``boundary_toggled(ibc, checked)`` follows a boundary set and
+        # ``mesh_toggled(checked)`` the wireframe.  ``_building`` suppresses
+        # the signal while ``set_mesh`` populates the check boxes.
+        self.boundary_toggled = None
+        self.mesh_toggled = None
+        self._building = False
+        self._tree.itemChanged.connect(self._on_item_changed)
         self.set_mesh(mh)
 
     @classmethod
@@ -89,21 +102,76 @@ class MeshInfoPanel(QWidget):
             sections.append(("Cell types", cells))
         return sections
 
+    @classmethod
+    def make_boundary_info(cls, mh):
+        """Return one ``[ibc, nface]`` row per boundary set.
+
+        Each boundary face records its set index in column 1 of ``bndfcs``,
+        so grouping the rows by that index yields the face count of every
+        set, including the trailing catch-all set of unspecified faces.
+        """
+        bnd = mh.bndfcs.ndarray
+        if bnd.size:
+            counts = np.bincount(bnd[:, 1], minlength=mh.nbcs)
+        else:
+            counts = np.zeros(mh.nbcs, dtype='int64')
+        return [[ibc, int(counts[ibc])] for ibc in range(mh.nbcs)]
+
     def set_mesh(self, mh):
         """Rebuild the tree from ``mh``, or show "No mesh loaded" when None."""
-        self._tree.clear()
-        if mh is None:
-            QTreeWidgetItem(self._tree, ["No mesh loaded"])
+        self._building = True
+        try:
+            self._tree.clear()
+            if mh is None:
+                QTreeWidgetItem(self._tree, ["No mesh loaded"])
+                return
+            root = QTreeWidgetItem(self._tree, [f"StaticMesh ({mh.ndim}D)"])
+            # Keep the display toggles (wireframe, then boundaries) together
+            # at the top, above the read-only information sections.
+            self._add_mesh_toggle(root)
+            self._add_boundary_group(root, mh)
+            for section, rows in self.make_mesh_info(mh):
+                group = QTreeWidgetItem(root, [section])
+                for prop, value in rows:
+                    QTreeWidgetItem(group, [f"{prop}: {value}"])
+                group.setExpanded(True)
+            root.setExpanded(True)
+            # Widen the column so long entries are not clipped.
+            self._tree.resizeColumnToContents(0)
+        finally:
+            self._building = False
+
+    def _add_mesh_toggle(self, root):
+        """Add the wireframe on/off check box (default on)."""
+        item = QTreeWidgetItem(root, ["wireframe"])
+        item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+        item.setData(0, self._ROLE_KIND, 'mesh')
+        item.setCheckState(0, Qt.Checked)
+
+    def _add_boundary_group(self, root, mh):
+        """Add the boundary sets as a group of check boxes (default off)."""
+        binfo = self.make_boundary_info(mh)
+        if not binfo:
             return
-        root = QTreeWidgetItem(self._tree, [f"StaticMesh ({mh.ndim}D)"])
-        for section, rows in self.make_mesh_info(mh):
-            group = QTreeWidgetItem(root, [section])
-            for prop, value in rows:
-                QTreeWidgetItem(group, [f"{prop}: {value}"])
-            group.setExpanded(True)
-        root.setExpanded(True)
-        # Widen the column so long entries are not clipped.
-        self._tree.resizeColumnToContents(0)
+        group = QTreeWidgetItem(root, ["Boundaries"])
+        for ibc, count in binfo:
+            item = QTreeWidgetItem(group, [f"bc {ibc}: {count} faces"])
+            item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+            item.setData(0, self._ROLE_KIND, 'boundary')
+            item.setData(0, self._ROLE_IBC, ibc)
+            item.setCheckState(0, Qt.Unchecked)
+        group.setExpanded(True)
+
+    def _on_item_changed(self, item, _column):
+        """Route a check-box toggle to its handler, ignoring plain rows."""
+        if self._building:
+            return
+        checked = item.checkState(0) == Qt.Checked
+        kind = item.data(0, self._ROLE_KIND)
+        if kind == 'boundary' and self.boundary_toggled is not None:
+            self.boundary_toggled(item.data(0, self._ROLE_IBC), checked)
+        elif kind == 'mesh' and self.mesh_toggled is not None:
+            self.mesh_toggled(checked)
 
 
 class MeshInfo(_gui_common.PilotFeature):
@@ -141,7 +209,9 @@ class MeshInfo(_gui_common.PilotFeature):
         """Build the dock lazily and follow sub-window activation."""
         if self._panel is not None:
             return
-        self._panel = MeshInfoPanel()
+        self._panel = MeshInfoTree()
+        self._panel.boundary_toggled = self._on_boundary_toggled
+        self._panel.mesh_toggled = self._on_mesh_toggled
         self._dock = QDockWidget("mesh")
         self._dock.setWidget(self._panel)
         self._mgr.mainWindow.addDockWidget(Qt.LeftDockWidgetArea,
@@ -165,6 +235,18 @@ class MeshInfo(_gui_common.PilotFeature):
     def _refresh(self):
         """Show the active sub-window's mesh."""
         self._panel.set_mesh(self._active_mesh())
+
+    def _on_boundary_toggled(self, ibc, checked):
+        """Highlight or clear boundary set ``ibc`` in the active viewer."""
+        widget = self._mgr.currentR3DWidget()
+        if widget is not None:
+            widget.showBoundary(ibc, checked)
+
+    def _on_mesh_toggled(self, checked):
+        """Show or hide the wireframe in the active viewer."""
+        widget = self._mgr.currentR3DWidget()
+        if widget is not None:
+            widget.showMesh(checked)
 
     def _mdi_area(self):
         return self._mainWindow.centralWidget()

--- a/tests/test_pilot_mesh_info.py
+++ b/tests/test_pilot_mesh_info.py
@@ -10,6 +10,7 @@ import solvcon
 try:
     from solvcon import pilot
     from solvcon.pilot import _mesh_info
+    from PySide6.QtCore import Qt
     from PySide6.QtWidgets import QApplication, QMenu
 except ImportError:
     pilot = None
@@ -80,7 +81,7 @@ def _tree_sections(tree):
 class MakeMeshInfoTC(unittest.TestCase):
     def test_excludes_ghost_entities(self):
         info = _section_map(
-            _mesh_info.MeshInfoPanel.make_mesh_info(_make_sample_mesh()))
+            _mesh_info.MeshInfoTree.make_mesh_info(_make_sample_mesh()))
         self.assertEqual(info["Counts"]["dim"], "2")
         self.assertEqual(info["Counts"]["node"], "6")
         self.assertEqual(info["Counts"]["cell"], "3")
@@ -90,6 +91,14 @@ class MakeMeshInfoTC(unittest.TestCase):
         # The bounding box must come from the body nodes only.
         self.assertEqual(info["Bounding box"]["x"], "[0, 2]")
         self.assertEqual(info["Bounding box"]["y"], "[0, 1]")
+
+    def test_boundary_info_groups_every_face(self):
+        mh = _make_sample_mesh()
+        binfo = _mesh_info.MeshInfoTree.make_boundary_info(mh)
+        # With no add_bc, build_boundary gathers every boundary face into a
+        # single catch-all set, so the one row must report all of them.
+        self.assertGreater(mh.nbound, 0)
+        self.assertEqual(binfo, [[0, mh.nbound]])
 
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
@@ -120,6 +129,53 @@ class MeshInfoTC(unittest.TestCase):
         sections = _tree_sections(feature._panel._tree)
         self.assertEqual(sections["Counts"]["cell"], "3")
         self.assertEqual(sections["Cell types"]["triangle"], "2")
+
+    def test_boundary_toggle_drives_viewer(self):
+        widget = self.mgr.add3DWidget()
+        widget.updateMesh(_make_sample_mesh())
+        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu)
+        feature.populate_menu()
+        feature._action.setChecked(True)
+        # Record the routed (ibc, checked) while still driving the real
+        # viewer hook, so the highlight build is exercised too.
+        calls = []
+        inner = feature._panel.boundary_toggled
+
+        def record(ibc, checked):
+            calls.append((ibc, checked))
+            inner(ibc, checked)
+        feature._panel.boundary_toggled = record
+        root = feature._panel._tree.topLevelItem(0)
+        group = next(root.child(i) for i in range(root.childCount())
+                     if root.child(i).text(0) == "Boundaries")
+        item = group.child(0)
+        self.assertEqual(item.checkState(0), Qt.Unchecked)  # default off
+        item.setCheckState(0, Qt.Checked)
+        item.setCheckState(0, Qt.Unchecked)
+        # Each flip routes the set index and its new state to the viewer.
+        self.assertEqual(calls, [(0, True), (0, False)])
+
+    def test_wireframe_toggle_drives_viewer(self):
+        widget = self.mgr.add3DWidget()
+        widget.updateMesh(_make_sample_mesh())
+        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu)
+        feature.populate_menu()
+        feature._action.setChecked(True)
+        calls = []
+        inner = feature._panel.mesh_toggled
+
+        def record(checked):
+            calls.append(checked)
+            inner(checked)
+        feature._panel.mesh_toggled = record
+        root = feature._panel._tree.topLevelItem(0)
+        item = next(root.child(i) for i in range(root.childCount())
+                    if root.child(i).text(0) == "wireframe")
+        self.assertEqual(item.checkState(0), Qt.Checked)  # default on
+        item.setCheckState(0, Qt.Unchecked)
+        item.setCheckState(0, Qt.Checked)
+        # The wireframe visibility flips reach the viewer in order.
+        self.assertEqual(calls, [False, True])
 
     def test_panel_without_mesh(self):
         self.mgr.add3DWidget()  # fresh viewer becomes current, no mesh


### PR DESCRIPTION
Extends the pilot mesh information panel so the user can inspect a mesh's boundary sets and control what the 3D viewer draws. The widget `MeshInfoTree` in the panel gains two kinds of display toggle at the top of the tree:

- **wireframe** — one check box, default **on**, that shows or hides the mesh wireframe.
- **Boundaries** — a group with one check box per boundary set, default **off**, each labeled with its face count; ticking one highlights that set's faces in the viewer.

In C++, add `RBoundary`, is a new Qt3D entity that draws a boundary set's faces as **thick colored ribbons** over the wireframe.  `R3DWidget` gains two new functions: `R3DWidget::showBoundary(ibc, show)` adds or removes a set's highlight, and `R3DWidget::showMesh(show)` shows or hides the wireframe.

In Python, `MeshInfoTree` is renamed from the old panel class to match its tree-centric role, and builds the toggles for both mesh and boundaries.

For issue #404.