### PR TITLE
Document the pilot domain visualizer and its C++ API

### DIFF
--- a/.claude/skills/commit-code/SKILL.md
+++ b/.claude/skills/commit-code/SKILL.md
@@ -49,9 +49,9 @@ These contradict common defaults, so apply them deliberately:
   with ..." trailers; this project keeps commits human-authored (see
   `create-pr`).
 - **No semantic prefixes.** Never use `feat:`, `fix:`, `docs:`, etc.
-- **No closing keywords.** Never use `close`/`fixes`/`resolves #n`.
-  Reference an issue only when necessary, ending the body with "Related
-  to #xxx" or "For issue #xxx".
+- **No closing keywords.** Never use `close`/`fixes`/`resolves #n`. Do
+  not reference an issue unless explicitly instructed; when you are, end
+  the body with "Related to #xxx" or "For issue #xxx".
 - **One concern per commit.** Each commit stands on its own. Do not pad:
   trivial, tightly-coupled edits belong together.
 - **Stage exact paths.** Never `git add -A` / `git add .`; never

--- a/doc/source/api/cpp.md
+++ b/doc/source/api/cpp.md
@@ -1,20 +1,69 @@
 # C++ API
 
-This page is bridged from Doxygen by ``breathe``.  Doxygen parses the existing
-``///`` and ``/**`` comments in `cpp/solvcon/` into XML; breathe turns that XML
-into the reference below.
+C++ API documentation written in Doxygen format in the C++ source code, bridged
+by [breathe](https://www.breathe-doc.org/).
 
-```{important}
-Run ``make doxygen`` once before ``make html`` so the Doxygen XML exists.
-Until then this directive renders empty (a warning, not an error).
-```
-
-Below is an example using `solvcon::ConcreteBuffer`.
+## Array and memory buffer
 
 ```{eval-rst}
 .. doxygenclass:: solvcon::ConcreteBuffer
    :project: solvcon
    :members:
+```
+
+## Pilot domain viewer
+
+The pilot's 3D viewer (see {doc}`../pilot/domain`) renders through
+[QRhi](https://doc.qt.io/qt-6/qrhi.html), Qt's portable graphics abstraction.
+
+{cpp:class}`solvcon::RDomainWidget` is the Python-facing control object.
+
+```{eval-rst}
+.. doxygenclass:: solvcon::RDomainWidget
+   :project: solvcon
+   :members:
+
+.. doxygenclass:: solvcon::RScene
+   :project: solvcon
+   :members:
+
+.. doxygenclass:: solvcon::RCameraController
+   :project: solvcon
+   :members:
+
+.. doxygenclass:: solvcon::RDrawable
+   :project: solvcon
+   :members:
+
+.. doxygenclass:: solvcon::RMeshFrame
+   :project: solvcon
+   :members:
+
+.. doxygenclass:: solvcon::RField
+   :project: solvcon
+   :members:
+
+.. doxygenclass:: solvcon::RBoundary
+   :project: solvcon
+   :members:
+
+.. doxygenclass:: solvcon::RAxisGizmo
+   :project: solvcon
+   :members:
+
+.. doxygenclass:: solvcon::RMaterial
+   :project: solvcon
+   :members:
+```
+
+## Notes on generating this C++ API document
+
+Doxygen parses the existing ``///`` and ``/**`` comments in `cpp/solvcon/` into
+XML; breathe turns that XML into the reference below.
+
+```{important}
+Run ``make doxygen`` once before ``make html`` so the Doxygen XML exists.
+Until then this directive renders empty (a warning, not an error).
 ```
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -14,7 +14,12 @@
 # first if you want the C++ API pages populated.
 
 import os
+import re
 import sys
+
+from docutils import nodes
+from sphinx import addnodes
+from sphinx.transforms.post_transforms import SphinxPostTransform
 
 # Make the in-tree ``solvcon`` package importable for autodoc.  The repo
 # root is two levels up from this file (doc/source/conf.py).
@@ -95,5 +100,122 @@ mathjax3_config = {
 }
 
 numfig = True
+
+# -- Link Qt types in the C++ API to the Qt documentation -------------------
+
+# Doxygen and breathe render Qt types (QRhiWidget, QImage, QMatrix4x4, ...) as
+# bare C++ identifiers, and there is no Sphinx inventory to resolve them
+# against, so the C++ domain leaves them as plain text in the generated
+# reference.  Catch those unresolved C++ references and point any Qt class (a
+# "Q" followed by CamelCase) at its Qt 6 manual page, so the Doxygen-bridged
+# pages cross-link to the official Qt docs.
+
+_qt_type_re = re.compile(r"^Q[A-Z][A-Za-z0-9]+$")
+
+
+def _resolve_qt_reference(app, env, node, contnode):
+    if node.get("refdomain") != "cpp":
+        return None
+    target = node.get("reftarget", "")
+    if not _qt_type_re.match(target):
+        return None
+    uri = "https://doc.qt.io/qt-6/%s.html" % target.lower()
+    refnode = nodes.reference("", "", internal=False, refuri=uri)
+    refnode += contnode
+    return refnode
+
+
+# -- Resolve cross-references written inside the Doxygen comments -----------
+
+# Breathe renders a class or function named in a Doxygen "///" or "/**" comment
+# as a std ":ref:" keyed by the raw Doxygen refid (e.g.
+# "classsolvcon_1_1_r_scene"), which the std domain cannot resolve, so the
+# reference falls back to plain text.  The post-transform below decodes the
+# refid back to a C++ name and resolves it through the cpp domain, so the
+# comment prose cross-links like the rest of the generated reference.
+
+
+_doxy_compound_re = re.compile(r"^(?:class|struct|union|namespace|group)(.+)$")
+_doxy_member_re = re.compile(r"_1[a-z][0-9a-f]{16,}$")
+
+
+class _BreatheRefidResolver(SphinxPostTransform):
+    # Breathe renders a reference inside Doxygen comment prose as a std
+    # ":ref:" keyed by the raw Doxygen refid, which the std domain cannot
+    # resolve, so it falls back to plain text.  Run before Sphinx's
+    # ReferencesResolver (priority 10), decode each such refid back to its C++
+    # name, and resolve it through the cpp domain so the comment prose links to
+    # the generated class and member reference like the rest of the page.
+    default_priority = 5
+
+    @classmethod
+    def _demangle_doxy_name(cls, mangled):
+        # Reverse Doxygen's refid encoding for a namespaced C++ name.
+        # Doxygen writes "::" as "_1_1" (each "_1" is a ":"), a literal "_"
+        # as "__", and an uppercase letter as "_" plus its lowercase form,
+        # so "solvcon_1_1_r_scene" decodes to "solvcon::RScene".
+        out = []
+        i, n = 0, len(mangled)
+        while i < n:
+            c = mangled[i]
+            if c == "_" and i + 1 < n:
+                nxt = mangled[i + 1]
+                if nxt == "1":
+                    out.append(":")
+                elif nxt == "_":
+                    out.append("_")
+                elif nxt.isalpha() and nxt.islower():
+                    out.append(nxt.upper())
+                else:
+                    out.append(c)
+                    i += 1
+                    continue
+                i += 2
+                continue
+            out.append(c)
+            i += 1
+        return "".join(out)
+
+    @classmethod
+    def _cpp_name_from_refid(cls, refid, text):
+        # Decode a Doxygen compound or member refid into a C++ qualified
+        # name the cpp domain can resolve: "classsolvcon_1_1_r_scene" ->
+        # "solvcon::RScene"; a member refid keeps the class and takes the
+        # member name from the displayed text
+        # ("solvcon::RScene::extendBoundingBox").
+        match = _doxy_compound_re.match(refid)
+        if not match:
+            return None
+        body = match.group(1)
+        member = _doxy_member_re.search(body)
+        if member:
+            owner = cls._demangle_doxy_name(body[:member.start()])
+            return "%s::%s" % (owner, text.rstrip("()")) if text else None
+        return cls._demangle_doxy_name(body)
+
+    def run(self, **kwargs):
+        cpp = self.env.get_domain("cpp")
+        for node in list(self.document.findall(addnodes.pending_xref)):
+            if node.get("refdomain") != "std" or node.get("reftype") != "ref":
+                continue
+            text = node.astext()
+            name = self._cpp_name_from_refid(node.get("reftarget", ""), text)
+            if not name:
+                continue
+            contnode = nodes.inline("", text)
+            try:
+                results = cpp.resolve_any_xref(self.env, self.env.docname,
+                                               self.app.builder, name, node,
+                                               contnode)
+            except Exception:
+                results = None
+            if results:
+                node.replace_self(results[0][1])
+
+
+def setup(app):
+    app.connect("missing-reference", _resolve_qt_reference)
+    app.add_post_transform(_BreatheRefidResolver)
+
 
 # vim: set ft=python ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/doc/source/pilot/airfoil.md
+++ b/doc/source/pilot/airfoil.md
@@ -1,3 +1,0 @@
-# Airfoil
-
-<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/pilot/domain.md
+++ b/doc/source/pilot/domain.md
@@ -1,0 +1,92 @@
+# Domain Visualizer
+
+The pilot's domain viewer ({cpp:class}`~solvcon::RDomainWidget`) shows 2D and
+3D unstructured-mesh domains and fields, rendered through Qt's
+[QRhi](https://doc.qt.io/qt-6/qrhi.html). It is hosted as a sub-window in the
+pilot and is fully controllable from Python: populate the scene, navigate the
+camera, toggle layers, and capture frames from code the same way the mouse
+drives them.
+
+## Showing a domain
+
+- **Mesh wireframe**: `updateMesh(mesh)` draws the unstructured mesh (2D faces
+  or 3D cells) as a wireframe; `showMesh(on)` toggles it.
+- **Colored field**: `updateColorField(vertices, colors, indices)` draws
+  per-vertex-colored triangles over the domain. The field is swappable at
+  runtime: call it again to replace the previous one.
+- **Boundary highlight**: `showBoundary(ibc, on)` highlights boundary set
+  `ibc`.
+- **Orientation guide**: `showAxis(on)` shows a small axis triad in the corner,
+  two axes for a 2D domain and three for a 3D one, oriented by the camera. It
+  is hidden by default.
+
+## Camera navigation
+
+The viewer has one camera with three modes; each suits a different domain.
+Choose the mode from the **View > Camera** menu, or set `cameraMode` from
+Python.
+
+| Menu item (View > Camera) | `cameraMode` | Domain | Drag | Wheel / pinch |
+| --- | --- | --- | --- | --- |
+| Orbit camera (3D) | `"orbit"` | 3D | swing the eye around the center | dolly toward or away from the center |
+| First-person camera (3D) | `"fps"` | 3D | look around in place | dolly along the view direction |
+| Pan / zoom camera (2D) | `"pan"` | 2D | pan in the plane | zoom the orthographic view |
+
+**Orbit is the default.** It is a turntable orbit: the up axis stays fixed, so
+the horizon never rolls and a hard pitch past vertical eases off instead of
+flipping the view. Loading a 2D domain switches to pan/zoom automatically,
+because the orthographic projection a 2D domain uses ignores the orbit dolly
+and wants the in-plane wheel zoom instead.
+
+### Mouse, wheel, and pinch
+
+- **Left-drag** rotates: orbit the center in orbit mode, look around in
+  first-person mode, or pan in 2D pan/zoom mode.
+- **Middle- or right-drag** pans in any mode.
+- **Wheel** zooms; what it does depends on the mode (see the table above).
+- **Pinch** on a trackpad or touchscreen zooms in any mode.
+
+### Keyboard
+
+- **W / A / S / D** or the **arrow keys** move the camera: forward and back,
+  and strafe left and right.
+- **Esc** reframes the whole domain (fit to scene).
+
+The **View > Camera move** submenu offers the same nudges as clickable actions,
+plus fixed-step yaw and pitch rotation and a reset.
+
+### From Python
+
+The camera exposes the same primitives the mouse and wheel drive, so a domain
+navigates identically from code:
+
+```python
+from solvcon import pilot
+
+mgr = pilot.RManager.instance.setUp()
+viewer = mgr.add3DWidget()
+
+viewer.updateMesh(mesh)             # show the wireframe
+viewer.cameraMode = "orbit"         # orbit a 3D domain (the default)
+viewer.fitCameraToScene()           # frame the whole domain
+
+viewer.rotateCamera(40.0, 15.0)     # orbit by a pixel delta
+viewer.panCamera(20.0, 0.0)         # pan by a pixel delta
+viewer.zoomCamera(3.0)              # zoom by wheel notches
+viewer.pinchCamera(1.5)             # zoom by a pinch factor (>1 zooms in)
+```
+
+The pose is readable and settable directly as `(x, y, z)` tuples through
+`cameraPosition`, `cameraTarget`, and `cameraUp`, so a view can be saved and
+restored, or set to an exact framing.
+
+## Capturing frames
+
+- `saveImage(path)` renders the current frame offscreen and writes it to an
+  image file.
+- `clipImage()` copies the current frame to the clipboard.
+
+Both grab the frame deterministically inside the Qt event loop, which is what
+the pytest screenshot tests rely on.
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/pilot/index.md
+++ b/doc/source/pilot/index.md
@@ -3,8 +3,7 @@
 ```{toctree}
 :maxdepth: 2
 
-viewer
-airfoil
+domain
 ```
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/pilot/viewer.md
+++ b/doc/source/pilot/viewer.md
@@ -1,3 +1,0 @@
-# 3D Viewer
-
-<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->


### PR DESCRIPTION
Add `domain.md`, a new pilot page documents the domain visualizer (`RDomainWidget`), and include the C++ API in `cpp.md`.

Add 2 Sphinx hooks in `conf.py` to make the reference link for Qt-related code properly, including the links to Qt reference manual and internal cross-reference for the `R*` classes.

Building the C++ pages takes a full rebuild after generating the XML.  Run `make doxygen` and then `make FORCE_BUILD=1 html` from `doc/`.

For issue #950.
