### PR TITLE
Document the GitHub Actions CI and add prose tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,20 @@ When opening a pull request, reference the related issue (e.g., "Related to
 "fixes #725". We do not let PR and commit log comments to mandate the
 management.
 
+## Writing Style for Prose
+
+This applies to every passage you write for humans: code comments, commit
+messages, PR and issue descriptions and comments, and documentation.
+
+- Minimize em-dashes (the "--" rendered as a long dash, or the Unicode `U+2014`
+  character). They are hard to read. Prefer a comma, a colon, parentheses, or
+  two separate sentences. Reserve a dash only when no other punctuation reads
+  as clearly.
+- Source files are ASCII-only (see "Code Style"), so never emit the Unicode
+  em-dash, en-dash, or "smart quotes" in them. The same restraint is expected
+  in GitHub prose even though GitHub accepts Unicode.
+- Write plainly. Short sentences beat long ones strung together with dashes.
+
 ## Development Workflow
 
 ### Build System Notes

--- a/contrib/lint/markdown-unwrap.py
+++ b/contrib/lint/markdown-unwrap.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Unwrap hard-wrapped Markdown paragraphs and list items.
+
+The project wraps Markdown prose at 79 columns.  This helper does the
+inverse: it joins each hard-wrapped paragraph onto a single continuous
+line, and likewise joins each list item (its marker plus the wrapped
+continuation lines) onto one line.  The result renders to the same HTML
+and is convenient to edit in a tool that re-wraps on demand.
+
+Blocks that must not be reflowed are passed through verbatim: fenced code
+blocks (```, ~~~, or :::), HTML comments, ATX headings, thematic breaks,
+block quotes, and pipe-table rows.  Blank lines, which separate blocks,
+are preserved.
+
+Usage:
+    markdown-unwrap.py FILE...      # write the result to stdout
+    markdown-unwrap.py -i FILE...   # rewrite the files in place
+    markdown-unwrap.py < in > out   # filter stdin to stdout
+"""
+
+import re
+import sys
+import argparse
+
+# A list item marker: a bullet (-, *, +) or an ordered marker (1. or 1)).
+LIST_RE = re.compile(r'^(\s*)([-*+]|\d+[.)])(\s+)(\S.*)$')
+# A fence opener: three or more backticks, tildes, or colons.
+FENCE_RE = re.compile(r'^(\s*)(`{3,}|~{3,}|:{3,})(.*)$')
+HEADING_RE = re.compile(r'^\s*#{1,6}(\s|$)')
+THEMATIC_RE = re.compile(r'^\s*([-*_])(\s*\1){2,}\s*$')
+TABLE_RE = re.compile(r'^\s*\|')
+QUOTE_RE = re.compile(r'^\s*>')
+BLANK_RE = re.compile(r'^\s*$')
+
+
+def is_blank(line):
+    return BLANK_RE.match(line) is not None
+
+
+def is_special(line):
+    """A line that begins a block which must not be joined into prose."""
+    return (
+        is_blank(line)
+        or FENCE_RE.match(line) is not None
+        or HEADING_RE.match(line) is not None
+        or THEMATIC_RE.match(line) is not None
+        or TABLE_RE.match(line) is not None
+        or QUOTE_RE.match(line) is not None
+        or LIST_RE.match(line) is not None
+        or line.lstrip().startswith('<!--')
+    )
+
+
+def fence_closer(opener):
+    """Return a regex matching the closing fence of the given opener."""
+    marker = FENCE_RE.match(opener).group(2)
+    char, length = marker[0], len(marker)
+    return re.compile(r'^\s*' + re.escape(char) + '{' + str(length) +
+                      r',}\s*$')
+
+
+def join_block(block):
+    """Collapse wrapped lines into one, keeping the first line's indent."""
+    first = block[0].rstrip()
+    rest = [line.strip() for line in block[1:]]
+    rest = [line for line in rest if line]
+    return first + (' ' + ' '.join(rest) if rest else '')
+
+
+def convert(text):
+    """Join wrapped paragraphs and list items in a Markdown string."""
+    lines = text.split('\n')
+    trailing_newline = bool(lines) and lines[-1] == ''
+    if trailing_newline:
+        lines = lines[:-1]
+    out = []
+    i, n = 0, len(lines)
+    while i < n:
+        line = lines[i]
+        if is_blank(line):
+            out.append('')
+            i += 1
+        elif FENCE_RE.match(line):
+            closer = fence_closer(line)
+            out.append(line.rstrip())
+            i += 1
+            while i < n and not closer.match(lines[i]):
+                out.append(lines[i].rstrip('\r'))
+                i += 1
+            if i < n:
+                out.append(lines[i].rstrip())
+                i += 1
+        elif line.lstrip().startswith('<!--'):
+            out.append(line.rstrip())
+            i += 1
+            while i < n and '-->' not in lines[i - 1]:
+                out.append(lines[i].rstrip())
+                i += 1
+        elif (HEADING_RE.match(line) or THEMATIC_RE.match(line)):
+            out.append(line.rstrip())
+            i += 1
+        elif TABLE_RE.match(line):
+            while i < n and TABLE_RE.match(lines[i]):
+                out.append(lines[i].rstrip())
+                i += 1
+        elif QUOTE_RE.match(line):
+            while i < n and QUOTE_RE.match(lines[i]):
+                out.append(lines[i].rstrip())
+                i += 1
+        else:
+            # A list item or a plain paragraph: collect the marker (if
+            # any) plus the wrapped continuation lines that follow it.
+            block = [line]
+            i += 1
+            while i < n and not is_special(lines[i]):
+                block.append(lines[i])
+                i += 1
+            out.append(join_block(block))
+    result = '\n'.join(out)
+    return result + '\n' if trailing_newline else result
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description='Join hard-wrapped Markdown paragraphs and list '
+        'items onto continuous single lines.'
+    )
+    parser.add_argument(
+        '-i', '--in-place',
+        action='store_true',
+        help='rewrite each file in place instead of writing to stdout'
+    )
+    parser.add_argument(
+        'files',
+        nargs='*',
+        help='Markdown files to convert (default: read from stdin)'
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    if not args.files:
+        if args.in_place:
+            print('error: --in-place requires file arguments',
+                  file=sys.stderr)
+            return 2
+        sys.stdout.write(convert(sys.stdin.read()))
+        return 0
+    for path in args.files:
+        with open(path, 'r', encoding='utf-8') as fobj:
+            converted = convert(fobj.read())
+        if args.in_place:
+            with open(path, 'w', encoding='utf-8') as fobj:
+                fobj.write(converted)
+        else:
+            sys.stdout.write(converted)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/doc/source/devguide/testing.md
+++ b/doc/source/devguide/testing.md
@@ -1,16 +1,16 @@
 # Testing
 
 Tests are driven through `make` from the repository root.  Python tests are the
-default and live in `tests/` as `test_*.py`; C++ tests live in `gtests/` as
+default and live in `tests/` as `test_*.py`. C++ tests live in `gtests/` as
 `test_nopython_*.cpp` and are reserved for behaviour that cannot or should not
 be reached from Python.
 
-- `make pytest` -- run the full Python test suite.
-- `make pytest PYTEST_OPTS="tests/test_buffer.py::SimpleArrayBasicTC"` --
+- `make pytest`: run the full Python test suite.
+- `make pytest PYTEST_OPTS="tests/test_buffer.py::SimpleArrayBasicTC"`:
   forward options verbatim to pytest to run a subset.
-- `make run_pilot_pytest` -- Python tests that need the pilot GUI.
-- `make gtest` -- build and run the full C++ test suite.
-- `make pyprof` -- run the profiling benchmarks (see {doc}`/system/profiling`).
+- `make run_pilot_pytest`: Python tests that need the pilot GUI.
+- `make gtest`: build and run the full C++ test suite.
+- `make pyprof`: run the profiling benchmarks (see {doc}`/system/profiling`).
 
 After `make gtest` has built the binary, a single C++ test can be run directly:
 
@@ -19,5 +19,81 @@ After `make gtest` has built the binary, a single C++ test can be run directly:
 ```
 
 where `<pyvminor>` is the active Python major and minor version, e.g. `314`.
+
+## Automatic Testing on GitHub Actions
+
+Continuous integration runs on GitHub Actions. The workflows live in
+`.github/workflows/`. Most checks run on every change, while the heavier and
+slowly-changing ones run on a nightly schedule. Each job drives the same `make`
+targets described above, so a failure can usually be reproduced locally.
+
+The fast set runs on every pull request and `master` push:
+
+- `check_skip`: decides whether to skip the heavy jobs (see below).
+- `lint`: `make cformat`, `cinclude`, `checkascii`, `checktws`, `flake8`, and
+  clang-tidy on the diff, on ubuntu and macOS.
+- `standalone_buffer`: the standalone buffer build on ubuntu.
+- `build`: `make gtest` plus `make pytest` with Qt off and on, and the pilot,
+  on ubuntu and macOS (Release).
+- `build_windows` (Release): the Windows build and tests.
+
+The heavy set runs on the nightly schedule only:
+
+- `build_windows` (Debug): the second Windows configuration.
+- `nouse_install`: the `setup.py install` packaging path.
+- the ASAN/UBSAN sanitizer build (`-DUSE_SANITIZER=ON` over the gtest suite).
+- `profiling`: the benchmark suite.
+- the Windows portable artifact.
+
+The nightly run is the superset: the fast set plus these extras.
+
+Compiler caches (`ccache` on Linux and macOS, `sccache` for MSVC on Windows)
+are saved by pushes to `master` and by nightly runs, and restored by pull
+requests. A pull request on a non-default base branch cannot read them and runs
+cold.
+
+### Skipping in a pull request
+
+- A pull request skips the heavy jobs when it carries the `skip-ci` label or a
+  repository member writes `[skip-ci]` alone on a line of its description or a
+  comment. A documentation-only pull request (only `doc/**`, `*.md`, `*.rst`,
+  or `contrib/prompt/**`) skips them automatically.
+- A pull request that touches no C++ or build file skips the Windows build but
+  still runs the Python build and lint.
+
+### Repository variables
+
+These variables tune the workflows. Set them as repository variables (under
+Settings, then Secrets and variables, then Actions, then the Variables tab).
+Each is read with a default, so an unset variable keeps the default behavior.
+
+- `MMGH_NIGHTLY`: set to `enable` to let the nightly schedule run its jobs.
+  Unset, every scheduled run is skipped.
+- `MMGH_PUSH_RUN_BRANCH`: which branches run the fast set on a `push`. Use `*`
+  for all branches, or a branch name (matched as a substring). Unset, a push
+  runs nothing.
+- `MMGH_FORCE_PROFILE`, `MMGH_FORCE_NOUSE_INSTALL`, `MMGH_FORCE_SANITIZER`: set
+  any to `enable` to force that nightly-only job to run on any event, so it can
+  be exercised from a pull request.
+- `MMGH_TIMEOUT_BUILD` (45), `MMGH_TIMEOUT_LINT` (45),
+  `MMGH_TIMEOUT_STANDALONE_BUFFER` (10), `MMGH_TIMEOUT_NOUSE_INSTALL` (30),
+  `MMGH_TIMEOUT_PROFILE` (30): per-job `timeout-minutes`. The number is the
+  default used when the variable is unset.
+
+### Behavior on a forked repository
+
+- A fork inherits neither these variables nor the secrets, so `MMGH_NIGHTLY`
+  and `MMGH_PUSH_RUN_BRANCH` are unset there. By default only `pull_request`
+  events run, so the fast set runs on a pull request opened in the fork, while
+  pushes and the nightly schedule run nothing until the variables are set.
+- Scheduled workflows run only on the default branch, and GitHub keeps Actions
+  disabled on a new fork until it is enabled (a public fork's schedule also
+  pauses after 60 days without activity).
+- To exercise a single nightly-only job on a fork, set the matching
+  `MMGH_FORCE_*` variable and open a pull request.
+- A fork pull request on a non-default base branch runs cold, since it cannot
+  read the warmed caches. The failure-notification job is guarded by
+  `github.event.repository.fork == false`, so it never runs on a fork (and the
+  email secrets it needs are unavailable there).
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->


### PR DESCRIPTION
Add a GitHub Actions CI section to the testing guide covering the fast and nightly job sets, the skip gates, the MMGH_* repository variables, and the behavior on a forked repository. Add contrib/lint/markdown-line-paragraph.py, which joins hard-wrapped Markdown paragraphs and list items onto continuous lines. Add a prose writing style section to CLAUDE.md.

Related to issue #939.