### PR TITLE
Reclaim the RBoundary and RScene class names

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -5,12 +5,12 @@ cmake_minimum_required(VERSION 4.0.1)
 
 set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RDomainWidget.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/RDomainScene.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RScene.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RDomainCameraController.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RDrawable.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMeshFrame.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RField.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/RMeshBoundary.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RBoundary.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RAxisGizmo.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMaterial.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/R2DWidget.hpp
@@ -26,12 +26,12 @@ set(SOLVCON_PILOT_PYMODHEADERS
 
 set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RDomainWidget.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/RDomainScene.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RScene.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RDomainCameraController.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RDrawable.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMeshFrame.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RField.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/RMeshBoundary.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RBoundary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RAxisGizmo.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMaterial.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/R2DWidget.cpp

--- a/cpp/solvcon/pilot/RBoundary.cpp
+++ b/cpp/solvcon/pilot/RBoundary.cpp
@@ -3,7 +3,7 @@
  * BSD 3-Clause License, see COPYING
  */
 
-#include <solvcon/pilot/RMeshBoundary.hpp> // Must be the first include.
+#include <solvcon/pilot/RBoundary.hpp> // Must be the first include.
 
 #include <array>
 #include <cmath>
@@ -32,13 +32,13 @@ std::array<float, 3> boundary_color(int ibc)
 
 } /* end namespace */
 
-RMeshBoundary::RMeshBoundary(std::shared_ptr<StaticMesh> const & mesh, int ibc)
+RBoundary::RBoundary(std::shared_ptr<StaticMesh> const & mesh, int ibc)
     : m_ibc(ibc)
 {
     build(*mesh, ibc);
 }
 
-void RMeshBoundary::build(StaticMesh const & mh, int ibc)
+void RBoundary::build(StaticMesh const & mh, int ibc)
 {
     // Gather the boundary-set edges as node-index pairs; with none there is
     // nothing to draw.
@@ -149,7 +149,7 @@ void RMeshBoundary::build(StaticMesh const & mh, int ibc)
     setColor(QVector4D(color[0], color[1], color[2], 1.0f));
 }
 
-QRhiVertexInputLayout RMeshBoundary::vertexInputLayout() const
+QRhiVertexInputLayout RBoundary::vertexInputLayout() const
 {
     QRhiVertexInputLayout layout;
     layout.setBindings({{6 * sizeof(float)}});
@@ -160,7 +160,7 @@ QRhiVertexInputLayout RMeshBoundary::vertexInputLayout() const
     return layout;
 }
 
-void RMeshBoundary::createGeometry(QRhi * rhi, QRhiResourceUpdateBatch * batch)
+void RBoundary::createGeometry(QRhi * rhi, QRhiResourceUpdateBatch * batch)
 {
     if (0 == m_interleaved.size() || 0 == m_indices.size())
     {

--- a/cpp/solvcon/pilot/RBoundary.hpp
+++ b/cpp/solvcon/pilot/RBoundary.hpp
@@ -24,13 +24,13 @@ namespace solvcon
  * slightly toward the viewer, because line width is clamped to one pixel in
  * the core profile. @ref ibc identifies which boundary set this draws.
  */
-class RMeshBoundary
+class RBoundary
     : public RDrawable
 {
 
 public:
 
-    RMeshBoundary(std::shared_ptr<StaticMesh> const & mesh, int ibc);
+    RBoundary(std::shared_ptr<StaticMesh> const & mesh, int ibc);
 
     int ibc() const { return m_ibc; }
 
@@ -56,7 +56,7 @@ private:
     SimpleCollector<float> m_interleaved;
     SimpleCollector<uint32_t> m_indices;
 
-}; /* end class RMeshBoundary */
+}; /* end class RBoundary */
 
 } /* end namespace solvcon */
 

--- a/cpp/solvcon/pilot/RDomainCameraController.cpp
+++ b/cpp/solvcon/pilot/RDomainCameraController.cpp
@@ -17,7 +17,7 @@ namespace solvcon
 namespace
 {
 
-constexpr float FOV_DEGREES = 45.0f; // Matches RDomainScene's perspective FOV.
+constexpr float FOV_DEGREES = 45.0f; // Matches RScene's perspective FOV.
 constexpr float LOOK_DEGREES_PER_PIXEL = 0.3f;
 constexpr float PAN_PIXELS_PER_EXTENT = 300.0f;
 constexpr float ZOOM_PER_STEP = 0.12f;

--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -5,8 +5,8 @@
 
 #include <solvcon/pilot/RDomainWidget.hpp> // Must be the first include.
 
+#include <solvcon/pilot/RBoundary.hpp>
 #include <solvcon/pilot/RField.hpp>
-#include <solvcon/pilot/RMeshBoundary.hpp>
 #include <solvcon/pilot/RMeshFrame.hpp>
 
 #include <QKeyEvent>
@@ -134,13 +134,13 @@ void RDomainWidget::showBoundary(int ibc, bool show)
     m_scene.removeDrawableIf(
         [ibc](RDrawable const * d)
         {
-            auto const * boundary = dynamic_cast<RMeshBoundary const *>(d);
+            auto const * boundary = dynamic_cast<RBoundary const *>(d);
             return nullptr != boundary && boundary->ibc() == ibc;
         });
 
     if (show && nullptr != m_mesh)
     {
-        auto boundary = std::make_unique<RMeshBoundary>(m_mesh, ibc);
+        auto boundary = std::make_unique<RBoundary>(m_mesh, ibc);
         if (boundary->hasGeometry())
         {
             m_scene.addDrawable(std::move(boundary));

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -8,7 +8,7 @@
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <solvcon/pilot/RAxisGizmo.hpp>
-#include <solvcon/pilot/RDomainScene.hpp>
+#include <solvcon/pilot/RScene.hpp>
 #include <solvcon/pilot/RDrawable.hpp>
 
 #include <solvcon/solvcon.hpp>
@@ -32,7 +32,7 @@ namespace solvcon
  *
  * It derived from QRhiWidget: Qt owns the swapchain, color and depth buffers,
  * and drives the render loop through initialize()/render(). The widget hosts
- * an RDomainScene (the drawables, the domain bounding box, and the framing
+ * an RScene (the drawables, the domain bounding box, and the framing
  * camera) and drives it.
  */
 class RDomainWidget
@@ -111,7 +111,7 @@ private:
     QRhiRenderPassDescriptor * m_rpdesc = nullptr; ///< Tracked to detect target changes.
     int m_sample_count = 0; ///< Tracked to detect MSAA changes.
 
-    RDomainScene m_scene;
+    RScene m_scene;
     RAxisGizmo m_gizmo;
     RDrawable * m_mesh_frame = nullptr; ///< Non-owning; lives in the scene.
     RDrawable * m_field = nullptr; ///< Non-owning; lives in the scene.

--- a/cpp/solvcon/pilot/RScene.cpp
+++ b/cpp/solvcon/pilot/RScene.cpp
@@ -3,7 +3,7 @@
  * BSD 3-Clause License, see COPYING
  */
 
-#include <solvcon/pilot/RDomainScene.hpp> // Must be the first include.
+#include <solvcon/pilot/RScene.hpp> // Must be the first include.
 
 #include <algorithm>
 
@@ -18,12 +18,12 @@ constexpr float FOV_DEGREES = 45.0f;
 
 } /* end namespace */
 
-void RDomainScene::addDrawable(std::unique_ptr<RDrawable> drawable)
+void RScene::addDrawable(std::unique_ptr<RDrawable> drawable)
 {
     m_drawables.push_back(std::move(drawable));
 }
 
-void RDomainScene::removeDrawable(RDrawable const * drawable)
+void RScene::removeDrawable(RDrawable const * drawable)
 {
     if (nullptr == drawable)
     {
@@ -35,7 +35,7 @@ void RDomainScene::removeDrawable(RDrawable const * drawable)
         { return d.get() == drawable; });
 }
 
-void RDomainScene::removeDrawableIf(std::function<bool(RDrawable const *)> const & pred)
+void RScene::removeDrawableIf(std::function<bool(RDrawable const *)> const & pred)
 {
     std::erase_if(
         m_drawables,
@@ -43,7 +43,7 @@ void RDomainScene::removeDrawableIf(std::function<bool(RDrawable const *)> const
         { return pred(d.get()); });
 }
 
-void RDomainScene::releaseAll()
+void RScene::releaseAll()
 {
     for (std::unique_ptr<RDrawable> const & drawable : m_drawables)
     {
@@ -51,12 +51,12 @@ void RDomainScene::releaseAll()
     }
 }
 
-void RDomainScene::resetBoundingBox()
+void RScene::resetBoundingBox()
 {
     m_has_bbox = false;
 }
 
-void RDomainScene::extendBoundingBox(QVector3D const & lo, QVector3D const & hi)
+void RScene::extendBoundingBox(QVector3D const & lo, QVector3D const & hi)
 {
     if (!m_has_bbox)
     {
@@ -75,13 +75,13 @@ void RDomainScene::extendBoundingBox(QVector3D const & lo, QVector3D const & hi)
         std::max(m_bbox_hi.z(), hi.z()));
 }
 
-float RDomainScene::boundingRadius() const
+float RScene::boundingRadius() const
 {
     float const radius = (m_bbox_hi - m_bbox_lo).length() * 0.5f;
     return (radius > 0.0f) ? radius : 1.0f;
 }
 
-void RDomainScene::fitCameraToScene(float aspect)
+void RScene::fitCameraToScene(float aspect)
 {
     if (!m_has_bbox)
     {
@@ -93,7 +93,7 @@ void RDomainScene::fitCameraToScene(float aspect)
     m_camera.fitToBoundingBox(m_bbox_lo, m_bbox_hi, m_ndim, aspect);
 }
 
-QMatrix4x4 RDomainScene::viewProjection(QSize pixel_size, QRhi * rhi) const
+QMatrix4x4 RScene::viewProjection(QSize pixel_size, QRhi * rhi) const
 {
     QMatrix4x4 clip = (nullptr != rhi) ? rhi->clipSpaceCorrMatrix() : QMatrix4x4();
     if (!m_has_bbox || pixel_size.height() <= 0 || pixel_size.width() <= 0)

--- a/cpp/solvcon/pilot/RScene.hpp
+++ b/cpp/solvcon/pilot/RScene.hpp
@@ -33,15 +33,15 @@ namespace solvcon
  * holds one scene and drives it; the scene itself is free of Qt widget and
  * device-loop concerns.
  */
-class RDomainScene
+class RScene
 {
 
 public:
 
-    RDomainScene() = default;
+    RScene() = default;
 
-    RDomainScene(RDomainScene const &) = delete;
-    RDomainScene & operator=(RDomainScene const &) = delete;
+    RScene(RScene const &) = delete;
+    RScene & operator=(RScene const &) = delete;
 
     /// Add a drawable; ownership transfers to the scene.
     void addDrawable(std::unique_ptr<RDrawable> drawable);
@@ -93,7 +93,7 @@ private:
 
     RDomainCameraController m_camera;
 
-}; /* end class RDomainScene */
+}; /* end class RScene */
 
 } /* end namespace solvcon */
 

--- a/doc/source/devguide/testing.md
+++ b/doc/source/devguide/testing.md
@@ -78,7 +78,10 @@ Each is read with a default, so an unset variable keeps the default behavior.
 - `MMGH_TIMEOUT_BUILD` (45), `MMGH_TIMEOUT_LINT` (45),
   `MMGH_TIMEOUT_STANDALONE_BUFFER` (10), `MMGH_TIMEOUT_NOUSE_INSTALL` (30),
   `MMGH_TIMEOUT_PROFILE` (30): per-job `timeout-minutes`. The number is the
-  default used when the variable is unset.
+  default used when the variable is unset. `MMGH_TIMEOUT_BUILD` is shared by
+  the ubuntu, macOS, and sanitizer builds (default 45) and the Windows build,
+  which defaults to 60 because its vcpkg plus MSVC compile runs slower than the
+  others.
 
 ### Behavior on a forked repository
 

--- a/doc/source/devplan/rdomainwidget.md
+++ b/doc/source/devplan/rdomainwidget.md
@@ -60,7 +60,9 @@ The new classes take names distinct from the prototype's existing `R*` classes:
 `RMaterial`, `RMeshFrame`, `RField`, `RMeshBoundary`, `RAxisGizmo`).
 The only rule is that the names do not collide, so the Qt 3D prototype keeps
 building and running side by side throughout development; the prototype's names
-are freed only when it is retired (slice 8).
+are freed only when it is retired (slice 8). Slice 9 then reclaims the two
+cleaner ones, renaming `RMeshBoundary` to `RBoundary` and `RDomainScene` to
+`RScene`.
 :::
 
 `RDomainWidget` is meant to grow into a tool for analyzing spatial domains and
@@ -115,12 +117,13 @@ driven through it:
   Python instantiates and controls. Owns the
   [`QRhi`](https://doc.qt.io/qt-6/qrhi.html), the per-frame render target and
   depth buffer, the main and overlay passes, the input dispatch, and the
-  `RDomainScene`. Renders into its own backing texture and composes with
+  `RScene`. Renders into its own backing texture and composes with
   sibling widgets (unlike the
   [`createWindowContainer`](https://doc.qt.io/qt-6/qwidget.html#createWindowContainer)
   the `R3DWidget` prototype uses). Hosts the entire pybind11-exposed API.
-- **`RDomainScene`** (prototype: `RScene`): owns the `RDrawable`s, the
-  domain bounding box, and the active camera and controller; selects an
+- **`RScene`** (prototype: `RScene`, the name reclaimed in slice 9 after
+  developing with the temporary name `RDomainScene`): owns the `RDrawable`s,
+  the domain bounding box, and the active camera and controller; selects an
   orthographic projection for 2D domains and a perspective projection for 3D,
   and computes the fit-to-scene framing.
 - **`RDrawable`** (new): abstract base for a renderable: owns its
@@ -132,7 +135,9 @@ driven through it:
     (`Lines` topology), 2D or 3D.
   - **`RField`** (prototype: `RColorField`): the field-colored cells
     (2D faces / 3D surface).
-  - **`RMeshBoundary`** (prototype: `RBoundary`): the boundary highlight.
+  - **`RBoundary`** (prototype: `RBoundary`, the name reclaimed in slice 9
+    after developing with the temporary name `RMeshBoundary`): the boundary
+    highlight.
   - **`RAxisGizmo`** (prototype: `RAxisMark`): the orientation guide
     (2- or 3-axis arrows and labels), drawn in the overlay pass.
 - **`RMaterial`** (new): wraps a


### PR DESCRIPTION
Rename (1) `RMeshBoundary` to `RBoundary` and (2) `RDomainScene` to `RScene`.  This is a pure rename and there is no change of behavior.

A small CI documentation fix (unrelated to the rename) is piggybacked in this PR.

For issue #934.