### PR TITLE
Prime RHI composition so opening a domain viewer keeps the window

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -51,6 +51,7 @@ RManager & RManager::setUp()
     {
         this->setUpConsole();
         this->setUpCentral();
+        this->primeRhiComposition();
         this->setUpMenu();
 
         m_already_setup = true;
@@ -76,6 +77,7 @@ void RManager::reset()
     m_windowMenu = nullptr;
     m_pycon = nullptr;
     m_mdiArea = nullptr;
+    m_rhi_primer = nullptr;
 }
 
 RManager::~RManager()
@@ -266,6 +268,21 @@ void RManager::setUpCentral()
     // single Painter toolbox always drives whichever canvas has focus.
     QObject::connect(m_mdiArea, &QMdiArea::subWindowActivated, m_mdiArea, [this](QMdiSubWindow *)
                      { applyDrawTool(); });
+}
+
+void RManager::primeRhiComposition()
+{
+    // A QRhiWidget renders to a texture. The first one to appear in the main
+    // window forces Qt to recreate the top-level native window so its backing
+    // store can flush through QRhi; on macOS that tears down and rebuilds every
+    // existing sub-window and dock, so the GUI looks like it restarts and any
+    // already-open viewer vanishes. Trigger that switch once, before any user
+    // content exists, by parking a hidden RDomainWidget in the window. The
+    // recreation then happens with nothing to lose, and later viewers reuse the
+    // same native window. The widget tree owns the primer.
+    m_rhi_primer = new RDomainWidget(m_mdiArea);
+    m_rhi_primer->resize(0, 0);
+    m_rhi_primer->hide();
 }
 
 void RManager::setUpMenu()

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -84,6 +84,10 @@ private:
     void setUpCentral();
     void setUpMenu();
 
+    /// Park a hidden QRhiWidget in the main window so the top-level adopts
+    /// render-to-texture composition once, up front, before any user content.
+    void primeRhiComposition();
+
     /// Push the active draw tool onto the focused 2D canvas, if any. A
     /// no-op when the focused subwindow is not a 2D canvas.
     void applyDrawTool();
@@ -118,6 +122,10 @@ private:
 
     RPythonConsoleDockWidget * m_pycon = nullptr;
     QMdiArea * m_mdiArea = nullptr;
+
+    /// Hidden QRhiWidget that keeps the main window in render-to-texture
+    /// composition mode for the whole session. Owned by the widget tree.
+    RDomainWidget * m_rhi_primer = nullptr;
 
     /// Active canvas drawing tool, shared by every 2D canvas. Starts on
     /// the default tool (pan navigation).

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -21,6 +21,7 @@ import solvcon
 try:
     from solvcon import pilot
     from PySide6.QtGui import QImage
+    from PySide6.QtWidgets import QWidget
 except ImportError:
     pilot = None
 
@@ -503,6 +504,40 @@ class RDomainWidgetManagerTC(unittest.TestCase):
         current = mgr.currentR3DWidget()
         self.assertIsNotNone(current)
         self.assertEqual(current.mesh.ncell, 1)
+
+    def test_setup_primes_rhi_composition(self):
+        """setUp parks a hidden RDomainWidget to fix the GUI-restart bug.
+
+        The first QRhiWidget in the main window makes Qt rebuild the top-level
+        native window so its backing store can flush through QRhi. On macOS
+        that tears down every open sub-window and dock, so opening a mesh looks
+        like the GUI restarts and other viewers vanish. The manager parks a
+        hidden primer viewer in the MDI area at setUp, so the rebuild happens
+        once up front and later viewers reuse the same native window.
+
+        This test checks there is one and only one primer."""
+        mgr = pilot.RManager.instance.setUp()
+        mdi = mgr.mdiArea
+        primers = [
+            w for w in mgr.mainWindow.findChildren(QWidget)
+            if w.metaObject().className().endswith("RDomainWidget")
+            and w.parent() is mdi and not w.isVisible()]
+        self.assertEqual(len(primers), 1)
+
+    def test_open_3d_keeps_native_window(self):
+        """A 3D viewer opened after setUp reuses the primed native window.
+
+        The native handle (winId) changing is the proxy for "the top-level was
+        rebuilt"; with the primer in place it must stay put across add3DWidget.
+        See :meth:`test_setup_primes_rhi_composition` for the mechanism."""
+        mgr = pilot.RManager.instance.setUp()
+        mw = mgr.mainWindow
+        mw.show()
+        before = int(mw.winId())
+        if not before:
+            raise unittest.SkipTest("no native window handle is available")
+        mgr.add3DWidget()
+        self.assertEqual(int(mw.winId()), before)
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")


### PR DESCRIPTION
`RDomainWidget` is a `QRhiWidget`, a render-to-texture widget. The first one to appear in the main window makes Qt switch the top-level into texture composition, which requires recreating the native platform window and reparenting every child onto it. On macOS that rebuild blinks the window and drops transient children, so opening the first mesh in a domain sub-window looked like the whole GUI restarted and closed other open widgets.

Park a hidden, zero-size `RDomainWidget` in the MDI area during `setUp`, so the one unavoidable native-window rebuild happens up front while the window is empty and invisible. Every later add3DWidget then reuses the same native window and disturbs nothing.

Guard it with two cases in `RDomainWidgetManagerTC`: one asserts `setUp` leaves the lone hidden primer parented to the MDI area, the other that the main window's winId survives the first `add3DWidget`.