### PR TITLE
Add Python API doc and restructure the API pages

### DIFF
--- a/doc/source/api/cpp.md
+++ b/doc/source/api/cpp.md
@@ -1,93 +1,29 @@
 # C++ API
 
 C++ API documentation written in Doxygen format in the C++ source code, bridged
-by [breathe](https://www.breathe-doc.org/).
+by [breathe](https://www.breathe-doc.org/).  Each page below renders one Doxygen
+group.
 
-## Core and memory
+```{toctree}
+:maxdepth: 1
 
-```{eval-rst}
-.. doxygengroup:: group_core
-   :project: solvcon
-   :content-only:
+cpp_core
+cpp_numerics
+cpp_geometry
+cpp_mesh
+cpp_onedim
+cpp_multidim
+cpp_inout
+cpp_canvas
+cpp_domain
 ```
 
-## Numerics
-
-```{eval-rst}
-.. doxygengroup:: group_numerics
-   :project: solvcon
-   :content-only:
-```
-
-## Geometry
-
-```{eval-rst}
-.. doxygengroup:: group_geometry
-   :project: solvcon
-   :content-only:
-```
-
-## Mesh
-
-```{eval-rst}
-.. doxygengroup:: group_mesh
-   :project: solvcon
-   :content-only:
-```
-
-## One-dimensional solvers
-
-```{eval-rst}
-.. doxygengroup:: group_onedim
-   :project: solvcon
-   :content-only:
-```
-
-## Multi-dimensional solvers
-
-```{eval-rst}
-.. doxygengroup:: group_multidim
-   :project: solvcon
-   :content-only:
-```
-
-## Input and output
-
-```{eval-rst}
-.. doxygengroup:: group_inout
-   :project: solvcon
-   :content-only:
-```
-
-## Graphical editor
-
-```{eval-rst}
-.. doxygengroup:: group_canvas
-   :project: solvcon
-   :content-only:
-```
-
-## Domain visualizer
-
-The 2/3D visualizer (see {doc}`../pilot/domain`) renders through
-[QRhi](https://doc.qt.io/qt-6/qrhi.html), Qt's portable graphics abstraction.
-
-{cpp:class}`solvcon::RDomainWidget` is the Python-facing control object.
-
-```{eval-rst}
-.. doxygengroup:: group_domain
-   :project: solvcon
-   :content-only:
-```
-
-## Notes on generating this C++ API document
-
-Doxygen parses the existing ``///`` and ``/**`` comments in `cpp/solvcon/` into
-XML; breathe turns that XML into the reference below.
-
-```{important}
+```{note}
 Run ``make doxygen`` once before ``make html`` so the Doxygen XML exists.
-Until then this directive renders empty (a warning, not an error).
+Until then these directives render empty (a warning, not an error). Doxygen
+parses the existing ``///`` and ``/**`` comments in `cpp/solvcon/` into XML;
+breathe turns that XML into the per-group reference pages.
 ```
+
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/api/cpp_canvas.md
+++ b/doc/source/api/cpp_canvas.md
@@ -1,0 +1,9 @@
+# Graphical editor
+
+```{eval-rst}
+.. doxygengroup:: group_canvas
+   :project: solvcon
+   :content-only:
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/api/cpp_core.md
+++ b/doc/source/api/cpp_core.md
@@ -1,0 +1,9 @@
+# Core and memory
+
+```{eval-rst}
+.. doxygengroup:: group_core
+   :project: solvcon
+   :content-only:
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/api/cpp_domain.md
+++ b/doc/source/api/cpp_domain.md
@@ -1,0 +1,14 @@
+# Domain visualizer
+
+The 2/3D visualizer (see {doc}`../pilot/domain`) renders through
+[QRhi](https://doc.qt.io/qt-6/qrhi.html), Qt's portable graphics abstraction.
+
+{cpp:class}`solvcon::RDomainWidget` is the Python-facing control object.
+
+```{eval-rst}
+.. doxygengroup:: group_domain
+   :project: solvcon
+   :content-only:
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/api/cpp_geometry.md
+++ b/doc/source/api/cpp_geometry.md
@@ -1,0 +1,9 @@
+# Geometry
+
+```{eval-rst}
+.. doxygengroup:: group_geometry
+   :project: solvcon
+   :content-only:
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/api/cpp_inout.md
+++ b/doc/source/api/cpp_inout.md
@@ -1,0 +1,9 @@
+# Input and output
+
+```{eval-rst}
+.. doxygengroup:: group_inout
+   :project: solvcon
+   :content-only:
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/api/cpp_mesh.md
+++ b/doc/source/api/cpp_mesh.md
@@ -1,0 +1,9 @@
+# Mesh
+
+```{eval-rst}
+.. doxygengroup:: group_mesh
+   :project: solvcon
+   :content-only:
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/api/cpp_multidim.md
+++ b/doc/source/api/cpp_multidim.md
@@ -1,0 +1,9 @@
+# Multi-dimensional solvers
+
+```{eval-rst}
+.. doxygengroup:: group_multidim
+   :project: solvcon
+   :content-only:
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/api/cpp_numerics.md
+++ b/doc/source/api/cpp_numerics.md
@@ -1,0 +1,9 @@
+# Numerics
+
+```{eval-rst}
+.. doxygengroup:: group_numerics
+   :project: solvcon
+   :content-only:
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/api/cpp_onedim.md
+++ b/doc/source/api/cpp_onedim.md
@@ -1,0 +1,9 @@
+# One-dimensional solvers
+
+```{eval-rst}
+.. doxygengroup:: group_onedim
+   :project: solvcon
+   :content-only:
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/api/python.md
+++ b/doc/source/api/python.md
@@ -1,15 +1,29 @@
 # Python API
 
-This page is generated from docstrings by ``autodoc``, so it stays in sync with
-the code automatically.  The compiled ``_solvcon`` extension is mocked during
-the build (see `conf.py`), so these pages render even on a clean checkout where
-the C++ layer has not been compiled.
+The Python API has two layers.  The pure-Python modules under `solvcon/`
+provide the high-level interface, and a compiled extension, `_solvcon`,
+supplies the performance-critical types through pybind11 wrappers.
 
-Below is an example that documents the one-dimensional Euler solver.  Point
-``automodule`` at any module to render its public surface.
+## Compiled extension wrappers
+
+{py:mod}`solvcon.core` loads the pybind11 wrappers from the {py:mod}`_solvcon`
+extension and re-exports them into the top-level {py:mod}`solvcon` namespace.
+
+## GUI ({py:mod}`solvcon.pilot`)
+
+The Qt-based {doc}`Pilot GUI </pilot/index>` lives in {py:mod}`solvcon.pilot`
+and needs Qt6 and PySide6.
+
+```{note}
+This section is a placeholder for GUI Python API documentation.
+```
+
+## Testing utilities ({py:mod}`solvcon.testing`)
+
+Helpers shared by the Python test suite.
 
 ```{eval-rst}
-.. automodule:: solvcon.onedim.euler1d
+.. automodule:: solvcon.testing
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -4,10 +4,10 @@ solvcon is an application platform for geometry-based computation: editing
 graphics and geometry, visualizing, meshing, and solving conservation laws.
 
 It is in the early-stage development. The system has been rewritten as a
-research code for a couple of time to explore for a good software architecture.
-Now we are transforming it into an integrated system that delivers high
-performance and ease of use at once. The documentation will evolve with the
-code.
+research code for a couple of times to explore for a good software
+architecture. Now we are transforming it into an integrated system that
+delivers high performance and ease of use at once. The documentation will
+evolve with the code.
 
 ```{toctree}
 :maxdepth: 1

--- a/solvcon/multidim/euler/oblique.py
+++ b/solvcon/multidim/euler/oblique.py
@@ -67,6 +67,7 @@ class ObliqueShockMesher(object):
         """Build a :class:`~solvcon.core.StaticMesh` of the selected flavor.
 
         ``cell_type`` selects the element shape:
+
         - ``'quad'`` keeps one quadrilateral per grid box,
         - ``'triangle'`` cuts each box along its lower-left-to-upper-right
           diagonal into two triangles (flipping the diagonal at two corners


### PR DESCRIPTION
This branch reworks the API reference documentation so the C++ and Python references. The single, monolithic C++ API page is split into one page per Doxygen group, and the Python API page is rewritten to describe the two-layer (pure-Python plus compiled extension) structure instead of a single solver example.

For issue #968.