### PR TITLE
Refine .clang-format to wrap long macro declarations

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -59,7 +59,7 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeComma
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit:     0
+ColumnLimit:     79
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false


### PR DESCRIPTION
Refine .clang-format to avoid extremely long single-line function declarations produced inside macros by clang-format. Set ColumnLimit from 0 to 79 so long template/macro declarations wrap sensibly and preserve readability.

Related to #526.