### PR TITLE
Speed up CI for pull requests

### DIFF
--- a/.github/actions/setup_linux/action.yml
+++ b/.github/actions/setup_linux/action.yml
@@ -186,11 +186,12 @@ runs:
         clang-format --version
         echo "::endgroup::"
 
-    - name: dependency (manual)
+    - name: install pybind11 (pip wheel)
       shell: bash
       run: |
-        echo "::group::dependency (manual)"
-        sudo ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
+        echo "::group::install pybind11 (pip wheel)"
+        sudo pip3 install 'pybind11==3.0.1'
+        echo "pybind11_ROOT=$(python3 -c 'import os, pybind11; print(os.path.dirname(pybind11.__file__))')" >> "$GITHUB_ENV"
         echo "::endgroup::"
 
     - name: show dependency

--- a/.github/actions/setup_macos/action.yml
+++ b/.github/actions/setup_macos/action.yml
@@ -99,11 +99,12 @@ runs:
         clang-format --version
         echo "::endgroup::"
 
-    - name: dependency (manual)
+    - name: install pybind11 (pip wheel)
       shell: bash
       run: |
-        echo "::group::dependency (manual)"
-        sudo NO_INSTALL_PREFIX=1 ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
+        echo "::group::install pybind11 (pip wheel)"
+        python3 -m pip install --break-system-packages --upgrade 'pybind11==3.0.1'
+        echo "pybind11_ROOT=$(python3 -c 'import os, pybind11; print(os.path.dirname(pybind11.__file__))')" >> "$GITHUB_ENV"
         echo "::endgroup::"
 
     - name: dependency (manual) for build

--- a/.github/workflows/check_skip_ci.yml
+++ b/.github/workflows/check_skip_ci.yml
@@ -29,6 +29,12 @@ on:
           "true" when CI should be skipped for the triggering pull request,
           "false" or empty otherwise.
         value: ${{ jobs.check.outputs.skip }}
+      cpp:
+        description: >-
+          "true" when the pull request touches C++ or build files (so the C++
+          matrix must run), "false" when it does not, empty for non-pull_request
+          events.
+        value: ${{ jobs.check.outputs.cpp }}
 
 permissions: {}
 
@@ -49,6 +55,7 @@ jobs:
 
     outputs:
       skip: ${{ steps.check.outputs.skip }}
+      cpp: ${{ steps.check.outputs.cpp }}
 
     steps:
 
@@ -101,4 +108,34 @@ jobs:
               return;
             }
 
+            // 4. Path-based gating. A documentation-only pull request skips all
+            // heavy CI automatically; a pull request that touches no C++ or
+            // build files reports cpp=false so the C++-only jobs can opt out
+            // while the Python tests and lint still run.
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100,
+              });
+            const paths = files.map(file => file.filename);
+            const isDoc = p =>
+              p.startsWith('doc/') || p.endsWith('.md') ||
+              p.endsWith('.rst') || p.startsWith('contrib/prompt/');
+            const isCpp = p =>
+              p.startsWith('cpp/') || p.startsWith('gtests/') ||
+              p.startsWith('thirdparty/') || p.startsWith('.github/') ||
+              p.endsWith('CMakeLists.txt') || p.endsWith('.cmake') ||
+              p.endsWith('.mk') || p === 'Makefile' || p === 'setup.py';
+
+            if (paths.length && paths.every(isDoc)) {
+              core.notice('CI skipped: documentation-only pull request.');
+              core.setOutput('skip', 'true');
+              core.setOutput('cpp', 'false');
+              return;
+            }
+
+            core.setOutput('cpp', paths.some(isCpp) ? 'true' : 'false');
             core.setOutput('skip', 'false');

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -307,6 +307,18 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: sccache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          variant: sccache
+          key: ${{ runner.os }}-sccache-${{ matrix.cmake_build_type }}
+          restore-keys: ${{ runner.os }}-sccache-${{ matrix.cmake_build_type }}
+          # Bound the cache so it does not grow without limit across the rolling
+          # key. A master push or nightly run saves this cache; pull requests
+          # restore it (a PR on a non-default base branch cannot, so it runs
+          # cold).
+          max-size: 500M
+
       - name: Cache vcpkg (install artifacts)
         uses: actions/cache@v4
         with:
@@ -363,23 +375,26 @@ jobs:
       - name: cmake ALL_BUILD
         run: |
           echo "::group::cmake ALL_BUILD"
-          cmake `
+          # Use the Ninja generator: CMAKE_<LANG>_COMPILER_LAUNCHER (the
+          # sccache hook) is honored only by Ninja/Makefile generators, not
+          # the Visual Studio (MSBuild) generator, which silently ignores it.
+          cmake -GNinja `
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} `
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache `
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache `
+            -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET="x64-windows" `
             -Dpybind11_DIR="$(pybind11-config --cmakedir)" `
             -S${{ github.workspace }} `
             -B${{ github.workspace }}/build
-          cmake --build ${{ github.workspace }}/build `
-            --config ${{ matrix.cmake_build_type }} `
-            --target ALL_BUILD
+          cmake --build ${{ github.workspace }}/build
           echo "::endgroup::"
 
       - name: cmake run_gtest
         run: |
           echo "::group::cmake run_gtest"
           cmake --build ${{ github.workspace }}/build `
-            --config ${{ matrix.cmake_build_type }} `
             --target run_gtest
           echo "::endgroup::"
 
@@ -387,7 +402,6 @@ jobs:
         run: |
           echo "::group::cmake run_pilot_pytest"
           cmake --build ${{ github.workspace }}/build `
-            --config ${{ matrix.cmake_build_type }} `
             --target run_pilot_pytest
           echo "::endgroup::"
 
@@ -432,12 +446,14 @@ jobs:
           # Remove redundant Qt DLLs from PySide6
           Remove-Item -Path $pyside6_path\Qt*.dll
 
-          # Configure and build the pilot
+          # Configure and build the pilot. The build dir is already
+          # configured with the Ninja single-config generator above, so reuse
+          # it without --config and read pilot.exe from the non-config path.
           cmake -Dpybind11_DIR="$(pybind11-config --cmakedir)" -S . -B build
-          cmake --build build --config Release --target pilot
+          cmake --build build --target pilot
 
           # Deploy the Qt environment for the pilot executable and copy necessary files
-          Copy-Item -Path ".\build\cpp\binary\pilot\Release\pilot.exe" -Destination $destination
+          Copy-Item -Path ".\build\cpp\binary\pilot\pilot.exe" -Destination $destination
           windeployqt --release "$destination\pilot.exe"
           Copy-Item -Path ".\solvcon" -Destination $destination -Recurse
           # Also include potential thirdparty

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -260,8 +260,11 @@ jobs:
     strategy:
       matrix:
         os: [windows-2022]
-        # Build Debug because there is not a job for windows in lint.yml (which uses the Debug build type)
-        cmake_build_type: [Release, Debug]
+        # Release runs on every pull request and master push. Debug is the
+        # only Windows Debug compile (lint.yml has no Windows job), but it is
+        # heavy and rarely breaks on its own, so it runs on the nightly
+        # schedule only.
+        cmake_build_type: ${{ (github.event_name == 'schedule' && fromJSON('["Release", "Debug"]')) || fromJSON('["Release"]') }}
 
       fail-fast: false
 

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -226,21 +226,6 @@ jobs:
         make run_pilot_pytest VERBOSE=1
         echo "::endgroup::"
 
-    # FIXME: turn off until all issues resolved
-    - name: make cmake USE_SANITIZER=ON & make pytest
-      run: |
-        echo "::group::make cmake USE_SANITIZER=ON & make pytest"
-        export ASAN_OPTIONS=verify_asan_link_order=0
-        rm -f build/*/Makefile
-        make cmake \
-          VERBOSE=1 USE_CLANG_TIDY=OFF \
-          BUILD_QT=OFF \
-          CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_SANITIZER=OFF"
-        make buildext VERBOSE=1
-        make pytest VERBOSE=1
-        echo "::endgroup::"
-
   build_windows:
 
     needs: [check_skip]

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -76,7 +76,9 @@ jobs:
 
   build:
 
-    needs: [check_skip]
+    # Gate the heavy build behind the fast standalone_buffer smoke compile so
+    # a broken build short-circuits before the full matrix launches.
+    needs: [check_skip, standalone_buffer]
 
     if: |
       needs.check_skip.outputs.skip != 'true' && (
@@ -228,7 +230,11 @@ jobs:
 
   build_windows:
 
-    needs: [check_skip]
+    # Gate the expensive Windows build behind the fast standalone_buffer smoke
+    # compile so it does not burn runner minutes in parallel with a build that
+    # is already broken. (lint lives in a separate workflow and cannot be named
+    # as a dependency here; standalone_buffer is the fast in-workflow gate.)
+    needs: [check_skip, standalone_buffer]
 
     if: |
       needs.check_skip.outputs.skip != 'true' && (

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -236,8 +236,11 @@ jobs:
     # as a dependency here; standalone_buffer is the fast in-workflow gate.)
     needs: [check_skip, standalone_buffer]
 
+    # cpp != 'false' keeps the expensive Windows build off pull requests that
+    # touch no C++ or build files (it is empty, so truthy, for push/schedule).
     if: |
-      needs.check_skip.outputs.skip != 'true' && (
+      needs.check_skip.outputs.skip != 'true' &&
+      needs.check_skip.outputs.cpp != 'false' && (
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
        (vars.MMGH_PUSH_RUN_BRANCH == '*' ||

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -277,7 +277,7 @@ jobs:
         # only Windows Debug compile (lint.yml has no Windows job), but it is
         # heavy and rarely breaks on its own, so it runs on the nightly
         # schedule only.
-        cmake_build_type: ${{ (github.event_name == 'schedule' && fromJSON('["Release", "Debug"]')) || fromJSON('["Release"]') }}
+        cmake_build_type: ${{ (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable' && fromJSON('["Release", "Debug"]')) || fromJSON('["Release"]') }}
 
       fail-fast: false
 
@@ -413,7 +413,7 @@ jobs:
           echo "::endgroup::"
 
       - name: generate portable
-        if: ${{ matrix.cmake_build_type == 'Release' && github.event_name == 'schedule' }}
+        if: ${{ matrix.cmake_build_type == 'Release' && github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable' }}
         run: |
           echo "::group::generate portable"
           # Get the Python version installed and extract the major+minor version components
@@ -468,7 +468,7 @@ jobs:
           echo "::endgroup::"
 
       - name: archive portable artifacts
-        if: ${{ matrix.cmake_build_type == 'Release' && github.event_name == 'schedule' }}
+        if: ${{ matrix.cmake_build_type == 'Release' && github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable' }}
         uses: actions/upload-artifact@v7
         with:
           name: solvcon-pilot-win64

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -406,7 +406,7 @@ jobs:
           echo "::endgroup::"
 
       - name: generate portable
-        if: ${{ matrix.cmake_build_type == 'Release' }}
+        if: ${{ matrix.cmake_build_type == 'Release' && github.event_name == 'schedule' }}
         run: |
           echo "::group::generate portable"
           # Get the Python version installed and extract the major+minor version components
@@ -461,7 +461,7 @@ jobs:
           echo "::endgroup::"
 
       - name: archive portable artifacts
-        if: ${{ matrix.cmake_build_type == 'Release' }}
+        if: ${{ matrix.cmake_build_type == 'Release' && github.event_name == 'schedule' }}
         uses: actions/upload-artifact@v7
         with:
           name: solvcon-pilot-win64

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -461,8 +461,73 @@ jobs:
           name: solvcon-pilot-win64
           path: solvcon-pilot-win64/
 
+  sanitizer:
+
+    needs: [check_skip]
+
+    # A genuine -DUSE_SANITIZER=ON ASAN/UBSAN build. It is slow, so it runs on
+    # the nightly schedule only (set MMGH_FORCE_SANITIZER to 'enable' to force
+    # it on a fork). This restores the real sanitizer coverage that the build
+    # job used to stub out by configuring -DUSE_SANITIZER=OFF.
+    if: |
+      needs.check_skip.outputs.skip != 'true' && (
+      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') ||
+      vars.MMGH_FORCE_SANITIZER == 'enable')
+
+    name: sanitizer_${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+
+    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_BUILD || '45') }}
+
+    env:
+      MAKE_PARALLEL: -j2
+      PIP_BREAK_SYSTEM_PACKAGES: 1
+
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+        cmake_build_type: [Release]
+
+      fail-fast: false
+
+    steps:
+
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+
+    - name: event name
+      run: |
+        echo "github.event_name: ${{ github.event_name }}"
+
+    - name: setup dependencies for Linux
+      uses: ./.github/actions/setup_linux
+      with:
+        workflow: 'build'
+
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2.23
+      with:
+        key: ${{ runner.os }}-sanitizer-${{ matrix.cmake_build_type }}
+        restore-keys: ${{ runner.os }}-sanitizer-${{ matrix.cmake_build_type }}
+        create-symlink: true
+
+    - name: make gtest USE_SANITIZER=ON
+      run: |
+        echo "::group::make gtest USE_SANITIZER=ON"
+        # Run ASAN/UBSAN over the C++ gtest binary rather than pytest. The
+        # gtest executable is linked directly against the sanitizer runtime,
+        # so ASan initializes first and intercepts every allocation.
+        make gtest \
+          VERBOSE=1 USE_CLANG_TIDY=OFF \
+          BUILD_QT=OFF \
+          CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
+          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_SANITIZER=ON"
+        echo "::endgroup::"
+
   send_email_on_failure:
-    needs: [standalone_buffer, build, build_windows]
+    needs: [standalone_buffer, build, build_windows, sanitizer]
     # Run if any of the dependencies failed in master branch
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     uses: ./.github/workflows/send_email_on_fail.yml
@@ -471,6 +536,7 @@ jobs:
         - standalone_buffer: ${{ needs.standalone_buffer.result }}
         - build: ${{ needs.build.result }}
         - build_windows: ${{ needs.build_windows.result }}
+        - sanitizer: ${{ needs.sanitizer.result }}
     secrets:
       EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
       EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -66,6 +66,11 @@ jobs:
           key: ${{ runner.os }}-standalone-buffer-${{ matrix.cmake_build_type }}
           restore-keys: ${{ runner.os }}-standalone-buffer-${{ matrix.cmake_build_type }}
           create-symlink: true
+          # Bound the cache so it does not grow without limit across the rolling
+          # key. A master push or nightly run saves this cache; pull requests
+          # restore it (a PR on a non-default base branch cannot, so it runs
+          # cold).
+          max-size: 500M
 
       - name: make standalone_buffer
         run: |
@@ -145,6 +150,11 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.cmake_build_type }}
         restore-keys: ${{ runner.os }}-${{ matrix.cmake_build_type }}
         create-symlink: true
+        # Bound the cache so it does not grow without limit across the rolling
+        # key. A master push or nightly run saves this cache; pull requests
+        # restore it (a PR on a non-default base branch cannot, so it runs
+        # cold).
+        max-size: 1500M
 
     - name: make gtest BUILD_QT=OFF
       run: |
@@ -515,6 +525,7 @@ jobs:
         key: ${{ runner.os }}-sanitizer-${{ matrix.cmake_build_type }}
         restore-keys: ${{ runner.os }}-sanitizer-${{ matrix.cmake_build_type }}
         create-symlink: true
+        max-size: 1500M
 
     - name: make gtest USE_SANITIZER=ON
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -93,6 +93,11 @@ jobs:
         key: ${{ runner.os }}-tidy-${{ matrix.cmake_build_type }}
         restore-keys: ${{ runner.os }}-tidy-${{ matrix.cmake_build_type }}
         create-symlink: true
+        # Bound the cache so it does not grow without limit across the rolling
+        # key. A master push or nightly run saves this cache; pull requests
+        # restore it (a PR on a non-default base branch cannot, so it runs
+        # cold).
+        max-size: 1500M
 
     - name: make cformat (clang-format check)
       run: |

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -24,13 +24,16 @@ jobs:
 
     needs: [check_skip]
 
+    # The setup.py install path re-verifies packaging and duplicates the build
+    # job's pytest. It does not gate correctness on a pull request, so it runs
+    # on the nightly schedule and on release tag pushes only, not on pull
+    # requests or master pushes. Set the MMGH_FORCE_NOUSE_INSTALL variable to
+    # 'enable' to force it on a fork.
     if: |
       needs.check_skip.outputs.skip != 'true' && (
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'push' &&
-       (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
-        contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
-      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable'))
+      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+      vars.MMGH_FORCE_NOUSE_INSTALL == 'enable')
 
     name: nouse_install_${{ matrix.os }}_Release
 

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -79,6 +79,11 @@ jobs:
           key: ${{ runner.os }}-Release
           restore-keys: ${{ runner.os }}-Release
           create-symlink: true
+          # Bound the cache so it does not grow without limit across the rolling
+          # key. A master push or nightly run saves this cache; pull requests
+          # restore it (a PR on a non-default base branch cannot, so it runs
+          # cold).
+          max-size: 1500M
 
       - name: setup.py install build_ext
         run: |

--- a/contrib/standalone_buffer/Makefile
+++ b/contrib/standalone_buffer/Makefile
@@ -12,6 +12,7 @@ CFLAGS := \
 	-std=c++23 -fPIC \
 	-I$(SETUPROOT) \
 	-I$(shell python3 -c 'import numpy as np; print(np.get_include())') \
+	-I$(shell python3 -c 'import pybind11; print(pybind11.get_include())') \
 	-I$(shell $(DIRNAME_PYTHON)/python3-config --prefix)/include \
 	$(shell $(DIRNAME_PYTHON)/python3-config --cflags)
 


### PR DESCRIPTION
This PR implements steps 1 to 10 in issue #939. Step 11 (Consolidate redundant per-OS builds) is abandoned. We want to keep macos build in PR and master merge.  After the PR, the CI will be reorganized as planned:

- Run on every pull request and `master` push (kept fast):
  - `check_skip`: skip gate, also auto-skips the C++ matrix for docs-only or Python-only PRs
  - `lint`: formatting, flake8, and clang-tidy on the diff (ubuntu, macOS)
  - `standalone_buffer`: the standalone buffer build (ubuntu)
  - `build`: gtest plus pytest with Qt off and on, and the pilot (ubuntu and macOS, Release)
  - `build_windows` Release: Windows build and tests, with sccache and no portable packaging
- Run nightly only (scheduled):
  - `build_windows` Debug: the second Windows configuration
  - `nouse_install`: the `setup.py install` packaging path (ubuntu, macOS)
  - a real ASAN/UBSAN sanitizer build
  - `profiling`: the benchmark suite (already nightly)
  - Windows portable: the distributable artifact packaging

The 10 steps are organized in the 10 commits in the PR.