### PR TITLE
Pass pybind11_ROOT into the nouse_install cmake args

### DIFF
--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -93,7 +93,7 @@ jobs:
             SUDO_CMD="sudo"
           fi
           $SUDO_CMD python3 setup.py install build_ext \
-            --cmake-args="${JOB_CMAKE_ARGS} -DPYTHON_EXECUTABLE=$(which python3)" \
+            --cmake-args="${JOB_CMAKE_ARGS} -DPYTHON_EXECUTABLE=$(which python3) -Dpybind11_ROOT=${pybind11_ROOT}" \
             --make-args="VERBOSE=1"
           echo "::endgroup::"
 


### PR DESCRIPTION
nouse_install build runs setup.py install under sudo on Linux.  sudo resets the environment and drops pybind11_ROOT that was set when installing pybind11 using the pip wheel. Then cmake failed.

See https://github.com/solvcon/solvcon/actions/runs/28195026599/job/83519430873 and https://github.com/solvcon/solvcon/actions/runs/28123311996 for the error messages:

```
  -- SOLVCON_PROFILE: OFF
  CMake Error at CMakeLists.txt:188 (find_package):
    Could not find a package configuration file provided by "pybind11"
    (requested version 2.12.0) with any of the following names:
  
      pybind11.cps
      pybind11Config.cmake
      pybind11-config.cmake
  
    Add the installation prefix of "pybind11" to CMAKE_PREFIX_PATH or set
    "pybind11_DIR" to a directory containing one of the above files.  If
    "pybind11" provides a separate development package or SDK, be sure it has
    been installed.
  
  
  -- Configuring incomplete, errors occurred!
  Traceback (most recent call last):
    File "/home/runner/work/solvcon/solvcon/setup.py", line 84, in <module>
      main()
    File "/home/runner/work/solvcon/solvcon/setup.py", line 64, in main
      setuptools.setup(
    File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 107, in setup
      return distutils.core.setup(**attrs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 185, in setup
      return run_commands(dist)
             ^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 201, in run_commands
      dist.run_commands()
    File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 969, in run_commands
      self.run_command(cmd)
    File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 1233, in run_command
      super().run_command(command)
    File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 988, in run_command
      cmd_obj.run()
    File "/usr/lib/python3/dist-packages/setuptools/command/install.py", line 84, in run
      self.do_egg_install()
    File "/usr/lib/python3/dist-packages/setuptools/command/install.py", line 132, in do_egg_install
      self.run_command('bdist_egg')
    File "/usr/lib/python3/dist-packages/setuptools/_distutils/cmd.py", line 318, in run_command
      self.distribution.run_command(command)
    File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 1233, in run_command
      super().run_command(command)
    File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 988, in run_command
      cmd_obj.run()
    File "/usr/lib/python3/dist-packages/setuptools/command/bdist_egg.py", line 167, in run
      cmd = self.call_command('install_lib', warn_dir=0)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3/dist-packages/setuptools/command/bdist_egg.py", line 153, in call_command
      self.run_command(cmdname)
    File "/usr/lib/python3/dist-packages/setuptools/_distutils/cmd.py", line 318, in run_command
      self.distribution.run_command(command)
    File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 1233, in run_command
      super().run_command(command)
    File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 988, in run_command
      cmd_obj.run()
    File "/usr/lib/python3/dist-packages/setuptools/command/install_lib.py", line 23, in run
      self.build()
    File "/usr/lib/python3/dist-packages/setuptools/_distutils/command/install_lib.py", line 111, in build
      self.run_command('build_ext')
    File "/usr/lib/python3/dist-packages/setuptools/_distutils/cmd.py", line 318, in run_command
      self.distribution.run_command(command)
    File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 1233, in run_command
      super().run_command(command)
    File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 988, in run_command
      cmd_obj.run()
    File "/home/runner/work/solvcon/solvcon/setup.py", line 36, in run
      self.build_cmake(ext)
    File "/home/runner/work/solvcon/solvcon/setup.py", line 54, in build_cmake
      raise RuntimeError('{} return {}'.format(cmd, proc.returncode))
  RuntimeError: cmake /home/runner/work/solvcon/solvcon -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=/home/runner/work/solvcon/solvcon/build/lib.linux-x86_64-cpython-312 -DBUILD_QT=OFF -DUSE_CLANG_TIDY=OFF -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=/usr/bin/python3 return 1
```

The fix is tested with a fork.  Because the failed job was run on nightly, the PR CI will not see difference.