### PR TITLE
Add the headless core of the solvcon.agent package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ def main():
         version="0.0",
         packages=[
             'solvcon',
+            'solvcon.agent',
             'solvcon.multidim',
             'solvcon.multidim.euler',
             'solvcon.onedim',

--- a/solvcon/agent/__init__.py
+++ b/solvcon/agent/__init__.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Agent: drive the 2D ``World`` with an AI backend, with or without a GUI.
+
+This package lives outside :mod:`solvcon.pilot` so it can also drive pure
+computation that needs no graphics.  The headless core (:mod:`_core`) and the
+backend abstraction (:mod:`_backend`) load without Qt, so they run in CI and a
+headless build.
+"""
+
+from . import _core  # noqa: F401
+from . import _backend  # noqa: F401
+
+# _core.py
+list_of_core = [
+    'AgentSession',
+    'TranscriptTurn',
+]
+
+# _backend.py
+list_of_backend = [
+    'AgentBackend',
+    'BackendResponse',
+    'EchoBackend',
+    'register',
+    'all_backends',
+    'available_backends',
+    'get_backend',
+]
+
+# TODO: when the Qt dock module exists in solvcon.pilot, point this at its
+# Agent class, guarded by _pilot_core.enable like the airfoil sub-package.
+Agent = None
+
+__all__ = list_of_core + list_of_backend + [  # noqa: F822
+    'Agent',
+]
+
+
+def _load(module, symbol_list):
+    for name in symbol_list:
+        globals()[name] = getattr(module, name)
+
+
+_load(_core, list_of_core)
+_load(_backend, list_of_backend)
+
+del _load
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/agent/_backend.py
+++ b/solvcon/agent/_backend.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Pluggable AI backend abstraction for the Agent.
+
+A backend turns a prompt (plus scene context and the Agent Draw tool surface)
+into a :class:`BackendResponse`: prose and a list of Agent Draw command dicts.
+Backends register in a process-wide registry so a caller can list the usable
+ones and let the user pick.  The module imports no Qt.  The offline
+:class:`EchoBackend` keeps the registry non-empty so there is always a working
+default.
+"""
+
+import abc
+import dataclasses
+
+
+@dataclasses.dataclass
+class BackendResponse:
+    """One backend reply: ``text`` prose, the proposed ``commands`` (Agent
+    Draw dicts the session applies; empty means no drawing), and an ``error``
+    reason or ``None``."""
+
+    text: str = ""
+    commands: list = dataclasses.field(default_factory=list)
+    error: str = None
+
+
+class AgentBackend(abc.ABC):
+    """Interface every AI backend implements: a stable :attr:`name`, an
+    :meth:`available` check, and :meth:`send`.  The tiny surface lets a caller
+    drive any backend from a background thread."""
+
+    @property
+    @abc.abstractmethod
+    def name(self):
+        """Short, stable identifier shown in the backend selector."""
+
+    @abc.abstractmethod
+    def available(self):
+        """Whether this backend can run now (CLI on PATH, key set, ...)."""
+
+    @abc.abstractmethod
+    def send(self, prompt, scene_context, tool_surface):
+        """Run the backend and return a :class:`BackendResponse`.
+
+        :param prompt: the user's natural-language request.
+        :param scene_context: a short text summary of the current world.
+        :param tool_surface: the Agent Draw tool definitions the model may
+            call.
+        """
+
+
+_REGISTRY = []
+
+
+def register(backend):
+    """Add a backend, replacing any with the same name (so a re-import does
+    not duplicate the built-in entries)."""
+    for index, existing in enumerate(_REGISTRY):
+        if existing.name == backend.name:
+            _REGISTRY[index] = backend
+            return backend
+    _REGISTRY.append(backend)
+    return backend
+
+
+def all_backends():
+    """Every registered backend, in registration order (a copy)."""
+    return list(_REGISTRY)
+
+
+def available_backends():
+    """Registered backends whose ``available()`` returns True."""
+    return [b for b in _REGISTRY if b.available()]
+
+
+def get_backend(name):
+    """The registered backend with ``name``, or ``None`` if absent."""
+    for backend in _REGISTRY:
+        if backend.name == name:
+            return backend
+    return None
+
+
+class EchoBackend(AgentBackend):
+    """Offline backend that proposes no drawing and echoes the prompt.
+
+    It is always :meth:`available` and fully deterministic, so a caller, the
+    tests, and a no-key demo always have a backend that exercises the whole
+    pipeline without any external process.
+    """
+
+    name = "echo (offline)"
+
+    def available(self):
+        return True
+
+    def send(self, prompt, scene_context, tool_surface):
+        return BackendResponse(text="echo: %s" % prompt, commands=[])
+
+
+register(EchoBackend())
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/agent/_core.py
+++ b/solvcon/agent/_core.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Headless core of the Agent.
+
+:class:`AgentSession` binds the active ``World``, an optional backend, and a
+command *runner* (the Agent Draw ``Executor`` by default), and records every
+applied command into a transcript a caller can render.  No Qt is imported.
+"""
+
+import json
+import dataclasses
+
+
+@dataclasses.dataclass
+class TranscriptTurn:
+    """One transcript entry: a ``role`` with its text, commands, and results.
+
+    ``results`` holds Agent Draw ``CommandResult`` objects (or any object with
+    an ``ok`` attribute).
+    """
+
+    role: str
+    text: str = ""
+    commands: list = dataclasses.field(default_factory=list)
+    results: list = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass
+class _OutcomeStub:
+    """Failed-result stand-in for when a runner raises instead of returning."""
+
+    op: str
+    ok: bool = False
+    error: str = None
+
+
+def _make_executor(world, renderer=None):
+    """Build an Agent Draw ``Executor`` for ``world``."""
+    # TODO: when the agentdraw package ships in-tree, import it at module
+    # level (here and in tool_surface) and drop the empty-list fallback.
+    from solvcon.pilot import agentdraw
+    return agentdraw.Executor(world, renderer)
+
+
+def tool_surface():
+    """The Agent Draw tool definitions for a backend, or ``[]`` if the
+    ``agentdraw`` package is unavailable."""
+    try:
+        from solvcon.pilot import agentdraw
+    except ImportError:
+        return []
+    return agentdraw.tool_definitions()
+
+
+class AgentSession:
+    """Bind a ``World``, a backend, and a runner; record a transcript.
+
+    ``runner`` is any object exposing ``run(command) -> result``; it defaults
+    to a lazily built Agent Draw ``Executor(world, renderer)``.  ``backend`` is
+    an :class:`~solvcon.agent.AgentBackend` or ``None``.
+    """
+
+    def __init__(self, world=None, backend=None, runner=None, renderer=None):
+        self.world = world
+        self.backend = backend
+        self._renderer = renderer
+        self._runner = runner
+        self._transcript = []
+
+    @property
+    def transcript(self):
+        """The recorded turns, oldest first (a copy)."""
+        return list(self._transcript)
+
+    @property
+    def runner(self):
+        """The command runner, built from ``agentdraw`` on first use."""
+        if self._runner is None:
+            self._runner = _make_executor(self.world, self._renderer)
+        return self._runner
+
+    def tool_surface(self):
+        """The Agent Draw tool definitions to hand the backend."""
+        return tool_surface()
+
+    def scene_context(self, level="basic"):
+        """A short text summary of the world for the model: the shape count
+        and distinct types from ``world.describe_state(...)`` (JSON), or a
+        plain count when it cannot be described."""
+        world = self.world
+        if world is None:
+            return "no active world"
+        try:
+            state = json.loads(world.describe_state(level=level))
+        except Exception:
+            return "world with %s shapes" % getattr(world, "nshape", "?")
+        shapes = state.get("shapes", [])
+        types = sorted({s["type"] for s in shapes if "type" in s})
+        kinds = ", ".join(types) if types else "none"
+        return "world with %d shapes (types: %s)" % (len(shapes), kinds)
+
+    def apply_commands(self, commands):
+        """Run each command, recording one transcript turn.  An empty batch is
+        a no-op that builds no runner; a runner that raises is captured into a
+        failed :class:`_OutcomeStub`, so one bad command never aborts a batch.
+        """
+        if not commands:
+            return []
+        runner = self.runner
+        results = []
+        for command in commands:
+            try:
+                results.append(runner.run(command))
+            except Exception as exc:
+                op = command.get("op", "?") if isinstance(command, dict) \
+                    else "?"
+                results.append(_OutcomeStub(
+                    op, error="%s: %s" % (type(exc).__name__, exc)))
+        self._transcript.append(TranscriptTurn(
+            role="agent", commands=list(commands), results=results))
+        return results
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_backend.py
+++ b/tests/test_agent_backend.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Tests for the Agent backend abstraction and registry.
+
+GUI-free: only the pure-Python backend module is imported, never an
+``RManager`` or a Qt widget, so these run in CI without a built GUI.
+"""
+
+import unittest
+
+from solvcon.agent import (
+    AgentBackend,
+    BackendResponse,
+    EchoBackend,
+    all_backends,
+    available_backends,
+    get_backend,
+    register,
+)
+
+
+class AgentBackendABCTC(unittest.TestCase):
+    def test_abstract_cannot_instantiate(self):
+        with self.assertRaises(TypeError):
+            AgentBackend()
+
+    def test_partial_subclass_cannot_instantiate(self):
+        # Missing send() leaves an abstract method, guarding the contract that
+        # every concrete backend (Claude, Codex, ...) fills all three.
+        class Partial(AgentBackend):
+            name = "partial"
+
+            def available(self):
+                return True
+
+        with self.assertRaises(TypeError):
+            Partial()
+
+
+class EchoBackendTC(unittest.TestCase):
+    def test_available_true_without_config(self):
+        # Needs no key or process, so it is the guaranteed default backend.
+        self.assertTrue(EchoBackend().available())
+
+    def test_send_is_deterministic_and_safe(self):
+        backend = EchoBackend()
+        first = backend.send("hello", "scene", [])
+        second = backend.send("hello", "scene", [])
+        self.assertEqual(first, second)
+        self.assertIsInstance(first, BackendResponse)
+        self.assertEqual(first.commands, [])  # no drawing: safe no-op
+        self.assertIn("hello", first.text)
+
+
+class RegistryTC(unittest.TestCase):
+    def test_echo_is_always_available(self):
+        # EchoBackend registers on import, so the selector always has an entry.
+        names = [b.name for b in available_backends()]
+        self.assertIn(EchoBackend().name, names)
+
+    def test_get_backend_by_name(self):
+        backend = get_backend(EchoBackend().name)
+        self.assertIsNotNone(backend)
+        self.assertEqual(backend.name, EchoBackend().name)
+
+    def test_register_replaces_same_name(self):
+        # Re-registering a name swaps the instance, so a re-import cannot grow
+        # the registry.
+        before = len(all_backends())
+
+        class Echo2(EchoBackend):
+            pass
+
+        replacement = Echo2()
+        try:
+            register(replacement)
+            self.assertEqual(len(all_backends()), before)
+            self.assertIs(get_backend(EchoBackend().name), replacement)
+        finally:
+            register(EchoBackend())  # restore default for other tests
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_core.py
+++ b/tests/test_agent_core.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Tests for the headless AgentSession core (GUI-free); a fake runner and
+world cover the orchestration, and the Agent Draw integration cases require
+the ``agentdraw`` package."""
+
+import json
+import unittest
+
+import solvcon
+from solvcon.agent import AgentSession
+
+try:
+    from solvcon.pilot import agentdraw  # noqa: F401
+    HAS_AGENTDRAW = True
+except ImportError:
+    HAS_AGENTDRAW = False
+
+
+class _FakeResult:
+    """Minimal Agent Draw result stand-in: the fields the session reads."""
+
+    def __init__(self, op, ok=True, error=None):
+        self.op = op
+        self.ok = ok
+        self.error = error
+
+
+class _RecordingRunner:
+    """Records commands and returns a result for each; ``fail_ops`` names ops
+    returned as failed, exercising the failure path without a real executor."""
+
+    def __init__(self, fail_ops=()):
+        self.commands = []
+        self._fail_ops = set(fail_ops)
+
+    def run(self, command):
+        self.commands.append(command)
+        op = command.get("op", "?")
+        ok = op not in self._fail_ops
+        return _FakeResult(op, ok=ok, error=None if ok else "bad command")
+
+
+class _FakeWorld:
+    """World stub with just nshape and describe_state (no concrete shapes)."""
+
+    def __init__(self, types):
+        self._types = list(types)
+
+    @property
+    def nshape(self):
+        return len(self._types)
+
+    def describe_state(self, level="basic"):
+        shapes = [{"id": i, "type": t} for i, t in enumerate(self._types)]
+        return json.dumps({"shapes": shapes})
+
+
+class ApplyCommandsTC(unittest.TestCase):
+    def test_applies_each_command_and_records_one_turn(self):
+        runner = _RecordingRunner()
+        session = AgentSession(runner=runner)
+        cmds = [{"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0},
+                {"op": "add_circle", "cx": 2.0, "cy": 0.0, "r": 1.0}]
+        results = session.apply_commands(cmds)
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(r.ok for r in results))
+        self.assertEqual(runner.commands, cmds)
+        # One agent turn captures the whole batch and its outcomes.
+        self.assertEqual(len(session.transcript), 1)
+        turn = session.transcript[0]
+        self.assertEqual(turn.role, "agent")
+        self.assertEqual(turn.results, results)
+
+    def test_failed_command_is_recorded_not_raised(self):
+        runner = _RecordingRunner(fail_ops={"remove_shape"})
+        session = AgentSession(runner=runner)
+        results = session.apply_commands(
+            [{"op": "remove_shape", "shape_id": 99}])
+        self.assertFalse(results[0].ok)
+        self.assertEqual(session.transcript[0].results[0].error,
+                         "bad command")
+
+    def test_runner_exception_is_captured(self):
+        class _Boom:
+            def run(self, command):
+                raise ValueError("boom")
+
+        session = AgentSession(runner=_Boom())
+        results = session.apply_commands([{"op": "add_circle"}])
+        self.assertFalse(results[0].ok)
+        self.assertIn("boom", results[0].error)
+        self.assertEqual(results[0].op, "add_circle")
+
+    def test_empty_batch_is_a_noop_without_runner(self):
+        # No commands must not build the runner.
+        session = AgentSession()
+        self.assertEqual(session.apply_commands([]), [])
+        self.assertEqual(session.transcript, [])
+
+
+class SceneContextTC(unittest.TestCase):
+    def test_no_world(self):
+        self.assertEqual(AgentSession().scene_context(), "no active world")
+
+    def test_reports_shape_count_and_types(self):
+        session = AgentSession(world=_FakeWorld(["circle", "rectangle"]))
+        context = session.scene_context()
+        self.assertIn("2 shapes", context)
+        self.assertIn("circle", context)
+        self.assertIn("rectangle", context)
+
+
+@unittest.skipUnless(HAS_AGENTDRAW, "requires the agentdraw package")
+class AgentDrawIntegrationTC(unittest.TestCase):
+    def test_default_runner_mutates_world(self):
+        world = solvcon.WorldFp64()
+        session = AgentSession(world=world)
+        results = session.apply_commands([
+            {"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0},
+            {"op": "add_circle", "cx": 3.0, "cy": 0.0, "r": 1.0}])
+        self.assertTrue(all(r.ok for r in results))
+        self.assertEqual(world.nshape, 2)
+
+    def test_tool_surface_matches_agentdraw(self):
+        self.assertEqual(AgentSession().tool_surface(),
+                         agentdraw.tool_definitions())
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Introduce `solvcon.agent`, the GUI-free foundation an AI backend uses to drive the 2D `World` from natural language. This core lands and is tested on its own, ahead of the user-facing GUI pieces.

The package sits outside `solvcon.pilot` so the agent can also drive pure computation that needs no graphics. It imports no Qt and reaches the Agent Draw executor through a lazy import with a fallback, so it never requires the pilot GUI by default.

What it adds:
- `AgentSession`: binds a `World`, an optional backend, and a command runner, then records every applied command into a transcript.
- `AgentBackend`: the pluggable backend interface, backed by a process-wide registry and an offline `EchoBackend` default.

Later PRs build on this core without changing it: the Claude and Codex backends, the background worker, and the dock panel.

Related to issue #966 and discussion #951.