### PR TITLE
Add a skill to web-serve Sphinx doc

### DIFF
--- a/.claude/skills/serve-docs/SKILL.md
+++ b/.claude/skills/serve-docs/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: serve-docs
+description: Build the solvcon Sphinx docs and serve them on specified network with guaranteed teardown when the Claude session ends. Use when the user asks to build and serve the documentation, preview the docs, or share the rendered docs online.
+---
+
+# Serve Docs (solvcon)
+
+Build `doc/build/html` and serve it on the network interface specified by the
+user so they can open it from another machine, usually on a trusted
+network, with a watchdog that shuts the server down within a few seconds of the
+Claude session ending. There is no documentation build job in CI, so the local
+build is also the only validation the docs get; always build before serving.
+
+## When to use
+
+The user wants to see the rendered docs, preview a doc change, or reach the
+docs from another machine on the trusted network. This skill owns the
+build-serve-teardown flow; pair it with `commit-code` and `create-pr` when the
+change is also being landed.
+
+## 1. Build locally
+
+Doxygen feeds the C++ API page through breathe, so run it before Sphinx;
+without it the C++ API page renders empty (a warning, not an error). From
+`doc/`, run the Doxygen target (`make doxygen`, which writes the C++ API XML
+to `build/doxygen/xml` and needs a system doxygen), then the HTML target
+(`make html`, which writes the site to `build/html/index.html`).
+
+Treat a non-empty `make html` warning list as a defect to fix. The
+pre-existing LaTeX `siunitx`/EPS image warnings from the CESE math pages
+are environment noise and can be ignored; a warning naming a file you
+edited cannot. For a faithful rebuild after only comment or XML changes,
+prefer `make clean html` (or `make doxygen` again): Sphinx does not track
+the Doxygen XML as a dependency and an incremental build can serve stale
+content.
+
+Whenever you rebuild during a session, report the document address to the
+user again (section 2): the server keeps serving the same URL, now with the
+refreshed content.
+
+## 2. Serve on the specified network, with teardown tied to the session
+
+`doc/contrib/serve-docs.sh` does the serving. Derive the trusted-network
+address the user named at run time (never hardcode it, never `0.0.0.0`) and
+pass it as the first argument; an optional second argument pins the port,
+otherwise the script takes the first free port in 8765-8769.
+
+The script ties the server's lifetime to a launcher PID and tears the server
+down when that process exits. Its default launcher is its own parent, which
+is useless here because each command runs in a throwaway shell, so pass the
+real session with `--launcher-pid`: the launcher is the nearest ancestor
+process named `claude`, found by climbing `PPid` in `/proc/<pid>/status` from
+the shell's parent. Invoke it as
+`doc/contrib/serve-docs.sh <bind-ip> --launcher-pid <pid>` (add the port as a
+second positional argument to pin it).
+
+The script binds `python3 -m http.server` to that address, starts a watchdog
+that kills the server within about half a minute of the launcher exiting,
+probes the URL with curl, and prints it. Report that
+`http://<trusted-network-ip>:<port>/` URL to the user.
+
+Report the URL again after every rebuild: the server serves straight from
+`build/html`, so a fresh `make html` updates the live site at the same
+address without a restart, no need to rerun the script. If the address has a
+DNS record, use it.
+
+## 3. Teardown
+
+The watchdog guarantees teardown: the server is killed within about half a
+minute of the session process exiting, so nothing is left listening after
+the session ends. To stop it earlier in the same session, kill the server
+PID the script printed (or `pkill -f "http.server <port>"`). A `SessionEnd`
+hook is a weaker backstop only, because a mid-session settings edit may not
+reload; the watchdog is the primary mechanism.
+
+## Gotchas
+
+- **Keep the serving logic in the script.** `doc/contrib/serve-docs.sh` is
+  reviewable, checked-in code; do not inline a copy of it back into this
+  skill. Read it before trusting it.
+- **Do not switch the script to `setsid`.** With job control setsid forks, so
+  `$!` is the dead parent, not the python PID, which breaks both the watchdog
+  and any explicit kill. The script uses `nohup ... &` then `disown` on
+  purpose.
+- **Pass `--launcher-pid`.** The script's default launcher is its parent
+  shell, a throwaway per-command shell here; without the real session PID the
+  watchdog would kill the server almost immediately. Pass the nearest
+  `claude` ancestor's PID.
+- **Bind to the specified network IP, not an all-interfaces address.**
+  Binding to all interfaces exposes the server on the local LAN.
+  `http.server` is unauthenticated, so anyone who can reach the bound address
+  can read everything under `build/html`; keep it on the trusted network. The
+  script refuses all-interfaces binds (`0.0.0.0`, `::`) and validates the
+  port and launcher PID, but it cannot tell a trusted address from a public
+  one, so deriving the right address is still the caller's job.
+- **Port collisions.** Sibling worktrees serving their own docs may hold 8000
+  or 8765; the script skips busy ports.
+- **No doc CI.** The local `make html` is the only doc validation, so a clean
+  build matters. A docs-only branch pushed to `pg1` auto-skips the heavy CI
+  matrix.
+
+<!-- vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: -->

--- a/doc/contrib/serve-docs.sh
+++ b/doc/contrib/serve-docs.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+#
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+#
+# Serve doc/build/html on a trusted-network address, with teardown tied to
+# the process that launched it. Driven by the serve-docs skill; see it for
+# the build-serve-teardown flow.
+#
+# Usage: doc/contrib/serve-docs.sh <bind-ip> [port] [--launcher-pid PID]
+#
+#   <bind-ip>           Trusted-network address to bind to. Never an
+#                       all-interfaces address (0.0.0.0, ::): the server is
+#                       an unauthenticated http.server and that would expose
+#                       build/html on the local LAN. Derive the address at
+#                       run time; do not hardcode it.
+#   [port]              Optional. Default is the first free port in 8765-8769.
+#   --launcher-pid PID  Optional. Tie teardown to PID instead of the parent
+#                       process. Supply this when the parent is short-lived,
+#                       for instance an agent that runs each command in a
+#                       throwaway shell, so the watchdog tracks the real
+#                       session. Defaults to $PPID.
+
+set -u
+
+# True only for a run of decimal digits with at least one non-zero, so empty,
+# zero, negative, and non-numeric inputs are all rejected without arithmetic.
+is_pos_int() {
+    case "$1" in
+        ''|*[!0-9]*) return 1 ;;
+        *[!0]*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+IP=""
+PORT=""
+LAUNCHER_PID=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --launcher-pid) LAUNCHER_PID="${2:?--launcher-pid needs a PID}"
+                        shift 2 ;;
+        --launcher-pid=*) LAUNCHER_PID="${1#*=}"; shift ;;
+        -*) echo "unknown option: $1" >&2; exit 1 ;;
+        *) if [ -z "$IP" ]; then IP="$1"
+           elif [ -z "$PORT" ]; then PORT="$1"
+           else echo "unexpected argument: $1" >&2; exit 1
+           fi
+           shift ;;
+    esac
+done
+[ -n "$IP" ] || {
+    echo "usage: serve-docs.sh <bind-ip> [port] [--launcher-pid PID]" >&2
+    exit 1
+}
+
+# Refuse all-interfaces binds; only those expose the server beyond the named
+# address. A real IPv6 trusted address still has colons and is allowed.
+case "$IP" in
+    0.0.0.0|0|::|::0|0:0:0:0:0:0:0:0)
+        echo "refusing to bind '$IP' (all interfaces); name a trusted IP" >&2
+        exit 1 ;;
+esac
+
+LAUNCHER_PID="${LAUNCHER_PID:-$PPID}"
+is_pos_int "$LAUNCHER_PID" || {
+    echo "launcher PID must be a positive integer" >&2; exit 1
+}
+if ! kill -0 "$LAUNCHER_PID" 2>/dev/null; then
+    echo "launcher PID $LAUNCHER_PID is not alive" >&2
+    exit 1
+fi
+
+if [ -n "$PORT" ] && { ! is_pos_int "$PORT" || [ "$PORT" -gt 65535 ]; }; then
+    echo "port must be an integer in 1-65535" >&2
+    exit 1
+fi
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || ROOT=""
+[ -n "$ROOT" ] || { echo "not inside a git repository" >&2; exit 1; }
+HTML="$ROOT/doc/build/html"
+LOG="$ROOT/doc/build/serve-docs.log"
+[ -f "$HTML/index.html" ] || {
+    echo "no build at $HTML; run 'make html' in doc/ first" >&2
+    exit 1
+}
+
+# A port is free when nothing answers a connect to it.
+port_free() { ! (exec 3<>"/dev/tcp/$IP/$1") 2>/dev/null; }
+if [ -n "$PORT" ]; then
+    port_free "$PORT" || { echo "port $PORT in use on $IP" >&2; exit 1; }
+else
+    # A sibling worktree may already hold a port; take the first free one.
+    for p in 8765 8766 8767 8768 8769; do
+        if port_free "$p"; then PORT=$p; break; fi
+    done
+    [ -n "$PORT" ] || { echo "no free port in 8765-8769" >&2; exit 1; }
+fi
+
+# Serve. Plain nohup (NOT setsid): nohup execs, so $! is the real python PID;
+# setsid forks and $! would be the dead parent, breaking the teardown kill.
+# --directory pins the served root, so it cannot drift to the current dir.
+nohup python3 -m http.server "$PORT" --bind "$IP" --directory "$HTML" \
+    > "$LOG" 2>&1 </dev/null &
+SERVER_PID=$!
+disown
+
+# Watchdog: poll the launcher PID, kill the server when it exits. The PIDs
+# are passed as positional args, never interpolated into the code string, so
+# a hostile value cannot inject shell commands.
+nohup bash -c '
+    while kill -0 "$1" 2>/dev/null; do sleep 30; done
+    kill "$2" 2>/dev/null
+' serve-docs-watchdog "$LAUNCHER_PID" "$SERVER_PID" >/dev/null 2>&1 &
+disown
+
+sleep 1
+curl -s -o /dev/null -w 'HTTP %{http_code}\n' "http://$IP:$PORT/index.html"
+echo "Docs: http://$IP:$PORT/  (use the host DNS name if it has one)"
+echo "Server PID $SERVER_PID watches launcher $LAUNCHER_PID."
+echo "Log: $LOG"
+echo "Stop early with: kill $SERVER_PID"
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Add the `serve-doc` skill to build the Sphinx doc and serve it using an HTTP server for previewing.

When using many agents to study different topics, it is convenient to ask them generate temporary documents for previewing.  Once the study is done, the document can removed or converted into other form of use.

It's not for serving in public.  Use with caution.