### PR TITLE
Add front/back, pop, and empty helpers to BufferExpander and SimpleCollector

### DIFF
--- a/cpp/solvcon/buffer/BufferExpander.hpp
+++ b/cpp/solvcon/buffer/BufferExpander.hpp
@@ -97,6 +97,8 @@ public:
         return static_cast<size_type>(this->m_end_cap - this->m_begin);
     }
 
+    bool empty() const noexcept { return size() == 0; }
+
     void reserve(size_type cap);
 
     void expand(size_type length)
@@ -124,6 +126,19 @@ public:
                             capacity()));
         }
         m_end += amount;
+    }
+
+    /**
+     * Pull the size down by amount, keeping the capacity intact.
+     * @param amount Number of bytes to pull down.
+     */
+    void pop_size(size_type amount)
+    {
+        if (amount > size())
+        {
+            throw std::out_of_range(std::format("{}: amount {} > size() {}", name(), amount, size()));
+        }
+        m_end -= amount;
     }
 
     std::shared_ptr<ConcreteBuffer> copy_concrete(size_type cap = 0) const;
@@ -200,4 +215,4 @@ private:
 
 } /* end namespace solvcon */
 
-/* vim: set et ts=4 sw=4: */
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/buffer/SimpleCollector.hpp
+++ b/cpp/solvcon/buffer/SimpleCollector.hpp
@@ -79,6 +79,7 @@ public:
     size_t size() const { return expander().size() / ITEMSIZE; }
     size_t capacity() const { return expander().capacity() / ITEMSIZE; }
     size_t alignment() const { return expander().alignment(); }
+    bool empty() const { return size() == 0; }
 
     value_type const & operator[](size_t it) const noexcept { return data(it); }
     value_type & operator[](size_t it) noexcept { return data(it); }
@@ -115,6 +116,20 @@ public:
         size_t const it = size();
         push_size();
         (*this)[it] = std::move(value);
+    }
+
+    value_type const & front() const noexcept { return (*this)[0]; }
+    value_type & front() noexcept { return (*this)[0]; }
+    value_type const & back() const noexcept { return (*this)[size() - 1]; }
+    value_type & back() noexcept { return (*this)[size() - 1]; }
+
+    void pop_back()
+    {
+        if (size() == 0)
+        {
+            throw std::out_of_range("SimpleCollector: pop_back on empty collector");
+        }
+        expander().pop_size(ITEMSIZE);
     }
 
     /* Backdoor */
@@ -165,4 +180,4 @@ private:
 
 } /* end namespace solvcon */
 
-/* vim: set et ts=4 sw=4: */
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -133,6 +133,52 @@ TEST(BufferExpander, iterator)
     }
 }
 
+TEST(BufferExpander, pop_size)
+{
+    using namespace solvcon;
+
+    auto buffer = BufferExpander::construct(4);
+    EXPECT_FALSE(buffer->empty());
+    EXPECT_EQ(buffer->size(), 4);
+    buffer->pop_size(3);
+    EXPECT_EQ(buffer->size(), 1);
+    // Capacity is left untouched when the size is pulled down.
+    EXPECT_EQ(buffer->capacity(), 4);
+    buffer->pop_size(1);
+    EXPECT_TRUE(buffer->empty());
+    EXPECT_THROW(buffer->pop_size(1), std::out_of_range);
+}
+
+TEST(SimpleCollector, pop_back)
+{
+    using namespace solvcon;
+
+    SimpleCollector<int32_t> coll;
+    EXPECT_TRUE(coll.empty());
+    coll.push_back(10);
+    coll.push_back(20);
+    coll.push_back(30);
+    EXPECT_EQ(coll.size(), 3);
+    EXPECT_EQ(coll.front(), 10);
+    EXPECT_EQ(coll.back(), 30);
+
+    coll.pop_back();
+    EXPECT_EQ(coll.size(), 2);
+    EXPECT_EQ(coll.back(), 20);
+
+    // pop_back keeps the surviving elements intact and reusable.
+    coll.push_back(40);
+    EXPECT_EQ(coll.front(), 10);
+    EXPECT_EQ(coll.back(), 40);
+    EXPECT_EQ(coll[0], 10);
+
+    coll.pop_back();
+    coll.pop_back();
+    coll.pop_back();
+    EXPECT_TRUE(coll.empty());
+    EXPECT_THROW(coll.pop_back(), std::out_of_range);
+}
+
 TEST(small_vector, select_kth)
 {
     const size_t n = 1024;


### PR DESCRIPTION
Add `empty()` and `pop_size()` to `BufferExpander`, and `empty()`,
`front()`, `back()`, and `pop_back()` to `SimpleCollector`, so it can act
as a LIFO stack of scalars.

Per review:

- Added `front()` as the companion of `back()`.
- `front()`/`back()` are unchecked accessors that mirror `operator[]`,
  following the `std::vector` convention (no `back_at()` bound-checking
  variant). They carry `noexcept` to match the existing `operator[]`.
- `pop_back()` throws `std::out_of_range` on an empty collector via
  `BufferExpander::pop_size`'s buffer-level guard.

Includes gtests.
