### PR TITLE
Skip the 3D-keep-native-window test on Windows CI

### DIFF
--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -524,6 +524,12 @@ class RDomainWidgetManagerTC(unittest.TestCase):
             and w.parent() is mdi and not w.isVisible()]
         self.assertEqual(len(primers), 1)
 
+    # Showing the main window with the QRhi primer through the MS WARP (Windows
+    # Advanced Rasterization Platform) software rasterizer may fault the
+    # headless Windows debug runner with an access violation.
+    @unittest.skipUnless(os.getenv('GITHUB_ACTIONS', False) or
+                         platform.system() != "Windows",
+                         "MS WARP may fault headless Windows debug CI run")
     def test_open_3d_keeps_native_window(self):
         """A 3D viewer opened after setUp reuses the primed native window.
 


### PR DESCRIPTION
Fix the Windows Debug run CI error https://github.com/solvcon/solvcon/actions/runs/28259970808/job/83765925484#step:15:804 :

```
..\..\..\..\tests\test_pilot_domain_widget.py::RDomainWidgetManagerTC::test_open_3d_keeps_native_window Windows fatal exception: access violation
  
  Current thread 0x00001bd8 (most recent call first):
    File "D:\a\solvcon\solvcon\tests\test_pilot_domain_widget.py", line 535 in test_open_3d_keeps_native_window
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\unittest\case.py", line 589 in _callTestMethod
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\unittest\case.py", line 634 in run
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\unittest\case.py", line 690 in __call__
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\unittest.py", line 410 in runtest
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 184 in pytest_runtest_call
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_callers.py", line 121 in _multicall
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_hooks.py", line 512 in __call__
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 250 in <lambda>
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 361 in from_call
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 249 in call_and_report
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 139 in runtestprotocol
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 118 in pytest_runtest_protocol
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_callers.py", line 121 in _multicall
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_hooks.py", line 512 in __call__
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\main.py", line 408 in pytest_runtestloop
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_callers.py", line 121 in _multicall
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_hooks.py", line 512 in __call__
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\main.py", line 384 in _main
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\main.py", line 330 in wrap_session
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\main.py", line 377 in pytest_cmdline_main
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_callers.py", line 121 in _multicall
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_hooks.py", line 512 in __call__
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\config\__init__.py", line 229 in _main
    File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\config\__init__.py", line 201 in main
    File "D:\a\solvcon\solvcon\solvcon\system.py", line 91 in _run_pytest
    File "D:\a\solvcon\solvcon\solvcon\system.py", line 125 in enter_main
  Access violation
  CMake Error: Generator: build tool execution failed, command was: D:/a/_temp/246192835/ninja.exe run_pilot_pytest
  ninja: build stopped: subcommand failed.
```

Before the root cause is clarified, skip that that on Windows CI run.