### PR TITLE
Add orbital camera control to `RDomainWidget`

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 4.0.1)
 set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RDomainWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RScene.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/RDomainCameraController.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RCameraController.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RDrawable.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMeshFrame.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RField.hpp
@@ -27,7 +27,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
 set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RDomainWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RScene.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/RDomainCameraController.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RCameraController.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RDrawable.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMeshFrame.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RField.cpp

--- a/cpp/solvcon/pilot/RCameraController.cpp
+++ b/cpp/solvcon/pilot/RCameraController.cpp
@@ -3,7 +3,7 @@
  * BSD 3-Clause License, see COPYING
  */
 
-#include <solvcon/pilot/RDomainCameraController.hpp> // Must be the first include.
+#include <solvcon/pilot/RCameraController.hpp> // Must be the first include.
 
 #include <QQuaternion>
 #include <QtMath>
@@ -23,34 +23,52 @@ constexpr float PAN_PIXELS_PER_EXTENT = 300.0f;
 constexpr float ZOOM_PER_STEP = 0.12f;
 constexpr float ORTHO_SCALE_MIN = 0.02f;
 constexpr float ORTHO_SCALE_MAX = 50.0f;
+constexpr float ORBIT_DISTANCE_MIN = 0.05f; // Times the scene radius.
+constexpr float ORBIT_DISTANCE_MAX = 20.0f; // Times the scene radius.
 
 } /* end namespace */
 
-RDomainCameraController::Mode RDomainCameraController::modeFromName(std::string const & name)
+RCameraController::Mode RCameraController::modeFromName(std::string const & name)
 {
-    return ("fps" == name) ? Mode::FirstPerson : Mode::PanZoom;
+    if ("fps" == name)
+    {
+        return Mode::FirstPerson;
+    }
+    if ("orbit" == name)
+    {
+        return Mode::Orbit;
+    }
+    return Mode::PanZoom;
 }
 
-std::string RDomainCameraController::modeName(Mode mode)
+std::string RCameraController::modeName(Mode mode)
 {
-    return (Mode::FirstPerson == mode) ? "fps" : "pan";
+    switch (mode)
+    {
+    case Mode::FirstPerson:
+        return "fps";
+    case Mode::Orbit:
+        return "orbit";
+    default:
+        return "pan";
+    }
 }
 
-QVector3D RDomainCameraController::forward() const
+QVector3D RCameraController::forward() const
 {
     QVector3D const dir = m_target - m_position;
     float const length = dir.length();
     return (length > 0.0f) ? dir / length : QVector3D(0.0f, 0.0f, -1.0f);
 }
 
-QVector3D RDomainCameraController::rightAxis() const
+QVector3D RCameraController::rightAxis() const
 {
     QVector3D const axis = QVector3D::crossProduct(forward(), m_up);
     float const length = axis.length();
     return (length > 0.0f) ? axis / length : QVector3D(1.0f, 0.0f, 0.0f);
 }
 
-void RDomainCameraController::fitToBoundingBox(
+void RCameraController::fitToBoundingBox(
     QVector3D const & lo, QVector3D const & hi, uint32_t ndim, float aspect)
 {
     QVector3D const center = (lo + hi) * 0.5f;
@@ -83,16 +101,40 @@ void RDomainCameraController::fitToBoundingBox(
     }
 }
 
-QMatrix4x4 RDomainCameraController::viewMatrix() const
+QMatrix4x4 RCameraController::viewMatrix() const
 {
     QMatrix4x4 view;
     view.lookAt(m_position, m_target, m_up);
     return view;
 }
 
-void RDomainCameraController::rotate(float dx, float dy)
+void RCameraController::rotate(float dx, float dy)
 {
-    if (Mode::FirstPerson == m_mode)
+    if (Mode::Orbit == m_mode)
+    {
+        // Swing the eye around the fixed target (the pivot): yaw about the up
+        // axis and pitch about the right axis, applied to the eye offset with
+        // the target held put. The up axis stays fixed, so the horizon never
+        // rolls (a turntable orbit). This mirrors the FirstPerson rotation,
+        // which instead holds the eye and swings the target.
+        QVector3D const offset = m_position - m_target;
+        QQuaternion const yaw = QQuaternion::fromAxisAndAngle(m_up, -dx * LOOK_DEGREES_PER_PIXEL);
+        QQuaternion const pitch = QQuaternion::fromAxisAndAngle(rightAxis(), -dy * LOOK_DEGREES_PER_PIXEL);
+        QVector3D rotated = (yaw * pitch).rotatedVector(offset);
+        // Avoid gimbal lock: do not let the eye-to-target direction reach the
+        // up axis (which would degenerate the right axis and flip the view).
+        // Drop the pitch if it would push past the pole, but always ease away.
+        QVector3D const up = m_up.normalized();
+        float const limit = std::cos(qDegreesToRadians(1.0f));
+        float const aligned = std::abs(QVector3D::dotProduct(rotated.normalized(), up));
+        float const aligned0 = std::abs(QVector3D::dotProduct(offset.normalized(), up));
+        if (aligned > limit && aligned > aligned0)
+        {
+            rotated = yaw.rotatedVector(offset);
+        }
+        m_position = m_target + rotated;
+    }
+    else if (Mode::FirstPerson == m_mode)
     {
         // Look around in place: yaw about the up axis, pitch about the right
         // axis, keeping the eye fixed and swinging the target.
@@ -119,7 +161,7 @@ void RDomainCameraController::rotate(float dx, float dy)
     }
 }
 
-void RDomainCameraController::pan(float dx, float dy)
+void RCameraController::pan(float dx, float dy)
 {
     // A drag across the viewport pans roughly the visible extent, moving in
     // the camera's own plane (the screen right and screen up axes). Screen up
@@ -133,9 +175,26 @@ void RDomainCameraController::pan(float dx, float dy)
     m_target += offset;
 }
 
-void RDomainCameraController::zoom(float steps)
+void RCameraController::zoom(float steps)
 {
-    if (Mode::FirstPerson == m_mode)
+    if (Mode::Orbit == m_mode)
+    {
+        // Dolly the eye along its offset to the target: a positive step moves
+        // it closer, a negative one farther. The scale is multiplicative so it
+        // feels uniform at any range, and the distance is clamped so the eye
+        // never reaches or crosses the pivot, nor flies arbitrarily far.
+        QVector3D const offset = m_position - m_target;
+        float const distance = offset.length();
+        if (distance > 0.0f)
+        {
+            float const scaled = std::clamp(
+                distance * std::exp(-steps * ZOOM_PER_STEP),
+                ORBIT_DISTANCE_MIN * m_radius,
+                ORBIT_DISTANCE_MAX * m_radius);
+            m_position = m_target + offset * (scaled / distance);
+        }
+    }
+    else if (Mode::FirstPerson == m_mode)
     {
         moveForward(steps * 0.1f);
     }
@@ -148,14 +207,26 @@ void RDomainCameraController::zoom(float steps)
     }
 }
 
-void RDomainCameraController::moveForward(float amount)
+void RCameraController::pinch(float factor)
+{
+    // A pinch reports a multiplicative scale; route it through the wheel zoom
+    // so both share one path. zoom() applies exp(-steps * ZOOM_PER_STEP), so
+    // steps = log(factor) / ZOOM_PER_STEP makes the zoom track the pinch
+    // exactly: a 2x spread zooms in 2x. A non-positive factor is ignored.
+    if (factor > 0.0f)
+    {
+        zoom(std::log(factor) / ZOOM_PER_STEP);
+    }
+}
+
+void RCameraController::moveForward(float amount)
 {
     QVector3D const step = forward() * (amount * m_radius);
     m_position += step;
     m_target += step;
 }
 
-void RDomainCameraController::moveRight(float amount)
+void RCameraController::moveRight(float amount)
 {
     QVector3D const step = rightAxis() * (amount * m_radius);
     m_position += step;

--- a/cpp/solvcon/pilot/RCameraController.hpp
+++ b/cpp/solvcon/pilot/RCameraController.hpp
@@ -16,19 +16,21 @@ namespace solvcon
 {
 
 /**
- * @brief A single camera controller with two interaction modes.
+ * @brief A single camera controller with three interaction modes.
  *
  * PanZoom frames a 2D domain head-on: dragging pans and the wheel zooms an
  * orthographic view. FirstPerson flies through a 3D domain: dragging looks
- * around and the wheel dollies along the view direction. The controller holds
- * one pose (position, target, up) plus an orthographic zoom factor, and feeds
- * a QMatrix4x4 view matrix.
+ * around and the wheel dollies along the view direction. Orbit inspects a 3D
+ * domain from outside: dragging swings the eye around the fixed target and the
+ * wheel dollies toward it, the up axis held fixed so the view never rolls (a
+ * turntable orbit). The controller holds one pose (position, target, up) plus
+ * an orthographic zoom factor, and feeds a QMatrix4x4 view matrix.
  *
  * The widget drives the controller from mouse and key events, and Python
  * drives the same primitives (rotate / zoom / pan) and reads or sets the pose
  * directly, so the domain navigates the same way from code as from the mouse.
  */
-class RDomainCameraController
+class RCameraController
 {
 
 public:
@@ -37,6 +39,7 @@ public:
     {
         PanZoom, ///< 2D: drag pans, wheel zooms the orthographic box.
         FirstPerson, ///< 3D: drag looks around, wheel dollies forward.
+        Orbit, ///< 3D: drag swings the eye around the target, wheel dollies in.
     };
 
     void setMode(Mode mode) { m_mode = mode; }
@@ -55,16 +58,22 @@ public:
     /// The orthographic zoom factor (smaller means zoomed in).
     float orthoScale() const { return m_ortho_scale; }
 
-    /// Drag interaction: pan in PanZoom, look around in FirstPerson.
-    /// @p dx and @p dy are pixel deltas.
+    /// Drag interaction: pan in PanZoom, look around in FirstPerson, swing the
+    /// eye around the target in Orbit. @p dx and @p dy are pixel deltas.
     void rotate(float dx, float dy);
 
     /// Pan the view in its own plane by the pixel deltas (both modes).
     void pan(float dx, float dy);
 
     /// Wheel interaction: change the orthographic zoom in PanZoom, dolly along
-    /// the view direction in FirstPerson. @p steps is the wheel notch count.
+    /// the view direction in FirstPerson, dolly toward the target in Orbit.
+    /// @p steps is the wheel notch count.
     void zoom(float steps);
+
+    /// Pinch interaction: zoom by a multiplicative @p factor (greater than 1
+    /// zooms in, less than 1 zooms out), as a trackpad or touch pinch reports.
+    /// Maps onto the same zoom path as the wheel.
+    void pinch(float factor);
 
     /// Move along the view direction (forward, +) or sideways (strafe, +right)
     /// by a fraction of the scene size; used by the first-person keys.
@@ -83,7 +92,7 @@ private:
     QVector3D forward() const;
     QVector3D rightAxis() const;
 
-    Mode m_mode = Mode::PanZoom;
+    Mode m_mode = Mode::Orbit; ///< Default; a 2D domain switches to PanZoom.
 
     QVector3D m_position{0.0f, 0.0f, 1.0f};
     QVector3D m_target{0.0f, 0.0f, 0.0f};
@@ -92,7 +101,7 @@ private:
     float m_ortho_scale = 1.0f; ///< PanZoom zoom factor.
     float m_radius = 1.0f; ///< Scene scale, sets pan and dolly speeds.
 
-}; /* end class RDomainCameraController */
+}; /* end class RCameraController */
 
 } /* end namespace solvcon */
 

--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -9,8 +9,11 @@
 #include <solvcon/pilot/RField.hpp>
 #include <solvcon/pilot/RMeshFrame.hpp>
 
+#include <QGestureEvent>
 #include <QKeyEvent>
 #include <QMouseEvent>
+#include <QNativeGestureEvent>
+#include <QPinchGesture>
 #include <QWheelEvent>
 
 #include <algorithm>
@@ -25,6 +28,9 @@ RDomainWidget::RDomainWidget(QWidget * parent)
     // Accept keyboard focus so the first-person movement keys reach the
     // widget, and track the mouse for drag-based navigation.
     setFocusPolicy(Qt::StrongFocus);
+    // Receive touchscreen pinch gestures (trackpad pinches arrive as native
+    // gesture events, which need no grab).
+    grabGesture(Qt::PinchGesture);
 }
 
 float RDomainWidget::viewportAspect() const
@@ -55,6 +61,14 @@ void RDomainWidget::updateMesh(std::shared_ptr<StaticMesh> const & mesh)
 
     StaticMesh const & mh = *mesh;
     m_scene.setDimension(mh.ndim());
+    // A 2D domain is viewed head-on, so it wants the in-plane pan/zoom whose
+    // wheel scales the orthographic box. The orbit and first-person wheel
+    // dolly the eye, which an orthographic projection ignores, so select
+    // pan/zoom for 2D. A 3D domain keeps its mode, orbit by default.
+    if (2 == mh.ndim())
+    {
+        m_scene.camera().setMode(RCameraController::Mode::PanZoom);
+    }
     QVector3D lo(
         std::numeric_limits<float>::max(),
         std::numeric_limits<float>::max(),
@@ -158,13 +172,13 @@ void RDomainWidget::fitCameraToScene()
 
 void RDomainWidget::setCameraMode(std::string const & name)
 {
-    m_scene.camera().setMode(RDomainCameraController::modeFromName(name));
+    m_scene.camera().setMode(RCameraController::modeFromName(name));
     update();
 }
 
 std::string RDomainWidget::cameraMode() const
 {
-    return RDomainCameraController::modeName(m_scene.camera().mode());
+    return RCameraController::modeName(m_scene.camera().mode());
 }
 
 QVector3D RDomainWidget::cameraPosition() const
@@ -218,6 +232,12 @@ void RDomainWidget::zoomCamera(float steps)
     update();
 }
 
+void RDomainWidget::pinchCamera(float factor)
+{
+    m_scene.camera().pinch(factor);
+    update();
+}
+
 void RDomainWidget::mousePressEvent(QMouseEvent * event)
 {
     m_last_mouse_pos = event->position().toPoint();
@@ -256,6 +276,33 @@ void RDomainWidget::wheelEvent(QWheelEvent * event)
     float const steps = static_cast<float>(event->angleDelta().y()) / 120.0f;
     m_scene.camera().zoom(steps);
     update();
+}
+
+bool RDomainWidget::event(QEvent * event)
+{
+    // A trackpad pinch arrives as a native zoom gesture whose value() is the
+    // incremental magnification (positive spreads, negative pinches); a
+    // touchscreen pinch arrives as a QPinchGesture whose scaleFactor() is the
+    // incremental multiplier. Feed both to pinchCamera as a scale around 1.
+    if (QEvent::NativeGesture == event->type())
+    {
+        auto * gesture = static_cast<QNativeGestureEvent *>(event);
+        if (Qt::ZoomNativeGesture == gesture->gestureType())
+        {
+            pinchCamera(1.0f + static_cast<float>(gesture->value()));
+            return true;
+        }
+    }
+    else if (QEvent::Gesture == event->type())
+    {
+        auto * gesture = static_cast<QGestureEvent *>(event);
+        if (auto * pinch = static_cast<QPinchGesture *>(gesture->gesture(Qt::PinchGesture)))
+        {
+            pinchCamera(static_cast<float>(pinch->scaleFactor()));
+            return true;
+        }
+    }
+    return QRhiWidget::event(event);
 }
 
 void RDomainWidget::keyPressEvent(QKeyEvent * event)

--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -61,10 +61,8 @@ void RDomainWidget::updateMesh(std::shared_ptr<StaticMesh> const & mesh)
 
     StaticMesh const & mh = *mesh;
     m_scene.setDimension(mh.ndim());
-    // A 2D domain is viewed head-on, so it wants the in-plane pan/zoom whose
-    // wheel scales the orthographic box. The orbit and first-person wheel
-    // dolly the eye, which an orthographic projection ignores, so select
-    // pan/zoom for 2D. A 3D domain keeps its mode, orbit by default.
+    // For now, limit 2D domain to the in-plane pan/zoom whose wheel scales the
+    // orthographic box.
     if (2 == mh.ndim())
     {
         m_scene.camera().setMode(RCameraController::Mode::PanZoom);

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -68,7 +68,8 @@ public:
     /// Show or hide the orientation-guide triad in the corner.
     void showAxis(bool show);
 
-    /// Select the camera mode: "pan" (2D pan/zoom) or "fps" (3D fly-through).
+    /// Select the camera mode: "pan" (2D pan/zoom), "fps" (3D fly-through), or
+    /// "orbit" (3D orbit around the target).
     void setCameraMode(std::string const & name);
     std::string cameraMode() const;
 
@@ -84,6 +85,9 @@ public:
     void rotateCamera(float dx, float dy);
     void panCamera(float dx, float dy);
     void zoomCamera(float steps);
+    /// Zoom by a multiplicative pinch @p factor (what a trackpad/touch pinch
+    /// drives); greater than 1 zooms in, less than 1 zooms out.
+    void pinchCamera(float factor);
 
     std::shared_ptr<StaticMesh> mesh() const { return m_mesh; }
 
@@ -102,6 +106,8 @@ protected:
     void mouseReleaseEvent(QMouseEvent * event) override;
     void wheelEvent(QWheelEvent * event) override;
     void keyPressEvent(QKeyEvent * event) override;
+    /// Route trackpad/touch pinch gestures to pinchCamera.
+    bool event(QEvent * event) override;
 
 private:
 

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -106,7 +106,6 @@ protected:
     void mouseReleaseEvent(QMouseEvent * event) override;
     void wheelEvent(QWheelEvent * event) override;
     void keyPressEvent(QKeyEvent * event) override;
-    /// Route trackpad/touch pinch gestures to pinchCamera.
     bool event(QEvent * event) override;
 
 private:

--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -352,16 +352,28 @@ void RManager::setUpCameraControllersMenuItems() const
         [set_mode]()
         { set_mode("fps"); });
 
+    auto * use_orbit_camera = new RAction(
+        QString("Orbit camera (3D)"),
+        QString("Orbit the domain around its center"),
+        [set_mode]()
+        { set_mode("orbit"); });
+
     auto * cameraGroup = new QActionGroup(m_mainWindow);
-    cameraGroup->addAction(use_pan_camera);
+    cameraGroup->addAction(use_orbit_camera);
     cameraGroup->addAction(use_fps_camera);
+    cameraGroup->addAction(use_pan_camera);
 
-    use_pan_camera->setCheckable(true);
+    use_orbit_camera->setCheckable(true);
     use_fps_camera->setCheckable(true);
-    use_pan_camera->setChecked(true);
+    use_pan_camera->setCheckable(true);
+    use_orbit_camera->setChecked(true);
 
-    m_viewMenu->addAction(use_pan_camera);
-    m_viewMenu->addAction(use_fps_camera);
+    // Group the camera selectors under a "Camera" submenu, orbit first as the
+    // default.
+    auto * cameraMenu = m_viewMenu->addMenu(QString("Camera"));
+    cameraMenu->addAction(use_orbit_camera);
+    cameraMenu->addAction(use_fps_camera);
+    cameraMenu->addAction(use_pan_camera);
 }
 
 void RManager::setUpCameraMovementMenuItems() const

--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -368,8 +368,6 @@ void RManager::setUpCameraControllersMenuItems() const
     use_pan_camera->setCheckable(true);
     use_orbit_camera->setChecked(true);
 
-    // Group the camera selectors under a "Camera" submenu, orbit first as the
-    // default.
     auto * cameraMenu = m_viewMenu->addMenu(QString("Camera"));
     cameraMenu->addAction(use_orbit_camera);
     cameraMenu->addAction(use_fps_camera);

--- a/cpp/solvcon/pilot/RScene.hpp
+++ b/cpp/solvcon/pilot/RScene.hpp
@@ -7,7 +7,7 @@
 
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
-#include <solvcon/pilot/RDomainCameraController.hpp>
+#include <solvcon/pilot/RCameraController.hpp>
 #include <solvcon/pilot/RDrawable.hpp>
 
 #include <rhi/qrhi.h>
@@ -68,8 +68,8 @@ public:
     void setDimension(uint32_t ndim) { m_ndim = ndim; }
     uint32_t dimension() const { return m_ndim; }
 
-    RDomainCameraController & camera() { return m_camera; }
-    RDomainCameraController const & camera() const { return m_camera; }
+    RCameraController & camera() { return m_camera; }
+    RCameraController const & camera() const { return m_camera; }
 
     /// Frame the camera so the whole bounding box is in view at the given
     /// viewport @p aspect (width / height).
@@ -91,7 +91,7 @@ private:
     bool m_has_bbox = false;
     uint32_t m_ndim = 0;
 
-    RDomainCameraController m_camera;
+    RCameraController m_camera;
 
 }; /* end class RScene */
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -170,7 +170,9 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                 [](wrapped_type & self, std::string const & name)
                 {
                     self.setCameraMode(name);
-                })
+                },
+                "Navigation mode: \"pan\" (2D pan/zoom), \"fps\" (3D "
+                "first-person), or \"orbit\" (3D orbit around the target).")
             .def(
                 "rotateCamera",
                 [](wrapped_type & self, float dx, float dy)
@@ -194,6 +196,13 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                     self.zoomCamera(steps);
                 },
                 py::arg("steps"))
+            .def(
+                "pinchCamera",
+                [](wrapped_type & self, float factor)
+                {
+                    self.pinchCamera(factor);
+                },
+                py::arg("factor"))
 #define MM_DECL_CAMERA_VECTOR(NAME, GETTER, SETTER)            \
     .def_property(                                             \
         NAME,                                                  \
@@ -526,7 +535,8 @@ void wrap_pilot(pybind11::module & mod)
         "fields. Drive it with updateMesh / showMesh, updateColorField, "
         "showBoundary, and showAxis; navigate with cameraMode, the "
         "cameraPosition / cameraTarget / cameraUp pose, rotateCamera / "
-        "panCamera / zoomCamera, and fitCameraToScene; capture frames with "
+        "panCamera / zoomCamera / pinchCamera, and fitCameraToScene; capture "
+        "frames with "
         "saveImage / clipImage.");
     WrapR2DWidget::commit(mod, "R2DWidget", "R2DWidget");
     WrapRPythonConsoleDockWidget::commit(mod, "RPythonConsoleDockWidget", "RPythonConsoleDockWidget");

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -384,12 +384,26 @@ class RDomainWidgetCameraTC(unittest.TestCase):
         pilot.RManager.instance.setUp()
 
     def test_camera_mode_round_trip(self):
-        """The camera mode switches between pan/zoom and first-person."""
+        """The camera defaults to orbit and switches between the modes."""
         widget = pilot.RDomainWidget()
-        self.assertEqual(widget.cameraMode, "pan")
+        self.assertEqual(widget.cameraMode, "orbit")
         widget.cameraMode = "fps"
         self.assertEqual(widget.cameraMode, "fps")
         widget.cameraMode = "pan"
+        self.assertEqual(widget.cameraMode, "pan")
+
+    def test_3d_mesh_keeps_orbit_default(self):
+        """A new widget defaults to orbit, and loading a 3D domain keeps it."""
+        widget = pilot.RDomainWidget()
+        self.assertEqual(widget.cameraMode, "orbit")
+        widget.updateMesh(_make_3d_mesh())
+        self.assertEqual(widget.cameraMode, "orbit")
+
+    def test_2d_mesh_selects_pan_camera(self):
+        """Loading a 2D domain selects pan/zoom, whose wheel zooms the
+        orthographic view (the orbit dolly has no effect there)."""
+        widget = pilot.RDomainWidget()
+        widget.updateMesh(_make_2d_mesh())
         self.assertEqual(widget.cameraMode, "pan")
 
     def test_camera_pose_round_trip(self):
@@ -457,6 +471,112 @@ class RDomainWidgetCameraTC(unittest.TestCase):
             widget.rotateCamera(0.0, 200.0)
         image = _grab_or_skip(widget)
         self.assertFalse(image.isNull())
+
+    def test_orbit_mode_round_trips(self):
+        """The camera mode switches to orbit and back to pan."""
+        widget = pilot.RDomainWidget()
+        widget.cameraMode = "orbit"
+        self.assertEqual(widget.cameraMode, "orbit")
+        widget.cameraMode = "pan"
+        self.assertEqual(widget.cameraMode, "pan")
+
+    def test_orbit_keeps_target_and_moves_eye(self):
+        """Orbit swings the eye around a fixed target; fps instead holds the
+        eye and swings the target."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_3d_mesh())
+        widget.cameraMode = "orbit"
+        target_before = tuple(widget.cameraTarget)
+        pos_before = tuple(widget.cameraPosition)
+        widget.rotateCamera(40.0, 15.0)
+        for before, after in zip(target_before, tuple(widget.cameraTarget)):
+            self.assertAlmostEqual(before, after, places=4)
+        moved = sum((a - b) ** 2 for a, b
+                    in zip(pos_before, tuple(widget.cameraPosition)))
+        self.assertGreater(moved, 0.0)
+
+    def test_orbit_preserves_distance_to_target(self):
+        """Orbiting is a rotation about the target, so the eye-to-target
+        distance is unchanged."""
+        import math
+        widget = pilot.RDomainWidget()
+        widget.updateMesh(_make_3d_mesh())
+        widget.cameraMode = "orbit"
+
+        def radius():
+            pos = tuple(widget.cameraPosition)
+            tgt = tuple(widget.cameraTarget)
+            return math.sqrt(sum((p - t) ** 2 for p, t in zip(pos, tgt)))
+
+        before = radius()
+        widget.rotateCamera(30.0, 20.0)
+        self.assertAlmostEqual(before, radius(), places=4)
+
+    def test_orbit_zoom_dollies_toward_target(self):
+        """Orbit zoom shrinks the eye-to-target distance on a positive step
+        without moving the target."""
+        import math
+        widget = pilot.RDomainWidget()
+        widget.updateMesh(_make_3d_mesh())
+        widget.cameraMode = "orbit"
+        target_before = tuple(widget.cameraTarget)
+
+        def radius():
+            pos = tuple(widget.cameraPosition)
+            tgt = tuple(widget.cameraTarget)
+            return math.sqrt(sum((p - t) ** 2 for p, t in zip(pos, tgt)))
+
+        before = radius()
+        widget.zoomCamera(3.0)
+        self.assertLess(radius(), before)
+        for a, b in zip(target_before, tuple(widget.cameraTarget)):
+            self.assertAlmostEqual(a, b, places=5)
+
+    def test_orbit_extreme_pitch_stays_stable(self):
+        """Orbiting hard past vertical does not flip or break the view: the
+        eye-to-target direction is held off the up axis (no gimbal lock)."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_3d_mesh())
+        widget.cameraMode = "orbit"
+        for _ in range(10):
+            widget.rotateCamera(0.0, 200.0)
+        image = _grab_or_skip(widget)
+        self.assertFalse(image.isNull())
+
+    def test_pinch_zooms_the_orbit_camera(self):
+        """A pinch scales the orbit eye-to-target distance inversely: a 2x
+        spread halves it (zoom in), and a 0.5x pinch restores it (zoom out)."""
+        import math
+        widget = pilot.RDomainWidget()
+        widget.updateMesh(_make_3d_mesh())  # orbit is the 3D default
+
+        def radius():
+            pos = tuple(widget.cameraPosition)
+            tgt = tuple(widget.cameraTarget)
+            return math.sqrt(sum((p - t) ** 2 for p, t in zip(pos, tgt)))
+
+        start = radius()
+        widget.pinchCamera(2.0)
+        self.assertAlmostEqual(radius(), start / 2.0, places=4)
+        widget.pinchCamera(0.5)
+        self.assertAlmostEqual(radius(), start, places=4)
+
+    def test_pinch_ignores_nonpositive_factor(self):
+        """A non-positive pinch factor is ignored rather than applied."""
+        import math
+        widget = pilot.RDomainWidget()
+        widget.updateMesh(_make_3d_mesh())
+
+        def radius():
+            pos = tuple(widget.cameraPosition)
+            tgt = tuple(widget.cameraTarget)
+            return math.sqrt(sum((p - t) ** 2 for p, t in zip(pos, tgt)))
+
+        start = radius()
+        widget.pinchCamera(0.0)
+        self.assertEqual(radius(), start)
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")


### PR DESCRIPTION
The domain viewer previously offered only a head-on pan/zoom for 2D and a first-person fly-through for 3D. This adds orbit as a third interaction mode and makes it the default.

`RDomainCameraController` is renamed to `RCameraController` and holds the 3 modes (PanZoom, FirstPerson, Orbit) behind one pose (position, target, up) plus an orthographic zoom factor. 

Zooming using trackpad and touchscreen pinch gestures is also supported.

Code is exposed to and tested in Python.

For issue #949.