### PR TITLE
Set up the Doxygen comment convention and tooling

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -425,9 +425,45 @@ Further conventions:
 
 ### C++ Comment
 
-The general comment rules above apply to C++. Comment blocks follow [the
-doxygen style guidelines](https://www.doxygen.nl/manual/docblocks.html) if
-convenient.
+C++ interface comments are [Doxygen](https://www.doxygen.nl/manual/docblocks.html)
+blocks. The general comment rules above still apply (full sentences,
+capitalized, closing period, ASCII only; state units, coordinate conventions,
+index base, array shape and contiguity, and a literature or equation citation
+with URL for any formula). Doxygen output is XML only, consumed by breathe and
+rendered by Sphinx (see `doc/Doxyfile` and `doc/source/api/cpp.md`).
+
+- **Markers.** Use `/** ... */` for any block of two or more lines, `///` for a
+  one-line brief on a declaration, and `///<` for a trailing comment on a
+  member or enumerator. Do not use `/*!`, `//!`, or a plain `//` or `/* */`
+  comment for interface documentation that must appear in the reference.
+- **Commands.** Always use the at-sign form (`@brief`, `@param`, `@file`).
+  Backslash commands are not allowed.
+- **Brief.** `JAVADOC_AUTOBRIEF` is on, so the first sentence is the brief.
+  Open each block with one capitalized sentence ending in a period. Add an
+  explicit `@brief` only when the brief spans multiple lines or its first
+  sentence contains an abbreviation or version number that would truncate it.
+- **Required tags.** Every header carries an `@file` block (bare `@file`,
+  description on the next line) with one `@ingroup` for its architectural
+  group. Every public class, struct, enum, and function has a brief; template
+  parameters use `@tparam`; value-returning functions use `@return` (not
+  `@returns`). Document each parameter with `@param`; use directional
+  `@param[in]`, `@param[out]`, or `@param[in,out]` only when an output
+  parameter is present, and then on every parameter of that function. Members
+  and enumerators carry a `///<` brief when their meaning, units, or sentinel
+  value is not obvious.
+- **Placement.** The doc block lives on the declaration in the header, never
+  duplicated on the `.cpp` definition. Implementation notes inside a `.cpp`
+  body stay plain `//`, or use `@internal` to keep them out of the public
+  reference.
+- **Grouping.** Coarse topic groups are defined once in `doc/groups.dox` with
+  `@defgroup`; tag types with one `@ingroup`. Inside a large class, group
+  related members with `@name` and `///@{ ... ///@}`. Keep grouping shallow.
+- **Markdown.** Doxygen Markdown is on, but the comment is parsed by Doxygen
+  and serialized to XML; Sphinx and MyST never see the raw text. Use `-` (not
+  `*`) for bullet lists, because leading-asterisk stripping breaks `*` bullets.
+  Use double backticks around inline code that contains a single quote. Prefer
+  `@ref Name` over a bare Markdown link for an internal cross-reference so the
+  breathe resolver can link it.
 
 ### Python Comment
 

--- a/cpp/solvcon/buffer/ConcreteBuffer.hpp
+++ b/cpp/solvcon/buffer/ConcreteBuffer.hpp
@@ -110,6 +110,8 @@ struct ConcreteBufferDataDeleter
 
 /**
  * Untyped and unresizeable memory buffer for contiguous data storage.
+ *
+ * @ingroup group_core
  */
 class ConcreteBuffer
     : public std::enable_shared_from_this<ConcreteBuffer>

--- a/cpp/solvcon/buffer/ConcreteBuffer.hpp
+++ b/cpp/solvcon/buffer/ConcreteBuffer.hpp
@@ -161,9 +161,9 @@ public:
     }
 
     /**
-     * \param[in] nbytes
+     * @param[in] nbytes
      *      Size of the memory buffer in bytes.
-     * \param[in] alignment
+     * @param[in] alignment
      *      Alignment for the memory buffer in bytes.
      *      0 means no alignment. Valid values are 0, 16, 32, or 64.
      */
@@ -178,14 +178,14 @@ public:
     }
 
     /**
-     * \param[in] nbytes
+     * @param[in] nbytes
      *      Size of the memory buffer in bytes.
-     * \param[in] data
+     * @param[in] data
      *      Pointer to the memory buffer that is not supposed to be owned by
      *      this ConcreteBuffer.
-     * \param[in] remover
+     * @param[in] remover
      *      The memory deallocator for the unowned data buffer passed in.
-     * \param[in] alignment
+     * @param[in] alignment
      *      Alignment for the memory buffer in bytes.
      *      0 means no alignment. Valid values are 0, 16, 32, or 64.
      */
@@ -288,4 +288,4 @@ private:
 
 } /* end namespace solvcon */
 
-/* vim: set et ts=4 sw=4: */
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -106,7 +106,7 @@ using sshape_type = small_vector<ssize_t>;
 using slice_type = small_vector<ssize_t>;
 
 /**
- * \brief Enumerate SimpleArray indices with nghost included.
+ * @brief Enumerate SimpleArray indices with nghost included.
  *
  * The first dimension starts at -nghost, while the other dimensions start
  * at 0. For example, an array with shape [4, 3, 2] and nghost = 1 is

--- a/cpp/solvcon/multidim/euler.hpp
+++ b/cpp/solvcon/multidim/euler.hpp
@@ -27,9 +27,11 @@ enum class EulerBC : uint8_t
     Inlet = 2,
 }; /* end enum class EulerBC */
 
-// One registered boundary condition: a handler kind over a set of boundary
-// faces (global face indices).  value carries the Inlet free stream as
-// [rho, v(ndim), p, gamma] and is unused by the other kinds.
+/**
+ * One registered boundary condition: a handler kind over a set of boundary
+ * faces (global face indices). value carries the Inlet free stream as
+ * [rho, v(ndim), p, gamma] and is unused by the other kinds.
+ */
 struct EulerBoundary
 {
     EulerBC kind = EulerBC::NonReflective;

--- a/cpp/solvcon/oasis/oasis_device.hpp
+++ b/cpp/solvcon/oasis/oasis_device.hpp
@@ -18,8 +18,7 @@ class OasisRecordPoly;
 class OasisRecordRect;
 
 /**
- * \class OasisDevice
- * \brief OASIS device converts coordinates information to OASIS format.
+ * OASIS device converts coordinates information to OASIS format.
  *
  * OasisDevice class store rectangles or polygons as OASIS format,
  * the implementation based on OASIS specification, convert coordinates
@@ -59,8 +58,7 @@ private:
 }; /* end class OasisDevice */
 
 /**
- * \class PolyRecord
- * \brief Convert Rect information to OASIS polygon record bytes.
+ * Convert vertex information to OASIS polygon record bytes.
  */
 class OasisRecordPoly
 {
@@ -82,8 +80,7 @@ private:
 }; /* end class OasisRecordPoly */
 
 /**
- * \class RectRecord
- * \brief Convert Rect information to OASIS rectangle record bytes.
+ * Convert rectangle information to OASIS rectangle record bytes.
  */
 class OasisRecordRect
 {

--- a/cpp/solvcon/pilot/RAxisGizmo.hpp
+++ b/cpp/solvcon/pilot/RAxisGizmo.hpp
@@ -35,6 +35,8 @@ namespace solvcon
  *
  * Resource updates happen in update() before the render pass begins; the
  * draw calls happen in draw() inside the pass.
+ *
+ * @ingroup group_domain
  */
 class RAxisGizmo
 {

--- a/cpp/solvcon/pilot/RBoundary.hpp
+++ b/cpp/solvcon/pilot/RBoundary.hpp
@@ -23,6 +23,8 @@ namespace solvcon
  * Each boundary edge is widened into a flat quad (two triangles) lifted
  * slightly toward the viewer, because line width is clamped to one pixel in
  * the core profile. @ref ibc identifies which boundary set this draws.
+ *
+ * @ingroup group_domain
  */
 class RBoundary
     : public RDrawable

--- a/cpp/solvcon/pilot/RCameraController.hpp
+++ b/cpp/solvcon/pilot/RCameraController.hpp
@@ -29,6 +29,8 @@ namespace solvcon
  * The widget drives the controller from mouse and key events, and Python
  * drives the same primitives (rotate / zoom / pan) and reads or sets the pose
  * directly, so the domain navigates the same way from code as from the mouse.
+ *
+ * @ingroup group_domain
  */
 class RCameraController
 {

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -34,6 +34,8 @@ namespace solvcon
  * and drives the render loop through initialize()/render(). The widget hosts
  * an RScene (the drawables, the domain bounding box, and the framing
  * camera) and drives it.
+ *
+ * @ingroup group_domain
  */
 class RDomainWidget
     : public QRhiWidget

--- a/cpp/solvcon/pilot/RDrawable.hpp
+++ b/cpp/solvcon/pilot/RDrawable.hpp
@@ -31,6 +31,8 @@ namespace solvcon
  * The device-owned resources are created lazily through prepare() once the
  * QRhi and the render target are known, and dropped through release() when
  * the device is lost or replaced.
+ *
+ * @ingroup group_domain
  */
 class RDrawable
 {

--- a/cpp/solvcon/pilot/RField.hpp
+++ b/cpp/solvcon/pilot/RField.hpp
@@ -23,6 +23,8 @@ namespace solvcon
  * [0, 1] range, and a triangle index table (ntri, 3). The colors are uploaded
  * interleaved with the positions and read by the per-vertex-color material,
  * so the field is swappable at runtime by replacing the drawable.
+ *
+ * @ingroup group_domain
  */
 class RField
     : public RDrawable

--- a/cpp/solvcon/pilot/RMaterial.hpp
+++ b/cpp/solvcon/pilot/RMaterial.hpp
@@ -21,6 +21,8 @@ namespace solvcon
  * The shader sources live next to this file under shaders/ and are baked to
  * .qsb by the qsb tool at build time (see cpp/solvcon/CMakeLists.txt). They
  * are embedded in the Qt resource system and loaded by resource path.
+ *
+ * @ingroup group_domain
  */
 class RMaterial
 {

--- a/cpp/solvcon/pilot/RMeshFrame.hpp
+++ b/cpp/solvcon/pilot/RMeshFrame.hpp
@@ -22,6 +22,8 @@ namespace solvcon
  * Edges come from the mesh edge list (StaticMesh::ednds); the node
  * coordinates feed a line-topology vertex buffer. Works for both 2D meshes
  * (drawn in the z = 0 plane) and 3D meshes.
+ *
+ * @ingroup group_domain
  */
 class RMeshFrame
     : public RDrawable

--- a/cpp/solvcon/pilot/RScene.hpp
+++ b/cpp/solvcon/pilot/RScene.hpp
@@ -32,6 +32,8 @@ namespace solvcon
  * projection for 3D ones, and frames the camera onto the box. RDomainWidget
  * holds one scene and drives it; the scene itself is free of Qt widget and
  * device-loop concerns.
+ *
+ * @ingroup group_domain
  */
 class RScene
 {

--- a/cpp/solvcon/pilot/RWorldRenderer2d.hpp
+++ b/cpp/solvcon/pilot/RWorldRenderer2d.hpp
@@ -23,6 +23,8 @@ namespace solvcon
  * transform. paint() draws geometry only; paint_canvas() adds the backdrop
  * and optional grid/axes/origin chrome.
  * m_world is non-owning and may be null.
+ *
+ * @ingroup group_domain
  */
 class RWorldRenderer2d
 {

--- a/cpp/solvcon/solvcon.hpp
+++ b/cpp/solvcon/solvcon.hpp
@@ -6,8 +6,9 @@
  */
 
 /**
- * \file This is a template library for the meshes for numerical calculations
- * of partial differential equations.
+ * @file
+ * This is a template library for the meshes for numerical calculations of
+ * partial differential equations.
  */
 
 #include <solvcon/base.hpp>

--- a/cpp/solvcon/universe/bezier.hpp
+++ b/cpp/solvcon/universe/bezier.hpp
@@ -6,7 +6,8 @@
  */
 
 /**
- * @file Bezier curve and its container.
+ * @file
+ * Bezier curve and its container.
  */
 
 #include <solvcon/base.hpp>

--- a/cpp/solvcon/universe/coord.hpp
+++ b/cpp/solvcon/universe/coord.hpp
@@ -6,7 +6,8 @@
  */
 
 /**
- * @file Points and line segments and their containers in 2 and 3 dimensional
+ * @file
+ * Points and line segments and their containers in 2 and 3 dimensional
  * spaces.
  */
 

--- a/cpp/solvcon/universe/polygon.hpp
+++ b/cpp/solvcon/universe/polygon.hpp
@@ -6,7 +6,8 @@
  */
 
 /**
- * @file Polygons and their containers in 2 and 3 dimensional spaces.
+ * @file
+ * Polygons and their containers in 2 and 3 dimensional spaces.
  */
 
 #include <solvcon/base.hpp>

--- a/cpp/solvcon/universe/polygon_boolean.hpp
+++ b/cpp/solvcon/universe/polygon_boolean.hpp
@@ -6,7 +6,8 @@
  */
 
 /**
- * @file Boolean operations on polygons using trapezoidal decomposition.
+ * @file
+ * Boolean operations on polygons using trapezoidal decomposition.
  *
  * Provides BooleanDecompositionHelper, a helper class that implements the
  * sweep-line algorithm for polygon boolean operations (union, intersection,

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1,23 +1,46 @@
-# Minimal Doxygen config for the solvcon C++ API.
+# Doxygen config for the solvcon C++ API.
 #
 # Emits XML only -- breathe consumes the XML and Sphinx renders it.  HTML
 # and LaTeX output are disabled so Sphinx remains the single front end.
 
 PROJECT_NAME      = solvcon
 OUTPUT_DIRECTORY  = build/doxygen
-INPUT             = ../cpp/solvcon
-FILE_PATTERNS     = *.hpp *.cpp
+XML_OUTPUT        = xml
+
+# Document the declaration in the header and drop implementation files, so a
+# symbol is not parsed twice (which makes breathe report "multiple matches").
+# groups.dox carries the @defgroup definitions for the topic groups.
+INPUT             = ../cpp/solvcon groups.dox
+FILE_PATTERNS     = *.hpp *.dox
 RECURSIVE         = YES
+
+# Keep the reference on the live public surface: the deprecated CESE tree,
+# the pybind translation units, and generated Qt files are not documented.
+EXCLUDE_PATTERNS  = */pymod/* */spacetime/* */moc_* */qrc_* *_moc.cpp
+EXCLUDE_SYMBOLS   = detail
 
 GENERATE_HTML     = NO
 GENERATE_LATEX    = NO
 GENERATE_XML      = YES
-XML_OUTPUT        = xml
+XML_PROGRAMLISTING = NO
 
 # Document declarations even where an explicit comment is missing, and read
 # the first comment sentence as the brief description.
 EXTRACT_ALL       = YES
 JAVADOC_AUTOBRIEF = YES
 QUIET             = YES
+
+# Neutralize binding and Qt macros so they do not leak into signatures or
+# emit spurious "not documented" warnings.
+ENABLE_PREPROCESSING = YES
+MACRO_EXPANSION      = YES
+EXPAND_ONLY_PREDEF   = YES
+PREDEFINED           = "PYBIND11_EXPORT=" \
+                       "Q_OBJECT=" \
+                       "Q_PROPERTY(x)=" \
+                       "Q_INVOKABLE=" \
+                       "Q_SIGNALS=signals" \
+                       "Q_SLOTS=slots" \
+                       "MM_DECL_SERIALIZABLE(x)="
 
 # vim: set ft=conf ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -28,7 +28,7 @@ doxygen:
 	mkdir -p "$(BUILDDIR)/doxygen"
 	doxygen Doxyfile
 
-html:
+html: doxygen
 ifdef FORCE_BUILD
 	rm -rf "$(BUILDDIR)/html"
 endif

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -1,0 +1,48 @@
+/**
+ * @file
+ * Topic-group definitions for the solvcon C++ API reference.
+ *
+ * Each @defgroup is declared once here; source headers join a group with a
+ * single @ingroup tag (or an @addtogroup block). doc/source/api/cpp.md renders
+ * one doxygengroup directive per group, so a newly tagged type appears in the
+ * reference without editing the page.
+ */
+
+/** @defgroup group_core Core and memory
+ *  Value-type bases, the string formatter, serialization, raw memory and the
+ *  typed multi-dimensional arrays (ConcreteBuffer, SimpleArray, small_vector),
+ *  the feature toggle, SIMD, and device compute.
+ */
+
+/** @defgroup group_mesh Mesh
+ *  Unstructured meshes with mixed element types (StaticMesh) and the static
+ *  grids (grid.hpp).
+ */
+
+/** @defgroup group_linalg Numerics
+ *  BLAS and LAPACK wrappers, dense factorizations, complex numbers, and
+ *  integral transforms.
+ */
+
+/** @defgroup group_universe Geometry
+ *  Three-dimensional geometry primitives and spatial indices.
+ */
+
+/** @defgroup group_onedim One-dimensional solvers
+ *  One-dimensional CESE solvers demonstrating the method.
+ */
+
+/** @defgroup group_multidim Multi-dimensional solvers
+ *  Multi-dimensional CESE conservation-law solvers and boundary conditions.
+ */
+
+/** @defgroup group_inout Input and output
+ *  Mesh and field readers and writers (Gmsh, Plot3d) and device-format
+ *  output (OASIS).
+ */
+
+/** @defgroup group_domain Domain visualizer
+ *  Qt-based GUI for spatial data visualization.
+ */
+
+/* vim: set ft=c ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: */

--- a/doc/source/api/cpp.md
+++ b/doc/source/api/cpp.md
@@ -3,57 +3,73 @@
 C++ API documentation written in Doxygen format in the C++ source code, bridged
 by [breathe](https://www.breathe-doc.org/).
 
-## Array and memory buffer
+## Core and memory
 
 ```{eval-rst}
-.. doxygenclass:: solvcon::ConcreteBuffer
+.. doxygengroup:: group_core
    :project: solvcon
-   :members:
+   :content-only:
 ```
 
-## Pilot domain viewer
+## Mesh
 
-The pilot's 3D viewer (see {doc}`../pilot/domain`) renders through
+```{eval-rst}
+.. doxygengroup:: group_mesh
+   :project: solvcon
+   :content-only:
+```
+
+## Numerics
+
+```{eval-rst}
+.. doxygengroup:: group_linalg
+   :project: solvcon
+   :content-only:
+```
+
+## Geometry
+
+```{eval-rst}
+.. doxygengroup:: group_universe
+   :project: solvcon
+   :content-only:
+```
+
+## One-dimensional solvers
+
+```{eval-rst}
+.. doxygengroup:: group_onedim
+   :project: solvcon
+   :content-only:
+```
+
+## Multi-dimensional solvers
+
+```{eval-rst}
+.. doxygengroup:: group_multidim
+   :project: solvcon
+   :content-only:
+```
+
+## Input and output
+
+```{eval-rst}
+.. doxygengroup:: group_inout
+   :project: solvcon
+   :content-only:
+```
+
+## Domain visualizer
+
+The 2/3D visualizer (see {doc}`../pilot/domain`) renders through
 [QRhi](https://doc.qt.io/qt-6/qrhi.html), Qt's portable graphics abstraction.
 
 {cpp:class}`solvcon::RDomainWidget` is the Python-facing control object.
 
 ```{eval-rst}
-.. doxygenclass:: solvcon::RDomainWidget
+.. doxygengroup:: group_domain
    :project: solvcon
-   :members:
-
-.. doxygenclass:: solvcon::RScene
-   :project: solvcon
-   :members:
-
-.. doxygenclass:: solvcon::RCameraController
-   :project: solvcon
-   :members:
-
-.. doxygenclass:: solvcon::RDrawable
-   :project: solvcon
-   :members:
-
-.. doxygenclass:: solvcon::RMeshFrame
-   :project: solvcon
-   :members:
-
-.. doxygenclass:: solvcon::RField
-   :project: solvcon
-   :members:
-
-.. doxygenclass:: solvcon::RBoundary
-   :project: solvcon
-   :members:
-
-.. doxygenclass:: solvcon::RAxisGizmo
-   :project: solvcon
-   :members:
-
-.. doxygenclass:: solvcon::RMaterial
-   :project: solvcon
-   :members:
+   :content-only:
 ```
 
 ## Notes on generating this C++ API document

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -74,6 +74,9 @@ intersphinx_mapping = {
 breathe_projects = {"solvcon": "../build/doxygen/xml"}
 breathe_default_project = "solvcon"
 
+# Render members by default so directives need not repeat ``:members:``.
+breathe_default_members = ("members",)
+
 # -- sphinxcontrib.bibtex ---------------------------------------------------
 
 bibtex_bibfiles = ["reference.bib"]


### PR DESCRIPTION
Set up rules for C++ interface-comment convention:
1. Codifies the rules in `STYLE.md`
2. Hardens the Doxygen configuration
3. Defines the topic groups
4. Switches `api/cpp.md` to render one group per section.

No new contents are added.

A new `groups.dox` declares the eight architectural groups once with `@defgroup`:
1. `group_core`: Core and memory.
2. `group_mesh`: Mesh.
3. `group_linalg`: Numerics.
4. `group_universe`: Geometry.
5. `group_onedim`: One-dimensional solvers.
6. `group_multidim`: Multi-dimensional solvers.
7. `group_inout`: Input and output.
8. `group_domain`: Domain visualizer.

For issue #954.