### PR TITLE
Select, move, and rotate shapes on the 2D canvas

### DIFF
--- a/cpp/solvcon/pilot/R2DWidget.cpp
+++ b/cpp/solvcon/pilot/R2DWidget.cpp
@@ -10,9 +10,12 @@
 #include <array>
 #include <cmath>
 
+#include <QColor>
 #include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
+#include <QPen>
+#include <QPolygonF>
 #include <QResizeEvent>
 #include <QWheelEvent>
 
@@ -32,6 +35,18 @@ constexpr double MAX_ZOOM = 1.0e6;
 // stray click in a shape tool does not drop a degenerate shape into the
 // world.
 constexpr double MIN_DRAW_DRAG_PX = 2.0;
+
+// Screen-pixel slop for picking a shape with the pan tool. Converted to a
+// world tolerance through the current zoom so thin shapes stay selectable.
+constexpr double PICK_TOLERANCE_PX = 5.0;
+
+// Rotate-handle geometry in cosmetic screen pixels: the outward gap from the
+// shape's corner, the drawn knob radius, and the hit radius.
+constexpr double ROTATE_HANDLE_GAP_PX = 16.0;
+constexpr double ROTATE_HANDLE_RADIUS_PX = 5.0;
+constexpr double ROTATE_HANDLE_HIT_PX = 9.0;
+
+QColor const SELECTION(120, 200, 255);
 
 double clamp_zoom(double zoom)
 {
@@ -98,8 +113,11 @@ void R2DWidget::setDrawTool(std::string const & name)
     // state changes so an invalid request leaves the current tool untouched.
     std::unique_ptr<DrawToolBase> tool = make_draw_tool(name);
     m_tool = std::move(tool);
-    // A tool switch abandons any in-progress drag without committing.
+    // A tool switch abandons any in-progress drag without committing and
+    // drops the pan-tool selection.
     m_drawing = false;
+    m_selected = -1;
+    m_drag = EditDrag::None;
     // A crosshair signals draw mode; the pan tool keeps the default arrow.
     if (m_tool->can_draw_shape())
     {
@@ -115,6 +133,9 @@ void R2DWidget::setDrawTool(std::string const & name)
 void R2DWidget::updateWorld(std::shared_ptr<WorldFp64> const & world)
 {
     m_world = world;
+    // A new world invalidates any shape id we held selected.
+    m_selected = -1;
+    m_drag = EditDrag::None;
     update();
 }
 
@@ -132,6 +153,9 @@ void R2DWidget::paintEvent(QPaintEvent * /*event*/)
 
     // Rubber-band preview of the shape currently being dragged, if any.
     paintDrawPreview(painter);
+
+    // Selection box and rotate handle for the pan tool, if any.
+    paintSelection(painter);
 }
 
 void R2DWidget::paintDrawPreview(QPainter & painter) const
@@ -147,6 +171,98 @@ void R2DWidget::paintDrawPreview(QPainter & painter) const
     }
     std::array<DrawPoint, 2> const points{{{m_draw_start_x, m_draw_start_y}, {m_draw_current_x, m_draw_current_y}}};
     m_tool->paint_preview(painter, m_view, points);
+}
+
+void R2DWidget::paintSelection(QPainter & painter) const
+{
+    if (m_tool->can_draw_shape() || m_selected < 0 || !m_world || !m_world->shape_is_live(m_selected))
+    {
+        return;
+    }
+    // The oriented bounding box wraps the shape at any orientation, so the
+    // box and its top-left handle rotate together and never separate.
+    obb_array_type const obb = m_world->shape_obb(m_selected);
+    QPolygonF box;
+
+    double sx = 0.0, sy = 0.0;
+    for (size_t i = 0; i < 4; ++i)
+    {
+        m_view.screen_from_world(obb[2 * i], obb[2 * i + 1], sx, sy);
+        box << QPointF(sx, sy);
+    }
+
+    // Draw the box and the rotate handle knob.
+    QPen pen(SELECTION);
+    pen.setCosmetic(true);
+    pen.setWidthF(1.5);
+    pen.setStyle(Qt::DashLine);
+    painter.setPen(pen);
+    painter.setBrush(Qt::NoBrush);
+    painter.drawPolygon(box);
+
+    // Short stem from the box's top-left corner out to the rotate knob.
+    QPointF const handle = rotateHandlePos();
+    pen.setStyle(Qt::SolidLine);
+    painter.setPen(pen);
+    painter.drawLine(box.front(), handle);
+    painter.setBrush(SELECTION);
+    painter.drawEllipse(handle, ROTATE_HANDLE_RADIUS_PX, ROTATE_HANDLE_RADIUS_PX);
+}
+
+int32_t R2DWidget::pickShapeAt(QPointF const & screen_pos) const
+{
+    if (!m_world)
+    {
+        return -1;
+    }
+    double wx = 0.0, wy = 0.0;
+    m_view.world_from_screen(screen_pos.x(), screen_pos.y(), wx, wy);
+    double const tol = PICK_TOLERANCE_PX / m_view.zoom();
+    return m_world->pick_shape(wx, wy, tol);
+}
+
+R2DWidget::coord2_type R2DWidget::selectionCenterWorld() const
+{
+    // Center of the oriented bounding box: midpoint of opposite corners.
+    obb_array_type const obb = m_world->shape_obb(m_selected);
+    return {(obb[0] + obb[4]) * 0.5, (obb[1] + obb[5]) * 0.5};
+}
+
+QPointF R2DWidget::rotateHandlePos() const
+{
+    // The handle anchor is always at the box's top-left corner (obb[0..1]).
+    obb_array_type const obb = m_world->shape_obb(m_selected);
+    double hx = 0.0, hy = 0.0, cx = 0.0, cy = 0.0;
+    m_view.screen_from_world(obb[0], obb[1], hx, hy);
+    m_view.screen_from_world((obb[0] + obb[4]) * 0.5, (obb[1] + obb[5]) * 0.5, cx, cy);
+    double const dx = hx - cx, dy = hy - cy;
+    double const len = std::hypot(dx, dy);
+    if (len > 1.0e-9)
+    {
+        hx += dx / len * ROTATE_HANDLE_GAP_PX;
+        hy += dy / len * ROTATE_HANDLE_GAP_PX;
+    }
+    return QPointF(hx, hy);
+}
+
+R2DWidget::coord2_type R2DWidget::rotateHandleScreen() const
+{
+    if (m_selected < 0 || !m_world || !m_world->shape_is_live(m_selected))
+    {
+        return {-1.0, -1.0};
+    }
+    QPointF const h = rotateHandlePos();
+    return {h.x(), h.y()};
+}
+
+bool R2DWidget::isOnRotateHandle(QPointF const & screen_pos) const
+{
+    if (m_selected < 0 || !m_world || !m_world->shape_is_live(m_selected))
+    {
+        return false;
+    }
+    QPointF const d = screen_pos - rotateHandlePos();
+    return std::hypot(d.x(), d.y()) <= ROTATE_HANDLE_HIT_PX;
 }
 
 void R2DWidget::wheelEvent(QWheelEvent * event)
@@ -182,9 +298,37 @@ void R2DWidget::mousePressEvent(QMouseEvent * event)
             event->accept();
             return;
         }
-        m_panning = true;
+        // Pan tool: rotate the selection, move a picked shape, or fall
+        // back to panning the view on empty space.
+        if (isOnRotateHandle(pos))
+        {
+            coord2_type const c = selectionCenterWorld();
+            m_rotate_cx = c[0];
+            m_rotate_cy = c[1];
+            double wx = 0.0, wy = 0.0;
+            m_view.world_from_screen(pos.x(), pos.y(), wx, wy);
+            m_rotate_last_angle = std::atan2(wy - m_rotate_cy, wx - m_rotate_cx);
+            m_drag = EditDrag::Rotate;
+            event->accept();
+            return;
+        }
+        int32_t const hit = pickShapeAt(pos);
+        if (hit >= 0)
+        {
+            m_selected = hit;
+            m_view.world_from_screen(pos.x(), pos.y(), m_move_last_x, m_move_last_y);
+            m_drag = EditDrag::Move;
+            setCursor(Qt::SizeAllCursor);
+            update();
+            event->accept();
+            return;
+        }
+        // Empty space: drop the selection and pan the view.
+        m_selected = -1;
+        m_drag = EditDrag::View;
         m_last_mouse_pos = pos;
         setCursor(Qt::ClosedHandCursor);
+        update();
         event->accept();
         return;
     }
@@ -201,7 +345,35 @@ void R2DWidget::mouseMoveEvent(QMouseEvent * event)
         event->accept();
         return;
     }
-    if (m_panning)
+    if (m_drag == EditDrag::Move)
+    {
+        double wx = 0.0, wy = 0.0;
+        m_view.world_from_screen(pos.x(), pos.y(), wx, wy);
+        if (m_world && m_world->shape_is_live(m_selected))
+        {
+            m_world->translate_shape(m_selected, wx - m_move_last_x, wy - m_move_last_y);
+        }
+        m_move_last_x = wx;
+        m_move_last_y = wy;
+        update();
+        event->accept();
+        return;
+    }
+    if (m_drag == EditDrag::Rotate)
+    {
+        double wx = 0.0, wy = 0.0;
+        m_view.world_from_screen(pos.x(), pos.y(), wx, wy);
+        double const angle = std::atan2(wy - m_rotate_cy, wx - m_rotate_cx);
+        if (m_world && m_world->shape_is_live(m_selected))
+        {
+            m_world->rotate_shape(m_selected, angle - m_rotate_last_angle, m_rotate_cx, m_rotate_cy);
+        }
+        m_rotate_last_angle = angle;
+        update();
+        event->accept();
+        return;
+    }
+    if (m_drag == EditDrag::View)
     {
         QPointF const delta = pos - m_last_mouse_pos;
         m_last_mouse_pos = pos;
@@ -235,10 +407,11 @@ void R2DWidget::mouseReleaseEvent(QMouseEvent * event)
         event->accept();
         return;
     }
-    if (event->button() == Qt::LeftButton && m_panning)
+    if (event->button() == Qt::LeftButton && m_drag != EditDrag::None)
     {
-        m_panning = false;
+        m_drag = EditDrag::None;
         unsetCursor();
+        update();
         event->accept();
         return;
     }

--- a/cpp/solvcon/pilot/R2DWidget.hpp
+++ b/cpp/solvcon/pilot/R2DWidget.hpp
@@ -7,10 +7,12 @@
 
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
+#include <solvcon/buffer/small_vector.hpp>
 #include <solvcon/pilot/DrawTool.hpp>
 #include <solvcon/universe/ViewTransform2d.hpp>
 #include <solvcon/universe/World.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -36,6 +38,9 @@ class R2DWidget
 {
     Q_OBJECT
 
+    using coord2_type = small_vector<double, 2>;
+    using obb_array_type = small_vector<double, 8>;
+
 public:
 
     explicit R2DWidget(QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
@@ -48,6 +53,14 @@ public:
 
     /// Select the active pointer tool by name
     void setDrawTool(std::string const & name);
+
+    /// Id of the shape selected with the pan tool, or -1 when none is
+    /// selected. Selection is cleared by switching tools or worlds.
+    int32_t selectedShape() const { return m_selected; }
+
+    /// Screen position [x, y] of the selection's rotate handle, or
+    /// [-1, -1] when nothing is selected. Exposed for tests and tooling.
+    coord2_type rotateHandleScreen() const;
 
     /// Replace the view state. Non-finite inputs are ignored and zoom
     /// is clamped to the widget's internal bounds, so the widget's
@@ -85,9 +98,36 @@ private:
     /// progress; a no-op for the pan tool or when no drag is underway.
     void paintDrawPreview(QPainter & painter) const;
 
+    /// Paint the selection box and rotate handle for the active selection;
+    /// a no-op unless the pan tool has a live shape selected.
+    void paintSelection(QPainter & painter) const;
+
+    /// Pick the shape under a screen point, or -1. Uses a pixel-sized world
+    /// tolerance so thin shapes (lines) stay selectable at any zoom.
+    int32_t pickShapeAt(QPointF const & screen_pos) const;
+
+    /// Screen position of the rotate handle for the current selection;
+    /// only meaningful while a live shape is selected.
+    QPointF rotateHandlePos() const;
+
+    /// World center of the selection's oriented bounding box -- the pivot a
+    /// rotate drag turns about. Only meaningful while a shape is selected.
+    coord2_type selectionCenterWorld() const;
+
+    /// True when `screen_pos` lands on the selection's rotate handle.
+    bool isOnRotateHandle(QPointF const & screen_pos) const;
+
+    /// Which gesture the current pan-tool left-drag performs.
+    enum class EditDrag
+    {
+        None, ///< no left-drag in progress
+        View, ///< panning the view
+        Move, ///< translating the selected shape
+        Rotate, ///< rotating the selected shape about a fixed pivot
+    };
+
     ViewTransform2dFp64 m_view;
     std::shared_ptr<WorldFp64> m_world;
-    bool m_panning = false;
     bool m_view_modified = false;
     QPointF m_last_mouse_pos;
 
@@ -97,6 +137,14 @@ private:
     double m_draw_start_y = 0.0;
     double m_draw_current_x = 0.0; ///< live pointer, world coordinates
     double m_draw_current_y = 0.0;
+
+    int32_t m_selected = -1; ///< pan-tool selected shape id, or -1
+    EditDrag m_drag = EditDrag::None; ///< active pan-tool left-drag gesture
+    double m_move_last_x = 0.0; ///< previous pointer, world coordinates (Move)
+    double m_move_last_y = 0.0;
+    double m_rotate_cx = 0.0; ///< rotation pivot, world coordinates (Rotate)
+    double m_rotate_cy = 0.0;
+    double m_rotate_last_angle = 0.0; ///< previous pointer angle about pivot
 
 }; /* end class R2DWidget */
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -254,6 +254,15 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapR2DWidget
             .def("requestRepaint", &wrapped_type::requestRepaint)
             .def("setDrawTool", &wrapped_type::setDrawTool, py::arg("name"))
             .def_property_readonly("drawTool", &wrapped_type::drawTool)
+            .def_property_readonly("selectedShape", &wrapped_type::selectedShape)
+            .def_property_readonly(
+                "rotateHandleScreen",
+                [](wrapped_type & self)
+                {
+                    // TODO: add pybind for small_vector to avoid this copy.
+                    auto const h = self.rotateHandleScreen();
+                    return std::vector<double>(h.begin(), h.end());
+                })
             //
             ;
 

--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -12,9 +12,9 @@
 #include <solvcon/universe/bezier.hpp>
 #include <solvcon/universe/rtree.hpp>
 
+#include <algorithm>
 #include <cmath>
-#include <deque>
-#include <numbers>
+#include <limits>
 #include <vector>
 
 namespace solvcon
@@ -183,11 +183,18 @@ private:
  */
 struct ShapeRecord
 {
+    using bbox_array_type = small_vector<double, 4>; ///< four corners, (x, y) pairs
+
     ShapeType type;
     size_t segment_offset; ///< first index in SegmentPad
     size_t segment_count; ///< number of segments this shape occupies
     size_t curve_offset; ///< first index in CurvePad
     size_t curve_count; ///< number of cubic Beziers this shape occupies
+
+    // Oriented bounding box in world coordinates, as four corners ordered
+    // top-left, top-right, bottom-right, bottom-left.
+    bbox_array_type obb_x;
+    bbox_array_type obb_y;
 }; /* end of struct ShapeRecord */
 
 /**
@@ -235,6 +242,10 @@ public:
     using curve_pad_type = CurvePad<T>;
     using bbox_type = BoundBox3d<T>;
     using rtree_type = RTree<ShapeEntry<T>, bbox_type>;
+
+    using coord2_type = small_vector<value_type, 2>; ///< an (x, y) pair
+    using bbox_array_type = small_vector<value_type, 4>; ///< [min_x, min_y, max_x, max_y]
+    using obb_array_type = small_vector<value_type, 8>; ///< 4 corners, (x, y) pairs
 
     template <typename... Args>
     static std::shared_ptr<World<T>> construct(Args &&... args)
@@ -359,6 +370,12 @@ public:
     void translate_shape(int32_t shape_id, value_type dx, value_type dy);
 
     /**
+     * Rotate all segments and curves belonging to a shape by `angle`
+     * radians (counter-clockwise in world space) about the pivot (cx, cy).
+     */
+    void rotate_shape(int32_t shape_id, value_type angle, value_type cx, value_type cy);
+
+    /**
      * Remove a shape from the R-tree and registry.
      * Segments and curves remain in their pads as dead data; use clear() to reclaim.
      */
@@ -379,6 +396,49 @@ public:
     bool can_redo() const { return !m_redo_stack.empty(); }
 
     size_t nshape() const { return m_nshape; }
+
+    /// True if `shape_id` refers to a live (non-DEAD) shape. Unlike the
+    /// accessors above this never throws, so callers can probe a stale id.
+    bool shape_is_live(int32_t shape_id) const
+    {
+        return shape_id >= 0 &&
+               static_cast<size_t>(shape_id) < m_shape_registry.size() &&
+               m_shape_registry[shape_id].type != ShapeType::DEAD;
+    }
+
+    /// Axis-aligned bounding box of a live shape, as
+    /// [min_x, min_y, max_x, max_y].
+    bbox_array_type shape_bbox(int32_t shape_id) const
+    {
+        bbox_type const bb = compute_shape_bbox(find_shape_or_throw(shape_id));
+        return {bb.min_x(), bb.min_y(), bb.max_x(), bb.max_y()};
+    }
+
+    /// World position of a live shape's rotate-handle anchor (the oriented
+    /// bounding box's top-left corner), as [x, y]. Carried by every
+    /// translate/rotate, so it stays put relative to the shape.
+    coord2_type shape_handle(int32_t shape_id) const
+    {
+        ShapeRecord const & rec = find_shape_or_throw(shape_id);
+        return {static_cast<value_type>(rec.obb_x[0]), static_cast<value_type>(rec.obb_y[0])};
+    }
+
+    /// Oriented bounding box of a live shape: four world corners ordered
+    /// top-left, top-right, bottom-right, bottom-left.
+    obb_array_type shape_obb(int32_t shape_id) const
+    {
+        ShapeRecord const & rec = find_shape_or_throw(shape_id);
+        obb_array_type out(8);
+        for (size_t i = 0; i < 4; ++i)
+        {
+            out[2 * i] = static_cast<value_type>(rec.obb_x[i]);
+            out[2 * i + 1] = static_cast<value_type>(rec.obb_y[i]);
+        }
+        return out;
+    }
+
+    /// Pick the live shape at world point (x, y).
+    int32_t pick_shape(value_type x, value_type y, value_type tol) const;
 
     /**
      * Query the R-tree for shapes whose bounding box overlaps the viewport.
@@ -434,6 +494,13 @@ private:
     }
 
     bbox_type compute_shape_bbox(ShapeRecord const & rec) const;
+
+    /// Minimum distance from world point (px, py) to a shape's drawn
+    /// geometry: its segments and its curves (sampled along each cubic).
+    T shape_point_distance(ShapeRecord const & rec, T px, T py) const;
+
+    /// Distance from point (px, py) to the segment (ax, ay)-(bx, by).
+    static T point_segment_distance(T px, T py, T ax, T ay, T bx, T by);
 
     /// Register a new shape owning [segment_offset, segment_offset + segment_count)
     /// in the segment pad and [curve_offset, curve_offset + curve_count) in the
@@ -496,7 +563,14 @@ int32_t World<T>::register_shape(ShapeType type,
     auto shape_id = static_cast<int32_t>(m_shape_registry.size());
     m_shape_registry.push_back(ShapeRecord{type, segment_offset, segment_count, curve_offset, curve_count}); // NOLINT(modernize-use-designated-initializers)
     ++m_nshape;
-    m_rtree->insert(ShapeEntry<T>{shape_id, compute_shape_bbox(m_shape_registry[shape_id])});
+    bbox_type const bb = compute_shape_bbox(m_shape_registry[shape_id]);
+
+    // Seed the oriented bounding box to the axis-aligned bbox corners.
+    // TODO: store the OBB directly in ShapeRecord at construction.
+    ShapeRecord & seeded = m_shape_registry[shape_id];
+    seeded.obb_x = ShapeRecord::bbox_array_type{bb.min_x(), bb.max_x(), bb.max_x(), bb.min_x()};
+    seeded.obb_y = ShapeRecord::bbox_array_type{bb.max_y(), bb.max_y(), bb.min_y(), bb.min_y()};
+    m_rtree->insert(ShapeEntry<T>{shape_id, bb});
 
     // Creating a shape becomes the newest undoable step and invalidates any
     // pending redo, mirroring the usual editor undo/redo semantics.
@@ -612,7 +686,7 @@ int32_t World<T>::add_bezier_shape(bezier_type const & bezier)
 template <typename T>
 void World<T>::translate_shape(int32_t shape_id, value_type dx, value_type dy)
 {
-    ShapeRecord const & rec = find_shape_or_throw(shape_id);
+    ShapeRecord & rec = find_shape_or_throw(shape_id);
     // Remove old entry from R-tree before modifying segments/curves.
     m_rtree->remove(ShapeEntry<T>{shape_id, compute_shape_bbox(rec)});
     for (uint32_t i = 0; i < rec.segment_count; ++i)
@@ -635,8 +709,145 @@ void World<T>::translate_shape(int32_t shape_id, value_type dx, value_type dy)
         m_curves->x3(idx) += dx;
         m_curves->y3(idx) += dy;
     }
+    // The oriented bounding box rides along with the shape.
+    for (uint32_t i = 0; i < 4; ++i)
+    {
+        rec.obb_x[i] += dx;
+        rec.obb_y[i] += dy;
+    }
     // Reinsert with updated bounding box.
     m_rtree->insert(ShapeEntry<T>{shape_id, compute_shape_bbox(rec)});
+}
+
+template <typename T>
+void World<T>::rotate_shape(int32_t shape_id, value_type angle, value_type cx, value_type cy)
+{
+    ShapeRecord & rec = find_shape_or_throw(shape_id);
+
+    // Remove old entry from R-tree before modifying segments/curves.
+    m_rtree->remove(ShapeEntry<T>{shape_id, compute_shape_bbox(rec)});
+
+    T const cos_a = std::cos(angle);
+    T const sin_a = std::sin(angle);
+
+    // Rotate one point about (cx, cy) in place; reads both coordinates
+    // before writing either, so x and y rotate from the same origin.
+    auto rotate = [&](T & x, T & y)
+    {
+        T const dx = x - cx;
+        T const dy = y - cy;
+        x = cx + cos_a * dx - sin_a * dy;
+        y = cy + sin_a * dx + cos_a * dy;
+    };
+
+    for (uint32_t i = 0; i < rec.segment_count; ++i)
+    {
+        size_t const idx = rec.segment_offset + i;
+        rotate(m_segments->x0(idx), m_segments->y0(idx));
+        rotate(m_segments->x1(idx), m_segments->y1(idx));
+    }
+    for (uint32_t i = 0; i < rec.curve_count; ++i)
+    {
+        size_t const idx = rec.curve_offset + i;
+        rotate(m_curves->x0(idx), m_curves->y0(idx));
+        rotate(m_curves->x1(idx), m_curves->y1(idx));
+        rotate(m_curves->x2(idx), m_curves->y2(idx));
+        rotate(m_curves->x3(idx), m_curves->y3(idx));
+    }
+
+    // Rotate the oriented bounding box about the same pivot so it stays
+    // fixed relative to the shape. Done in `double` to match its storage.
+    auto const dcos = static_cast<double>(cos_a);
+    auto const dsin = static_cast<double>(sin_a);
+    for (uint32_t i = 0; i < 4; ++i)
+    {
+        double const ox = rec.obb_x[i] - cx;
+        double const oy = rec.obb_y[i] - cy;
+        rec.obb_x[i] = cx + dcos * ox - dsin * oy;
+        rec.obb_y[i] = cy + dsin * ox + dcos * oy;
+    }
+    // Reinsert with updated bounding box.
+    m_rtree->insert(ShapeEntry<T>{shape_id, compute_shape_bbox(rec)});
+}
+
+template <typename T>
+T World<T>::point_segment_distance(T px, T py, T ax, T ay, T bx, T by)
+{
+    T const dx = bx - ax;
+    T const dy = by - ay;
+    T const len2 = dx * dx + dy * dy;
+    if (len2 <= T(0)) // degenerate segment: distance to the point
+    {
+        return std::hypot(px - ax, py - ay);
+    }
+    T t = ((px - ax) * dx + (py - ay) * dy) / len2;
+    t = std::max(T(0), std::min(T(1), t)); // clamp to the segment
+    return std::hypot(px - (ax + t * dx), py - (ay + t * dy));
+}
+
+template <typename T>
+T World<T>::shape_point_distance(ShapeRecord const & rec, T px, T py) const
+{
+    T best = std::numeric_limits<T>::max();
+    for (uint32_t i = 0; i < rec.segment_count; ++i)
+    {
+        size_t const idx = rec.segment_offset + i;
+        best = std::min(best, point_segment_distance(px, py, m_segments->x0(idx), m_segments->y0(idx), m_segments->x1(idx), m_segments->y1(idx)));
+    }
+    // Flatten each cubic into short chords and measure the point against them.
+    constexpr uint32_t SAMPLES = 16;
+    for (uint32_t i = 0; i < rec.curve_count; ++i)
+    {
+        size_t const idx = rec.curve_offset + i;
+        T const x0 = m_curves->x0(idx), y0 = m_curves->y0(idx);
+        T const x1 = m_curves->x1(idx), y1 = m_curves->y1(idx);
+        T const x2 = m_curves->x2(idx), y2 = m_curves->y2(idx);
+        T const x3 = m_curves->x3(idx), y3 = m_curves->y3(idx);
+        T prev_x = x0, prev_y = y0;
+        for (uint32_t s = 1; s <= SAMPLES; ++s)
+        {
+            T const u = static_cast<T>(s) / static_cast<T>(SAMPLES);
+            T const v = T(1) - u;
+            T const b0 = v * v * v, b1 = T(3) * v * v * u, b2 = T(3) * v * u * u, b3 = u * u * u;
+            T const cx = b0 * x0 + b1 * x1 + b2 * x2 + b3 * x3;
+            T const cy = b0 * y0 + b1 * y1 + b2 * y2 + b3 * y3;
+            best = std::min(best, point_segment_distance(px, py, prev_x, prev_y, cx, cy));
+            prev_x = cx;
+            prev_y = cy;
+        }
+    }
+    return best;
+}
+
+template <typename T>
+int32_t World<T>::pick_shape(value_type x, value_type y, value_type tol) const
+{
+    T const t = tol > T(0) ? tol : T(0);
+    std::vector<int32_t> const candidates = query_visible(x - t, y - t, x + t, y + t);
+    int32_t best = -1;
+    T best_area = T(0);
+    for (int32_t const id : candidates)
+    {
+        ShapeRecord const & rec = m_shape_registry[static_cast<size_t>(id)];
+        if (rec.type == ShapeType::DEAD)
+        {
+            continue;
+        }
+        bbox_type const bb = compute_shape_bbox(rec);
+        bool const inside = x >= bb.min_x() && x <= bb.max_x() && y >= bb.min_y() && y <= bb.max_y();
+        if (!inside && shape_point_distance(rec, x, y) > t)
+        {
+            continue;
+        }
+        // Prefer the smallest box (inner shapes), ties to the newest shape.
+        T const area = (bb.max_x() - bb.min_x()) * (bb.max_y() - bb.min_y());
+        if (best == -1 || area < best_area || (area == best_area && id > best))
+        {
+            best = id;
+            best_area = area;
+        }
+    }
+    return best;
 }
 
 template <typename T>

--- a/cpp/solvcon/universe/pymod/wrap_World.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_World.cpp
@@ -104,6 +104,47 @@ WrapWorld<T> & WrapWorld<T>::wrap_management()
             py::arg("dx"),
             py::arg("dy"))
         .def(
+            "rotate_shape",
+            &wrapped_type::rotate_shape,
+            py::arg("shape_id"),
+            py::arg("angle"),
+            py::arg("cx"),
+            py::arg("cy"))
+        .def(
+            "shape_is_live",
+            &wrapped_type::shape_is_live,
+            py::arg("shape_id"))
+        .def(
+            "shape_bbox",
+            [](wrapped_type const & self, int32_t shape_id)
+            {
+                auto const bb = self.shape_bbox(shape_id);
+                return std::vector<value_type>(bb.begin(), bb.end());
+            },
+            py::arg("shape_id"))
+        .def(
+            "shape_handle",
+            [](wrapped_type const & self, int32_t shape_id)
+            {
+                auto const h = self.shape_handle(shape_id);
+                return std::vector<value_type>(h.begin(), h.end());
+            },
+            py::arg("shape_id"))
+        .def(
+            "shape_obb",
+            [](wrapped_type const & self, int32_t shape_id)
+            {
+                auto const obb = self.shape_obb(shape_id);
+                return std::vector<value_type>(obb.begin(), obb.end());
+            },
+            py::arg("shape_id"))
+        .def(
+            "pick_shape",
+            &wrapped_type::pick_shape,
+            py::arg("x"),
+            py::arg("y"),
+            py::arg("tol"))
+        .def(
             "query_visible",
             &wrapped_type::query_visible,
             py::arg("min_x"),

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -159,6 +159,11 @@ class R2DWidgetWorldTC(unittest.TestCase):
         # An invalid request leaves the previous tool untouched.
         self.assertEqual(self.widget.drawTool, "pan")
 
+    def test_selected_shape_defaults_to_none(self):
+        """A fresh canvas has nothing selected; selectedShape reads -1."""
+        self.widget.updateWorld(solvcon.WorldFp64())
+        self.assertEqual(self.widget.selectedShape, -1)
+
     @unittest.skip("TODO: pixel-level DEAD-shape culling assertions")
     def test_dead_shape_culling_renders_pixels(self):
         """Assert live geometry is painted and DEAD shapes are culled.
@@ -175,6 +180,53 @@ class R2DWidgetWorldTC(unittest.TestCase):
         # self.assertGreater(foreground_pixels(img, region_A), 0)
         # self.assertEqual(foreground_pixels(img, region_B), 0)
         raise NotImplementedError
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "live-GUI interaction is unstable under GitHub Actions")
+class R2DWidgetPanSelectTC(unittest.TestCase):
+    """Drive the pan tool through select, move, rotate, and deselect."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mgr = pilot.RManager.instance.setUp()
+
+    def setUp(self):
+        from PySide6 import QtWidgets
+        self.widget = self.mgr.add2DWidget()
+        self.widget.setDrawTool("pan")
+        self.world = solvcon.WorldFp64()
+        # A rectangle centered on the origin.
+        self.sid = self.world.add_rectangle(-2, -1, 2, 1)
+        self.widget.updateWorld(self.world)
+        v = solvcon.ViewTransform2dFp64()
+        v.pan(100.0, 100.0)
+        v.zoom = 20.0
+        # Set the view before showing so the resize auto-centering, which a
+        # well-formed transform disables, leaves the mapping deterministic.
+        self.widget.setViewTransform(v)
+        self.mgr.show()
+        self.sub = self.mgr.mdiArea.subWindowList()[-1]
+        self.sub.show()
+        self.mgr.mdiArea.setActiveSubWindow(self.sub)
+        # The PySide6 widget wraps the same C++ object the handle above does.
+        self.target = self.sub.widget()
+        QtWidgets.QApplication.processEvents()
+
+    def test_select_move_rotate_run_through(self):
+        # Press on the shape to select it, then drag to move it.
+        _send_mouse(self.target, 'press', 100, 100)
+        _send_mouse(self.target, 'move', 140, 100)
+        _send_mouse(self.target, 'release', 140, 100)
+        self.assertEqual(self.widget.selectedShape, self.sid)
+        # Grab the rotate handle and swing it.
+        hx, hy = self.widget.rotateHandleScreen
+        _send_mouse(self.target, 'press', hx, hy)
+        _send_mouse(self.target, 'move', hx + 30, hy + 30)
+        _send_mouse(self.target, 'release', hx + 30, hy + 30)
+        # Switching tools drops the selection.
+        self.widget.setDrawTool("circle")
+        self.assertEqual(self.widget.selectedShape, -1)
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -3,6 +3,7 @@
 
 
 import json
+import math
 import unittest
 
 import numpy as np
@@ -442,6 +443,57 @@ class WorldViewportTC(unittest.TestCase):
         sid = self.w.add_triangle(0, 0, 1, 0, 0, 1)
         self.w.remove_shape(sid)
         self.assertEqual(len(self.w.query_visible(-1, -1, 10, 10)), 0)
+
+
+class WorldRotateTC(unittest.TestCase):
+    """rotate_shape: go-through that rotation runs without raising."""
+
+    def setUp(self):
+        self.w = solvcon.WorldFp64()
+
+    def test_rotate_runs(self):
+        sid = self.w.add_rectangle(-2, -1, 2, 1)
+        self.w.rotate_shape(sid, math.pi / 2, 0, 0)
+        self.assertTrue(self.w.shape_is_live(sid))
+
+    def test_rotate_dead_raises(self):
+        sid = self.w.add_line(0, 0, 1, 0)
+        self.w.remove_shape(sid)
+        with self.assertRaises(ValueError):
+            self.w.rotate_shape(sid, 1.0, 0, 0)
+
+
+class WorldPickTC(unittest.TestCase):
+    """pick_shape: go-through that hit-testing runs."""
+
+    def setUp(self):
+        self.w = solvcon.WorldFp64()
+
+    def test_pick_runs(self):
+        sid = self.w.add_rectangle(0, 0, 4, 4)
+        self.assertEqual(self.w.pick_shape(2, 2, 0.1), sid)
+
+    def test_pick_empty_world_returns_minus_one(self):
+        self.assertEqual(self.w.pick_shape(0, 0, 1.0), -1)
+
+
+class WorldShapeAccessorTC(unittest.TestCase):
+    """shape_is_live, shape_bbox, shape_handle, shape_obb: go-through that
+    each accessor runs and returns a sensibly-shaped result."""
+
+    def setUp(self):
+        self.w = solvcon.WorldFp64()
+        self.sid = self.w.add_rectangle(-2, -1, 2, 1)
+
+    def test_accessors_run(self):
+        self.assertTrue(self.w.shape_is_live(self.sid))
+        self.assertEqual(len(self.w.shape_bbox(self.sid)), 4)
+        self.assertEqual(len(self.w.shape_handle(self.sid)), 2)
+        self.assertEqual(len(self.w.shape_obb(self.sid)), 8)
+
+    def test_dead_shape_not_live(self):
+        self.w.remove_shape(self.sid)
+        self.assertFalse(self.w.shape_is_live(self.sid))
 
 
 class WorldLineTC(unittest.TestCase):


### PR DESCRIPTION
The 2D canvas pan tool can now select a shape and edit it in place: drag the shape body to move it, or drag the rotate handle to turn it. Dragging empty space still pans the view.

<img width="1007" height="369" alt="Screenshot 2026-06-26 at 9 40 11 PM" src="https://github.com/user-attachments/assets/7975a505-ceac-479f-86d6-68ba42a91f65" />

https://github.com/user-attachments/assets/c22470ee-ce3f-4feb-99de-4df001ccdce8


Related to #754.
