### PR TITLE
Tolerate a broken pilot import in setup_process

### DIFF
--- a/solvcon/system.py
+++ b/solvcon/system.py
@@ -12,6 +12,7 @@ import sys
 import os
 import argparse
 import traceback
+import warnings
 
 import solvcon
 from . import apputil
@@ -97,8 +98,13 @@ def setup_process(argv):
     builtins.sc = solvcon
 
     if solvcon.HAS_PILOT:
-        from . import pilot
-        builtins.pilot = pilot
+        # Tolerate a broken pilot import so the GUI can still be entered;
+        # warn instead of crashing the whole process.
+        try:
+            from . import pilot
+            builtins.pilot = pilot
+        except ImportError as e:
+            warnings.warn("failed to import pilot: {}".format(e))
 
 
 def enter_main(argv):

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -39,6 +39,22 @@ class SetupProcessTC(unittest.TestCase):
         self.assertIs(builtins.sc, solvcon)
         self.assertIs(builtins.pilot, pilot)
 
+    def test_broken_pilot_import_warns(self):
+        import sys
+        from unittest import mock
+        from solvcon import system
+        # Force "from . import pilot" to raise ImportError: drop the cached
+        # attribute so the import re-runs, and poison sys.modules so it
+        # fails. setup_process must warn instead of crashing.
+        saved = solvcon.pilot
+        del solvcon.pilot
+        try:
+            with mock.patch.dict(sys.modules, {'solvcon.pilot': None}):
+                with self.assertWarns(UserWarning):
+                    system.setup_process([])
+        finally:
+            solvcon.pilot = saved
+
 
 class PilotCameraTB:
     camera_type = None


### PR DESCRIPTION
The Pilot console's default-import setup (PR #930) imported the pilot package unconditionally whenever HAS_PILOT was set. As yungyuc noted in review, that is fragile: if HAS_PILOT is true but the pilot package fails to load for any reason, the ImportError propagates out of setup_process and aborts the whole process, so no one can enter the GUI.

This change wraps the import in a try/except that catches ImportError and issues a warning instead of crashing. The rest of the namespace setup (solvcon and sc) is unaffected, and the GUI can still be entered even when pilot is broken.

A test in SetupProcessTC exercises the failure path by dropping the cached solvcon.pilot attribute and poisoning sys.modules so the re-import raises ImportError, then asserts that setup_process warns rather than propagating the error.

Related to #927.
