### PR TITLE
Add SimpleArray argwhere

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -1350,6 +1350,9 @@ public:
         }
         return max_index;
     }
+
+    SimpleArray<uint64_t> argwhere() const;
+
 }; /* end class SimpleArrayMixinSearch */
 
 template <typename A, typename T>
@@ -2634,6 +2637,42 @@ A detail::SimpleArrayMixinSort<A, T>::take_along_axis(SimpleArray<I> const & ind
         ++src;
     }
     return ret;
+}
+
+template <typename A, typename T>
+SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argwhere() const
+{
+    auto athis = static_cast<A const *>(this);
+
+    size_t count = 0;
+    for (size_t i = 0; i < athis->size(); ++i)
+    {
+        if (athis->data(i) != value_type(0))
+        {
+            ++count;
+        }
+    }
+
+    size_t const ndim = athis->ndim();
+    shape_type res_shape{count, ndim};
+    SimpleArray<uint64_t> result(res_shape);
+
+    size_t idx = 0;
+    for (size_t i = 0; i < athis->size(); ++i)
+    {
+        if (athis->data(i) == value_type(0)) { continue; }
+
+        size_t offset = i;
+        for (size_t dim = 0; dim < ndim; ++dim)
+        {
+            size_t stride = athis->stride(dim);
+            result(idx, dim) = static_cast<uint64_t>(offset / stride);
+            offset %= stride;
+        }
+        ++idx;
+    }
+
+    return result;
 }
 
 // The declaration lives in namespace detail and is excluded from the API

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -2660,7 +2660,10 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argwhere() const
     size_t idx = 0;
     for (size_t i = 0; i < athis->size(); ++i)
     {
-        if (athis->data(i) == value_type(0)) { continue; }
+        if (athis->data(i) == value_type(0))
+        {
+            continue;
+        }
 
         size_t offset = i;
         for (size_t dim = 0; dim < ndim; ++dim)

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -2654,7 +2654,7 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argwhere() const
     }
 
     size_t const ndim = athis->ndim();
-    shape_type res_shape{count, ndim};
+    shape_type const res_shape{count, ndim};
     SimpleArray<uint64_t> result(res_shape);
 
     size_t idx = 0;
@@ -2668,7 +2668,7 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argwhere() const
         size_t offset = i;
         for (size_t dim = 0; dim < ndim; ++dim)
         {
-            size_t stride = athis->stride(dim);
+            size_t const stride = athis->stride(dim);
             result(idx, dim) = static_cast<uint64_t>(offset / stride);
             offset %= stride;
         }

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -584,6 +584,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
         (*this)
             .def("argmin", &wrapped_type::argmin)
             .def("argmax", &wrapped_type::argmax)
+            .def("argwhere", &wrapped_type::argwhere)
             //
             ;
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -3843,6 +3843,27 @@ class SimpleArraySearchTC(unittest.TestCase):
         self.assertEqual(sarr.argmax(), 9)
         self.assertEqual(narr.argmin(), sarr.argmin())
         self.assertEqual(narr.argmax(), sarr.argmax())
+    
+    def test_argwhere(self):
+        # test 1-D data
+        data = [1, 3, 5, 7, 9]
+        narr = np.array(data, dtype='uint64')
+        sarr = solvcon.SimpleArrayUint64(array=narr)
+
+        ret = sarr.eq(5).argwhere()
+        np.testing.assert_array_equal(ret.ndarray, np.argwhere(narr == 5))
+
+        # test N-D data
+        data = [
+            [1, 3, 5, 7, 9],
+            [2, 4, 6, 8, 10],
+            [1, 10, 1, 10, 1]
+        ]
+        narr = np.array(data, dtype='float64')
+        sarr = solvcon.SimpleArrayFloat64(array=narr)
+
+        ret = sarr.eq(10).argwhere()
+        np.testing.assert_array_equal(ret.ndarray, np.argwhere(narr == 10))
 
 
 class SimpleArrayPlexTC(unittest.TestCase):

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -3843,7 +3843,7 @@ class SimpleArraySearchTC(unittest.TestCase):
         self.assertEqual(sarr.argmax(), 9)
         self.assertEqual(narr.argmin(), sarr.argmin())
         self.assertEqual(narr.argmax(), sarr.argmax())
-    
+
     def test_argwhere(self):
         # test 1-D data
         data = [1, 3, 5, 7, 9]


### PR DESCRIPTION
Add `SimpleArray::argwhere()` as the first part of the second stage of search-method work.

The new method returns the coordinates of non-zero entries as a two-dimensional `SimpleArray<uint64_t>` with shape `{count, ndim}`. It scans the array storage and converts each matching flat index back into multi-dimensional coordinates.

Expose `argwhere()` through the Python bindings for the existing `SimpleArray` specializations, and add Python unittest coverage for both one-dimensional and N-dimensional arrays.

`SimpleArray::where()` is left for follow-up work.

Related to #519 

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
