### PR TITLE
Add basic Doxygen comment for C++ API documentation

### DIFF
--- a/cpp/solvcon/base.hpp
+++ b/cpp/solvcon/base.hpp
@@ -5,6 +5,14 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Core foundations shared across the library, e.g., the value-type bases, the
+ * Formatter string builder, macros, etc.
+ *
+ * @ingroup group_core
+ */
+
 // Used in this file.
 #include <cstdint>
 
@@ -23,8 +31,10 @@
 typedef SSIZE_T ssize_t;
 #endif
 
+/// Throw exception @p EXC carrying a "@p CLS: @p MSG" message.
 #define SOLVCON_EXCEPT(CLS, EXC, MSG) throw EXC(#CLS ": " MSG);
 
+/// Width in bytes of the solvcon integer type: 4 (int32) or 8 (int64).
 #ifndef SOLVCON_INTSIZE
 #define SOLVCON_INTSIZE 4
 #endif // SOLVCON_INTSIZE
@@ -70,6 +80,14 @@ using int_type = int64_t;
 #error SOLVCON_INTSIZE is not supported
 #endif // SOLVCON_INTSIZE
 
+/**
+ * Fixes the integer and real value types for spatial data structures.
+ *
+ * @tparam I Integral index type.
+ * @tparam R Floating-point real type.
+ *
+ * @ingroup group_core
+ */
 template <typename I, typename R>
 class NumberBase
 {
@@ -89,6 +107,8 @@ public:
 /**
  * Spatial table basic information.  Any table-based data store for spatial
  * data should inherit this class template.
+ *
+ * @ingroup group_core
  */
 template <uint8_t ND, typename I, typename R>
 class SpaceBase : public NumberBase<I, R>
@@ -109,7 +129,15 @@ public:
 
 }; /* end class SpaceBase */
 
-// Taken from https://stackoverflow.com/a/12262626
+/**
+ * Deprecated ostringstream-based string builder; prefer std::format.
+ *
+ * Streams values with operator<< and yields the accumulated text through
+ * str() or an implicit std::string conversion. Taken from
+ * https://stackoverflow.com/a/12262626 .
+ *
+ * @ingroup group_core
+ */
 class [[deprecated("Use std::format instead")]] Formatter
 {
 

--- a/cpp/solvcon/buffer/ConcreteBuffer.hpp
+++ b/cpp/solvcon/buffer/ConcreteBuffer.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Reference-counted contiguous memory buffer.
+ *
+ * @ingroup group_core
+ */
+
 #include <solvcon/base.hpp>
 #include <solvcon/buffer/BufferBase.hpp>
 #include <solvcon/buffer/small_vector.hpp>

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Typed multi-dimensional array over a shared memory buffer.
+ *
+ * @ingroup group_core
+ */
+
 #include <solvcon/buffer/ConcreteBuffer.hpp>
 #include <solvcon/buffer/matmul.hpp>
 #include <solvcon/math/math.hpp>
@@ -1542,6 +1549,8 @@ struct with_alignment_t
  * Simple array type for contiguous memory storage. Size does not change. The
  * copy semantics performs data copy. The move semantics invalidates the
  * existing memory buffer.
+ *
+ * @ingroup group_core
  */
 template <typename T>
 class SimpleArray
@@ -2623,6 +2632,10 @@ A detail::SimpleArrayMixinSort<A, T>::take_along_axis(SimpleArray<I> const & ind
     return ret;
 }
 
+// The declaration lives in namespace detail and is excluded from the API
+// reference (EXCLUDE_SYMBOLS=detail); @cond stops Doxygen from trying to match
+// this out-of-line definition against that excluded declaration.
+/// @cond
 template <IntegralType T>
 T const * detail::check_index_range(SimpleArray<T> const & indices, size_t max_idx)
 {
@@ -2635,6 +2648,7 @@ T const * detail::check_index_range(SimpleArray<T> const & indices, size_t max_i
 
     return simd::check_between<T>(indices.begin(), indices.end(), 0, max_idx);
 }
+/// @endcond
 
 template <typename T, IntegralType I>
 void detail::indexed_copy(T * dest, T const * data, I const * index0, I const * const index1)
@@ -2724,6 +2738,16 @@ using SimpleArrayFloat64 = SimpleArray<double>;
 using SimpleArrayComplex64 = SimpleArray<Complex<float>>;
 using SimpleArrayComplex128 = SimpleArray<Complex<double>>;
 
+/**
+ * Runtime element-type tag mirroring the scalar types a SimpleArray supports.
+ *
+ * Covers bool, the signed and unsigned 8- to 64-bit integers, the 32- and
+ * 64-bit floats, and the 64- and 128-bit complex types. Converts to and from
+ * its enum and a type string, and DataType::from<T>() maps a C++ type to its
+ * tag.
+ *
+ * @ingroup group_core
+ */
 class DataType
 {
 public:
@@ -2767,6 +2791,15 @@ private:
 
 }; /* end class DataType */
 
+/**
+ * Type-erased SimpleArray pairing a buffer and shape with a runtime DataType.
+ *
+ * Holds an array of any supported element type behind one handle, dispatching
+ * on the DataType, so code generic over the element type can store and pass
+ * arrays uniformly.
+ *
+ * @ingroup group_core
+ */
 class SimpleArrayPlex
 {
 public:

--- a/cpp/solvcon/buffer/SimpleCollector.hpp
+++ b/cpp/solvcon/buffer/SimpleCollector.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Growable typed buffer that collects elements contiguously.
+ *
+ * @ingroup group_core
+ */
+
 #include <solvcon/buffer/BufferExpander.hpp>
 #include <solvcon/buffer/SimpleArray.hpp>
 
@@ -14,6 +21,17 @@
 namespace solvcon
 {
 
+/**
+ * Growable typed buffer that collects elements of type @p T contiguously.
+ *
+ * Backs storage with a BufferExpander, grows as elements are appended, and
+ * hands the result to a SimpleArray without copying. Prefer it over a
+ * std::vector when the data must become a SimpleArray.
+ *
+ * @tparam T Element value type.
+ *
+ * @ingroup group_core
+ */
 template <typename T>
 class SimpleCollector
 {

--- a/cpp/solvcon/buffer/small_vector.hpp
+++ b/cpp/solvcon/buffer/small_vector.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Vector with small-buffer optimization.
+ *
+ * @ingroup group_core
+ */
+
 #include <stdexcept>
 #include <array>
 #include <vector>
@@ -17,6 +24,17 @@
 namespace solvcon
 {
 
+/**
+ * Vector with small-buffer optimization.
+ *
+ * Stores up to @p N elements inline and moves to a heap allocation only when
+ * the size exceeds @p N, avoiding allocation for the common short case.
+ *
+ * @tparam T Element value type.
+ * @tparam N Inline capacity before the first heap allocation.
+ *
+ * @ingroup group_core
+ */
 template <typename T, size_t N = 3>
 class small_vector
 {
@@ -435,4 +453,4 @@ static_assert(sizeof(small_vector<size_t>) == 40, "small_vector<size_t> should u
 
 } /* end namespace solvcon */
 
-/* vim: set et ts=4 sw=4: */
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/device/metal/metal.hpp
+++ b/cpp/solvcon/device/metal/metal.hpp
@@ -5,6 +5,14 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Singleton manager for the Metal GPU device used by the linear algebra
+ * backend.
+ *
+ * @ingroup group_core
+ */
+
 // forward declaration.
 namespace MTL
 {
@@ -17,6 +25,15 @@ namespace solvcon
 namespace device
 {
 
+/**
+ * Process-wide owner of the single Metal device handle.
+ *
+ * The instance is created on first access and acquires the Metal device in
+ * startup(); shutdown() releases it. Copy and move are deleted so the device
+ * has exactly one owner.
+ *
+ * @ingroup group_core
+ */
 class MetalManager
 {
 

--- a/cpp/solvcon/grid.hpp
+++ b/cpp/solvcon/grid.hpp
@@ -6,7 +6,10 @@
  */
 
 /**
- * Structured grid.
+ * @file
+ * Structured grids.
+ *
+ * @ingroup group_mesh
  */
 
 #include <solvcon/base.hpp>
@@ -17,7 +20,11 @@ namespace solvcon
 {
 
 /**
- * Base class template for structured grid.
+ * Base class template for a structured grid.
+ *
+ * @tparam ND Spatial dimension count.
+ *
+ * @ingroup group_mesh
  */
 template <uint8_t ND>
 class StaticGridBase : public SpaceBase<ND, int32_t, double>
@@ -25,7 +32,9 @@ class StaticGridBase : public SpaceBase<ND, int32_t, double>
 }; /* end class StaticGridBase */
 
 /**
- * 1D grid whose coordnate ascends with index.
+ * One-dimensional grid whose coordinate ascends with the index.
+ *
+ * @ingroup group_mesh
  */
 class AscendantGrid1d : public StaticGridBase<1>
 {
@@ -73,7 +82,9 @@ private:
 }; /* end class AscendantGrid1d */
 
 /**
- * 1D grid.
+ * One-dimensional structured grid.
+ *
+ * @ingroup group_mesh
  */
 class StaticGrid1d : public StaticGridBase<1>
 {
@@ -155,10 +166,20 @@ private:
 
 }; /* end class StaticGrid1d */
 
+/**
+ * Two-dimensional structured grid.
+ *
+ * @ingroup group_mesh
+ */
 class StaticGrid2d : public StaticGridBase<2>
 {
 }; /* end class StaticGrid2d */
 
+/**
+ * Three-dimensional structured grid.
+ *
+ * @ingroup group_mesh
+ */
 class StaticGrid3d : public StaticGridBase<3>
 {
 }; /* end class StaticGrid3d */

--- a/cpp/solvcon/inout/gmsh.hpp
+++ b/cpp/solvcon/inout/gmsh.hpp
@@ -1,5 +1,12 @@
 #pragma once
 
+/**
+ * @file
+ * Reader for Gmsh MSH text mesh files and the element-type table it uses.
+ *
+ * @ingroup group_inout
+ */
+
 #include <string>
 #include <sstream>
 #include <vector>
@@ -15,6 +22,18 @@ namespace solvcon
 {
 namespace inout
 {
+
+/**
+ * Definition of one Gmsh element type mapped to the solvcon mesh
+ * representation.
+ *
+ * It carries the spatial dimension, the node count, the solvcon cell type
+ * number, and the node ordering (mmcl) that rearranges Gmsh nodes into the
+ * solvcon cell order. by_id() returns the definition for a given Gmsh element
+ * type id.
+ *
+ * @ingroup group_inout
+ */
 struct GmshElementDef
 {
     static GmshElementDef by_id(uint16_t id);
@@ -47,6 +66,17 @@ private:
     small_vector<uint8_t> m_mmcl; /* solvcon cell order  */
 }; /* end struct GmshElementDef */
 
+/**
+ * Reader that parses a Gmsh MSH text mesh into a solvcon StaticMesh.
+ *
+ * Only the ASCII MSH format version 2.2 is supported. Construct it with the
+ * file contents as a string, then call to_block() to build the mesh. A finite
+ * state machine walks the MeshFormat, PhysicalNames, Nodes, and Elements
+ * sections in order. Node and element indices are converted from the Gmsh
+ * 1-based numbering to the solvcon 0-based numbering.
+ *
+ * @ingroup group_inout
+ */
 class Gmsh
     : public NumberBase<int32_t, double>
 {

--- a/cpp/solvcon/inout/plot3d.hpp
+++ b/cpp/solvcon/inout/plot3d.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Reader that turns Plot3D structured grid data into a solvcon mesh.
+ *
+ * @ingroup group_inout
+ */
+
 #include <queue>
 #include <string>
 #include <sstream>
@@ -22,6 +29,15 @@ namespace solvcon
 namespace inout
 {
 
+/**
+ * Parser that converts Plot3D structured grid data into a StaticMesh.
+ *
+ * The grid is read from an in-memory string holding one or more blocks.
+ * Node coordinates are parsed per block, indexed by the per-block x, y,
+ * and z shapes, and assembled into hexahedron elements to build the mesh.
+ *
+ * @ingroup group_inout
+ */
 class Plot3d
     : public NumberBase<int32_t, double>
 {

--- a/cpp/solvcon/linalg/EigenSystem.hpp
+++ b/cpp/solvcon/linalg/EigenSystem.hpp
@@ -6,12 +6,15 @@
  */
 
 /**
+ * @file
  * Eigenvalue and eigenvector computation for general (non-symmetric) matrices
  * using LAPACK *GEEV: SGEEV (float), DGEEV (double), CGEEV (Complex<float>),
  * and ZGEEV (Complex<double>).
  *
  * The LAPACK backend is selected by the build system via MM_HAS_VENDOR_LAPACK:
  * Apple's vecLib (Accelerate framework) on macOS and OpenBLAS on Linux.
+ *
+ * @ingroup group_numerics
  */
 
 #ifndef MM_HAS_VENDOR_LAPACK
@@ -39,6 +42,8 @@ namespace solvcon
  * Complex<double>.  Construction validates the input shape and prepares
  * column-major workspace buffers.  Call run() to invoke the matching *GEEV
  * routine to calculate eigenvalues and eigenvectors.
+ *
+ * @ingroup group_numerics
  */
 template <typename T>
 class EigenSystem
@@ -301,6 +306,8 @@ std::string EigenSystem<T>::format_shape(array_type const & arr)
  * Accepts a SimpleArrayPlex and dispatches on its runtime element type to the
  * matching EigenSystem<T> (float, double, Complex<float>, Complex<double>).
  * Results are returned as type-erased SimpleArrayPlex.
+ *
+ * @ingroup group_numerics
  */
 class EigenSystemPlex
 {

--- a/cpp/solvcon/linalg/factorization.hpp
+++ b/cpp/solvcon/linalg/factorization.hpp
@@ -5,6 +5,14 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Cholesky (L L^T) factorization and linear solve for symmetric positive
+ * definite matrices.
+ *
+ * @ingroup group_numerics
+ */
+
 #include <solvcon/buffer/buffer.hpp>
 
 namespace solvcon

--- a/cpp/solvcon/linalg/kalman_filter.hpp
+++ b/cpp/solvcon/linalg/kalman_filter.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Kalman filter for linear state estimation with predict and update steps.
+ *
+ * @ingroup group_numerics
+ */
+
 #include <solvcon/linalg/factorization.hpp>
 #include <solvcon/math/math.hpp>
 
@@ -31,6 +38,8 @@ struct select_real_t;
  *
  * @see KalmanStateInfo<T> KalmanFilter<T>::batch_filter(array_type const & zs)
  * @see KalmanStateInfo<T> KalmanFilter<T>::batch_filter(array_type const & zs, array_type const & us)
+ *
+ * @ingroup group_numerics
  */
 template <typename T>
 struct KalmanStateInfo
@@ -54,8 +63,19 @@ struct KalmanStateInfo
 }; /* end struct KalmanStateInfo */
 
 /**
+ * Kalman filter for linear Gaussian state estimation.
+ *
+ * Implements the discrete predict and update recursion over a state mean
+ * vector and its covariance matrix, using the transition matrix F, process
+ * noise covariance Q, measurement matrix H, measurement noise covariance R,
+ * and an optional control matrix B. The update step forms the Kalman gain
+ * through an LLT solve and applies the Joseph-form covariance update for
+ * numerical stability.
+ *
  * Reference: FilterPy KalmanFilter documentation
  * https://filterpy.readthedocs.io/en/latest/kalman/KalmanFilter.html
+ *
+ * @ingroup group_numerics
  */
 template <typename T>
 class KalmanFilter

--- a/cpp/solvcon/linalg/lu_factorization.hpp
+++ b/cpp/solvcon/linalg/lu_factorization.hpp
@@ -5,6 +5,14 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * LU factorization with partial pivoting for general matrices, with
+ * linear-solve, inverse, and determinant helpers.
+ *
+ * @ingroup group_numerics
+ */
+
 #include <algorithm>
 #include <cstdint>
 #include <format>
@@ -41,6 +49,8 @@ namespace solvcon
  * of redoing it.
  *
  * Supported element types: float, double, Complex<float>, Complex<double>.
+ *
+ * @ingroup group_numerics
  */
 template <typename T>
 class LuFactorization

--- a/cpp/solvcon/math/Complex.hpp
+++ b/cpp/solvcon/math/Complex.hpp
@@ -5,6 +5,14 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Complex number type with a std::complex-compatible layout and the
+ * related type traits.
+ *
+ * @ingroup group_core
+ */
+
 #include <type_traits>
 #include <cmath>
 #include <stdexcept>
@@ -260,12 +268,25 @@ std::complex<T> * as_std_complex_pointer(Complex<T> * ptr)
 }
 
 // clang-format off
+/**
+ * Type trait that reports whether a type is a solvcon Complex.
+ *
+ * The primary template inherits std::false_type; the specialization for
+ * Complex<T> inherits std::true_type.
+ *
+ * @ingroup group_core
+ */
 template <typename T>
 struct is_complex : std::false_type {};
 
 template <typename T>
 struct is_complex<Complex<T>> : std::true_type {};
 
+/**
+ * Type trait that reports whether a type is a real floating-point type.
+ *
+ * @ingroup group_core
+ */
 template <typename T>
 struct is_real : std::is_floating_point<T> {};
 // clang-format on

--- a/cpp/solvcon/mesh/StaticMesh.hpp
+++ b/cpp/solvcon/mesh/StaticMesh.hpp
@@ -6,7 +6,10 @@
  */
 
 /**
- * Unstructured mesh.
+ * @file
+ * Unstructured mesh with mixed element types.
+ *
+ * @ingroup group_mesh
  */
 
 #include <solvcon/base.hpp>
@@ -124,6 +127,12 @@ inline CellType CellType::by_id(uint8_t id)
 #undef MM_DECL_SWITCH_CELL_TYPE
 }
 
+/**
+ * Compile-time mesh connectivity bounds: maximum nodes per face and per cell,
+ * maximum faces per cell, and the face and boundary relation widths.
+ *
+ * @ingroup group_mesh
+ */
 struct StaticMeshConstant
 {
 
@@ -135,6 +144,15 @@ struct StaticMeshConstant
 
 }; /* end struct StaticMeshConstant */
 
+/**
+ * One boundary-condition group of a StaticMesh: the boundary faces it owns.
+ *
+ * The faces live in the m_facn index table whose three columns are the face
+ * index in the block, the face index in bndfcs, and the face index in the
+ * related block when one exists.
+ *
+ * @ingroup group_mesh
+ */
 // TODO: StaticMeshBC may use polymorphism.
 class StaticMeshBC
     : public NumberBase<int32_t, double>
@@ -216,6 +234,17 @@ public:
 
 }; /* end class StaticMeshBC */
 
+/**
+ * Static unstructured mesh storing nodes, faces, and cells of mixed element
+ * types.
+ *
+ * Coordinates are row-major and contiguous, and node indices are zero-based.
+ * The CESE solver reads cell connectivity through the fcicl and fcjcl
+ * face-to-cell accessors. build_interior, build_boundary, and build_ghost
+ * populate the derived tables.
+ *
+ * @ingroup group_mesh
+ */
 class StaticMesh
     : public NumberBase<int32_t, double>
     , public StaticMeshConstant

--- a/cpp/solvcon/multidim/GradientElement.hpp
+++ b/cpp/solvcon/multidim/GradientElement.hpp
@@ -6,8 +6,10 @@
  */
 
 /**
+ * @file
  * Gradient element geometry for the CESE dual mesh.
- * Port of solvcon GradientElement.hpp.
+ *
+ * @ingroup group_multidim
  */
 
 #include <solvcon/mesh/mesh.hpp>
@@ -17,6 +19,14 @@
 namespace solvcon
 {
 
+/**
+ * Per-cell-type constants for least-squares gradient reconstruction.
+ *
+ * Holds the face count, its reciprocal used as the uniform gradient weight,
+ * and the 1-based gradient-eval-point face indices per cell type.
+ *
+ * @ingroup group_multidim
+ */
 struct GradientElementType
 {
 
@@ -65,6 +75,14 @@ inline GradientElementType const & getype(size_t id)
     return detail::GradientElementTypeGroup::get_instance()[id];
 }
 
+/**
+ * Per-cell gradient reconstruction over a StaticMesh.
+ *
+ * Solves the small ndim-by-ndim least-squares systems on the CESE dual mesh
+ * with fixed 3-capacity matrices, so it allocates nothing per cell.
+ *
+ * @ingroup group_multidim
+ */
 class GradientElement
 {
 

--- a/cpp/solvcon/multidim/euler.hpp
+++ b/cpp/solvcon/multidim/euler.hpp
@@ -6,7 +6,10 @@
  */
 
 /**
- * The space-time CESE solver for the Euler equation.
+ * @file
+ * The space-time CESE solver for the Euler equations.
+ *
+ * @ingroup group_multidim
  */
 
 #include <solvcon/mesh/mesh.hpp>
@@ -31,6 +34,8 @@ enum class EulerBC : uint8_t
  * One registered boundary condition: a handler kind over a set of boundary
  * faces (global face indices). value carries the Inlet free stream as
  * [rho, v(ndim), p, gamma] and is unused by the other kinds.
+ *
+ * @ingroup group_multidim
  */
 struct EulerBoundary
 {
@@ -39,6 +44,15 @@ struct EulerBoundary
     SimpleCollector<double> value;
 }; /* end struct EulerBoundary */
 
+/**
+ * Multi-dimensional CESE solver core for the compressible Euler equations.
+ *
+ * Advances the conserved fields on a StaticMesh by one space-time step per
+ * call. The conserved set is density, the ndim momentum components, and total
+ * energy. Construct through EulerCore::construct so the instance is shared.
+ *
+ * @ingroup group_multidim
+ */
 class EulerCore
     : public NumberBase<int32_t, double>
     , public std::enable_shared_from_this<EulerCore>

--- a/cpp/solvcon/oasis/oasis_device.hpp
+++ b/cpp/solvcon/oasis/oasis_device.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Encode rectangle and polygon geometry as OASIS format byte records.
+ *
+ * @ingroup group_inout
+ */
+
 #include <solvcon/base.hpp>
 
 #include <cstdint>
@@ -25,6 +32,8 @@ class OasisRecordRect;
  * information (xy) to OASIS geometry format. The format are represented as
  * byte-continuations. LSB present that the next bytes is belonging the
  * group or not.
+ *
+ * @ingroup group_inout
  */
 class OasisDevice
 {
@@ -59,6 +68,8 @@ private:
 
 /**
  * Convert vertex information to OASIS polygon record bytes.
+ *
+ * @ingroup group_inout
  */
 class OasisRecordPoly
 {
@@ -81,6 +92,8 @@ private:
 
 /**
  * Convert rectangle information to OASIS rectangle record bytes.
+ *
+ * @ingroup group_inout
  */
 class OasisRecordRect
 {

--- a/cpp/solvcon/onedim/Euler1DCore.hpp
+++ b/cpp/solvcon/onedim/Euler1DCore.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * One-dimensional Euler equation solver core using the CESE method.
+ *
+ * @ingroup group_onedim
+ */
+
 #include <solvcon/onedim/core.hpp>
 #include <solvcon/base.hpp>
 #include <solvcon/math/math.hpp>
@@ -18,6 +25,17 @@ namespace solvcon
 namespace onedim
 {
 
+/**
+ * One-dimensional Euler solver core using the CESE method.
+ *
+ * @ingroup group_onedim
+ *
+ * It holds the NVAR (3) conserved variables (density, momentum, and
+ * total energy) in the so0 array of shape (ncoord, NVAR) and their
+ * spatial derivatives in so1, and marches them in space-time. Accessors
+ * derive density, velocity, pressure, temperature, internal energy, and
+ * entropy from the conserved variables.
+ */
 class Euler1DCore
     : public std::enable_shared_from_this<Euler1DCore>
 {
@@ -149,6 +167,16 @@ inline double Euler1DCore::internal_energy(size_t it) const
     return ret;
 }
 
+/**
+ * Per-element computation kernel for the one-dimensional Euler solver.
+ *
+ * @ingroup group_onedim
+ *
+ * It caches one solution element state (the conserved variables u, their
+ * spatial derivative ux, and the local geometry) and derives the
+ * Jacobian, flux, and space-time derivatives used to integrate the
+ * conservation element flux.
+ */
 struct Euler1DKernel
 {
     static constexpr double tiny = 1.e-100;

--- a/cpp/solvcon/pilot/DrawTool.hpp
+++ b/cpp/solvcon/pilot/DrawTool.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Pilot 2D canvas drawing tools and their registry.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <solvcon/universe/ViewTransform2d.hpp>
@@ -20,14 +27,22 @@ class QPainter;
 namespace solvcon
 {
 
-/// A point in world coordinates -- the unit a drawing gesture is built from.
+/**
+ * A point in world coordinates, the unit a drawing gesture is built from.
+ *
+ * @ingroup group_domain
+ */
 struct DrawPoint
 {
     double x;
     double y;
 }; /* end struct DrawPoint */
 
-/// Abstract base class for a 2D canvas drawing tool.
+/**
+ * Abstract base class for a 2D canvas drawing tool.
+ *
+ * @ingroup group_domain
+ */
 class DrawToolBase
 {
 
@@ -58,21 +73,38 @@ protected:
 
 }; /* end class DrawToolBase */
 
-/// Get the names of all registered tools, in Painter-toolbox order. The
-/// first entry is the default tool (see `default_draw_tool_name`).
+/**
+ * Get the names of all registered tools, in Painter-toolbox order. The
+ * first entry is the default tool (see `default_draw_tool_name`).
+ *
+ * @return The registered tool names in Painter-toolbox order.
+ */
 std::vector<std::string> const & draw_tool_names();
 
-/// Name of the default tool a fresh canvas starts with: the first
-/// registered tool, which is the pan navigation tool.
+/**
+ * Name of the default tool a fresh canvas starts with: the first
+ * registered tool, which is the pan navigation tool.
+ *
+ * @return The default tool name.
+ */
 std::string const & default_draw_tool_name();
 
-/// Build the tool registered under `name`.
-/// @return A unique pointer to the tool, never null for a valid name.
-/// @throw std::invalid_argument for an unknown name.
+/**
+ * Build the tool registered under `name`.
+ *
+ * @param name The registered name of the tool to build.
+ * @return A unique pointer to the tool, never null for a valid name.
+ * @throw std::invalid_argument for an unknown name.
+ */
 std::unique_ptr<DrawToolBase> make_draw_tool(std::string const & name);
 
-/// True if `name` is a registered tool R2DWidget accepts. Lets callers
-/// validate a name without building a tool.
+/**
+ * True if `name` is a registered tool R2DWidget accepts. Lets callers
+ * validate a name without building a tool.
+ *
+ * @param name The tool name to check.
+ * @return True if `name` is a registered tool, false otherwise.
+ */
 bool is_draw_tool(std::string const & name);
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/R2DWidget.hpp
+++ b/cpp/solvcon/pilot/R2DWidget.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Strictly-2D drawing widget that paints world geometry with QPainter.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <solvcon/buffer/small_vector.hpp>
@@ -32,6 +39,8 @@ namespace solvcon
  * Strictly-2D drawing widget for the pilot. Paints the geometry of a
  * `World<double>` by mapping it to screen space through a 2D view
  * transform, drawn with QPainter.
+ *
+ * @ingroup group_domain
  */
 class R2DWidget
     : public QWidget

--- a/cpp/solvcon/pilot/RAction.hpp
+++ b/cpp/solvcon/pilot/RAction.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * A QAction that runs a user-supplied callback when triggered.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <QAction>
@@ -12,6 +19,15 @@
 namespace solvcon
 {
 
+/**
+ * A QAction that invokes a stored callback when the action is triggered.
+ *
+ * @ingroup group_domain
+ *
+ * The constructor wires the QAction text and status tip and connects the
+ * triggered signal to the supplied callback, so callers can build a menu or
+ * toolbar action from a single function object.
+ */
 class RAction
     : public QAction
 {

--- a/cpp/solvcon/pilot/RAxisGizmo.hpp
+++ b/cpp/solvcon/pilot/RAxisGizmo.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Corner-of-viewport orientation gizmo that draws a colored axis triad.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <solvcon/pilot/RMaterial.hpp>

--- a/cpp/solvcon/pilot/RBoundary.hpp
+++ b/cpp/solvcon/pilot/RBoundary.hpp
@@ -5,6 +5,14 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Draw a single mesh boundary set as thick colored ribbons over the
+ * wireframe.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <solvcon/pilot/RDrawable.hpp>

--- a/cpp/solvcon/pilot/RCameraController.hpp
+++ b/cpp/solvcon/pilot/RCameraController.hpp
@@ -5,6 +5,14 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * The camera controller for the pilot domain viewer, with pan-zoom,
+ * first-person, and orbit interaction modes.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <QMatrix4x4>
@@ -37,6 +45,12 @@ class RCameraController
 
 public:
 
+    /**
+     * The interaction mode that selects how drag, wheel, and key input
+     * move the camera.
+     *
+     * @ingroup group_domain
+     */
     enum class Mode
     {
         PanZoom, ///< 2D: drag pans, wheel zooms the orthographic box.

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -5,6 +5,14 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Interactive QRhi widget that renders spatial domains and fields on
+ * unstructured meshes and routes camera control from Python.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <solvcon/pilot/RAxisGizmo.hpp>

--- a/cpp/solvcon/pilot/RDrawable.hpp
+++ b/cpp/solvcon/pilot/RDrawable.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Base class for a renderable object in the pilot domain scene.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <solvcon/pilot/RMaterial.hpp>

--- a/cpp/solvcon/pilot/RField.hpp
+++ b/cpp/solvcon/pilot/RField.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * A drawable field of per-vertex-colored triangles for the pilot viewer.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <solvcon/pilot/RDrawable.hpp>

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Singleton manager that owns the pilot main window and its child widgets.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <solvcon/pilot/DrawTool.hpp>
@@ -24,6 +31,17 @@
 namespace solvcon
 {
 
+/**
+ * @brief Singleton that owns the pilot main window and coordinates its
+ * widgets, menus, and the active canvas drawing tool.
+ *
+ * The manager holds the QCoreApplication, the QMainWindow with its menus and
+ * MDI area, and the Python console dock. It creates and tracks the 2D and 3D
+ * domain widgets, exposes the currently focused canvas, and routes the active
+ * drawing tool to it. Access the single instance through instance().
+ *
+ * @ingroup group_domain
+ */
 class RManager
     : public QObject
 {

--- a/cpp/solvcon/pilot/RMaterial.hpp
+++ b/cpp/solvcon/pilot/RMaterial.hpp
@@ -5,6 +5,14 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Rendering material that pairs a baked GLSL shader set with a graphics
+ * pipeline builder.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <rhi/qrhi.h>
@@ -29,7 +37,12 @@ class RMaterial
 
 public:
 
-    /// The shader variant. More variants are added as the renderer grows.
+    /**
+     * @brief The shader variant. More variants are added as the renderer
+     * grows.
+     *
+     * @ingroup group_domain
+     */
     enum class Kind
     {
         FlatColor, ///< One uniform color for the whole primitive.

--- a/cpp/solvcon/pilot/RMeshFrame.hpp
+++ b/cpp/solvcon/pilot/RMeshFrame.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Renders the unstructured-mesh domain as a wireframe drawable.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <solvcon/pilot/RDrawable.hpp>

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
@@ -5,6 +5,14 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Qt dock widget that hosts an interactive Python console with command
+ * history and tab-triggered auto-completion.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/python/common.hpp> // must be first.
 
 #include <string>
@@ -21,6 +29,18 @@
 namespace solvcon
 {
 
+/**
+ * The command input editor that drives Python auto-completion and
+ * reports execution and history navigation.
+ *
+ * On Tab the editor extracts the identifier prefix behind the cursor
+ * and emits completionRequested, or inserts a literal tab when there is
+ * no prefix. It emits execute on Enter, navigate on Up or Down at the
+ * first or last line, and inserts the match chosen from the completer
+ * popup.
+ *
+ * @ingroup group_domain
+ */
 class RPythonCommandTextEdit
     : public QTextEdit
 {
@@ -50,6 +70,14 @@ private:
 
 }; /* end class RPythonCommandTextEdit */
 
+/**
+ * The read-only transcript view that shows committed commands and their
+ * captured output.
+ *
+ * A double-click selects the entire transcript.
+ *
+ * @ingroup group_domain
+ */
 class RPythonHistoryTextEdit
     : public QTextEdit
 {
@@ -58,6 +86,18 @@ class RPythonHistoryTextEdit
     void mouseDoubleClickEvent(QMouseEvent *) override;
 }; /* end class RPythonHistoryTextEdit */
 
+/**
+ * The dockable Python console that pairs a transcript view with a
+ * command editor and runs each command in the embedded interpreter.
+ *
+ * Submitting a command appends it to the history, executes it through
+ * the Python interpreter, and writes the captured stdout and stderr to
+ * the transcript when the redirect is active. Up and Down walk the
+ * committed-command history, and the widget brokers the editor's
+ * completion requests against the interpreter's completer.
+ *
+ * @ingroup group_domain
+ */
 class RPythonConsoleDockWidget
     : public QDockWidget
 {

--- a/cpp/solvcon/pilot/RScene.hpp
+++ b/cpp/solvcon/pilot/RScene.hpp
@@ -5,6 +5,14 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Defines the RScene class that owns the drawables, the domain bounding
+ * box, and the framing camera for the pilot viewer.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <solvcon/pilot/RCameraController.hpp>

--- a/cpp/solvcon/pilot/RWorldRenderer2d.hpp
+++ b/cpp/solvcon/pilot/RWorldRenderer2d.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Renders a world's geometry into a QPainter through a 2D view transform.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <solvcon/universe/ViewTransform2d.hpp>

--- a/cpp/solvcon/pilot/common_detail.hpp
+++ b/cpp/solvcon/pilot/common_detail.hpp
@@ -6,7 +6,10 @@
  */
 
 /**
- * This file is shared by all code in the view directory.
+ * @file
+ * Shared helpers for all code in the pilot directory.
+ *
+ * @ingroup group_domain
  */
 
 #include <solvcon/python/python.hpp> // Must be the first include.
@@ -20,8 +23,11 @@ namespace solvcon
 /**
  * @brief Return a SimpleArray from the buffer of the input QByteArray.
  *
+ * @param qbarr The QByteArray whose raw bytes back the returned array.
+ * @param shape The dimensions of the returned SimpleArray.
  * @param view If true, the returned SimpleArray reuses (shares) the memory
  * buffer of the input array, and gives up (does not own) the memory buffer.
+ * @return A SimpleArray of the requested shape over the byte buffer.
  */
 template <typename T>
 SimpleArray<T> makeSimpleArray(QByteArray & qbarr, small_vector<size_t> shape, bool view = false)
@@ -55,6 +61,12 @@ SimpleArray<T> makeSimpleArray(QByteArray & qbarr, small_vector<size_t> shape, b
     return SimpleArray<T>(small_vector<size_t>(shape), cbuf);
 }
 
+/**
+ * @brief Return a QByteArray holding a copy of the SimpleArray buffer.
+ *
+ * @param sarr The source SimpleArray to copy from.
+ * @return A QByteArray containing a copy of the array bytes.
+ */
 template <typename T>
 QByteArray makeQByteArray(SimpleArray<T> const & sarr)
 {

--- a/cpp/solvcon/pilot/pilot.hpp
+++ b/cpp/solvcon/pilot/pilot.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Umbrella header that aggregates the pilot GUI component headers.
+ *
+ * @ingroup group_domain
+ */
+
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <solvcon/pilot/RDomainWidget.hpp>

--- a/cpp/solvcon/serialization/SerializableItem.hpp
+++ b/cpp/solvcon/serialization/SerializableItem.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Abstract interface and helpers for JSON serialization.
+ *
+ * @ingroup group_core
+ */
+
 #include <iomanip>
 #include <sstream>
 #include <string_view>
@@ -18,6 +25,11 @@
 namespace solvcon
 {
 
+/**
+ * Abstract interface for objects that serialize to and from JSON.
+ *
+ * @ingroup group_core
+ */
 // FIXME: NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 class SerializableItem
 {

--- a/cpp/solvcon/toggle/RadixTree.hpp
+++ b/cpp/solvcon/toggle/RadixTree.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Radix tree container and the hierarchical call profiler built on it.
+ *
+ * @ingroup group_core
+ */
+
 #include <algorithm>
 #include <chrono>
 #include <vector>
@@ -21,6 +28,14 @@
 
 namespace solvcon
 {
+/**
+ * A node in a RadixTree.
+ *
+ * Each node owns a signed integer key, a name, a value of type T,
+ * a list of owned child nodes, and a back pointer to its parent.
+ *
+ * @ingroup group_core
+ */
 template <typename T>
 class RadixTreeNode
 {
@@ -100,6 +115,15 @@ class CallProfilerTest; // for gtest
 } /* end namespace detail */
 
 class SerializableRadixTree; // forward declaration
+/**
+ * A radix tree that maps names to stable integer ids.
+ *
+ * Each distinct name receives a unique signed integer id, and a current
+ * node pointer walks down the tree as named entries are visited. A
+ * stable snapshot of the id map supports re-entrant-safe reads.
+ *
+ * @ingroup group_core
+ */
 template <typename T>
 class RadixTree
 {
@@ -181,7 +205,15 @@ private:
     key_type m_stable_unique_id = 0; // Re-entrant safe
 }; /* end class RadixTree */
 
-// The profiling result of the caller
+/**
+ * The profiling result of one caller.
+ *
+ * It records the stopwatch start time, the total elapsed time in
+ * nanoseconds, the call count, and stable snapshots of the total time
+ * and call count for re-entrant-safe reads.
+ *
+ * @ingroup group_core
+ */
 struct CallerProfile
 {
     void start_stopwatch()
@@ -213,7 +245,11 @@ struct CallerProfile
     bool is_running = false;
 }; /* end struct CallerProfile */
 
-/// The profiler that profiles the hierarchical caller stack.
+/**
+ * The profiler that profiles the hierarchical caller stack.
+ *
+ * @ingroup group_core
+ */
 class CallProfiler
 {
 private:
@@ -285,7 +321,11 @@ private:
     friend detail::CallProfilerTest;
 }; /* end class CallProfiler */
 
-/// Utility to profile a call
+/**
+ * Utility to profile a call.
+ *
+ * @ingroup group_core
+ */
 class CallProfilerProbe
 {
 public:

--- a/cpp/solvcon/toggle/SerializableProfiler.hpp
+++ b/cpp/solvcon/toggle/SerializableProfiler.hpp
@@ -5,12 +5,29 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Serializable mirror of the call profiler radix tree for JSON export.
+ *
+ * @ingroup group_core
+ */
+
 #include <solvcon/toggle/RadixTree.hpp>
 #include <solvcon/serialization/SerializableItem.hpp>
 
 namespace solvcon
 {
 
+/**
+ * Serializable snapshot of one call profiler radix tree node.
+ *
+ * It captures the node key, name, accumulated total time (nanoseconds),
+ * and call count, plus the child nodes whose stable call count is
+ * positive. The running flag and start time are intentionally omitted
+ * because they carry no meaning after deserialization.
+ *
+ * @ingroup group_core
+ */
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class SerializableRadixTreeNode : public SerializableItem
 {
@@ -66,6 +83,15 @@ private:
     child_list_type m_children;
 }; /* end class SerializableRadixTreeNode */
 
+/**
+ * Serializable snapshot of a whole call profiler radix tree.
+ *
+ * It holds the root node, the name-to-key identifier map, and the next
+ * unique node identifier, mirroring the stable state of a
+ * RadixTree<CallerProfile>.
+ *
+ * @ingroup group_core
+ */
 // FIXME: NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class SerializableRadixTree : public SerializableItem
 {
@@ -99,7 +125,11 @@ private:
     key_type m_unique_id;
 }; /* end class SerializableRadixTree */
 
-/// Utility to serialize and deserialize CallProfiler.
+/**
+ * Utility to serialize and deserialize CallProfiler.
+ *
+ * @ingroup group_core
+ */
 class CallProfilerSerializer
 {
 

--- a/cpp/solvcon/toggle/profile.hpp
+++ b/cpp/solvcon/toggle/profile.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Wall-time timing helpers for the runtime profiler.
+ *
+ * @ingroup group_core
+ */
+
 #include <solvcon/base.hpp>
 #include <chrono>
 
@@ -13,6 +20,8 @@ namespace solvcon
 
 /**
  * Simple timer for wall time using high-resolution clock.
+ *
+ * @ingroup group_core
  */
 class StopWatch
 {

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Toggle configuration system and process and command-line information.
+ *
+ * @ingroup group_core
+ */
+
 #include <solvcon/base.hpp>
 #include <solvcon/buffer/buffer.hpp>
 #include <solvcon/toggle/profile.hpp>
@@ -19,9 +26,23 @@ namespace solvcon
 
 int setenv(const char * name, const char * value, int overwrite);
 
+/**
+ * Index and type tag that locates a dynamic toggle value in its typed
+ * storage vector.
+ *
+ * The bool conversion is true when the type is not TYPE_NONE, and index
+ * is a 32-bit offset into the storage vector for the given Type.
+ *
+ * @ingroup group_core
+ */
 struct DynamicToggleIndex
 {
 
+    /**
+     * Data type tag for a dynamic toggle value.
+     *
+     * @ingroup group_core
+     */
     enum Type : uint8_t
     {
         TYPE_NONE, // 0
@@ -54,6 +75,16 @@ struct DynamicToggleIndex
 
 class DynamicToggleTable;
 
+/**
+ * Hierarchical accessor that reads and writes a DynamicToggleTable
+ * through dotted keys.
+ *
+ * It holds a base prefix and joins it to a key with a "." separator
+ * (see rekey), so nested subkeys can be reached without repeating the
+ * full path.
+ *
+ * @ingroup group_core
+ */
 class HierarchicalToggleAccess
 {
 
@@ -102,6 +133,15 @@ private:
 
 }; /* end class HierarchicalToggleAccess */
 
+/**
+ * Runtime table of dynamic toggles keyed by name.
+ *
+ * Each key maps to a DynamicToggleIndex that selects one of the per-type
+ * storage vectors (bool, int8, int16, int32, int64, real, and string).
+ * Values can be added, read, written, and cleared during runtime.
+ *
+ * @ingroup group_core
+ */
 // All data members are class types with their own default constructors.
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class DynamicToggleTable
@@ -169,6 +209,15 @@ public:                                    \
 private:                                   \
     bool m_##NAME;
 
+/**
+ * Toggles whose values are determined at compile time and read-only
+ * during the process lifetime.
+ *
+ * Each accessor (for example use_pyside) returns a bool member that has
+ * an address and cannot be optimized out, unlike a macro or constexpr.
+ *
+ * @ingroup group_core
+ */
 class SolidToggle
 {
 
@@ -188,6 +237,16 @@ public:                                          \
 private:                                         \
     bool m_##NAME = DEFAULT;
 
+/**
+ * Toggles whose names are fixed at compile time but whose bool values
+ * can change at runtime.
+ *
+ * Access needs no table lookup because the member addresses are known
+ * to the compiler and linker (for example python_redirect and
+ * show_axis).
+ *
+ * @ingroup group_core
+ */
 class FixedToggle
 {
 
@@ -240,6 +299,8 @@ public:
  *    hierarchical access may use attribute syntax:
  *
  *      tg.top_level.second_level.key_name = value
+ *
+ * @ingroup group_core
  */
 class Toggle
 {
@@ -297,6 +358,15 @@ private:
 
 class ProcessInfo;
 
+/**
+ * Captured command-line state for the current process.
+ *
+ * It stores the executable basename and the original, populated, and
+ * Python argument vectors. Once frozen, set_python_argv is ignored. It
+ * also builds the C-style argv buffer used to launch a Python main.
+ *
+ * @ingroup group_core
+ */
 // The std::vector data members are default-constructed.
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class CommandLineInfo
@@ -363,6 +433,14 @@ private:
 
 }; /* end class CommandLineInfo */
 
+/**
+ * Process-wide information accessed as a singleton.
+ *
+ * It owns the CommandLineInfo for the process and offers helpers to
+ * populate the command line and set environment variables.
+ *
+ * @ingroup group_core
+ */
 // NOLINTNEXTLINE(bugprone-exception-escape)
 class ProcessInfo
 {

--- a/cpp/solvcon/transform/fourier.hpp
+++ b/cpp/solvcon/transform/fourier.hpp
@@ -1,5 +1,13 @@
 #pragma once
 
+/**
+ * @file
+ * Fourier transform algorithms (FFT, inverse FFT, and DFT) for complex
+ * SimpleArray data.
+ *
+ * @ingroup group_numerics
+ */
+
 #include <solvcon/math/math.hpp>
 #include <solvcon/buffer/buffer.hpp>
 
@@ -52,6 +60,20 @@ void fft_radix_2(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
 
 } /* end namespace detail */
 
+/**
+ * Discrete Fourier transform of complex-valued arrays.
+ *
+ * The static methods operate on a SimpleArray of complex elements
+ * (T1<T2>, for example a complex type over double) holding one signal.
+ * fft() computes the forward transform, dispatching to a radix-2
+ * Cooley-Tukey step when the length N is a power of two and to the
+ * Bluestein algorithm otherwise. ifft() computes the inverse by
+ * conjugating the input, reusing fft(), and scaling by 1/N. dft()
+ * evaluates the direct O(N^2) sum. The forward transform uses the
+ * twiddle factor exp(-2 * pi * i * k / N).
+ *
+ * @ingroup group_numerics
+ */
 class FourierTransform
 {
 public:

--- a/cpp/solvcon/universe/ViewTransform2d.hpp
+++ b/cpp/solvcon/universe/ViewTransform2d.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Affine 2D view transform from world coordinates to Qt screen pixels.
+ *
+ * @ingroup group_geometry
+ */
+
 #include <cmath>
 #include <type_traits>
 
@@ -22,6 +29,8 @@ namespace solvcon
  *
  * The class is intentionally Qt-free so the math can be unit-tested in the
  * `test_nopython` gtest target without linking Qt.
+ *
+ * @ingroup group_geometry
  */
 template <typename T>
 class ViewTransform2d

--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -5,6 +5,14 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * Geometry world container for points, segments, cubic Bezier curves, and
+ * shapes, with an R-tree spatial index.
+ *
+ * @ingroup group_geometry
+ */
+
 #include <solvcon/base.hpp>
 #include <solvcon/buffer/SimpleCollector.hpp>
 #include <solvcon/serialization/SerializableItem.hpp>
@@ -20,6 +28,14 @@
 namespace solvcon
 {
 
+/**
+ * Kind of geometry shape, stored as a one-byte tag.
+ *
+ * DEAD marks a deleted or unused registry slot; the remaining values name
+ * the 0D, 1D, and 2D shapes the world can hold.
+ *
+ * @ingroup group_geometry
+ */
 enum class ShapeType : uint8_t
 {
     DEAD = 0, ///< deleted / unused slot
@@ -56,8 +72,12 @@ inline std::string shape_type_name(ShapeType st)
     }
 }
 
-/// Level of detail for World::describe_state. C++ callers pass the enum; the
-/// Python binding accepts the equivalent lower-case string.
+/**
+ * Level of detail for World::describe_state. C++ callers pass the enum; the
+ * Python binding accepts the equivalent lower-case string.
+ *
+ * @ingroup group_geometry
+ */
 enum class DescribeLevel : uint8_t
 {
     BASIC = 0, ///< only what the 2D image draws
@@ -73,13 +93,17 @@ inline DescribeLevel describe_level_from_string(std::string const & level)
         std::format("World: describe_state level '{}' not supported", level));
 }
 
-/// JSON-serializable view of one shape's rendered 2D geometry: its id, type,
-/// bounding box, segment endpoints, and curve control points. The z component
-/// is not rendered, so coordinates are 2D.
 // TODO: The shared JSON tool formats numbers with std::to_string, which keeps
 // only 6 decimal places. Coordinates that differ past the 6th decimal then
 // serialize identically and small magnitudes round to 0, which can confuse the
 // numeric oracles downstream.
+/**
+ * JSON-serializable view of one shape's rendered 2D geometry: its id, type,
+ * bounding box, segment endpoints, and curve control points. The z component
+ * is not rendered, so coordinates are 2D.
+ *
+ * @ingroup group_geometry
+ */
 class WorldShapeState : public SerializableItem
 {
 
@@ -130,8 +154,12 @@ private:
 
 }; /* end class WorldShapeState */
 
-/// JSON view of the whole world: shapes plus the bare segments, bare curves,
-/// and free points that also render but belong to no shape.
+/**
+ * JSON view of the whole world: shapes plus the bare segments, bare curves,
+ * and free points that also render but belong to no shape.
+ *
+ * @ingroup group_geometry
+ */
 class WorldState : public SerializableItem
 {
 
@@ -180,6 +208,8 @@ private:
  * Lightweight record mapping a shape ID to the segment and curve ranges
  * it owns in the world's pads. A shape may own segments only
  * (triangle, line, rectangle), curves only (ellipse, circle), or both.
+ *
+ * @ingroup group_geometry
  */
 struct ShapeRecord
 {
@@ -199,6 +229,8 @@ struct ShapeRecord
 
 /**
  * Entry stored in the R-tree: shape ID + bounding box.
+ *
+ * @ingroup group_geometry
  */
 template <typename T>
 struct ShapeEntry
@@ -208,6 +240,12 @@ struct ShapeEntry
     bool operator==(ShapeEntry const & other) const { return shape_id == other.shape_id; }
 }; /* end of struct ShapeEntry */
 
+/**
+ * RTreeValueOps specialization that gives the R-tree the bounding box of a
+ * ShapeEntry.
+ *
+ * @ingroup group_geometry
+ */
 template <typename T>
 struct RTreeValueOps<ShapeEntry<T>, BoundBox3d<T>>
 {
@@ -216,6 +254,8 @@ struct RTreeValueOps<ShapeEntry<T>, BoundBox3d<T>>
 
 /**
  * Manage all geometry entities.
+ *
+ * @ingroup group_geometry
  */
 template <typename T>
 class World

--- a/cpp/solvcon/universe/bezier.hpp
+++ b/cpp/solvcon/universe/bezier.hpp
@@ -8,6 +8,8 @@
 /**
  * @file
  * Bezier curve and its container.
+ *
+ * @ingroup group_geometry
  */
 
 #include <solvcon/base.hpp>
@@ -40,6 +42,8 @@ union Bezier3dData
  * Bezier curve up to degree 3 in three-dimensional space.
  *
  * @tparam T floating-point type
+ *
+ * @ingroup group_geometry
  */
 template <typename T>
 class Bezier3d
@@ -217,6 +221,8 @@ using Bezier3dFp64 = Bezier3d<double>;
  * Store curves that are compatible to SVG
  * https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths
  * @tparam T
+ *
+ * @ingroup group_geometry
  */
 template <typename T>
 class CurvePad
@@ -476,6 +482,17 @@ private:
 using CurvePadFp32 = CurvePad<float>;
 using CurvePadFp64 = CurvePad<double>;
 
+/**
+ * Sample cubic Bezier curves into connected line segments.
+ *
+ * Each curve is approximated by straight segments stored in a
+ * SegmentPad. The number of segments follows the chord length
+ * divided by a target segment length.
+ *
+ * @tparam T floating-point type
+ *
+ * @ingroup group_geometry
+ */
 template <typename T>
 class CubicBezierSampler
 {

--- a/cpp/solvcon/universe/coord.hpp
+++ b/cpp/solvcon/universe/coord.hpp
@@ -9,6 +9,8 @@
  * @file
  * Points and line segments and their containers in 2 and 3 dimensional
  * spaces.
+ *
+ * @ingroup group_geometry
  */
 
 #include <solvcon/base.hpp>
@@ -19,6 +21,8 @@ namespace solvcon
 
 /**
  * Axis enumeration for 3D space.
+ *
+ * @ingroup group_geometry
  */
 enum class Axis : uint8_t
 {
@@ -31,6 +35,8 @@ enum class Axis : uint8_t
  * Point in three-dimensional space.
  *
  * @tparam T floating-point type
+ *
+ * @ingroup group_geometry
  */
 template <typename T>
 class Point3d
@@ -259,6 +265,17 @@ Point3d<T> operator/(Point3d<T> const & lhs, typename Point3d<T>::value_type rhs
 using Point3dFp32 = Point3d<float>;
 using Point3dFp64 = Point3d<double>;
 
+/**
+ * Container of points in two- or three-dimensional space.
+ *
+ * Coordinates are stored as separate per-axis arrays (x, y, and, for
+ * three dimensions, z), so the layout is structure-of-arrays. The
+ * dimensionality (2 or 3) is fixed at construction and cannot change.
+ *
+ * @tparam T floating-point type
+ *
+ * @ingroup group_geometry
+ */
 template <typename T>
 class PointPad
     : public NumberBase<int32_t, T>
@@ -733,6 +750,8 @@ union Segment3dData
  * Segment in three-dimensional space.
  *
  * @tparam T floating-point type
+ *
+ * @ingroup group_geometry
  */
 template <typename T>
 class Segment3d
@@ -879,6 +898,17 @@ private:
 using Segment3dFp32 = Segment3d<float>;
 using Segment3dFp64 = Segment3d<double>;
 
+/**
+ * Container of line segments in two- or three-dimensional space.
+ *
+ * Each segment is stored as a pair of endpoints, held in two PointPad
+ * objects (one for each endpoint). The dimensionality (2 or 3) comes
+ * from the underlying point pads.
+ *
+ * @tparam T floating-point type
+ *
+ * @ingroup group_geometry
+ */
 template <typename T>
 class SegmentPad
     : public NumberBase<int32_t, T>

--- a/cpp/solvcon/universe/polygon.hpp
+++ b/cpp/solvcon/universe/polygon.hpp
@@ -8,6 +8,8 @@
 /**
  * @file
  * Polygons and their containers in 2 and 3 dimensional spaces.
+ *
+ * @ingroup group_geometry
  */
 
 #include <solvcon/base.hpp>
@@ -62,7 +64,11 @@ union Trapezoid3dData
 /**
  * Trapezoid in three-dimensional space.
  *
+ * Stores the four corner points (p0, p1, p2, p3) as twelve scalar
+ * coordinates in a flat buffer.
+ *
  * @tparam T floating-point type
+ * @ingroup group_geometry
  */
 template <typename T>
 class Trapezoid3d
@@ -271,6 +277,16 @@ private:
 using Trapezoid3dFp32 = Trapezoid3d<float>;
 using Trapezoid3dFp64 = Trapezoid3d<double>;
 
+/**
+ * Container for many trapezoids stored as four parallel point columns.
+ *
+ * The four corner points (p0, p1, p2, p3) of every trapezoid are kept in four
+ * separate PointPad instances, so trapezoid i is read by gathering element i
+ * from each column. The pad works for both 2 and 3 dimensional points.
+ *
+ * @tparam T floating-point type
+ * @ingroup group_geometry
+ */
 template <typename T>
 class TrapezoidPad
     : public NumberBase<int32_t, T>
@@ -913,6 +929,7 @@ class PolygonPad;
  * trapezoids. The decomposition is used for polygon boolean operations.
  *
  * @tparam T floating-point type
+ * @ingroup group_geometry
  */
 template <typename T>
 class TrapezoidalDecomposer
@@ -1170,6 +1187,7 @@ std::pair<size_t, size_t> TrapezoidalDecomposer<T>::decompose(size_t polygon_id,
  * into trapezoids and merging overlapping regions.
  *
  * @tparam T floating-point type
+ * @ingroup group_geometry
  */
 template <typename T>
 class AreaBooleanUnion
@@ -1209,6 +1227,7 @@ using AreaBooleanUnionFp64 = AreaBooleanUnion<double>;
  * into trapezoids and finding overlapping regions.
  *
  * @tparam T floating-point type
+ * @ingroup group_geometry
  */
 template <typename T>
 class AreaBooleanIntersection
@@ -1248,6 +1267,7 @@ using AreaBooleanIntersectionFp64 = AreaBooleanIntersection<double>;
  * them into trapezoids and removing overlapping regions.
  *
  * @tparam T floating-point type
+ * @ingroup group_geometry
  */
 template <typename T>
 class AreaBooleanDifference
@@ -1285,7 +1305,11 @@ using AreaBooleanDifferenceFp64 = AreaBooleanDifference<double>;
 /**
  * Triangle in three-dimensional space.
  *
+ * Stores the three corner points (p0, p1, p2) as nine scalar coordinates in a
+ * flat buffer.
+ *
  * @tparam T floating-point type
+ * @ingroup group_geometry
  */
 template <typename T>
 class Triangle3d
@@ -1475,7 +1499,16 @@ private:
 using Triangle3dFp32 = Triangle3d<float>;
 using Triangle3dFp64 = Triangle3d<double>;
 
-/// TrianglePad class for storing multiple Triangle3d objects
+/**
+ * Container for many triangles stored as three parallel point columns.
+ *
+ * The three corner points (p0, p1, p2) of every triangle are kept in three
+ * separate PointPad instances, so triangle i is read by gathering element i
+ * from each column. The pad works for both 2 and 3 dimensional points.
+ *
+ * @tparam T floating-point type
+ * @ingroup group_geometry
+ */
 template <typename T>
 class TrianglePad
     : public NumberBase<int32_t, T>
@@ -2025,6 +2058,7 @@ using TrianglePadFp64 = TrianglePad<double>;
  * The handle uses polygon_id as public API, with internal offset/count for efficient access.
  *
  * @tparam T floating-point type
+ * @ingroup group_geometry
  */
 template <typename T>
 class Polygon3d
@@ -2164,6 +2198,7 @@ private:
  * Reference: http://www0.cs.ucl.ac.uk/staff/m.slater/Teaching/CG/1997-98/Solutions/Trap/
  *
  * @tparam T floating-point type
+ * @ingroup group_geometry
  */
 template <typename T>
 class PolygonPad
@@ -2429,6 +2464,15 @@ using PolygonPadFp64 = PolygonPad<double>;
 using Polygon3dFp32 = Polygon3d<float>;
 using Polygon3dFp64 = Polygon3d<double>;
 
+/**
+ * RTreeValueOps specialization that bounds Segment3d items with BoundBox3d.
+ *
+ * Teaches the RTree how to compute the axis-aligned bounding box of a single
+ * segment and of a group of segments, used when indexing polygon edges.
+ *
+ * @tparam T floating-point type
+ * @ingroup group_geometry
+ */
 template <typename T>
 struct RTreeValueOps<Segment3d<T>, BoundBox3d<T>>
 {

--- a/cpp/solvcon/universe/polygon_boolean.hpp
+++ b/cpp/solvcon/universe/polygon_boolean.hpp
@@ -13,6 +13,8 @@
  * sweep-line algorithm for polygon boolean operations (union, intersection,
  * difference).  Extracted from compute_boolean_with_decomposition() in
  * polygon.hpp to improve readability and avoid lambda closures in tight loops.
+ *
+ * @ingroup group_geometry
  */
 
 #include <algorithm>

--- a/cpp/solvcon/universe/rtree.hpp
+++ b/cpp/solvcon/universe/rtree.hpp
@@ -5,6 +5,13 @@
  * BSD 3-Clause License, see COPYING
  */
 
+/**
+ * @file
+ * R-tree spatial index for 2D and 3D bounding boxes.
+ *
+ * @ingroup group_geometry
+ */
+
 // This library implement R-tree based on "R Trees: A Dynamic Index Structure for Spatial Searchin" by Guttman in 1984
 // https://doi.org/10.1145/971697.602266
 
@@ -19,9 +26,15 @@
 namespace solvcon
 {
 
-/// Bounding box for 2D and 3D objects, e.g., Point3d, Segment3d, Triangle3d, etc.
-/// For 2D usage, callers pass min_z = max_z = 0 explicitly.
-/// @tparam T floating-point type
+/**
+ * Bounding box for 2D and 3D objects, e.g., Point3d, Segment3d,
+ * Triangle3d, etc. For 2D usage, callers pass min_z = max_z = 0
+ * explicitly.
+ *
+ * @tparam T Floating-point coordinate type.
+ *
+ * @ingroup group_geometry
+ */
 template <typename T>
 class BoundBox3d : public NumberBase<int32_t, T>
 {
@@ -103,9 +116,14 @@ public:
     }
 }; /* end of struct BoundBox3d */
 
-/// Value operations traits for R-tree
-/// @tparam E Item type to be stored in R-tree
-/// @tparam B Bounding box type associated with the item E
+/**
+ * Value operations traits for the R-tree.
+ *
+ * @tparam E Item type to be stored in the R-tree.
+ * @tparam B Bounding box type associated with the item E.
+ *
+ * @ingroup group_geometry
+ */
 template <typename E, typename B>
 struct RTreeValueOps
 {
@@ -116,10 +134,19 @@ struct RTreeValueOps
     static B calc_group_bound_box(std::vector<E> const & items);
 }; /* end of struct RTreeValueOps */
 
-/// R-tree node structure
-/// @tparam E Item type to be stored in R-tree
-/// @tparam B Bounding box type associated
-/// @tparam ValueOps Value operations traits for E and B
+/**
+ * R-tree node structure.
+ *
+ * A node is a leaf when it holds items and an internal node when it
+ * holds child nodes; the two vectors are not populated at the same
+ * time.
+ *
+ * @tparam E Item type to be stored in the R-tree.
+ * @tparam B Bounding box type associated with the item E.
+ * @tparam ValueOpsType Value operations traits for E and B.
+ *
+ * @ingroup group_geometry
+ */
 template <typename E, typename B, typename ValueOpsType>
 struct RTreeNode
 {
@@ -199,11 +226,19 @@ struct RTreeNode
     }
 }; /* end of struct RTreeNode */
 
-/// R-tree implementation for spatial index based on Guttman's R-tree paper
-/// @tparam E Item type to be stored in R-tree
-/// @tparam B Bounding box type associated with E
-/// @tparam ValueOps Value operations traits for E and B
-/// @tparam MAX_ITEMS_PER_NODE Maximum number of items per R-tree node
+/**
+ * R-tree spatial index based on Guttman's 1984 R-tree paper.
+ *
+ * Supports insert, search by bounding box, and remove. A node holds at
+ * most MAX_ITEMS_PER_NODE entries and splits when it overflows.
+ *
+ * @tparam E Item type to be stored in the R-tree.
+ * @tparam B Bounding box type associated with E.
+ * @tparam ValueOps Value operations traits for E and B.
+ * @tparam MAX_ITEMS_PER_NODE Maximum number of entries per R-tree node.
+ *
+ * @ingroup group_geometry
+ */
 template <typename E, typename B, typename ValueOps = RTreeValueOps<E, B>, int MAX_ITEMS_PER_NODE = 64>
 class RTree
 {

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -24,7 +24,7 @@
  *  BLAS and LAPACK wrappers, dense factorizations, and integral transforms.
  */
 
-/** @defgroup group_universe Geometry
+/** @defgroup group_geometry Geometry
  *  Three-dimensional geometry primitives and spatial indices.
  */
 

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -46,7 +46,7 @@
  */
 
 /** @defgroup group_domain Domain visualizer
- *  Qt-based GUI for spatial data visualization.
+ *  Qt-based GUI for spatial data analysis.
  */
 
 /* vim: set ft=c ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: */

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -9,9 +9,10 @@
  */
 
 /** @defgroup group_core Core and memory
- *  Value-type bases, the string formatter, serialization, raw memory and the
- *  typed multi-dimensional arrays (ConcreteBuffer, SimpleArray, small_vector),
- *  the feature toggle, SIMD, and device compute.
+ *  Value-type bases, complex numbers and fundamental mathematical helpers, the
+ *  string formatter, serialization, raw memory and the typed multi-dimensional
+ *  arrays (ConcreteBuffer, SimpleArray, small_vector), the feature toggle,
+ *  SIMD, and device compute.
  */
 
 /** @defgroup group_mesh Mesh

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -41,6 +41,10 @@
  *  output (OASIS).
  */
 
+/** @defgroup group_canvas 2D graphical editor
+ *  Qt-based GUI for creating 2D graphics.
+ */
+
 /** @defgroup group_domain Domain visualizer
  *  Qt-based GUI for spatial data visualization.
  */

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -15,17 +15,17 @@
  *  SIMD, and device compute.
  */
 
-/** @defgroup group_mesh Mesh
- *  Unstructured meshes with mixed element types (StaticMesh) and the static
- *  grids (grid.hpp).
- */
-
 /** @defgroup group_numerics Numerics
  *  BLAS and LAPACK wrappers, dense factorizations, and integral transforms.
  */
 
 /** @defgroup group_geometry Geometry
  *  Three-dimensional geometry primitives and spatial indices.
+ */
+
+/** @defgroup group_mesh Mesh
+ *  Unstructured meshes with mixed element types (StaticMesh) and the static
+ *  grids (grid.hpp).
  */
 
 /** @defgroup group_onedim One-dimensional solvers

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -20,9 +20,8 @@
  *  grids (grid.hpp).
  */
 
-/** @defgroup group_linalg Numerics
- *  BLAS and LAPACK wrappers, dense factorizations, complex numbers, and
- *  integral transforms.
+/** @defgroup group_numerics Numerics
+ *  BLAS and LAPACK wrappers, dense factorizations, and integral transforms.
  */
 
 /** @defgroup group_universe Geometry

--- a/doc/source/api/cpp.md
+++ b/doc/source/api/cpp.md
@@ -11,14 +11,6 @@ by [breathe](https://www.breathe-doc.org/).
    :content-only:
 ```
 
-## Mesh
-
-```{eval-rst}
-.. doxygengroup:: group_mesh
-   :project: solvcon
-   :content-only:
-```
-
 ## Numerics
 
 ```{eval-rst}
@@ -31,6 +23,14 @@ by [breathe](https://www.breathe-doc.org/).
 
 ```{eval-rst}
 .. doxygengroup:: group_geometry
+   :project: solvcon
+   :content-only:
+```
+
+## Mesh
+
+```{eval-rst}
+.. doxygengroup:: group_mesh
    :project: solvcon
    :content-only:
 ```

--- a/doc/source/api/cpp.md
+++ b/doc/source/api/cpp.md
@@ -59,6 +59,14 @@ by [breathe](https://www.breathe-doc.org/).
    :content-only:
 ```
 
+## Graphical editor
+
+```{eval-rst}
+.. doxygengroup:: group_canvas
+   :project: solvcon
+   :content-only:
+```
+
 ## Domain visualizer
 
 The 2/3D visualizer (see {doc}`../pilot/domain`) renders through

--- a/doc/source/api/cpp.md
+++ b/doc/source/api/cpp.md
@@ -22,7 +22,7 @@ by [breathe](https://www.breathe-doc.org/).
 ## Numerics
 
 ```{eval-rst}
-.. doxygengroup:: group_linalg
+.. doxygengroup:: group_numerics
    :project: solvcon
    :content-only:
 ```

--- a/doc/source/api/cpp.md
+++ b/doc/source/api/cpp.md
@@ -30,7 +30,7 @@ by [breathe](https://www.breathe-doc.org/).
 ## Geometry
 
 ```{eval-rst}
-.. doxygengroup:: group_universe
+.. doxygengroup:: group_geometry
    :project: solvcon
    :content-only:
 ```


### PR DESCRIPTION
Document the C++ headers with Doxygen and organize the public types into topic groups so the C++ API reference renders a complete, navigable tree.

Doxygen comments (`@file`, `@ingroup`, `@brief`) are added across the C++ headers, one commit per topic group:

1. Core and memory: buffer, serialization, toggle, and device headers, with the complex-number type folded in beside the core math helpers.
2. Numerics: linalg and transform headers, under the renamed `group_numerics`.
3. Geometry: universe headers, under `group_geometry`.
4. Mesh: mesh and grid headers, ordered after Geometry.
5. One-dimensional solvers: the onedim header.
6. Multi-dimensional solvers: the multidim headers.
7. Input and output: the inout and oasis headers.
8. Domain visualizer: the pilot headers.

The group definitions in `doc/groups.dox` and the reference page in `doc/source/api/cpp.md` are updated to match:

- Groups are renamed to stable, intent-revealing ids (`group_numerics`, `group_geometry`) and reordered so Geometry precedes Mesh.
- A new `group_canvas` group is declared for the Qt-based 2D graphics editor, with a matching "Graphical editor" section on the reference page.

This PR is twice as long as an OK length for review.  Instead, review the individual commits, which are intentionally made short for review.

For issue #954.