### PR TITLE
Fix the Windows skip on the 3D-keep-native-window test

### DIFF
--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -647,9 +647,9 @@ class RDomainWidgetManagerTC(unittest.TestCase):
     # Showing the main window with the QRhi primer through the MS WARP (Windows
     # Advanced Rasterization Platform) software rasterizer may fault the
     # headless Windows debug runner with an access violation.
-    @unittest.skipUnless(os.getenv('GITHUB_ACTIONS', False) or
-                         platform.system() != "Windows",
-                         "MS WARP may fault headless Windows debug CI run")
+    @unittest.skipIf(os.getenv('GITHUB_ACTIONS', False) and
+                     platform.system() == "Windows",
+                     "MS WARP may fault headless Windows debug CI run")
     def test_open_3d_keeps_native_window(self):
         """A 3D viewer opened after setUp reuses the primed native window.
 


### PR DESCRIPTION
The guard on test_open_3d_keeps_native_window (introduced in PR #952) was wrongly written as skipUnless(GITHUB_ACTIONS or non-Windows). Correct it and avoid the error-prone double negation by using skipIf.