### PR TITLE
Add a diagnostics level to World::describe_state

### DIFF
--- a/cpp/solvcon/serialization/SerializableItem.hpp
+++ b/cpp/solvcon/serialization/SerializableItem.hpp
@@ -13,6 +13,7 @@
  */
 
 #include <iomanip>
+#include <optional>
 #include <sstream>
 #include <string_view>
 #include <type_traits>
@@ -152,6 +153,10 @@ std::string JsonHelper::to_json_string(const T & value) // FIXME: NOLINT(misc-no
     {
         return value ? "true" : "false";
     }
+    else if constexpr (is_specialization_of_v<std::optional, T>)
+    {
+        return value.has_value() ? to_json_string(*value) : std::string("null");
+    }
     else if constexpr (is_specialization_of_v<std::vector, T>)
     {
         std::ostringstream oss;
@@ -262,6 +267,12 @@ void JsonHelper::from_json_string(const std::unique_ptr<JsonNode> & node, T & va
         // NOLINTNEXTLINE(misc-no-recursion)
         value.from_json(std::get<JsonMap>(node->value)); /* recursive here */
     }
+    else if constexpr (is_specialization_of_v<std::optional, T>)
+    {
+        value.emplace();
+        // NOLINTNEXTLINE(misc-no-recursion)
+        from_json_string(node, *value); /* recursive here */
+    }
     else if constexpr (is_specialization_of_v<std::unordered_map, T>)
     {
         if (node->type != detail::JsonType::Object)
@@ -324,6 +335,14 @@ public:                                                                         
         const char * separator = "";                                                                \
         auto register_member = [&](const char * name, auto && value)                                \
         {                                                                                           \
+            using member_type = std::remove_cvref_t<decltype(value)>;                               \
+            if constexpr (detail::is_specialization_of_v<std::optional, member_type>)               \
+            {                                                                                       \
+                if (!value.has_value())                                                             \
+                {                                                                                   \
+                    return;                                                                         \
+                }                                                                                   \
+            }                                                                                       \
             oss << separator << "\"" << name << "\":" << detail::JsonHelper::to_json_string(value); \
             separator = ",";                                                                        \
         };                                                                                          \

--- a/cpp/solvcon/universe/CMakeLists.txt
+++ b/cpp/solvcon/universe/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOLVCON_UNIVERSE_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/polygon_boolean.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ViewTransform2d.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/World.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/WorldDiagnostics.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rtree.hpp
     CACHE FILEPATH "" FORCE)
 

--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -19,10 +19,12 @@
 #include <solvcon/universe/bernstein.hpp>
 #include <solvcon/universe/bezier.hpp>
 #include <solvcon/universe/rtree.hpp>
+#include <solvcon/universe/WorldDiagnostics.hpp>
 
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <optional>
 #include <vector>
 
 namespace solvcon
@@ -81,6 +83,7 @@ inline std::string shape_type_name(ShapeType st)
 enum class DescribeLevel : uint8_t
 {
     BASIC = 0, ///< only what the 2D image draws
+    DIAGNOSTICS = 1, ///< BASIC plus derived facts: intersections, degeneracies
 }; /* end enum class DescribeLevel */
 
 inline DescribeLevel describe_level_from_string(std::string const & level)
@@ -88,6 +91,10 @@ inline DescribeLevel describe_level_from_string(std::string const & level)
     if (level == "basic")
     {
         return DescribeLevel::BASIC;
+    }
+    if (level == "diagnostics")
+    {
+        return DescribeLevel::DIAGNOSTICS;
     }
     throw std::invalid_argument(
         std::format("World: describe_state level '{}' not supported", level));
@@ -189,11 +196,15 @@ public:
     point_list_type const & points() const { return m_points; }
     point_list_type & points() { return m_points; }
 
+    std::optional<WorldDiagnostics> const & diagnostics() const { return m_diagnostics; }
+    std::optional<WorldDiagnostics> & diagnostics() { return m_diagnostics; }
+
     MM_DECL_SERIALIZABLE(
         register_member("shapes", m_shapes);
         register_member("segments", m_segments);
         register_member("curves", m_curves);
-        register_member("points", m_points);)
+        register_member("points", m_points);
+        register_member("diagnostics", m_diagnostics);)
 
 private:
 
@@ -201,6 +212,7 @@ private:
     segment_list_type m_segments; ///< bare segments
     curve_list_type m_curves; ///< bare curves
     point_list_type m_points; ///< free points, each [x, y]
+    std::optional<WorldDiagnostics> m_diagnostics; ///< "diagnostics"-level facts; empty (omitted) at the basic level
 
 }; /* end class WorldState */
 
@@ -541,6 +553,34 @@ private:
 
     /// Distance from point (px, py) to the segment (ax, ay)-(bx, by).
     static T point_segment_distance(T px, T py, T ax, T ay, T bx, T by);
+
+    /**
+     * Derived facts for the "diagnostics" level: proper crossings between
+     * live segments and degenerate shapes/primitives.
+     */
+    WorldDiagnostics compute_diagnostics() const;
+
+    /**
+     * Owner id of each segment and curve: a live shape id, -1 for bare
+     * geometry, or the dead sentinel for geometry whose shape was removed.
+     */
+    void compute_geometry_owners(small_vector<int32_t> & seg_owner, small_vector<int32_t> & curve_owner) const;
+
+    /**
+     * Append every proper crossing between two live segments, in ascending
+     * index order so the output is deterministic.
+     */
+    void append_intersections(WorldDiagnostics & diag, small_vector<int32_t> const & seg_owner) const;
+
+    /// Append the degeneracy (if any) of one live shape, dispatched by type.
+    void append_shape_degeneracy(WorldDiagnostics & diag, int32_t sid, ShapeRecord const & rec) const;
+
+    /**
+     * Append degeneracies of bare segments and curves (those with no owning
+     * shape), leaving live-shape degeneracies to append_shape_degeneracy.
+     */
+    void append_bare_degeneracies(
+        WorldDiagnostics & diag, small_vector<int32_t> const & seg_owner, small_vector<int32_t> const & curve_owner) const;
 
     /// Register a new shape owning [segment_offset, segment_offset + segment_count)
     /// in the segment pad and [curve_offset, curve_offset + curve_count) in the
@@ -1069,8 +1109,6 @@ void World<T>::check_shape_id(int32_t shape_id) const
 template <typename T>
 std::string World<T>::describe_state(DescribeLevel level) const
 {
-    (void)level; // Only BASIC exists today; richer levels are added later.
-
     // Find the segments and curves owned by live shapes
     small_vector<bool> segment_owned(m_segments->size(), false);
     small_vector<bool> curve_owned(m_curves->size(), false);
@@ -1128,7 +1166,159 @@ std::string World<T>::describe_state(DescribeLevel level) const
         state.points().push_back({p.x(), p.y()});
     }
 
+    if (level == DescribeLevel::DIAGNOSTICS)
+    {
+        state.diagnostics() = compute_diagnostics();
+    }
     return state.to_json();
+}
+
+template <typename T>
+WorldDiagnostics World<T>::compute_diagnostics() const
+{
+    small_vector<int32_t> seg_owner(m_segments->size(), -1);
+    small_vector<int32_t> curve_owner(m_curves->size(), -1);
+    compute_geometry_owners(seg_owner, curve_owner);
+
+    WorldDiagnostics diag;
+    append_intersections(diag, seg_owner);
+
+    for (size_t sid = 0; sid < m_shape_registry.size(); ++sid)
+    {
+        ShapeRecord const & rec = m_shape_registry[sid];
+        if (rec.type != ShapeType::DEAD)
+        {
+            append_shape_degeneracy(diag, static_cast<int32_t>(sid), rec);
+        }
+    }
+    append_bare_degeneracies(diag, seg_owner, curve_owner);
+    return diag;
+}
+
+template <typename T>
+void World<T>::compute_geometry_owners(small_vector<int32_t> & seg_owner, small_vector<int32_t> & curve_owner) const
+{
+    // The dead sentinel marks geometry whose shape was removed, so callers can
+    // exclude it; bare geometry keeps the -1 the caller initialized it with.
+    constexpr int32_t dead_owner = std::numeric_limits<int32_t>::min();
+    for (size_t sid = 0; sid < m_shape_registry.size(); ++sid)
+    {
+        ShapeRecord const & rec = m_shape_registry[sid];
+        int32_t const owner = (rec.type == ShapeType::DEAD) ? dead_owner : static_cast<int32_t>(sid);
+        for (uint32_t i = 0; i < rec.segment_count; ++i)
+        {
+            seg_owner[rec.segment_offset + i] = owner;
+        }
+        for (uint32_t i = 0; i < rec.curve_count; ++i)
+        {
+            curve_owner[rec.curve_offset + i] = owner;
+        }
+    }
+}
+
+template <typename T>
+void World<T>::append_intersections(WorldDiagnostics & diag, small_vector<int32_t> const & seg_owner) const
+{
+    constexpr int32_t dead_owner = std::numeric_limits<int32_t>::min();
+    for (size_t i = 0; i < m_segments->size(); ++i)
+    {
+        if (seg_owner[i] == dead_owner)
+        {
+            continue;
+        }
+        for (size_t j = i + 1; j < m_segments->size(); ++j)
+        {
+            if (seg_owner[j] == dead_owner)
+            {
+                continue;
+            }
+            auto const hit = detail::segment_proper_intersection(
+                m_segments->x0(i), m_segments->y0(i), m_segments->x1(i), m_segments->y1(i), m_segments->x0(j), m_segments->y0(j), m_segments->x1(j), m_segments->y1(j));
+            if (hit)
+            {
+                diag.add_intersection(seg_owner[i], seg_owner[j], (*hit)[0], (*hit)[1]);
+            }
+        }
+    }
+}
+
+template <typename T>
+void World<T>::append_bare_degeneracies(
+    WorldDiagnostics & diag, small_vector<int32_t> const & seg_owner, small_vector<int32_t> const & curve_owner) const
+{
+    for (size_t i = 0; i < m_segments->size(); ++i)
+    {
+        if (seg_owner[i] == -1 && detail::is_zero_length(m_segments->x0(i), m_segments->y0(i), m_segments->x1(i), m_segments->y1(i)))
+        {
+            diag.add_degeneracy(-1, "segment", "zero-length");
+        }
+    }
+    for (size_t i = 0; i < m_curves->size(); ++i)
+    {
+        if (curve_owner[i] == -1 && detail::is_coincident_controls(m_curves->x0(i), m_curves->y0(i), m_curves->x1(i), m_curves->y1(i), m_curves->x2(i), m_curves->y2(i), m_curves->x3(i), m_curves->y3(i)))
+        {
+            diag.add_degeneracy(-1, "bezier", "coincident-controls");
+        }
+    }
+}
+
+template <typename T>
+void World<T>::append_shape_degeneracy(WorldDiagnostics & diag, int32_t sid, ShapeRecord const & rec) const
+{
+    switch (rec.type)
+    {
+    case ShapeType::LINE:
+    {
+        size_t const idx = rec.segment_offset;
+        if (detail::is_zero_length(m_segments->x0(idx), m_segments->y0(idx), m_segments->x1(idx), m_segments->y1(idx)))
+        {
+            diag.add_degeneracy(sid, "line", "zero-length");
+        }
+        break;
+    }
+    case ShapeType::TRIANGLE:
+    {
+        // Vertices A, B, C are the first two segments' endpoints.
+        size_t const s0 = rec.segment_offset;
+        size_t const s1 = rec.segment_offset + 1;
+        if (detail::is_collinear(m_segments->x0(s0), m_segments->y0(s0), m_segments->x1(s0), m_segments->y1(s0), m_segments->x1(s1), m_segments->y1(s1)))
+        {
+            diag.add_degeneracy(sid, "triangle", "collinear");
+        }
+        break;
+    }
+    case ShapeType::RECTANGLE:
+    case ShapeType::SQUARE:
+    {
+        bbox_type const bb = compute_shape_bbox(rec);
+        if (detail::is_zero_extent(bb.min_x(), bb.min_y(), bb.max_x(), bb.max_y()))
+        {
+            diag.add_degeneracy(sid, shape_type_name(rec.type), "zero-area");
+        }
+        break;
+    }
+    case ShapeType::ELLIPSE:
+    case ShapeType::CIRCLE:
+    {
+        bbox_type const bb = compute_shape_bbox(rec);
+        if (detail::is_zero_extent(bb.min_x(), bb.min_y(), bb.max_x(), bb.max_y()))
+        {
+            diag.add_degeneracy(sid, shape_type_name(rec.type), "zero-radius");
+        }
+        break;
+    }
+    case ShapeType::BEZIER:
+    {
+        size_t const idx = rec.curve_offset;
+        if (detail::is_coincident_controls(m_curves->x0(idx), m_curves->y0(idx), m_curves->x1(idx), m_curves->y1(idx), m_curves->x2(idx), m_curves->y2(idx), m_curves->x3(idx), m_curves->y3(idx)))
+        {
+            diag.add_degeneracy(sid, "bezier", "coincident-controls");
+        }
+        break;
+    }
+    default:
+        break;
+    }
 }
 
 using WorldFp32 = World<float>;

--- a/cpp/solvcon/universe/WorldDiagnostics.hpp
+++ b/cpp/solvcon/universe/WorldDiagnostics.hpp
@@ -1,0 +1,260 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Derived geometric facts for the "diagnostics" level of World::describe_state.
+ * These are facts a careful viewer could read off the rendered image but that
+ * the basic state never spells out: proper crossings between drawn segments,
+ * and shapes that have collapsed to a lower dimension. They sit in a distinct
+ * level so the basic output stays a byte-for-byte subset for callers that do
+ * not ask for them.
+ *
+ * @ingroup group_geometry
+ */
+
+#include <solvcon/buffer/small_vector.hpp>
+#include <solvcon/serialization/SerializableItem.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <initializer_list>
+#include <limits>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace solvcon
+{
+
+/**
+ * One proper crossing between two drawn segments.
+ *
+ * @ingroup group_geometry
+ */
+class WorldIntersection : public SerializableItem
+{
+
+public:
+
+    WorldIntersection() = default;
+    WorldIntersection(WorldIntersection const &) = default;
+    WorldIntersection(WorldIntersection &&) = default;
+    WorldIntersection & operator=(WorldIntersection const &) = default;
+    WorldIntersection & operator=(WorldIntersection &&) = default;
+    ~WorldIntersection() override = default;
+
+    WorldIntersection(int32_t shape_a, int32_t shape_b, double x, double y)
+        : m_shapes{shape_a, shape_b}
+        , m_point{x, y}
+    {
+    }
+
+    MM_DECL_SERIALIZABLE(
+        register_member("shapes", m_shapes);
+        register_member("point", m_point);)
+
+private:
+
+    std::vector<int32_t> m_shapes; ///< the two owning shape ids; -1 marks a bare segment
+    std::vector<double> m_point; ///< {x, y} of the crossing
+
+}; /* end class WorldIntersection */
+
+/**
+ * One shape (or bare primitive) that has collapsed to a lower dimension.
+ *
+ * @ingroup group_geometry
+ */
+class WorldDegeneracy : public SerializableItem
+{
+
+public:
+
+    WorldDegeneracy() = default;
+    WorldDegeneracy(WorldDegeneracy const &) = default;
+    WorldDegeneracy(WorldDegeneracy &&) = default;
+    WorldDegeneracy & operator=(WorldDegeneracy const &) = default;
+    WorldDegeneracy & operator=(WorldDegeneracy &&) = default;
+    ~WorldDegeneracy() override = default;
+
+    WorldDegeneracy(int32_t shape, std::string type, std::string reason)
+        : m_shape(shape)
+        , m_type(std::move(type))
+        , m_reason(std::move(reason))
+    {
+    }
+
+    MM_DECL_SERIALIZABLE(
+        register_member("shape", m_shape);
+        register_member("type", m_type);
+        register_member("reason", m_reason);)
+
+private:
+
+    int32_t m_shape = -1; ///< owning shape id; -1 for bare geometry
+    std::string m_type; ///< primitive kind, e.g. "triangle", "circle", "segment"
+    std::string m_reason; ///< why it is degenerate, e.g. "collinear"
+
+}; /* end class WorldDegeneracy */
+
+/**
+ * JSON view of the world's derived facts: crossings and degeneracies. The
+ * arrays are empty (but present) when nothing is found.
+ *
+ * @ingroup group_geometry
+ */
+class WorldDiagnostics : public SerializableItem
+{
+
+public:
+
+    WorldDiagnostics() = default;
+    WorldDiagnostics(WorldDiagnostics const &) = default;
+    WorldDiagnostics(WorldDiagnostics &&) = default;
+    WorldDiagnostics & operator=(WorldDiagnostics const &) = default;
+    WorldDiagnostics & operator=(WorldDiagnostics &&) = default;
+    ~WorldDiagnostics() override = default;
+
+    void add_intersection(int32_t shape_a, int32_t shape_b, double x, double y)
+    {
+        m_intersections.emplace_back(shape_a, shape_b, x, y);
+    }
+
+    void add_degeneracy(int32_t shape, std::string type, std::string reason)
+    {
+        m_degeneracies.emplace_back(shape, std::move(type), std::move(reason));
+    }
+
+    MM_DECL_SERIALIZABLE(
+        register_member("intersections", m_intersections);
+        register_member("degeneracies", m_degeneracies);)
+
+private:
+
+    std::vector<WorldIntersection> m_intersections;
+    std::vector<WorldDegeneracy> m_degeneracies;
+
+}; /* end class WorldDiagnostics */
+
+namespace detail
+{
+
+/**
+ * Relative tolerance for the diagnostic predicates, matching the scale the
+ * polygon boolean sweep-line uses. Diagnostics are computed in double
+ * regardless of the world's coordinate type, so the double epsilon applies.
+ */
+inline constexpr double diag_eps = std::numeric_limits<double>::epsilon() * 100;
+
+/// Z component of the 2D cross product of (ax, ay) and (bx, by).
+inline double diag_cross(double ax, double ay, double bx, double by)
+{
+    return ax * by - ay * bx;
+}
+
+/**
+ * Collapse a signed zero to positive zero so a serialized coordinate never
+ * reads as "-0.000000".
+ */
+inline double diag_norm_zero(double v)
+{
+    return v == 0.0 ? 0.0 : v;
+}
+
+/**
+ * Largest coordinate magnitude among the values, floored at 1, used to scale
+ * the absolute tolerance of the degeneracy tests.
+ */
+inline double diag_scale(std::initializer_list<double> values)
+{
+    double scale = 1.0;
+    for (double const v : values)
+    {
+        scale = std::max(scale, std::abs(v));
+    }
+    return scale;
+}
+
+/**
+ * The single point strictly interior to both segments where they cross, or
+ * nullopt when they are parallel, collinear, or only touch at an endpoint.
+ */
+inline std::optional<small_vector<double, 2>> segment_proper_intersection(
+    double ax0, double ay0, double ax1, double ay1, double bx0, double by0, double bx1, double by1)
+{
+    double const dax = ax1 - ax0;
+    double const day = ay1 - ay0;
+    double const dbx = bx1 - bx0;
+    double const dby = by1 - by0;
+    double const denom = diag_cross(dax, day, dbx, dby);
+    double const len_a = std::sqrt(dax * dax + day * day);
+    double const len_b = std::sqrt(dbx * dbx + dby * dby);
+    // Parallel, collinear, or a zero-length segment: no single proper crossing.
+    if (std::abs(denom) <= diag_eps * std::max(len_a * len_b, 1.0))
+    {
+        return std::nullopt;
+    }
+    double const t = diag_cross(bx0 - ax0, by0 - ay0, dbx, dby) / denom;
+    double const s = diag_cross(bx0 - ax0, by0 - ay0, dax, day) / denom;
+    // Require both parameters strictly inside (0, 1) so shared endpoints and
+    // T-junctions do not count as crossings.
+    if (t <= diag_eps || t >= 1.0 - diag_eps || s <= diag_eps || s >= 1.0 - diag_eps)
+    {
+        return std::nullopt;
+    }
+    return small_vector<double, 2>{diag_norm_zero(ax0 + t * dax), diag_norm_zero(ay0 + t * day)};
+}
+
+/// A segment whose endpoints coincide (it renders as a point, not a line).
+inline bool is_zero_length(double x0, double y0, double x1, double y1)
+{
+    double const len = std::sqrt((x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0));
+    return len <= diag_eps * diag_scale({x0, y0, x1, y1});
+}
+
+/**
+ * Three vertices on one line (zero-area triangle), including the case where
+ * two of them coincide.
+ */
+inline bool is_collinear(double ax, double ay, double bx, double by, double cx, double cy)
+{
+    double const area2 = diag_cross(bx - ax, by - ay, cx - ax, cy - ay);
+    double const len_ab = std::sqrt((bx - ax) * (bx - ax) + (by - ay) * (by - ay));
+    double const len_ac = std::sqrt((cx - ax) * (cx - ax) + (cy - ay) * (cy - ay));
+    return std::abs(area2) <= diag_eps * std::max(len_ab * len_ac, 1.0);
+}
+
+/// An axis-aligned box that has collapsed in x or y (zero width or height).
+inline bool is_zero_extent(double min_x, double min_y, double max_x, double max_y)
+{
+    double const scale = diag_scale({min_x, min_y, max_x, max_y});
+    return (max_x - min_x) <= diag_eps * scale || (max_y - min_y) <= diag_eps * scale;
+}
+
+/**
+ * Four cubic control points that all coincide (the curve renders as a point).
+ * Both extents must collapse; a curve flat in only one axis is still a line.
+ */
+inline bool is_coincident_controls(
+    double x0, double y0, double x1, double y1, double x2, double y2, double x3, double y3)
+{
+    double const min_x = std::min({x0, x1, x2, x3});
+    double const max_x = std::max({x0, x1, x2, x3});
+    double const min_y = std::min({y0, y1, y2, y3});
+    double const max_y = std::max({y0, y1, y2, y3});
+    double const scale = diag_scale({x0, y0, x1, y1, x2, y2, x3, y3});
+    return (max_x - min_x) <= diag_eps * scale && (max_y - min_y) <= diag_eps * scale;
+}
+
+} /* end namespace detail */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -833,7 +833,7 @@ class WorldDescribeStateTC(unittest.TestCase):
     def test_unknown_level_raises(self):
         self.w.add_triangle(0, 0, 1, 0, 0, 1)
         with self.assertRaises(ValueError):
-            self.w.describe_state(level="+diagnostics")
+            self.w.describe_state(level="bogus")
 
     def test_fp32(self):
         w = solvcon.WorldFp32()
@@ -841,5 +841,226 @@ class WorldDescribeStateTC(unittest.TestCase):
         shape = json.loads(w.describe_state())["shapes"][0]
         self.assertEqual(shape["type"], "line")
         self.assertEqual(shape["segments"], [[0, 0, 1, 1]])
+
+
+class WorldDescribeDiagnosticsTC(unittest.TestCase):
+    """describe_state(level="diagnostics"): derived facts."""
+
+    def setUp(self):
+        self.w = solvcon.WorldFp64()
+
+    def diag(self):
+        state = json.loads(self.w.describe_state(level="diagnostics"))
+        return state["diagnostics"]
+
+    def assert_one_degeneracy(self, shape, kind, reason):
+        degs = self.diag()["degeneracies"]
+        self.assertEqual(
+            degs, [{"shape": shape, "type": kind, "reason": reason}])
+
+    def test_basic_omits_diagnostics(self):
+        # Crossing geometry must not leak diagnostics into the basic level.
+        self.w.add_line(0, 0, 2, 2)
+        self.w.add_line(0, 2, 2, 0)
+        self.assertNotIn("diagnostics", json.loads(self.w.describe_state()))
+
+    def test_diagnostics_is_superset_of_basic(self):
+        self.w.add_triangle(0, 0, 1, 0, 0, 1)
+        basic = json.loads(self.w.describe_state(level="basic"))
+        full = json.loads(self.w.describe_state(level="diagnostics"))
+        for key in ("shapes", "segments", "curves", "points"):
+            self.assertEqual(full[key], basic[key])
+        self.assertIn("diagnostics", full)
+
+    def test_clean_world_empty_diagnostics(self):
+        self.w.add_triangle(0, 0, 4, 0, 0, 3)
+        self.w.add_circle(10, 10, 1)
+        diag = self.diag()
+        self.assertEqual(diag["intersections"], [])
+        self.assertEqual(diag["degeneracies"], [])
+
+    def test_crossing_lines(self):
+        a = self.w.add_line(0, 0, 2, 2)
+        b = self.w.add_line(0, 2, 2, 0)
+        hits = self.diag()["intersections"]
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["shapes"], [a, b])
+        self.assertEqual(hits[0]["point"], [1, 1])
+
+    def test_parallel_lines_no_crossing(self):
+        self.w.add_line(0, 0, 2, 0)
+        self.w.add_line(0, 1, 2, 1)
+        self.assertEqual(self.diag()["intersections"], [])
+
+    def test_shared_vertices_not_reported(self):
+        # A triangle's edges meet only at its vertices (endpoints), which are
+        # not proper crossings.
+        self.w.add_triangle(0, 0, 4, 0, 0, 3)
+        self.assertEqual(self.diag()["intersections"], [])
+
+    def test_touching_endpoint_not_reported(self):
+        # An endpoint resting on another segment's interior (a T-junction) is
+        # endpoint contact, not a proper crossing.
+        self.w.add_line(0, 0, 2, 0)
+        self.w.add_line(1, 0, 1, 2)
+        self.assertEqual(self.diag()["intersections"], [])
+
+    def test_line_through_triangle(self):
+        # The classic invisible bug: a line slices two triangle edges.
+        tri = self.w.add_triangle(0, 0, 4, 0, 0, 4)
+        line = self.w.add_line(-1, 1, 5, 1)
+        hits = self.diag()["intersections"]
+        self.assertEqual(len(hits), 2)
+        for hit in hits:
+            self.assertEqual(hit["shapes"], [tri, line])
+        points = sorted(hit["point"] for hit in hits)
+        self.assertEqual(points, [[0, 1], [3, 1]])
+
+    def test_bare_segments_crossing(self):
+        p = solvcon.Point3dFp64
+        self.w.add_segment(p(0, 0), p(2, 2))
+        self.w.add_segment(p(0, 2), p(2, 0))
+        hits = self.diag()["intersections"]
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["shapes"], [-1, -1])
+        self.assertEqual(hits[0]["point"], [1, 1])
+
+    def test_removed_shape_excluded(self):
+        self.w.add_line(0, 0, 2, 2)
+        drop = self.w.add_line(0, 2, 2, 0)
+        self.w.remove_shape(drop)
+        self.assertEqual(self.diag()["intersections"], [])
+
+    def test_undone_shape_excluded(self):
+        # An undone shape is dead, so it drops out of the diagnostics, and
+        # redo brings it and its crossing back. This matches how the basic
+        # level treats dead shapes, now against undo/redo.
+        self.w.add_line(0, 0, 2, 2)
+        self.w.add_line(0, 2, 2, 0)
+        self.assertEqual(len(self.diag()["intersections"]), 1)
+        self.w.undo()
+        self.assertEqual(self.diag()["intersections"], [])
+        self.w.redo()
+        self.assertEqual(len(self.diag()["intersections"]), 1)
+
+    def test_collinear_triangle(self):
+        sid = self.w.add_triangle(0, 0, 1, 1, 2, 2)
+        self.assert_one_degeneracy(sid, "triangle", "collinear")
+
+    def test_zero_radius_circle(self):
+        sid = self.w.add_circle(0, 0, 0)
+        self.assert_one_degeneracy(sid, "circle", "zero-radius")
+
+    def test_zero_area_rectangle(self):
+        sid = self.w.add_rectangle(0, 0, 2, 0)
+        self.assert_one_degeneracy(sid, "rectangle", "zero-area")
+
+    def test_zero_length_line(self):
+        sid = self.w.add_line(1, 1, 1, 1)
+        self.assert_one_degeneracy(sid, "line", "zero-length")
+
+    def test_coincident_bezier(self):
+        p = solvcon.Point3dFp64
+        sid = self.w.add_bezier_shape(p(1, 1, 0), p(1, 1, 0),
+                                      p(1, 1, 0), p(1, 1, 0))
+        self.assert_one_degeneracy(sid, "bezier", "coincident-controls")
+
+    def test_bare_zero_length_segment(self):
+        p = solvcon.Point3dFp64
+        self.w.add_segment(p(3, 3), p(3, 3))
+        self.assert_one_degeneracy(-1, "segment", "zero-length")
+
+    def test_healthy_shapes_no_degeneracies(self):
+        self.w.add_triangle(0, 0, 4, 0, 0, 3)
+        self.w.add_circle(10, 10, 2)
+        self.w.add_rectangle(-5, -5, -1, -2)
+        self.assertEqual(self.diag()["degeneracies"], [])
+
+    def test_fractional_crossing_point(self):
+        # A crossing whose point has fractional coordinates and whose two
+        # parameters differ (t=1/6, s=1/2), guarding the 6-decimal serializer
+        # and a t-vs-s mixup in the point computation.
+        a = self.w.add_line(0, 0, 3, 3)
+        b = self.w.add_line(0, 1, 1, 0)
+        hits = self.diag()["intersections"]
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["shapes"], [a, b])
+        self.assertEqual(hits[0]["point"], [0.5, 0.5])
+
+    def test_shape_crossing_bare_segment(self):
+        # A mixed pair: the slots carry the live shape id and the bare -1.
+        p = solvcon.Point3dFp64
+        sid = self.w.add_line(0, 0, 2, 2)
+        self.w.add_segment(p(0, 2), p(2, 0))
+        hits = self.diag()["intersections"]
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["shapes"], [sid, -1])
+        self.assertEqual(hits[0]["point"], [1, 1])
+
+    def test_near_miss_not_crossing(self):
+        # The vertical segment stops just short of the horizontal one, so the
+        # near parameter falls outside (0, 1) and nothing is reported.
+        self.w.add_line(0, 0, 2, 0)
+        self.w.add_line(1, 0.0001, 1, 2)
+        self.assertEqual(self.diag()["intersections"], [])
+
+    def test_collinear_overlap_not_crossing(self):
+        # Two segments on the same line overlap but share no single crossing
+        # point, so the collinear short-circuit reports nothing.
+        self.w.add_line(0, 0, 4, 0)
+        self.w.add_line(2, 0, 6, 0)
+        self.assertEqual(self.diag()["intersections"], [])
+
+    def test_zero_one_axis_ellipse(self):
+        sid = self.w.add_ellipse(0, 0, 0, 5)
+        self.assert_one_degeneracy(sid, "ellipse", "zero-radius")
+
+    def test_healthy_ellipse_no_degeneracy(self):
+        self.w.add_ellipse(0, 0, 3, 1)
+        self.assertEqual(self.diag()["degeneracies"], [])
+
+    def test_zero_area_square(self):
+        sid = self.w.add_square(0, 0, 0)
+        self.assert_one_degeneracy(sid, "square", "zero-area")
+
+    def test_multiple_degeneracies_ordered(self):
+        # Documented order: live shapes by id, then bare segments, then bare
+        # curves.
+        p = solvcon.Point3dFp64
+        tri = self.w.add_triangle(0, 0, 1, 1, 2, 2)
+        cir = self.w.add_circle(5, 5, 0)
+        self.w.add_segment(p(8, 8), p(8, 8))
+        self.w.add_bezier(p(9, 9), p(9, 9), p(9, 9), p(9, 9))
+        self.assertEqual(self.diag()["degeneracies"], [
+            {"shape": tri, "type": "triangle", "reason": "collinear"},
+            {"shape": cir, "type": "circle", "reason": "zero-radius"},
+            {"shape": -1, "type": "segment", "reason": "zero-length"},
+            {"shape": -1, "type": "bezier",
+             "reason": "coincident-controls"},
+        ])
+
+    def test_deterministic(self):
+        def build(w):
+            w.add_line(0, 0, 2, 2)
+            w.add_line(0, 2, 2, 0)
+            w.add_circle(5, 5, 0)
+        build(self.w)
+        other = solvcon.WorldFp64()
+        build(other)
+        self.assertEqual(
+            self.w.describe_state(level="diagnostics"),
+            self.w.describe_state(level="diagnostics"))
+        self.assertEqual(
+            self.w.describe_state(level="diagnostics"),
+            other.describe_state(level="diagnostics"))
+
+    def test_fp32(self):
+        w = solvcon.WorldFp32()
+        w.add_line(0, 0, 2, 2)
+        w.add_line(0, 2, 2, 0)
+        diag = json.loads(
+            w.describe_state(level="diagnostics"))["diagnostics"]
+        self.assertEqual(len(diag["intersections"]), 1)
+        self.assertEqual(diag["intersections"][0]["point"], [1, 1])
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
World::describe_state gains a "diagnostics" level that reports derived facts the basic state leaves out: segment intersections and degenerate (collapsed) shapes.


## Test

Open a blank 2D canvas and draw some shapes, then run the python codes:

```
[1] w = pilot.controller.canvas._blank_worlds[-1]
[2] print(json.dumps(json.loads(w.describe_state(level="+diagnostics")), indent=2))
```

<img width="1048" height="831" alt="Screenshot 2026-06-28 at 10 33 02 PM" src="https://github.com/user-attachments/assets/8a893000-08b4-42f4-916e-f4e961a5a0b4" />

## TODO

Add a UI panel for the diagnostic info.


Related to #896.
