### PR TITLE
Add undo and redo for canvas shape drawing

### DIFF
--- a/cpp/solvcon/buffer/BufferExpander.hpp
+++ b/cpp/solvcon/buffer/BufferExpander.hpp
@@ -97,6 +97,8 @@ public:
         return static_cast<size_type>(this->m_end_cap - this->m_begin);
     }
 
+    bool empty() const noexcept { return size() == 0; }
+
     void reserve(size_type cap);
 
     void expand(size_type length)
@@ -124,6 +126,19 @@ public:
                             capacity()));
         }
         m_end += amount;
+    }
+
+    /**
+     * Pull the size down by amount, keeping the capacity intact.
+     * @param amount Number of bytes to pull down.
+     */
+    void pop_size(size_type amount)
+    {
+        if (amount > size())
+        {
+            throw std::out_of_range(std::format("{}: amount {} > size() {}", name(), amount, size()));
+        }
+        m_end -= amount;
     }
 
     std::shared_ptr<ConcreteBuffer> copy_concrete(size_type cap = 0) const;
@@ -200,4 +215,4 @@ private:
 
 } /* end namespace solvcon */
 
-/* vim: set et ts=4 sw=4: */
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/buffer/SimpleCollector.hpp
+++ b/cpp/solvcon/buffer/SimpleCollector.hpp
@@ -79,6 +79,7 @@ public:
     size_t size() const { return expander().size() / ITEMSIZE; }
     size_t capacity() const { return expander().capacity() / ITEMSIZE; }
     size_t alignment() const { return expander().alignment(); }
+    bool empty() const { return size() == 0; }
 
     value_type const & operator[](size_t it) const noexcept { return data(it); }
     value_type & operator[](size_t it) noexcept { return data(it); }
@@ -115,6 +116,20 @@ public:
         size_t const it = size();
         push_size();
         (*this)[it] = std::move(value);
+    }
+
+    value_type const & front() const noexcept { return (*this)[0]; }
+    value_type & front() noexcept { return (*this)[0]; }
+    value_type const & back() const noexcept { return (*this)[size() - 1]; }
+    value_type & back() noexcept { return (*this)[size() - 1]; }
+
+    void pop_back()
+    {
+        if (size() == 0)
+        {
+            throw std::out_of_range("SimpleCollector: pop_back on empty collector");
+        }
+        expander().pop_size(ITEMSIZE);
     }
 
     /* Backdoor */
@@ -165,4 +180,4 @@ private:
 
 } /* end namespace solvcon */
 
-/* vim: set et ts=4 sw=4: */
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -65,6 +65,7 @@ void RManager::reset()
     m_core.reset();
     m_mainWindow = nullptr;
     m_fileMenu = nullptr;
+    m_editMenu = nullptr;
     m_viewMenu = nullptr;
     m_oneMenu = nullptr;
     m_meshMenu = nullptr;
@@ -181,6 +182,30 @@ void RManager::applyDrawTool()
     }
 }
 
+void RManager::undoCanvas() const
+{
+    auto const * subwin = m_mdiArea ? m_mdiArea->currentSubWindow() : nullptr;
+    auto * canvas = subwin ? dynamic_cast<R2DWidget *>(subwin->widget()) : nullptr;
+    if (canvas == nullptr || canvas->world() == nullptr)
+    {
+        return;
+    }
+    canvas->world()->undo();
+    canvas->requestRepaint();
+}
+
+void RManager::redoCanvas() const
+{
+    auto const * subwin = m_mdiArea ? m_mdiArea->currentSubWindow() : nullptr;
+    auto * canvas = subwin ? dynamic_cast<R2DWidget *>(subwin->widget()) : nullptr;
+    if (canvas == nullptr || canvas->world() == nullptr)
+    {
+        return;
+    }
+    canvas->world()->redo();
+    canvas->requestRepaint();
+}
+
 void RManager::toggleConsole()
 {
     if (m_pycon)
@@ -222,6 +247,8 @@ void RManager::setUpMenu()
     // "exited with code -1073740791".  The reason is not yet clarified.
 
     m_fileMenu = m_mainWindow->menuBar()->addMenu(QString("File"));
+    m_editMenu = m_mainWindow->menuBar()->addMenu(QString("Edit"));
+    setUpEditMenuItems();
     m_viewMenu = m_mainWindow->menuBar()->addMenu(QString("View"));
     {
         // Code for controlling camera is not exposed to Python yet
@@ -233,6 +260,26 @@ void RManager::setUpMenu()
     m_canvasMenu = m_mainWindow->menuBar()->addMenu(QString("Canvas"));
     m_profilingMenu = m_mainWindow->menuBar()->addMenu(QString("Profiling"));
     m_windowMenu = m_mainWindow->menuBar()->addMenu(QString("Window"));
+}
+
+void RManager::setUpEditMenuItems() const
+{
+    auto * undo_action = new RAction(
+        QString("Undo"),
+        QString("Undo the last shape drawn on the focused 2D canvas"),
+        [this]()
+        { undoCanvas(); });
+    undo_action->setShortcut(QKeySequence::Undo);
+
+    auto * redo_action = new RAction(
+        QString("Redo"),
+        QString("Redo the last undone shape on the focused 2D canvas"),
+        [this]()
+        { redoCanvas(); });
+    redo_action->setShortcut(QKeySequence::Redo);
+
+    m_editMenu->addAction(undo_action);
+    m_editMenu->addAction(redo_action);
 }
 
 void RManager::setUpCameraControllersMenuItems() const

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -61,6 +61,7 @@ public:
     QMdiSubWindow * addSubWindow(Args &&... args);
 
     QMenu * fileMenu() { return m_fileMenu; }
+    QMenu * editMenu() { return m_editMenu; }
     QMenu * viewMenu() { return m_viewMenu; }
     QMenu * oneMenu() { return m_oneMenu; }
     QMenu * meshMenu() { return m_meshMenu; }
@@ -87,8 +88,14 @@ private:
     /// no-op when the focused subwindow is not a 2D canvas.
     void applyDrawTool();
 
+    void setUpEditMenuItems() const;
     void setUpCameraControllersMenuItems() const;
     void setUpCameraMovementMenuItems() const;
+
+    /// Undo or redo the most recent shape change on the focused 2D canvas,
+    /// then repaint it. A no-op when no 2D canvas is focused.
+    void undoCanvas() const;
+    void redoCanvas() const;
 
     std::function<void()> createCameraMovementItemHandler(const std::function<void(CameraInputState &)> &) const;
 
@@ -99,6 +106,7 @@ private:
     QMainWindow * m_mainWindow = nullptr;
 
     QMenu * m_fileMenu = nullptr;
+    QMenu * m_editMenu = nullptr;
     QMenu * m_viewMenu = nullptr;
     QMenu * m_oneMenu = nullptr;
     QMenu * m_meshMenu = nullptr;

--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -366,6 +366,18 @@ public:
 
     ShapeType shape_type_of(int32_t shape_id) const { return find_shape_or_throw(shape_id).type; }
 
+    /// Undo the most recent shape creation.
+    void undo();
+
+    /// Redo the most recent undone shape creation.
+    void redo();
+
+    /// Whether a shape creation is available to undo.
+    bool can_undo() const { return !m_undo_stack.empty(); }
+
+    /// Whether an undone shape creation is available to redo.
+    bool can_redo() const { return !m_redo_stack.empty(); }
+
     size_t nshape() const { return m_nshape; }
 
     /**
@@ -462,6 +474,16 @@ private:
     size_t m_nshape = 0; ///< count of live (non-DEAD) shapes
     std::unique_ptr<rtree_type> m_rtree; ///< spatial index for shapes for viewport query
 
+    /// A shape creation recorded for redo: its id and the type to restore.
+    struct ShapeRedoRecord
+    {
+        int32_t shape_id;
+        ShapeType type;
+    }; /* end of struct ShapeRedoRecord */
+
+    SimpleCollector<int32_t> m_undo_stack; ///< Created shape ids, oldest first; the back is the next to undo.
+    std::vector<ShapeRedoRecord> m_redo_stack; ///< Undone shapes awaiting redo
+
 }; /* end class World */
 
 template <typename T>
@@ -475,6 +497,12 @@ int32_t World<T>::register_shape(ShapeType type,
     m_shape_registry.push_back(ShapeRecord{type, segment_offset, segment_count, curve_offset, curve_count}); // NOLINT(modernize-use-designated-initializers)
     ++m_nshape;
     m_rtree->insert(ShapeEntry<T>{shape_id, compute_shape_bbox(m_shape_registry[shape_id])});
+
+    // Creating a shape becomes the newest undoable step and invalidates any
+    // pending redo, mirroring the usual editor undo/redo semantics.
+    m_undo_stack.push_back(shape_id);
+    m_redo_stack.clear();
+
     return shape_id;
 }
 
@@ -621,6 +649,44 @@ void World<T>::remove_shape(int32_t shape_id)
 }
 
 template <typename T>
+void World<T>::undo()
+{
+    // Skip ids already killed by a direct remove_shape so undo never tries to
+    // drop the same shape twice.
+    while (!m_undo_stack.empty())
+    {
+        int32_t const shape_id = m_undo_stack.back();
+        m_undo_stack.pop_back();
+        ShapeRecord & rec = m_shape_registry[shape_id];
+        if (rec.type == ShapeType::DEAD)
+        {
+            continue;
+        }
+        m_rtree->remove(ShapeEntry<T>{shape_id, compute_shape_bbox(rec)});
+        m_redo_stack.push_back(ShapeRedoRecord{shape_id, rec.type});
+        rec.type = ShapeType::DEAD;
+        --m_nshape;
+        return;
+    }
+}
+
+template <typename T>
+void World<T>::redo()
+{
+    if (m_redo_stack.empty())
+    {
+        return;
+    }
+    ShapeRedoRecord const record = m_redo_stack.back();
+    m_redo_stack.pop_back();
+    ShapeRecord & rec = m_shape_registry[record.shape_id];
+    rec.type = record.type;
+    ++m_nshape;
+    m_rtree->insert(ShapeEntry<T>{record.shape_id, compute_shape_bbox(rec)});
+    m_undo_stack.push_back(record.shape_id);
+}
+
+template <typename T>
 std::vector<int32_t> World<T>::query_visible(T min_x, T min_y, T max_x, T max_y) const
 {
     bbox_type const viewport(min_x, min_y, T(0), max_x, max_y, T(0));
@@ -701,6 +767,8 @@ void World<T>::clear()
     m_shape_registry.clear();
     m_nshape = 0;
     m_rtree = std::make_unique<rtree_type>();
+    m_undo_stack.clear();
+    m_redo_stack.clear();
 }
 
 template <typename T>

--- a/cpp/solvcon/universe/pymod/wrap_World.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_World.cpp
@@ -74,6 +74,10 @@ WrapWorld<T> & WrapWorld<T>::wrap_management()
 
     (*this)
         .def_property_readonly("nshape", &wrapped_type::nshape)
+        .def("undo", &wrapped_type::undo)
+        .def("redo", &wrapped_type::redo)
+        .def_property_readonly("can_undo", &wrapped_type::can_undo)
+        .def_property_readonly("can_redo", &wrapped_type::can_redo)
         .def(
             "remove_shape",
             &wrapped_type::remove_shape,

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -133,6 +133,52 @@ TEST(BufferExpander, iterator)
     }
 }
 
+TEST(BufferExpander, pop_size)
+{
+    using namespace solvcon;
+
+    auto buffer = BufferExpander::construct(4);
+    EXPECT_FALSE(buffer->empty());
+    EXPECT_EQ(buffer->size(), 4);
+    buffer->pop_size(3);
+    EXPECT_EQ(buffer->size(), 1);
+    // Capacity is left untouched when the size is pulled down.
+    EXPECT_EQ(buffer->capacity(), 4);
+    buffer->pop_size(1);
+    EXPECT_TRUE(buffer->empty());
+    EXPECT_THROW(buffer->pop_size(1), std::out_of_range);
+}
+
+TEST(SimpleCollector, pop_back)
+{
+    using namespace solvcon;
+
+    SimpleCollector<int32_t> coll;
+    EXPECT_TRUE(coll.empty());
+    coll.push_back(10);
+    coll.push_back(20);
+    coll.push_back(30);
+    EXPECT_EQ(coll.size(), 3);
+    EXPECT_EQ(coll.front(), 10);
+    EXPECT_EQ(coll.back(), 30);
+
+    coll.pop_back();
+    EXPECT_EQ(coll.size(), 2);
+    EXPECT_EQ(coll.back(), 20);
+
+    // pop_back keeps the surviving elements intact and reusable.
+    coll.push_back(40);
+    EXPECT_EQ(coll.front(), 10);
+    EXPECT_EQ(coll.back(), 40);
+    EXPECT_EQ(coll[0], 10);
+
+    coll.pop_back();
+    coll.pop_back();
+    coll.pop_back();
+    EXPECT_TRUE(coll.empty());
+    EXPECT_THROW(coll.pop_back(), std::out_of_range);
+}
+
 TEST(small_vector, select_kth)
 {
     const size_t n = 1024;

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -331,6 +331,84 @@ class WorldShapeTC(unittest.TestCase):
         self.assertEqual(self.w.nsegment, 0)
 
 
+class WorldUndoRedoTC(unittest.TestCase):
+    """Undo and redo of shape creation."""
+
+    def setUp(self):
+        self.w = solvcon.WorldFp64()
+
+    def test_empty_world(self):
+        self.assertFalse(self.w.can_undo)
+        self.assertFalse(self.w.can_redo)
+        # Undo/redo on an empty world are harmless no-ops.
+        self.w.undo()
+        self.w.redo()
+        self.assertEqual(self.w.nshape, 0)
+
+    def test_undo_removes_last_shape(self):
+        self.w.add_circle(0, 0, 5)
+        self.assertTrue(self.w.can_undo)
+        self.assertFalse(self.w.can_redo)
+        self.w.undo()
+        self.assertEqual(self.w.nshape, 0)
+        self.assertFalse(self.w.can_undo)
+        self.assertTrue(self.w.can_redo)
+
+    def test_redo_restores_shape(self):
+        sid = self.w.add_circle(0, 0, 5)
+        self.w.undo()
+        self.w.redo()
+        self.assertEqual(self.w.nshape, 1)
+        self.assertEqual(self.w.shape_type_of(sid), "circle")
+        self.assertTrue(self.w.can_undo)
+        self.assertFalse(self.w.can_redo)
+
+    def test_undo_redo_order(self):
+        s0 = self.w.add_circle(0, 0, 1)
+        s1 = self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        self.w.undo()
+        self.assertEqual(self.w.nshape, 1)
+        self.assertEqual(self.w.shape_type_of(s0), "circle")
+        with self.assertRaises(ValueError):
+            self.w.shape_type_of(s1)
+        self.w.undo()
+        self.assertEqual(self.w.nshape, 0)
+
+    def test_redo_restores_in_reverse(self):
+        self.w.add_circle(0, 0, 1)
+        self.w.add_square(0, 0, 2)
+        self.w.undo()
+        self.w.undo()
+        self.w.redo()
+        self.assertEqual(self.w.nshape, 1)
+        self.w.redo()
+        self.assertEqual(self.w.nshape, 2)
+
+    def test_new_shape_clears_redo(self):
+        self.w.add_circle(0, 0, 1)
+        self.w.undo()
+        self.assertTrue(self.w.can_redo)
+        self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        # A fresh creation discards the redo history.
+        self.assertFalse(self.w.can_redo)
+        self.w.redo()
+        self.assertEqual(self.w.nshape, 1)
+
+    def test_undone_shape_not_visible(self):
+        self.w.add_circle(0, 0, 1)
+        self.w.undo()
+        self.assertEqual(len(self.w.query_visible(-10, -10, 10, 10)), 0)
+        self.w.redo()
+        self.assertEqual(len(self.w.query_visible(-10, -10, 10, 10)), 1)
+
+    def test_clear_resets_history(self):
+        self.w.add_circle(0, 0, 1)
+        self.w.undo()
+        self.w.clear()
+        self.assertFalse(self.w.can_undo)
+        self.assertFalse(self.w.can_redo)
+
+
 class WorldViewportTC(unittest.TestCase):
     """R-tree spatial index and viewport query."""
 


### PR DESCRIPTION
Add undo and redo for shapes drawn on the 2D canvas. The new Edit menu provides Undo and Redo entries, also available through the standard keyboard shortcuts.

Depends on #937.

Related to #754 
