### PR TITLE
Enable flake8 E226 check and fix existing violations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+extend-select = E226
+exclude = thirdparty,tmp,_deps

--- a/Makefile
+++ b/Makefile
@@ -223,8 +223,6 @@ CLANG_FORMAT_CI_VERSION ?= 20
 #   E201,E202,E203,E241   whitespace inside brackets / around commas; preserve
 #                         deliberate `# noqa` numeric alignment such as in
 #                         `tests/test_mesh.py`
-#   E226                  whitespace around arithmetic operator
-#                         (flake8 default-ignored)
 #   E301,E303             blank-line rules that pycodestyle does not flag in
 #                         their current uses (docstring-followed methods and
 #                         nested defs inside `if HAS_SPHINX:`); autopep8 would
@@ -234,7 +232,7 @@ CLANG_FORMAT_CI_VERSION ?= 20
 #   W503,W504             line-break style around binary operators
 #                         (flake8 default-ignored)
 AUTOPEP8_OPTS ?= --recursive --max-line-length=79 \
-                 --ignore=E121,E123,E126,E201,E202,E203,E226,E241,E301,E303,E501,W503,W504 \
+                 --ignore=E121,E123,E126,E201,E202,E203,E241,E301,E303,E501,W503,W504 \
                  --exclude=thirdparty,tmp,_deps
 
 CFFILES = $(shell find cpp gtests -type f -name '*.[ch]pp' | sort)
@@ -273,7 +271,7 @@ flake8:
 		echo "  Install: pip install flake8"; \
 		exit 1; \
 	}
-	$(FLAKE8) . --jobs $(NPROC) --exclude thirdparty,tmp,_deps
+	$(FLAKE8) . --jobs $(NPROC)
 
 .PHONY: checkascii
 checkascii:

--- a/profiling/profile_arithmetic_simd.py
+++ b/profiling/profile_arithmetic_simd.py
@@ -167,7 +167,8 @@ def profile_arithmetic_operation(op, val_range, prof_func, dtype, it=10):
     npbase = out["np"]
     sabase = out["sa"]
     for k, v in out.items():
-        print_row(f"{k:8s}", f"{v:.3E}", f"{v/npbase:.3f}", f"{v/sabase:.3f}")
+        print_row(f"{k:8s}", f"{v:.3E}",
+                  f"{v / npbase:.3f}", f"{v / sabase:.3f}")
 
     print()
 

--- a/profiling/profile_statistic_ops.py
+++ b/profiling/profile_statistic_ops.py
@@ -94,7 +94,7 @@ def profile_stat_op(op, prof_func_np, prof_func_sa, dtype, sizes, it=10,
 
     for N in sizes:
         if axis is not None:
-            shape = (N//100, 100) if axis == 1 else (100, N//100)
+            shape = (N // 100, 100) if axis == 1 else (100, N // 100)
             if min(shape) <= 0:
                 continue
             if np.issubdtype(dtype, np.floating):
@@ -148,13 +148,13 @@ def profile_stat_op(op, prof_func_np, prof_func_sa, dtype, sizes, it=10,
         def print_row(*cols):
             print(str.format("| {:10s} | {:15s} | {:15s} |", *(cols[0:3])))
         print_row('func', 'per call (ms)', 'cmp to np')
-        print_row('-'*10, '-'*15, '-'*15)
+        print_row('-' * 10, '-' * 15, '-' * 15)
         if axis is not None:
             npbase = out.get("np_axis", 1e-12)
         else:
             npbase = out.get("np", 1e-12)
         for k, v in out.items():
-            print_row(f"{k:8s}", f"{v:.3E}", f"{v/npbase:.3f}")
+            print_row(f"{k:8s}", f"{v:.3E}", f"{v / npbase:.3f}")
         print()
 
     return results
@@ -225,7 +225,7 @@ def create_1d_performance_plot(all_results, op, dtypes):
     sorted_dtypes = sorted(dtypes)
     n_dtypes = len(sorted_dtypes)
 
-    fig, axes = plt.subplots(n_dtypes, 2, figsize=(15, 4*n_dtypes))
+    fig, axes = plt.subplots(n_dtypes, 2, figsize=(15, 4 * n_dtypes))
     fig.suptitle(f'1D Performance: {op.title()}', fontsize=16)
 
     if n_dtypes == 1:
@@ -272,7 +272,7 @@ def create_axis_performance_plot(all_results, op, dtypes):
     sorted_dtypes = sorted(dtypes)
     n_dtypes = len(sorted_dtypes)
 
-    fig, axes = plt.subplots(n_dtypes, 4, figsize=(20, 4*n_dtypes))
+    fig, axes = plt.subplots(n_dtypes, 4, figsize=(20, 4 * n_dtypes))
     fig.suptitle(f'Axis Performance: {op.title()}', fontsize=16)
 
     if n_dtypes == 1:

--- a/profiling/profile_take_along_axis.py
+++ b/profiling/profile_take_along_axis.py
@@ -49,7 +49,7 @@ def profile_take_along_axis(pow, it=10):
     solvcon.call_profiler.reset()
     for _ in range(it):
         test_data = np.arange(0, N, dtype=dtype)
-        indices = np.arange(0, N-1, dtype=dtype)
+        indices = np.arange(0, N - 1, dtype=dtype)
         np.random.shuffle(test_data)
         np.random.shuffle(indices)
         test_sa = make_container(test_data)
@@ -77,7 +77,8 @@ def profile_take_along_axis(pow, it=10):
     npbase = out["np"]
     sabase = out["sa"]
     for k, v in out.items():
-        print_row(f"{k:8s}", f"{v:.3E}", f"{v/npbase:.3f}", f"{v/sabase:.3f}")
+        print_row(f"{k:8s}", f"{v:.3E}",
+                  f"{v / npbase:.3f}", f"{v / sabase:.3f}")
 
     print()
 

--- a/solvcon/pilot/_burgers1d.py
+++ b/solvcon/pilot/_burgers1d.py
@@ -97,8 +97,8 @@ class Burgers1DApp(_base_app.OneDimBaseApp):
             x_des = f"The point {i} of x axis"
             region.append([x_var, x, x_des])
         for i, vel in enumerate(self.region_velocity):
-            vel_var = f"velocity{i}{i+1}"
-            vel_des = f"The velocity between point {i} and {i+1}"
+            vel_var = f"velocity{i}{i + 1}"
+            vel_des = f"The velocity between point {i} and {i + 1}"
             region.append([vel_var, vel, vel_des])
         return region
 
@@ -112,7 +112,7 @@ class Burgers1DApp(_base_app.OneDimBaseApp):
             self.region_x.append(self.solver_config[x_var]["value"])
         self.region_velocity = []
         for i in range(self.num_region):
-            vel_var = f"velocity{i}{i+1}"
+            vel_var = f"velocity{i}{i + 1}"
             self.region_velocity.append(self.solver_config[vel_var]["value"])
 
     def init_solver_config(self):
@@ -175,9 +175,9 @@ class Burgers1DApp(_base_app.OneDimBaseApp):
                   self.region_x[-1],
                   f"The point {pos_x} of x axis"]
         pos_vel = self.num_region * 2 - 1
-        data_vel = [f"velocity{pos_x-1}{pos_x}",
+        data_vel = [f"velocity{pos_x - 1}{pos_x}",
                     self.region_velocity[-1],
-                    f"The velocity between point {pos_x-1} and {pos_x}"]
+                    f"The velocity between point {pos_x - 1} and {pos_x}"]
         return [(pos_x, data_x), (pos_vel, data_vel)]
 
     def get_region_delete(self):

--- a/solvcon/plot/plane_layer.py
+++ b/solvcon/plot/plane_layer.py
@@ -8,10 +8,10 @@ class PlaneLayer:
 
     def add_rectangle(self, x, y, w, h):
         rect = [
-            [(x, y), (x+w, y)],
-            [(x+w, y), (x+w, y+h)],
-            [(x+w, y+h), (x, y+h)],
-            [(x, y+h), (x, y)]
+            [(x, y), (x + w, y)],
+            [(x + w, y), (x + w, y + h)],
+            [(x + w, y + h), (x, y + h)],
+            [(x, y + h), (x, y)]
         ]
 
         self.polys.append(rect)
@@ -25,8 +25,8 @@ class PlaneLayer:
             curr_idx = i * 2
             next_idx = ((i + 1) % point_count) * 2
             poly.append([
-                (coords[curr_idx], coords[curr_idx+1]),
-                (coords[next_idx], coords[next_idx+1])])
+                (coords[curr_idx], coords[curr_idx + 1]),
+                (coords[next_idx], coords[next_idx + 1])])
 
         self.polys.append(poly)
 

--- a/solvcon/plot/svg.py
+++ b/solvcon/plot/svg.py
@@ -110,12 +110,12 @@ class EPath(object):
 
         # compute angles (start, delta)
         def angle(u, v):
-            dot = u[0]*v[0] + u[1]*v[1]
-            det = u[0]*v[1] - u[1]*v[0]
+            dot = u[0] * v[0] + u[1] * v[1]
+            det = u[0] * v[1] - u[1] * v[0]
             return math.atan2(det, dot)
 
-        u = [(xp - cxp)/rx, (yp - cyp)/ry]
-        v = [(-xp - cxp)/rx, (-yp - cyp)/ry]
+        u = [(xp - cxp) / rx, (yp - cyp) / ry]
+        v = [(-xp - cxp) / rx, (-yp - cyp) / ry]
 
         theta1 = angle([1, 0], u)
         delta_theta = angle(u, v)
@@ -157,7 +157,7 @@ class EPath(object):
                 # Move position:
                 #   command: [M|m] (relative position in lowercase command)
                 #   parameter: (dx, dy)+
-                dx, dy = coords[i:i+2]
+                dx, dy = coords[i:i + 2]
                 x_cur, y_cur = current_pos[0], current_pos[1]
 
                 if cmd == 'M':
@@ -172,7 +172,7 @@ class EPath(object):
 
                 # implicit line-to command
                 while i + 1 < len(coords):
-                    dx, dy = coords[i:i+2]
+                    dx, dy = coords[i:i + 2]
                     x_cur, y_cur = current_pos[0], current_pos[1]
 
                     x_end = dx
@@ -193,7 +193,7 @@ class EPath(object):
                 #   command: [L|l] (relative position in lowercase command)
                 #   parameter: (dx1, dy1)+
                 while i + 1 < len(coords):
-                    dx, dy = coords[i:i+2]
+                    dx, dy = coords[i:i + 2]
                     x_cur, y_cur = current_pos[0], current_pos[1]
 
                     x_end = dx
@@ -249,7 +249,7 @@ class EPath(object):
                 #   command: [C|c] (relative position in lowercase command)
                 #   parameter: (dx1, dy1, dx2, dy2, dx3, dy3)+
                 while i + 5 < len(coords):
-                    dx1, dy1, dx2, dy2, dx3, dy3 = coords[i:i+6]
+                    dx1, dy1, dx2, dy2, dx3, dy3 = coords[i:i + 6]
                     x_cur, y_cur = current_pos[0], current_pos[1]
 
                     if cmd == 'C':
@@ -281,7 +281,7 @@ class EPath(object):
                 # command: [S|s] (relative position in lowercase command)
                 # parameter: (dx2, dy2, dx3, dy3)+
                 while i + 3 < len(coords):
-                    dx2, dy2, dx3, dy3 = coords[i:i+4]
+                    dx2, dy2, dx3, dy3 = coords[i:i + 4]
                     x_cur, y_cur = current_pos[0], current_pos[1]
 
                     if cmd == 'S':
@@ -317,7 +317,7 @@ class EPath(object):
                 #   command: [Q|q] (relative position in lowercase command)
                 #   parameter: (dx1, dy1, dx2, dy2)+
                 while i + 3 < len(coords):
-                    dx1, dy1, dx2, dy2 = coords[i:i+4]
+                    dx1, dy1, dx2, dy2 = coords[i:i + 4]
                     x_cur, y_cur = current_pos[0], current_pos[1]
 
                     if cmd == 'Q':
@@ -346,7 +346,7 @@ class EPath(object):
                 #   command: [T|t] (relative position in lowercase command)
                 #   parameter: (dx2, dy2)+
                 while i + 1 < len(coords):
-                    dx2, dy2 = coords[i:i+2]
+                    dx2, dy2 = coords[i:i + 2]
                     x_cur, y_cur = current_pos[0], current_pos[1]
 
                     if cmd == 'T':
@@ -381,7 +381,7 @@ class EPath(object):
                 while i + 6 < len(coords):
                     start_pt = current_pos
                     (rx, ry, rotation,
-                     Flarge_arc, Fsweep, dx, dy) = coords[i:i+7]
+                     Flarge_arc, Fsweep, dx, dy) = coords[i:i + 7]
                     x_cur, y_cur = current_pos[0], current_pos[1]
 
                     x_end = dx
@@ -394,9 +394,9 @@ class EPath(object):
                     arc_pts = self.calc_arc2pnts(start_pt, end, rx, ry,
                                                  rotation, Flarge_arc, Fsweep)
 
-                    for p in range(arc_pts.shape[0]-1):
+                    for p in range(arc_pts.shape[0] - 1):
                         p_from = Point(arc_pts[p][0], arc_pts[p][1], 0)
-                        p_to = Point(arc_pts[p+1][0], arc_pts[p+1][1], 0)
+                        p_to = Point(arc_pts[p + 1][0], arc_pts[p + 1][1], 0)
                         sp2d.append(Segment(p_from, p_to))
 
                     current_pos = end

--- a/solvcon/profiling/__main__.py
+++ b/solvcon/profiling/__main__.py
@@ -177,7 +177,7 @@ def main():
     solvcon.call_profiler.reset()
     for _ in range(it):
         test_data = np.arange(0, N, dtype='uint32')
-        indices = np.arange(0, N-1, dtype='uint32')
+        indices = np.arange(0, N - 1, dtype='uint32')
         test_sa = make_container(test_data)
         idx_sa = make_container(indices)
         profile_take_along_axis_np(test_data, indices)
@@ -198,7 +198,7 @@ def main():
     solvcon.call_profiler.reset()
     for _ in range(it):
         test_data = np.arange(N, 0, -1, dtype='uint32')
-        indices = np.arange(N-1, 0, -1, dtype='uint32')
+        indices = np.arange(N - 1, 0, -1, dtype='uint32')
         test_sa = make_container(test_data)
         idx_sa = make_container(indices)
         profile_take_along_axis_np(test_data, indices)
@@ -219,7 +219,7 @@ def main():
     solvcon.call_profiler.reset()
     for _ in range(it):
         test_data = np.arange(0, N, dtype='uint32')
-        indices = np.arange(0, N-1, dtype='uint32')
+        indices = np.arange(0, N - 1, dtype='uint32')
         np.random.shuffle(test_data)
         np.random.shuffle(indices)
         test_sa = make_container(test_data)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -38,11 +38,12 @@ class TestLinalgFactorization(unittest.TestCase):
 
     def test_llt_factorization_complex_5x5(self):
         L_desired = np.array([
-            [2.0+0.0j, 0.0+0.0j, 0.0+0.0j, 0.0+0.0j, 0.0+0.0j],
-            [1.0+0.5j, 1.5+0.0j, 0.0+0.0j, 0.0+0.0j, 0.0+0.0j],
-            [0.5+0.25j, 0.75+0.375j, 1.0+0.0j, 0.0+0.0j, 0.0+0.0j],
-            [0.25+0.0j, 0.375+0.0j, 0.5+0.0j, 0.75+0.0j, 0.0+0.0j],
-            [0.125+0.0625j, 0.1875+0.09375j, 0.25+0.0j, 0.375+0.0j, 0.5+0.0j]
+            [2.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [1.0 + 0.5j, 1.5 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.5 + 0.25j, 0.75 + 0.375j, 1.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+            [0.25 + 0.0j, 0.375 + 0.0j, 0.5 + 0.0j, 0.75 + 0.0j, 0.0 + 0.0j],
+            [0.125 + 0.0625j, 0.1875 + 0.09375j, 0.25 + 0.0j, 0.375 + 0.0j,
+             0.5 + 0.0j]
         ])
         A_np = L_desired @ L_desired.conj().T
         A = sc.SimpleArrayComplex128(array=A_np)
@@ -104,14 +105,17 @@ class TestLinalgSolver(unittest.TestCase):
 
     def test_llt_solve_complex_5x5(self):
         B_np = np.array([
-            [2.0+0.0j, 1.0+0.5j, 0.5+0.25j, 0.25+0.0j, 0.125+0.0625j],
-            [0.0+0.0j, 1.5+0.0j, 0.75+0.375j, 0.375+0.0j, 0.1875+0.09375j],
-            [0.0+0.0j, 0.0+0.0j, 1.0+0.0j, 0.5+0.0j, 0.25+0.0j],
-            [0.0+0.0j, 0.0+0.0j, 0.0+0.0j, 0.75+0.0j, 0.375+0.0j],
-            [0.0+0.0j, 0.0+0.0j, 0.0+0.0j, 0.0+0.0j, 0.5+0.0j]
+            [2.0 + 0.0j, 1.0 + 0.5j, 0.5 + 0.25j, 0.25 + 0.0j,
+             0.125 + 0.0625j],
+            [0.0 + 0.0j, 1.5 + 0.0j, 0.75 + 0.375j, 0.375 + 0.0j,
+             0.1875 + 0.09375j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 1.0 + 0.0j, 0.5 + 0.0j, 0.25 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.75 + 0.0j, 0.375 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.5 + 0.0j]
         ])
         A_np = B_np.conj().T @ B_np + np.eye(5, dtype=complex)
-        b_np = np.array([1.0+0.0j, 2.0+0.0j, 3.0+0.0j, 4.0+0.0j, 5.0+0.0j])
+        b_np = np.array([1.0 + 0.0j, 2.0 + 0.0j, 3.0 + 0.0j, 4.0 + 0.0j,
+                         5.0 + 0.0j])
         A = sc.SimpleArrayComplex128(array=A_np)
         b = sc.SimpleArrayComplex128(array=b_np)
         x = sc.llt_solve(A, b)
@@ -156,17 +160,17 @@ class TestLinalgSolver(unittest.TestCase):
 
     def test_llt_solve_2d_multi_rhs_complex(self):
         B_np = np.array([
-            [2.0+0.0j, 1.0+0.5j, 0.5+0.25j, 0.25+0.0j],
-            [0.0+0.0j, 1.5+0.0j, 0.75+0.375j, 0.375+0.0j],
-            [0.0+0.0j, 0.0+0.0j, 1.0+0.0j, 0.5+0.0j],
-            [0.0+0.0j, 0.0+0.0j, 0.0+0.0j, 0.75+0.0j]
+            [2.0 + 0.0j, 1.0 + 0.5j, 0.5 + 0.25j, 0.25 + 0.0j],
+            [0.0 + 0.0j, 1.5 + 0.0j, 0.75 + 0.375j, 0.375 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 1.0 + 0.0j, 0.5 + 0.0j],
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.75 + 0.0j]
         ])
         A_np = B_np.conj().T @ B_np + np.eye(4, dtype=complex)
         b_2d_np = np.array([
-            [1.0+0.0j, 2.0+0.5j, 3.0+1.0j],
-            [4.0+0.0j, 5.0+0.5j, 6.0+1.0j],
-            [7.0+0.0j, 8.0+0.5j, 9.0+1.0j],
-            [10.0+0.0j, 11.0+0.5j, 12.0+1.0j]
+            [1.0 + 0.0j, 2.0 + 0.5j, 3.0 + 1.0j],
+            [4.0 + 0.0j, 5.0 + 0.5j, 6.0 + 1.0j],
+            [7.0 + 0.0j, 8.0 + 0.5j, 9.0 + 1.0j],
+            [10.0 + 0.0j, 11.0 + 0.5j, 12.0 + 1.0j]
         ])
         A = sc.SimpleArrayComplex128(array=A_np)
         b_2d = sc.SimpleArrayComplex128(array=b_2d_np)
@@ -356,9 +360,9 @@ class KalmanFilterPredictTC(unittest.TestCase):
 
     def test_predict_cp128(self):
         n = 2
-        x0 = np.array([1.0+0.5j, 2.0-0.3j], dtype=np.complex128)
-        f = np.array([[1.1+0.1j, 0.2-0.1j],
-                      [0.1+0.1j, 0.9+0.0j]], dtype=np.complex128)
+        x0 = np.array([1.0 + 0.5j, 2.0 - 0.3j], dtype=np.complex128)
+        f = np.array([[1.1 + 0.1j, 0.2 - 0.1j],
+                      [0.1 + 0.1j, 0.9 + 0.0j]], dtype=np.complex128)
         p0 = np.eye(n, dtype=np.complex128)
         sigma_w = 0.316
         q = (sigma_w**2) * np.eye(n, dtype=np.complex128)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -35,10 +35,13 @@ class StaticMeshTC(unittest.TestCase):
         self.assertEqual((mh.ngstcell + mh.ncell,), mh.cltpn.shape)
         self.assertEqual((mh.ngstcell + mh.ncell,), mh.clgrp.shape)
 
-        self.assertEqual((mh.ngstface + mh.nface, mh.FCMND+1), mh.fcnds.shape)
+        self.assertEqual(
+            (mh.ngstface + mh.nface, mh.FCMND + 1), mh.fcnds.shape)
         self.assertEqual((mh.ngstface + mh.nface, mh.FCREL), mh.fccls.shape)
-        self.assertEqual((mh.ngstcell + mh.ncell, mh.CLMND+1), mh.clnds.shape)
-        self.assertEqual((mh.ngstcell + mh.ncell, mh.CLMFC+1), mh.clfcs.shape)
+        self.assertEqual(
+            (mh.ngstcell + mh.ncell, mh.CLMND + 1), mh.clnds.shape)
+        self.assertEqual(
+            (mh.ngstcell + mh.ncell, mh.CLMFC + 1), mh.clfcs.shape)
 
     def _check_metric_trivial(self, mh):
         self.assertTrue((mh.fccnd.ndarray[:, :] == 0).all())

--- a/tests/test_spacetime_celm_selm.py
+++ b/tests/test_spacetime_celm_selm.py
@@ -217,8 +217,8 @@ class SelmTC(unittest.TestCase):
         self.assertEqual(0.5, self.se0.xpos)
         self.assertEqual(self.se0.xpos - self.se0.xneg, self.se0.dx)
         self.assertEqual(self.dt, self.se0.dt)
-        self.assertEqual(self.dt/2, self.se0.hdt)
-        self.assertEqual(self.dt/4, self.se0.qdt)
+        self.assertEqual(self.dt / 2, self.se0.hdt)
+        self.assertEqual(self.dt / 4, self.se0.qdt)
 
     def test_move_is_inplace(self):
 

--- a/tests/test_spacetime_grid.py
+++ b/tests/test_spacetime_grid.py
@@ -57,10 +57,11 @@ class GridTC(unittest.TestCase):
 
     def test_xcoord(self):
 
-        nx = (self.grid10.ncelm + self.grid10.BOUND_COUNT)*2 + 1
+        nx = (self.grid10.ncelm + self.grid10.BOUND_COUNT) * 2 + 1
         golden_x = np.arange(0.0, 10.1, 0.5)
         golden_front = golden_x[0] - golden_x[self.grid10.BOUND_COUNT:0:-1]
-        golden_back = golden_x[-1] - golden_x[-2:-self.grid10.BOUND_COUNT-2:-1]
+        golden_back = (
+            golden_x[-1] - golden_x[-2:-self.grid10.BOUND_COUNT - 2:-1])
         golden_back += golden_x[-1]
         golden_x = np.hstack([golden_front, golden_x, golden_back])
 
@@ -68,7 +69,7 @@ class GridTC(unittest.TestCase):
         self.assertEqual(golden_x.tolist(),
                          self.grid10.xcoord.ndarray.tolist())
         self.grid10.xcoord.ndarray.fill(10)
-        self.assertEqual([10]*nx, self.grid10.xcoord.ndarray.tolist())
+        self.assertEqual([10] * nx, self.grid10.xcoord.ndarray.tolist())
 
     def test_number(self):
 

--- a/tests/test_spacetime_inviscid_burgers.py
+++ b/tests/test_spacetime_inviscid_burgers.py
@@ -14,13 +14,13 @@ class InviscidBurgersSolverTC(unittest.TestCase):
     def _build_solver(resolution):
 
         # Build grid.
-        xcrd = np.arange(resolution+1) / resolution
+        xcrd = np.arange(resolution + 1) / resolution
         xcrd *= 2 * np.pi
         grid = libst.Grid(xcrd)
         dx = (grid.xmax - grid.xmin) / grid.ncelm
 
         # Build solver.
-        time_stop = 2*np.pi
+        time_stop = 2 * np.pi
         cfl_max = 1.0
         dt_max = dx * cfl_max
         nstep = int(np.ceil(time_stop / dt_max))
@@ -46,7 +46,7 @@ class InviscidBurgersSolverTC(unittest.TestCase):
 
     def test_result_bound(self):
 
-        for it in range(self.nstep*self.cycle):
+        for it in range(self.nstep * self.cycle):
             res = self.svr.get_so0(0).ndarray
             self.assertLessEqual(res.max(), 1)
             self.assertGreaterEqual(res.min(), -1)

--- a/tests/test_spacetime_linear_scalar.py
+++ b/tests/test_spacetime_linear_scalar.py
@@ -16,13 +16,13 @@ class LinearScalarSolverTC(unittest.TestCase):
     def _build_solver(resolution):
 
         # Build grid.
-        xcrd = np.arange(resolution+1) / resolution
+        xcrd = np.arange(resolution + 1) / resolution
         xcrd *= 2 * np.pi
         grid = libst.Grid(xcrd)
         dx = (grid.xmax - grid.xmin) / grid.ncelm
 
         # Build solver.
-        time_stop = 2*np.pi
+        time_stop = 2 * np.pi
         cfl_max = 1.0
         dt_max = dx * cfl_max
         nstep = int(np.ceil(time_stop / dt_max))
@@ -45,7 +45,7 @@ class LinearScalarSolverTC(unittest.TestCase):
     def test_xctr(self):
 
         # On even plane.
-        self.assertEqual(len(self.svr.xctr()), self.svr.grid.ncelm+1)
+        self.assertEqual(len(self.svr.xctr()), self.svr.grid.ncelm + 1)
         self.assertEqual(self.svr.xctr().tolist(), self.xcrd.tolist())
         self.assertEqual(self.svr.xctr().tolist(),
                          [e.xctr for e in self.svr.selms(odd_plane=False)])
@@ -65,7 +65,7 @@ class LinearScalarSolverTC(unittest.TestCase):
 
         v1 = [e.get_so0(0) for e in self.svr.selms(odd_plane=False)]
         v2 = self.svr.get_so0(0).ndarray.tolist()
-        self.assertEqual(self.svr.grid.ncelm+1, len(v2))
+        self.assertEqual(self.svr.grid.ncelm + 1, len(v2))
         self.assertEqual(v1, v2)
 
         with self.assertRaisesRegex(IndexError, "out of nvar range"):
@@ -75,7 +75,7 @@ class LinearScalarSolverTC(unittest.TestCase):
 
         v1 = [e.get_so1(0) for e in self.svr.selms(odd_plane=False)]
         v2 = self.svr.get_so1(0).ndarray.tolist()
-        self.assertEqual(self.svr.grid.ncelm+1, len(v2))
+        self.assertEqual(self.svr.grid.ncelm + 1, len(v2))
         self.assertEqual(v1, v2)
 
         with self.assertRaisesRegex(IndexError, "out of nvar range"):
@@ -105,7 +105,7 @@ class LinearScalarSolverTC(unittest.TestCase):
 
     def test_march(self):
 
-        self.svr.march_alpha2(self.nstep*self.cycle)
+        self.svr.march_alpha2(self.nstep * self.cycle)
         np.testing.assert_allclose(self.svr.get_so0(0), np.sin(self.xcrd),
                                    rtol=0, atol=1.e-14)
         ones = np.ones(self.svr.grid.nselm, dtype='float64')
@@ -129,7 +129,7 @@ class LinearScalarSolverTC(unittest.TestCase):
 
         svr2 = self._build_solver(self.resolution)[-1]
 
-        for it in range(self.nstep*self.cycle):
+        for it in range(self.nstep * self.cycle):
             _march()
             svr2.march_alpha2(steps=1)
             self.assertEqual(self.svr.get_so0(0).ndarray.tolist(),
@@ -207,15 +207,15 @@ class LinearScalarGridTestTC(unittest.TestCase):
         def _check(v, r):
             self.assertAlmostEqual(v, r, places=1)
 
-        _check(1.0, _rate(err[0]/err[1], dx[0]/dx[1]))
-        _check(1.0, _rate(err[1]/err[2], dx[1]/dx[2]))
-        _check(1.1, _rate(err[2]/err[3], dx[2]/dx[3]))
-        _check(1.0, _rate(err[3]/err[4], dx[3]/dx[4]))
-        _check(1.0, _rate(err[4]/err[5], dx[4]/dx[5]))
-        _check(1.0, _rate(err[5]/err[6], dx[5]/dx[6]))
-        _check(0.87, _rate(err[6]/err[7], dx[6]/dx[7]))
-        _check(1.0, _rate(err[7]/err[8], dx[7]/dx[8]))
-        _check(1.0, _rate(err[8]/err[9], dx[8]/dx[9]))
-        _check(1.0, _rate(err[9]/err[10], dx[9]/dx[10]))
+        _check(1.0, _rate(err[0] / err[1], dx[0] / dx[1]))
+        _check(1.0, _rate(err[1] / err[2], dx[1] / dx[2]))
+        _check(1.1, _rate(err[2] / err[3], dx[2] / dx[3]))
+        _check(1.0, _rate(err[3] / err[4], dx[3] / dx[4]))
+        _check(1.0, _rate(err[4] / err[5], dx[4] / dx[5]))
+        _check(1.0, _rate(err[5] / err[6], dx[5] / dx[6]))
+        _check(0.87, _rate(err[6] / err[7], dx[6] / dx[7]))
+        _check(1.0, _rate(err[7] / err[8], dx[7] / dx[8]))
+        _check(1.0, _rate(err[8] / err[9], dx[8] / dx[9]))
+        _check(1.0, _rate(err[9] / err[10], dx[9] / dx[10]))
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Related to #894. After surveying, I found the issue relates to [PEP8 E226](https://www.flake8rules.com/rules/E226.html). However, the E226 check is not enabled by default in flake8.

Therefore, I added a `.flake8` config to extend the rule set with this check.

After enabling it, I used autopep8 to fix the E226 violations found in the current Python code.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
