### PR TITLE
Default-load common imports in the Pilot console

### DIFF
--- a/solvcon/system.py
+++ b/solvcon/system.py
@@ -96,6 +96,10 @@ def setup_process(argv):
     builtins.solvcon = solvcon
     builtins.sc = solvcon
 
+    if solvcon.HAS_PILOT:
+        from . import pilot
+        builtins.pilot = pilot
+
 
 def enter_main(argv):
     args = _parse_command_line(argv)

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -28,6 +28,18 @@ class PilotTC(unittest.TestCase):
         self.assertFalse(pilot.mgr.pycon.python_redirect)
 
 
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class SetupProcessTC(unittest.TestCase):
+
+    def test_namespace_includes_pilot(self):
+        import builtins
+        from solvcon import system, pilot
+        system.setup_process([])
+        self.assertIs(builtins.solvcon, solvcon)
+        self.assertIs(builtins.sc, solvcon)
+        self.assertIs(builtins.pilot, pilot)
+
+
 class PilotCameraTB:
     camera_type = None
 


### PR DESCRIPTION
Install `solvcon`, `sc`, and `pilot` into the builtin namespace in `setup_process` so the Pilot console has them available without the user retyping the imports at every launch. The `pilot` name pulls in Qt/PySide6, so it is installed only when the build has the GUI.
