### PR TITLE
Make shape as a signed vector in SimpleArray

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.cpp
+++ b/cpp/solvcon/buffer/SimpleArray.cpp
@@ -193,8 +193,8 @@ void SimpleArrayCopier::memcpy() const
  */
 void SimpleArrayCopier::tiled_2d() const
 {
-    auto const n0 = static_cast<ssize_t>(m_shape[0]);
-    auto const n1 = static_cast<ssize_t>(m_shape[1]);
+    ssize_t const n0 = m_shape[0];
+    ssize_t const n1 = m_shape[1];
     // Element strides scaled to byte strides once; the inner loop uses byte
     // arithmetic throughout.
     auto const itemsize = static_cast<ssize_t>(m_itemsize);
@@ -223,7 +223,7 @@ void SimpleArrayCopier::tiled_nd() const
     auto const itemsize = static_cast<ssize_t>(m_itemsize);
     if (ndim == 1)
     {
-        auto const n = static_cast<ssize_t>(m_shape[0]);
+        ssize_t const n = m_shape[0];
         ssize_t const ss = m_src_stride[0] * itemsize;
         ssize_t const os = m_dst_stride[0] * itemsize;
         for (ssize_t i = 0; i < n; ++i)
@@ -236,21 +236,21 @@ void SimpleArrayCopier::tiled_nd() const
     // See tiled_2d for the rationale behind the block size.
     size_t const ia = ndim - 2;
     size_t const ib = ndim - 1;
-    auto const n_a = static_cast<ssize_t>(m_shape[ia]);
-    auto const n_b = static_cast<ssize_t>(m_shape[ib]);
+    ssize_t const n_a = m_shape[ia];
+    ssize_t const n_b = m_shape[ib];
     ssize_t const ss_a = m_src_stride[ia] * itemsize;
     ssize_t const ss_b = m_src_stride[ib] * itemsize;
     ssize_t const os_a = m_dst_stride[ia] * itemsize;
     ssize_t const os_b = m_dst_stride[ib] * itemsize;
 
-    size_t outer_total = 1;
+    ssize_t outer_total = 1;
     for (size_t k = 0; k < ia; ++k)
     {
         outer_total *= m_shape[k];
     }
 
     detail::sshape_type outer_idx(ia, 0);
-    for (size_t step = 0; step < outer_total; ++step)
+    for (ssize_t step = 0; step < outer_total; ++step)
     {
         // Resolve outer-axis base offsets (in bytes) for this slab.
         ssize_t src_base = 0;
@@ -265,7 +265,7 @@ void SimpleArrayCopier::tiled_nd() const
         // Carry-propagating increment of the outer index.
         for (size_t i = ia; i-- > 0;)
         {
-            if (++outer_idx[i] < static_cast<ssize_t>(m_shape[i]))
+            if (++outer_idx[i] < m_shape[i])
             {
                 break;
             }
@@ -286,8 +286,8 @@ void SimpleArrayCopier::naive() const
     {
         return;
     }
-    size_t total = 1;
-    for (size_t const s : m_shape)
+    ssize_t total = 1;
+    for (ssize_t const s : m_shape)
     {
         total *= s;
     }
@@ -299,7 +299,7 @@ void SimpleArrayCopier::naive() const
     size_t const itemsize = m_itemsize;
     auto const signed_itemsize = static_cast<ssize_t>(itemsize);
     detail::sshape_type idx(ndim, 0);
-    for (size_t step = 0; step < total; ++step)
+    for (ssize_t step = 0; step < total; ++step)
     {
         ssize_t src_off = 0;
         ssize_t dst_off = 0;
@@ -316,7 +316,7 @@ void SimpleArrayCopier::naive() const
         // wrap to 0 and carry into the next-most-significant axis.
         for (size_t i = ndim; i-- > 0;)
         {
-            if (++idx[i] < static_cast<ssize_t>(m_shape[i]))
+            if (++idx[i] < m_shape[i])
             {
                 break;
             }
@@ -956,7 +956,7 @@ std::string format_shape(shape_type const & shape)
     return ret;
 }
 
-std::string format_flat_index(shape_type const & shape, size_t offset)
+std::string format_flat_index(shape_type const & shape, ssize_t offset)
 {
     if (shape.empty())
     {

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -108,7 +108,7 @@ inline ssize_t buffer_offset(small_vector<ssize_t> const & stride, small_vector<
 namespace detail
 {
 
-using shape_type = small_vector<size_t>;
+using shape_type = small_vector<ssize_t>;
 using sshape_type = small_vector<ssize_t>;
 
 /**
@@ -141,13 +141,13 @@ public:
     }
 
     template <typename Array>
-    IndexRange(Array const & array, small_vector<size_t> const & axes)
+    IndexRange(Array const & array, shape_type const & axes)
         : m_lower(axes.size(), 0)
         , m_upper(axes.size(), 0)
     {
         for (size_t k = 0; k < axes.size(); ++k)
         {
-            size_t const dim = axes[k];
+            ssize_t const dim = axes[k];
             m_lower[k] = lower_bound(array, dim);
             m_upper[k] = upper_bound(array, dim);
         }
@@ -169,7 +169,7 @@ public:
     }
 
     template <typename Array>
-    static ssize_t index_from_offset(Array const & array, size_t dim, ssize_t offset)
+    static ssize_t index_from_offset(Array const & array, ssize_t dim, ssize_t offset)
     {
         return lower_bound(array, dim) + offset;
     }
@@ -180,7 +180,7 @@ private:
     sshape_type m_upper;
 
     template <typename Array>
-    static ssize_t lower_bound(Array const & array, size_t dim)
+    static ssize_t lower_bound(Array const & array, ssize_t dim)
     {
         if (dim == 0)
         {
@@ -190,14 +190,14 @@ private:
     }
 
     template <typename Array>
-    static ssize_t upper_bound(Array const & array, size_t dim)
+    static ssize_t upper_bound(Array const & array, ssize_t dim)
     {
-        return lower_bound(array, dim) + static_cast<ssize_t>(array.shape(dim));
+        return lower_bound(array, dim) + array.shape(dim);
     }
 };
 
 std::string format_shape(shape_type const & shape);
-std::string format_flat_index(shape_type const & shape, size_t offset);
+std::string format_flat_index(shape_type const & shape, ssize_t offset);
 
 template <typename T>
 struct SimpleArrayInternalTypes
@@ -318,7 +318,7 @@ private:
                                   sshape_type const & stride)
     {
         const size_t ndim = shape.size();
-        auto const last_dim = static_cast<ssize_t>(shape[ndim - 1]);
+        ssize_t const last_dim = shape[ndim - 1];
         const ssize_t last_stride = stride[ndim - 1];
 
         value_type acc = zero();
@@ -344,7 +344,7 @@ private:
     {
         for (size_t i = idx.size(); i > 0; --i)
         {
-            if (++idx[i - 1] < static_cast<ssize_t>(shape[i - 1]))
+            if (++idx[i - 1] < shape[i - 1])
             {
                 return true;
             }
@@ -366,6 +366,8 @@ private:
 public:
 
     using value_type = typename internal_types::value_type;
+    using shape_type = typename internal_types::shape_type;
+    using sshape_type = typename internal_types::sshape_type;
     using real_type = typename detail::select_real_t<value_type>::type;
 
     template <typename RedFn, typename... RedArgs>
@@ -380,10 +382,10 @@ public:
         using ret_type = typename A::template rebind<element_type>;
 
         auto athis = static_cast<const A *>(this);
-        const size_t ndim = athis->ndim();
+        const ssize_t ndim = athis->ndim();
 
         small_vector<bool> reduce_mask(ndim, false);
-        for (size_t const ax : axis)
+        for (ssize_t const ax : axis)
         {
             if (ax >= ndim || ax < 0)
             {
@@ -392,14 +394,14 @@ public:
             reduce_mask[ax] = true;
         }
 
-        size_t const red_count = reduce_mask.count(true);
+        ssize_t const red_count = reduce_mask.count(true);
         if (red_count == 0 || red_count == ndim)
         {
             throw std::runtime_error("reduce: no axis to reduce or all axes are reduced");
         }
 
-        small_vector<size_t> out_shape(ndim - red_count);
-        for (size_t i = 0, l = 0; i < ndim; ++i)
+        shape_type out_shape(ndim - red_count);
+        for (ssize_t i = 0, l = 0; i < ndim; ++i)
         {
             if (!reduce_mask[i])
             {
@@ -408,8 +410,8 @@ public:
         }
         ret_type result(out_shape);
 
-        small_vector<size_t> red_axes(red_count);
-        for (size_t i = 0, l = 0; i < ndim; ++i)
+        shape_type red_axes(red_count);
+        for (ssize_t i = 0, l = 0; i < ndim; ++i)
         {
             if (reduce_mask[i])
             {
@@ -424,7 +426,7 @@ public:
 
         do
         {
-            for (size_t i = 0, out_dim = 0; i < ndim; ++i)
+            for (ssize_t i = 0, out_dim = 0; i < ndim; ++i)
             {
                 if (!reduce_mask[i])
                 {
@@ -457,7 +459,7 @@ public:
 
     value_type median_freq(small_vector<value_type> & sv) const;
 
-    A median(const small_vector<size_t> & axis) const
+    A median(const shape_type & axis) const
     {
         return reduce(axis, &SimpleArrayMixinCalculators::median_op);
     }
@@ -500,7 +502,7 @@ public:
         return sum / total_weight;
     }
 
-    A average(const small_vector<size_t> & axis, A const & weight) const
+    A average(const shape_type & axis, A const & weight) const
     {
         small_vector<value_type> weight_sv(weight.size());
         auto const range = IndexRange(weight);
@@ -553,7 +555,7 @@ public:
         return sum / static_cast<value_type>(n);
     }
 
-    A mean(const small_vector<size_t> & axis) const
+    A mean(const shape_type & axis) const
     {
         return reduce(axis, &SimpleArrayMixinCalculators::mean_op);
     }
@@ -599,7 +601,7 @@ public:
         return acc / static_cast<real_type>(n - ddof);
     }
 
-    auto var(const small_vector<size_t> & axis, size_t ddof) const
+    auto var(const shape_type & axis, size_t ddof) const
     {
         return reduce(axis, &SimpleArrayMixinCalculators::var_op, ddof);
     }
@@ -648,7 +650,7 @@ public:
         return std::sqrt(var_op(sv, ddof));
     }
 
-    auto std(const small_vector<size_t> & axis, size_t ddof) const
+    auto std(const shape_type & axis, size_t ddof) const
     {
         return reduce(axis, &SimpleArrayMixinCalculators::std_op, ddof);
     }
@@ -1070,13 +1072,13 @@ public:
     A matmul_blas(A const & other) const;
     A & imatmul_blas(A const & other);
     A matmul_fast(A const & other,
-                  size_t tile_x,
-                  size_t tile_y,
-                  size_t tile_z) const;
+                  ssize_t tile_x,
+                  ssize_t tile_y,
+                  ssize_t tile_z) const;
     A & imatmul_fast(A const & other,
-                     size_t tile_x,
-                     size_t tile_y,
-                     size_t tile_z);
+                     ssize_t tile_x,
+                     ssize_t tile_y,
+                     ssize_t tile_z);
 
 private:
     static void find_two_bins(const uint32_t * freq, size_t n, int & bin1, int & bin2);
@@ -1232,9 +1234,9 @@ A & SimpleArrayMixinCalculators<A, T>::imatmul_blas(A const & other)
  */
 template <typename A, typename T>
 A SimpleArrayMixinCalculators<A, T>::matmul_fast(A const & other,
-                                                 size_t tile_x,
-                                                 size_t tile_y,
-                                                 size_t tile_z) const
+                                                 ssize_t tile_x,
+                                                 ssize_t tile_y,
+                                                 ssize_t tile_z) const
 {
     auto const * athis = static_cast<A const *>(this);
     SimpleArrayMatmulHelper<A, T> helper(*athis, other, tile_x, tile_y, tile_z);
@@ -1248,9 +1250,9 @@ A SimpleArrayMixinCalculators<A, T>::matmul_fast(A const & other,
  */
 template <typename A, typename T>
 A & SimpleArrayMixinCalculators<A, T>::imatmul_fast(A const & other,
-                                                    size_t tile_x,
-                                                    size_t tile_y,
-                                                    size_t tile_z)
+                                                    ssize_t tile_x,
+                                                    ssize_t tile_y,
+                                                    ssize_t tile_z)
 {
     auto athis = static_cast<A *>(this);
     A result = athis->matmul_fast(other, tile_x, tile_y, tile_z);
@@ -1331,7 +1333,7 @@ template <typename T, IntegralType I>
 void indexed_copy(T * dest, T const * data, I const * begin, I const * const end); // NOLINT(readability-avoid-const-params-in-decls)
 
 template <IntegralType T>
-T const * check_index_range(SimpleArray<T> const & indices, size_t max_idx);
+T const * check_index_range(SimpleArray<T> const & indices, ssize_t max_idx);
 
 template <typename A, typename T>
 class SimpleArrayMixinSearch
@@ -1398,7 +1400,7 @@ public:
     static A eye(ssize_t n)
     {
         validate_positive("eye", n);
-        shape_type const shape{static_cast<size_t>(n), static_cast<size_t>(n)};
+        shape_type const shape{n, n};
         A result(shape, static_cast<value_type>(0));
 
         for (ssize_t i = 0; i < n; ++i)
@@ -1412,7 +1414,7 @@ public:
     static A scaled_eye(ssize_t n, value_type scale)
     {
         validate_positive("scaled_eye", n);
-        shape_type const shape{static_cast<size_t>(n), static_cast<size_t>(n)};
+        shape_type const shape{n, n};
         A result(shape, static_cast<value_type>(0));
 
         for (ssize_t i = 0; i < n; ++i)
@@ -1612,11 +1614,8 @@ public:
     /// Constructor with length and optional alignment
     /// @param length the length of the array in items
     /// @param alignment the memory alignment in bytes (default: 0, no special alignment, and valid values are 16, 32, and 64)
-    explicit SimpleArray(size_t length, size_t alignment = 0)
-        : m_buffer(buffer_type::construct(length * ITEMSIZE, alignment))
-        , m_shape{length}
-        , m_stride{1}
-        , m_body(m_buffer->template data<T>())
+    explicit SimpleArray(ssize_t length, size_t alignment = 0)
+        : SimpleArray(shape_type{length}, alignment, with_alignment_t{})
     {
     }
 
@@ -1634,7 +1633,7 @@ public:
     {
         if (!m_shape.empty())
         {
-            m_buffer = buffer_type::construct(m_shape[0] * static_cast<size_t>(m_stride[0]) * ITEMSIZE, 0);
+            m_buffer = buffer_type::construct(static_cast<size_t>(storage_size(m_shape, m_stride)) * ITEMSIZE, 0);
             m_body = m_buffer->template data<T>();
         }
     }
@@ -1646,7 +1645,7 @@ public:
     {
         if (!m_shape.empty())
         {
-            m_buffer = buffer_type::construct(m_shape[0] * static_cast<size_t>(m_stride[0]) * ITEMSIZE, alignment);
+            m_buffer = buffer_type::construct(static_cast<size_t>(storage_size(m_shape, m_stride)) * ITEMSIZE, alignment);
             m_body = m_buffer->template data<T>();
         }
     }
@@ -1663,38 +1662,24 @@ public:
         std::fill(begin(), end(), value);
     }
 
-    explicit SimpleArray(std::vector<size_t> const & shape)
-        : m_shape(shape)
-        , m_stride(calc_stride(m_shape))
+    explicit SimpleArray(std::vector<ssize_t> const & shape)
+        : SimpleArray(shape_type(shape))
     {
-        if (!m_shape.empty())
-        {
-            m_buffer = buffer_type::construct(m_shape[0] * static_cast<size_t>(m_stride[0]) * ITEMSIZE, 0);
-            m_body = m_buffer->template data<T>();
-        }
     }
 
-    SimpleArray(std::vector<size_t> const & shape, size_t alignment, with_alignment_t)
-        : m_shape(shape)
-        , m_stride(calc_stride(m_shape))
+    SimpleArray(std::vector<ssize_t> const & shape, size_t alignment, with_alignment_t const & tag)
+        : SimpleArray(shape_type(shape), alignment, tag)
     {
-        if (!m_shape.empty())
-        {
-            m_buffer = buffer_type::construct(m_shape[0] * static_cast<size_t>(m_stride[0]) * ITEMSIZE, alignment);
-            m_body = m_buffer->template data<T>();
-        }
     }
 
-    SimpleArray(std::vector<size_t> const & shape, value_type const & value, size_t alignment)
-        : SimpleArray(shape, alignment, with_alignment_t{})
+    SimpleArray(std::vector<ssize_t> const & shape, value_type const & value, size_t alignment)
+        : SimpleArray(shape_type(shape), value, alignment)
     {
-        std::fill(begin(), end(), value);
     }
 
-    SimpleArray(std::vector<size_t> const & shape, value_type const & value)
-        : SimpleArray(shape)
+    SimpleArray(std::vector<ssize_t> const & shape, value_type const & value)
+        : SimpleArray(shape_type(shape), value)
     {
-        std::fill(begin(), end(), value);
     }
 
     explicit SimpleArray(std::shared_ptr<buffer_type> const & buffer)
@@ -1706,7 +1691,7 @@ public:
             {
                 throw std::runtime_error("SimpleArray: input buffer size must be divisible");
             }
-            m_shape = shape_type{nitem};
+            m_shape = shape_type{static_cast<ssize_t>(nitem)};
             m_stride = sshape_type{1};
             m_buffer = buffer;
             m_body = m_buffer->template data<T>();
@@ -1724,7 +1709,7 @@ public:
         {
             m_shape = shape;
             m_stride = calc_stride(m_shape);
-            const size_t nbytes = m_shape[0] * static_cast<size_t>(m_stride[0]) * ITEMSIZE;
+            const size_t nbytes = static_cast<size_t>(storage_size(m_shape, m_stride)) * ITEMSIZE;
             if (nbytes != buffer->nbytes())
             {
                 throw std::runtime_error(
@@ -1834,19 +1819,20 @@ public:
 
     static sshape_type calc_stride(shape_type const & shape)
     {
+        validate_shape(shape);
         sshape_type stride(shape.size());
         if (!shape.empty())
         {
             stride[shape.size() - 1] = 1;
             for (size_t it = shape.size() - 1; it > 0; --it)
             {
-                stride[it - 1] = stride[it] * static_cast<ssize_t>(shape[it]);
+                stride[it - 1] = stride[it] * shape[it];
             }
         }
         return stride;
     }
 
-    static T * calc_body(T * data, sshape_type const & stride, size_t nghost)
+    static T * calc_body(T * data, sshape_type const & stride, ssize_t nghost)
     {
         if (nullptr == data || stride.empty() || 0 == nghost)
         {
@@ -1855,7 +1841,7 @@ public:
         else
         {
             sshape_type idx(stride.size(), 0);
-            idx[0] = static_cast<ssize_t>(nghost);
+            idx[0] = nghost;
             data += buffer_offset(stride, idx);
         }
         return data;
@@ -1872,12 +1858,12 @@ public:
      */
     size_t size() const noexcept
     {
-        size_t size = 1;
+        ssize_t size = 1;
         for (size_t it = 0; it < m_shape.size(); ++it)
         {
             size *= m_shape[it];
         }
-        return size;
+        return static_cast<size_t>(size);
     }
 
     /// Return the underlying buffer alignment in bytes. If no buffer or no alignment, return 0.
@@ -1925,19 +1911,24 @@ public:
         return *(data() + offset);
     }
 
-    size_t ndim() const noexcept { return m_shape.size(); }
+    ssize_t ndim() const noexcept { return static_cast<ssize_t>(m_shape.size()); }
     shape_type const & shape() const { return m_shape; }
-    size_t shape(size_t it) const noexcept { return m_shape[it]; }
-    size_t & shape(size_t it) noexcept { return m_shape[it]; }
+    ssize_t shape(ssize_t it) const noexcept { return m_shape[it]; }
+    ssize_t & shape(ssize_t it) noexcept { return m_shape[it]; }
     sshape_type const & stride() const { return m_stride; }
-    ssize_t stride(size_t it) const noexcept { return m_stride[it]; }
-    ssize_t & stride(size_t it) noexcept { return m_stride[it]; }
+    ssize_t stride(ssize_t it) const noexcept { return m_stride[it]; }
+    ssize_t & stride(ssize_t it) noexcept { return m_stride[it]; }
 
-    size_t nghost() const { return m_nghost; }
-    size_t nbody() const { return m_shape.empty() ? 0 : m_shape[0] - m_nghost; }
+    ssize_t nghost() const { return m_nghost; }
+    ssize_t nbody() const { return m_shape.empty() ? 0 : m_shape[0] - m_nghost; }
     bool has_ghost() const { return m_nghost != 0; }
-    void set_nghost(size_t nghost)
+    void set_nghost(ssize_t nghost)
     {
+        if (nghost < 0)
+        {
+            throw std::out_of_range(
+                std::format("SimpleArray: cannot set negative nghost {}", nghost));
+        }
         if (0 != nghost)
         {
             if (0 == ndim())
@@ -2018,26 +2009,26 @@ public:
     }
 
     template <size_t N>
-    std::mdspan<value_type, std::dextents<size_t, N>, std::layout_stride> as_mdspan()
+    std::mdspan<value_type, std::dextents<ssize_t, N>, std::layout_stride> as_mdspan()
     {
         if (ndim() != N)
         {
             throw std::out_of_range(
                 std::format("SimpleArray::as_mdspan: rank {} does not match ndim() {}", N, ndim()));
         }
-        return std::mdspan<value_type, std::dextents<size_t, N>, std::layout_stride>(
+        return std::mdspan<value_type, std::dextents<ssize_t, N>, std::layout_stride>(
             data(), make_mdspan_mapping<N>());
     }
 
     template <size_t N>
-    std::mdspan<value_type const, std::dextents<size_t, N>, std::layout_stride> as_mdspan() const
+    std::mdspan<value_type const, std::dextents<ssize_t, N>, std::layout_stride> as_mdspan() const
     {
         if (ndim() != N)
         {
             throw std::out_of_range(
                 std::format("SimpleArray::as_mdspan: rank {} does not match ndim() {}", N, ndim()));
         }
-        return std::mdspan<value_type const, std::dextents<size_t, N>, std::layout_stride>(
+        return std::mdspan<value_type const, std::dextents<ssize_t, N>, std::layout_stride>(
             data(), make_mdspan_mapping<N>());
     }
 
@@ -2060,23 +2051,23 @@ private:
     void copy_logical_into(SimpleArray & out) const;
 
     template <size_t N, size_t... I>
-    std::layout_stride::mapping<std::dextents<size_t, N>> make_mdspan_mapping_impl(std::index_sequence<I...>) const
+    std::layout_stride::mapping<std::dextents<ssize_t, N>> make_mdspan_mapping_impl(std::index_sequence<I...>) const
     {
-        std::array<size_t, N> strides;
+        std::array<ssize_t, N> strides;
         for (size_t i = 0; i < N; ++i)
         {
             if (stride(i) < 0)
             {
                 throw std::runtime_error("SimpleArray::as_mdspan: negative stride is not supported");
             }
-            strides[i] = static_cast<size_t>(stride(i));
+            strides[i] = stride(i);
         }
-        return std::layout_stride::mapping<std::dextents<size_t, N>>(
-            std::dextents<size_t, N>(shape(I)...), strides);
+        return std::layout_stride::mapping<std::dextents<ssize_t, N>>(
+            std::dextents<ssize_t, N>(shape(I)...), strides);
     }
 
     template <size_t N>
-    std::layout_stride::mapping<std::dextents<size_t, N>> make_mdspan_mapping() const
+    std::layout_stride::mapping<std::dextents<ssize_t, N>> make_mdspan_mapping() const
     {
         return make_mdspan_mapping_impl<N>(std::make_index_sequence<N>{});
     }
@@ -2090,7 +2081,7 @@ private:
         }
         for (size_t it = 0; it < shape.size() - 1; ++it)
         {
-            if (stride[it] != static_cast<ssize_t>(shape[it + 1]) * stride[it + 1])
+            if (stride[it] != shape[it + 1] * stride[it + 1])
             {
                 return false;
             }
@@ -2107,7 +2098,7 @@ private:
         }
         for (size_t it = 0; it < shape.size() - 1; ++it)
         {
-            if (stride[it + 1] != static_cast<ssize_t>(shape[it]) * stride[it])
+            if (stride[it + 1] != shape[it] * stride[it])
             {
                 return false;
             }
@@ -2171,7 +2162,7 @@ private:
         return to_nonnegative_index(shifted_index, dim_length);
     }
 
-    sshape_type normalize_index(small_vector<ssize_t> const & idx) const
+    sshape_type normalize_index(sshape_type const & idx) const
     {
         auto index2string = [&idx]() -> std::string
         {
@@ -2208,7 +2199,7 @@ private:
         sshape_type normalized(idx.size());
         for (size_t dim = 0; dim < m_shape.size(); ++dim)
         {
-            auto const dim_length = static_cast<ssize_t>(m_shape[dim]);
+            ssize_t const dim_length = m_shape[dim];
             ssize_t ghost_offset = 0;
             if (dim == 0)
             {
@@ -2260,6 +2251,27 @@ private:
         return index;
     }
 
+    static void validate_shape(shape_type const & shape)
+    {
+        for (ssize_t const dim : shape)
+        {
+            if (dim < 0)
+            {
+                throw std::out_of_range(
+                    std::format("SimpleArray: shape dimension must be non-negative, but got {}", dim));
+            }
+        }
+    }
+
+    static ssize_t storage_size(shape_type const & shape, sshape_type const & stride)
+    {
+        if (shape.empty())
+        {
+            return 0;
+        }
+        return shape[0] * stride[0];
+    }
+
     /// Contiguous data buffer for the array.
     std::shared_ptr<buffer_type> m_buffer;
     /// Each element in this vector is the number of element in the
@@ -2269,7 +2281,7 @@ private:
     /// bytes) to skip for advancing an index in the corresponding dimension.
     sshape_type m_stride;
 
-    size_t m_nghost = 0;
+    ssize_t m_nghost = 0;
     value_type * m_body = nullptr;
 }; /* end class SimpleArray */
 
@@ -2409,7 +2421,7 @@ class SimpleArrayCopier
 
 public:
 
-    using shape_type = small_vector<size_t>;
+    using shape_type = detail::shape_type;
     using sshape_type = detail::sshape_type;
     using buffer_type = ConcreteBuffer;
 
@@ -2489,9 +2501,9 @@ void SimpleArray<T>::transpose(shape_type const & axis, bool copy)
     }
     shape_type new_shape(m_shape.size(), -1);
     sshape_type new_stride(m_stride.size());
-    for (size_t it = 0; it < m_shape.size(); ++it)
+    for (ssize_t it = 0; it < ndim(); ++it)
     {
-        if (axis[it] >= m_shape.size() || axis[it] < 0)
+        if (axis[it] < 0 || axis[it] >= ndim())
         {
             throw std::runtime_error("SimpleArray::transpose: axis out of range");
         }
@@ -2599,13 +2611,13 @@ SimpleArray<T> SimpleArray<T>::to_column_major() const
         fstride[i] = fstride[i - 1] * m_shape[i - 1];
     }
     // Calculate buffer size.
-    size_t nelem = 1;
-    for (size_t const s : m_shape)
+    ssize_t nelem = 1;
+    for (ssize_t const s : m_shape)
     {
         nelem *= s;
     }
     // Create a fresh array, copy, and return.
-    auto buf = buffer_type::construct(nelem * ITEMSIZE, 0);
+    auto buf = buffer_type::construct(static_cast<size_t>(nelem) * ITEMSIZE, 0);
     SimpleArray out(m_shape, fstride, buf);
     copy_logical_into(out);
     return out;
@@ -2628,8 +2640,8 @@ void SimpleArray<T>::copy_logical_into(SimpleArray & out) const
     {
         return;
     }
-    size_t total = 1;
-    for (size_t const s : m_shape)
+    ssize_t total = 1;
+    for (ssize_t const s : m_shape)
     {
         total *= s;
     }
@@ -2708,14 +2720,14 @@ A detail::SimpleArrayMixinSort<A, T>::take_along_axis(SimpleArray<I> const & ind
                         athis->ndim()));
     }
 
-    size_t max_idx = athis->shape()[0];
+    ssize_t const max_idx = athis->shape()[0];
     I const * src = indices.begin();
     I const * const end = indices.end();
     while (src < end)
     {
-        if (*src < 0 || *src > max_idx)
+        if (std::cmp_less(*src, 0) || std::cmp_greater_equal(*src, max_idx))
         {
-            size_t const offset = src - indices.begin();
+            ssize_t const offset = src - indices.begin();
             std::string const indices_str = format_flat_index(indices.shape(), offset);
 
             throw std::out_of_range(
@@ -2734,7 +2746,7 @@ A detail::SimpleArrayMixinSort<A, T>::take_along_axis(SimpleArray<I> const & ind
     T * dst = ret.begin();
     while (src < end)
     {
-        T const * valp = data + static_cast<size_t>(*src);
+        T const * valp = data + static_cast<ssize_t>(*src);
         *dst = *valp;
         ++dst;
         ++src;
@@ -2747,7 +2759,7 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argwhere() const
 {
     auto athis = static_cast<A const *>(this);
 
-    size_t count = 0;
+    ssize_t count = 0;
     for (size_t i = 0; i < athis->size(); ++i)
     {
         if (athis->data(i) != value_type(0))
@@ -2756,11 +2768,11 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argwhere() const
         }
     }
 
-    size_t const ndim = athis->ndim();
+    ssize_t const ndim = athis->ndim();
     shape_type const res_shape{count, ndim};
     SimpleArray<uint64_t> result(res_shape);
 
-    size_t idx = 0;
+    ssize_t idx = 0;
     for (size_t i = 0; i < athis->size(); ++i)
     {
         if (athis->data(i) == value_type(0))
@@ -2768,10 +2780,10 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argwhere() const
             continue;
         }
 
-        size_t offset = i;
-        for (size_t dim = 0; dim < ndim; ++dim)
+        auto offset = static_cast<ssize_t>(i);
+        for (ssize_t dim = 0; dim < ndim; ++dim)
         {
-            size_t const stride = athis->stride(dim);
+            ssize_t const stride = athis->stride(dim);
             result(idx, dim) = static_cast<uint64_t>(offset / stride);
             offset %= stride;
         }
@@ -2786,16 +2798,19 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argwhere() const
 // this out-of-line definition against that excluded declaration.
 /// @cond
 template <IntegralType T>
-T const * detail::check_index_range(SimpleArray<T> const & indices, size_t max_idx)
+T const * detail::check_index_range(SimpleArray<T> const & indices, ssize_t max_idx)
 {
-    constexpr T DataTypeMax = std::numeric_limits<T>::max();
-    constexpr T DataTypeMin = std::numeric_limits<T>::min();
-    if (max_idx >= DataTypeMax && DataTypeMin == 0)
+    T const * src = indices.begin();
+    T const * const end = indices.end();
+    while (src < end)
     {
-        return nullptr;
+        if (std::cmp_less(*src, 0) || std::cmp_greater_equal(*src, max_idx))
+        {
+            return src;
+        }
+        ++src;
     }
-
-    return simd::check_between<T>(indices.begin(), indices.end(), 0, max_idx);
+    return nullptr;
 }
 /// @endcond
 
@@ -2806,7 +2821,7 @@ void detail::indexed_copy(T * dest, T const * data, I const * index0, I const * 
     I const * src = index0;
     while (src < index1)
     {
-        T const * valp = data + static_cast<size_t>(*src);
+        T const * valp = data + static_cast<ssize_t>(*src);
         *dst = *valp;
         ++dst;
         ++src;
@@ -2831,12 +2846,12 @@ A detail::SimpleArrayMixinSort<A, T>::take_along_axis_simd(SimpleArray<I> const 
         return A(indices.shape());
     }
 
-    size_t max_idx = athis->shape()[0];
+    ssize_t const max_idx = athis->shape()[0];
 
     I const * oor_ptr = check_index_range(indices, max_idx);
     if (oor_ptr != nullptr)
     {
-        size_t const offset = oor_ptr - indices.begin();
+        ssize_t const offset = oor_ptr - indices.begin();
         std::string const indices_str = format_flat_index(indices.shape(), offset);
 
         const auto err = std::format("SimpleArray::take_along_axis_simd(): "

--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -35,15 +35,15 @@ class SimpleArrayMatmulHelper
 public:
 
     using value_type = T;
-    using shape_type = small_vector<size_t>;
+    using shape_type = typename A::shape_type;
 
     SimpleArrayMatmulHelper() = delete;
     SimpleArrayMatmulHelper(A const & lhs, A const & rhs);
     SimpleArrayMatmulHelper(A const & lhs,
                             A const & rhs,
-                            size_t tile_x,
-                            size_t tile_y,
-                            size_t tile_z);
+                            ssize_t tile_x,
+                            ssize_t tile_y,
+                            ssize_t tile_z);
     ~SimpleArrayMatmulHelper() = default;
 
     SimpleArrayMatmulHelper(SimpleArrayMatmulHelper const &) = delete;
@@ -69,22 +69,22 @@ private:
     A matmul_mat_vec_blas();
     A matmul_mat_mat();
     A matmul_mat_mat_blas();
-    A pack_rhs(size_t n, size_t k);
+    A pack_rhs(ssize_t n, ssize_t k);
     void accumulate_tile(A const & packed_rhs,
-                         size_t row_begin,
-                         size_t row_end,
-                         size_t col_begin,
-                         size_t col_end,
-                         size_t inner_begin,
-                         size_t inner_end);
+                         ssize_t row_begin,
+                         ssize_t row_end,
+                         ssize_t col_begin,
+                         ssize_t col_end,
+                         ssize_t inner_begin,
+                         ssize_t inner_end);
     A matmul_mat_mat_tiled();
 
     A const & m_lhs;
     A const & m_rhs;
     A m_result;
-    size_t m_tile_x;
-    size_t m_tile_y;
-    size_t m_tile_z;
+    ssize_t m_tile_x;
+    ssize_t m_tile_y;
+    ssize_t m_tile_z;
 
 }; /* end class SimpleArrayMatmulHelper */
 
@@ -97,9 +97,9 @@ SimpleArrayMatmulHelper<A, T>::SimpleArrayMatmulHelper(A const & lhs, A const & 
 template <typename A, typename T>
 SimpleArrayMatmulHelper<A, T>::SimpleArrayMatmulHelper(A const & lhs,
                                                        A const & rhs,
-                                                       size_t tile_x,
-                                                       size_t tile_y,
-                                                       size_t tile_z)
+                                                       ssize_t tile_x,
+                                                       ssize_t tile_y,
+                                                       ssize_t tile_z)
     : m_lhs(lhs)
     , m_rhs(rhs)
     , m_tile_x(tile_x)
@@ -278,9 +278,9 @@ void SimpleArrayMatmulHelper<A, T>::check_tiles() const
 template <typename A, typename T>
 A SimpleArrayMatmulHelper<A, T>::matmul_vec_vec()
 {
-    size_t const k = m_lhs.shape(0);
+    ssize_t const k = m_lhs.shape(0);
     value_type v = 0;
-    for (size_t i = 0; i < k; ++i)
+    for (ssize_t i = 0; i < k; ++i)
     {
         v += m_lhs(i) * m_rhs.data(i);
     }
@@ -298,7 +298,7 @@ A SimpleArrayMatmulHelper<A, T>::matmul_vec_vec_blas()
 
     if constexpr (can_matmul_blas_v<value_type>)
     {
-        size_t const k = m_lhs.shape(0);
+        ssize_t const k = m_lhs.shape(0);
         m_result.data(0) = dot_blas(k, m_lhs.data(), m_rhs.data());
         return std::move(m_result);
     }
@@ -311,12 +311,12 @@ A SimpleArrayMatmulHelper<A, T>::matmul_vec_vec_blas()
 template <typename A, typename T>
 A SimpleArrayMatmulHelper<A, T>::matmul_vec_mat()
 {
-    size_t const n = m_result.size();
-    size_t const k = m_lhs.shape(0);
-    for (size_t j = 0; j < n; ++j)
+    ssize_t const n = m_result.shape(0);
+    ssize_t const k = m_lhs.shape(0);
+    for (ssize_t j = 0; j < n; ++j)
     {
         value_type v = 0;
-        for (size_t l = 0; l < k; ++l)
+        for (ssize_t l = 0; l < k; ++l)
         {
             v += m_lhs(l) * m_rhs(l, j);
         }
@@ -335,8 +335,8 @@ A SimpleArrayMatmulHelper<A, T>::matmul_vec_mat_blas()
 
     if constexpr (can_matmul_blas_v<value_type>)
     {
-        size_t const k = m_rhs.shape(0);
-        size_t const n = m_rhs.shape(1);
+        ssize_t const k = m_rhs.shape(0);
+        ssize_t const n = m_rhs.shape(1);
         bool const transpose_matrix = true;
         gemv_blas(k,
                   n,
@@ -355,12 +355,12 @@ A SimpleArrayMatmulHelper<A, T>::matmul_vec_mat_blas()
 template <typename A, typename T>
 A SimpleArrayMatmulHelper<A, T>::matmul_mat_vec()
 {
-    size_t const m = m_result.size();
-    size_t const k = m_lhs.shape(1);
-    for (size_t i = 0; i < m; ++i)
+    ssize_t const m = m_result.shape(0);
+    ssize_t const k = m_lhs.shape(1);
+    for (ssize_t i = 0; i < m; ++i)
     {
         value_type v = 0;
-        for (size_t l = 0; l < k; ++l)
+        for (ssize_t l = 0; l < k; ++l)
         {
             v += m_lhs(i, l) * m_rhs(l);
         }
@@ -379,8 +379,8 @@ A SimpleArrayMatmulHelper<A, T>::matmul_mat_vec_blas()
 
     if constexpr (can_matmul_blas_v<value_type>)
     {
-        size_t const m = m_lhs.shape(0);
-        size_t const k = m_lhs.shape(1);
+        ssize_t const m = m_lhs.shape(0);
+        ssize_t const k = m_lhs.shape(1);
         bool const transpose_matrix = false;
         gemv_blas(m,
                   k,
@@ -399,15 +399,15 @@ A SimpleArrayMatmulHelper<A, T>::matmul_mat_vec_blas()
 template <typename A, typename T>
 A SimpleArrayMatmulHelper<A, T>::matmul_mat_mat()
 {
-    size_t const m = m_result.shape(0);
-    size_t const n = m_result.shape(1);
-    size_t const k = m_lhs.shape(1);
-    for (size_t i = 0; i < m; ++i)
+    ssize_t const m = m_result.shape(0);
+    ssize_t const n = m_result.shape(1);
+    ssize_t const k = m_lhs.shape(1);
+    for (ssize_t i = 0; i < m; ++i)
     {
-        for (size_t j = 0; j < n; ++j)
+        for (ssize_t j = 0; j < n; ++j)
         {
             value_type v = 0;
-            for (size_t l = 0; l < k; ++l)
+            for (ssize_t l = 0; l < k; ++l)
             {
                 v += m_lhs(i, l) * m_rhs(l, j);
             }
@@ -427,9 +427,9 @@ A SimpleArrayMatmulHelper<A, T>::matmul_mat_mat_blas()
 
     if constexpr (can_matmul_blas_v<value_type>)
     {
-        size_t const m = m_result.shape(0);
-        size_t const n = m_result.shape(1);
-        size_t const k = m_lhs.shape(1);
+        ssize_t const m = m_result.shape(0);
+        ssize_t const n = m_result.shape(1);
+        ssize_t const k = m_lhs.shape(1);
         gemm_blas(m, n, k, m_lhs.data(), m_rhs.data(), m_result.data());
         return std::move(m_result);
     }
@@ -440,13 +440,13 @@ A SimpleArrayMatmulHelper<A, T>::matmul_mat_mat_blas()
 }
 
 template <typename A, typename T>
-A SimpleArrayMatmulHelper<A, T>::pack_rhs(size_t n, size_t k)
+A SimpleArrayMatmulHelper<A, T>::pack_rhs(ssize_t n, ssize_t k)
 {
     shape_type const packing_shape{n, k};
     A packing(packing_shape);
-    for (size_t i = 0; i < n; ++i)
+    for (ssize_t i = 0; i < n; ++i)
     {
-        for (size_t j = 0; j < k; ++j)
+        for (ssize_t j = 0; j < k; ++j)
         {
             packing(i, j) = m_rhs(j, i);
         }
@@ -456,19 +456,19 @@ A SimpleArrayMatmulHelper<A, T>::pack_rhs(size_t n, size_t k)
 
 template <typename A, typename T>
 void SimpleArrayMatmulHelper<A, T>::accumulate_tile(A const & packed_rhs,
-                                                    size_t row_begin,
-                                                    size_t row_end,
-                                                    size_t col_begin,
-                                                    size_t col_end,
-                                                    size_t inner_begin,
-                                                    size_t inner_end)
+                                                    ssize_t row_begin,
+                                                    ssize_t row_end,
+                                                    ssize_t col_begin,
+                                                    ssize_t col_end,
+                                                    ssize_t inner_begin,
+                                                    ssize_t inner_end)
 {
-    for (size_t i = row_begin; i < row_end; ++i)
+    for (ssize_t i = row_begin; i < row_end; ++i)
     {
-        for (size_t j = col_begin; j < col_end; ++j)
+        for (ssize_t j = col_begin; j < col_end; ++j)
         {
             value_type v = m_result(i, j);
-            for (size_t l = inner_begin; l < inner_end; ++l)
+            for (ssize_t l = inner_begin; l < inner_end; ++l)
             {
                 v += m_lhs(i, l) * packed_rhs(j, l);
             }
@@ -480,23 +480,23 @@ void SimpleArrayMatmulHelper<A, T>::accumulate_tile(A const & packed_rhs,
 template <typename A, typename T>
 A SimpleArrayMatmulHelper<A, T>::matmul_mat_mat_tiled()
 {
-    size_t const m = m_result.shape(0);
-    size_t const n = m_result.shape(1);
-    size_t const k = m_lhs.shape(1);
+    ssize_t const m = m_result.shape(0);
+    ssize_t const n = m_result.shape(1);
+    ssize_t const k = m_lhs.shape(1);
     A packed_rhs = pack_rhs(n, k);
     for (size_t i = 0; i < m_result.size(); ++i)
     {
         m_result.data(i) = value_type{0};
     }
-    for (size_t row = 0; row < m; row += m_tile_x)
+    for (ssize_t row = 0; row < m; row += m_tile_x)
     {
-        size_t const row_end = std::min(row + m_tile_x, m);
-        for (size_t col = 0; col < n; col += m_tile_y)
+        ssize_t const row_end = std::min(row + m_tile_x, m);
+        for (ssize_t col = 0; col < n; col += m_tile_y)
         {
-            size_t const col_end = std::min(col + m_tile_y, n);
-            for (size_t inner = 0; inner < k; inner += m_tile_z)
+            ssize_t const col_end = std::min(col + m_tile_y, n);
+            for (ssize_t inner = 0; inner < k; inner += m_tile_z)
             {
-                size_t const inner_end = std::min(inner + m_tile_z, k);
+                ssize_t const inner_end = std::min(inner + m_tile_z, k);
                 accumulate_tile(packed_rhs, row, row_end, col, col_end, inner, inner_end);
             }
         }

--- a/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
+++ b/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
@@ -38,7 +38,7 @@ struct TypeBroadcastImpl
         }
 
         auto const axis = static_cast<size_t>(dim);
-        auto const length = static_cast<ssize_t>(left_shape[axis]);
+        ssize_t const length = left_shape[axis];
         for (ssize_t i = 0; i < length; ++i)
         {
             sidx[axis] = i;
@@ -53,10 +53,12 @@ struct TypeBroadcastImpl
             const D * ptr_in = arr_in->data() + offset_in;
 
             ssize_t offset_out = 0;
-            for (size_t it = 0; it < arr_out.ndim(); ++it)
+            ssize_t const ndim = arr_out.ndim();
+            for (ssize_t it = 0; it < ndim; ++it)
             {
-                ssize_t const step = slices[it][2];
-                offset_out += arr_out.stride(it) * sidx[it] * step;
+                auto const axis_index = static_cast<size_t>(it);
+                ssize_t const step = slices[axis_index][2];
+                offset_out += arr_out.stride(it) * sidx[axis_index] * step;
             }
 
             constexpr bool valid_conversion = (!is_complex_v<T> && !is_complex_v<D>) || (is_complex_v<T> && is_complex_v<D> && std::is_same_v<T, D>);
@@ -84,23 +86,24 @@ struct TypeBroadcastImpl
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         auto * arr_new = reinterpret_cast<pybind11::array_t<D> const *>(&arr_in);
 
-        shape_type left_shape(arr_out.ndim());
-        for (size_t i = 0; i < arr_out.ndim(); i++)
+        ssize_t const ndim = arr_out.ndim();
+        shape_type left_shape(ndim);
+        for (ssize_t axis = 0; axis < ndim; ++axis)
         {
-            sshape_type const & slice = slices[i];
+            sshape_type const & slice = slices[axis];
             if ((slice[1] - slice[0]) % slice[2] == 0)
             {
-                left_shape[i] = (slice[1] - slice[0]) / slice[2];
+                left_shape[axis] = (slice[1] - slice[0]) / slice[2];
             }
             else
             {
-                left_shape[i] = (slice[1] - slice[0]) / slice[2] + 1;
+                left_shape[axis] = (slice[1] - slice[0]) / slice[2] + 1;
             }
         }
 
-        sshape_type const sidx_init(arr_out.ndim(), 0);
+        sshape_type const sidx_init(ndim, 0);
 
-        copy_idx(arr_out, slices, arr_new, left_shape, sidx_init, static_cast<ssize_t>(arr_out.ndim()) - 1);
+        copy_idx(arr_out, slices, arr_new, left_shape, sidx_init, ndim - 1);
     }
 }; /* end struct TypeBroadcastImpl */
 
@@ -114,35 +117,37 @@ struct TypeBroadcast
                             std::vector<sshape_type> const & slices,
                             pybind11::array const & arr_in)
     {
-        shape_type right_shape(arr_in.ndim());
-        for (pybind11::ssize_t i = 0; i < arr_in.ndim(); i++)
+        pybind11::ssize_t const right_ndim = arr_in.ndim();
+        shape_type right_shape(right_ndim);
+        for (pybind11::ssize_t axis = 0; axis < right_ndim; ++axis)
         {
-            right_shape[i] = arr_in.shape(i);
+            right_shape[axis] = arr_in.shape(axis);
         }
 
-        shape_type left_shape(arr_out.ndim());
+        ssize_t const ndim = arr_out.ndim();
+        shape_type left_shape(ndim);
         // TODO: range check
-        for (size_t i = 0; i < arr_out.ndim(); i++)
+        for (ssize_t axis = 0; axis < ndim; ++axis)
         {
-            sshape_type const & slice = slices[i];
+            sshape_type const & slice = slices[axis];
             if ((slice[1] - slice[0]) % slice[2] == 0)
             {
-                left_shape[i] = (slice[1] - slice[0]) / slice[2];
+                left_shape[axis] = (slice[1] - slice[0]) / slice[2];
             }
             else
             {
-                left_shape[i] = (slice[1] - slice[0]) / slice[2] + 1;
+                left_shape[axis] = (slice[1] - slice[0]) / slice[2] + 1;
             }
         }
 
-        if (arr_out.ndim() != static_cast<size_t>(arr_in.ndim()))
+        if (arr_out.ndim() != arr_in.ndim())
         {
             throw_shape_error(left_shape, right_shape);
         }
 
-        for (size_t i = 0; i < left_shape.size(); ++i)
+        for (ssize_t i = 0; i < ndim; ++i)
         {
-            if (left_shape[i] != static_cast<size_t>(right_shape[i]))
+            if (left_shape[i] != right_shape[i])
             {
                 throw_shape_error(left_shape, right_shape);
             }

--- a/cpp/solvcon/buffer/pymod/array_common.hpp
+++ b/cpp/solvcon/buffer/pymod/array_common.hpp
@@ -145,11 +145,11 @@ inline solvcon::detail::shape_type make_shape(pybind11::object const & shape_in)
     solvcon::detail::shape_type shape;
     try
     {
-        shape.push_back(shape_in.cast<size_t>());
+        shape.push_back(shape_in.cast<ssize_t>());
     }
     catch (const pybind11::cast_error &)
     {
-        shape = shape_in.cast<std::vector<size_t>>();
+        shape = shape_in.cast<std::vector<ssize_t>>();
     }
     return shape;
 }
@@ -168,7 +168,7 @@ public:
 
         TypeBroadcast<T>::check_shape(arr_out, slices, arr_in);
 
-        const size_t nghost = arr_out.nghost();
+        const ssize_t nghost = arr_out.nghost();
         if (0 != nghost)
         {
             arr_out.set_nghost(0);
@@ -280,7 +280,7 @@ public:
             sizeof(T), /* Size of one scalar */
             format, /* Python struct-style format descriptor */
             array.ndim(), /* Number of dimensions */
-            std::vector<size_t>(array.shape().begin(), array.shape().end()), /* Buffer dimensions */
+            std::vector<pybind11::ssize_t>(array.shape().begin(), array.shape().end()), /* Buffer dimensions */
             stride /* Strides (in bytes) for each index */
         );
     }
@@ -341,12 +341,13 @@ private:
     static std::vector<sshape_type> make_default_slices(SimpleArray<T> const & arr)
     {
         std::vector<sshape_type> slices;
-        slices.reserve(arr.ndim());
-        for (size_t i = 0; i < arr.ndim(); ++i)
+        auto const & shape = arr.shape();
+        slices.reserve(shape.size());
+        for (ssize_t const dim : shape)
         {
             sshape_type default_slice(3);
             default_slice[0] = 0; // start
-            default_slice[1] = static_cast<ssize_t>(arr.shape(i)); // stop
+            default_slice[1] = dim; // stop
             default_slice[2] = 1; // step
             slices.push_back(std::move(default_slice));
         }
@@ -364,12 +365,12 @@ private:
         slice_out[2] = step == "None" ? slice_out[2] : std::stoi(step);
     }
 
-    static void slice_syntax_check(pybind11::tuple const & tuple, size_t ndim)
+    static void slice_syntax_check(pybind11::tuple const & tuple, ssize_t ndim)
     {
         namespace py = pybind11;
 
-        size_t ellipsis_cnt = 0;
-        size_t slice_cnt = 0;
+        ssize_t ellipsis_cnt = 0;
+        ssize_t slice_cnt = 0;
 
         for (auto it = tuple.begin(); it != tuple.end(); it++)
         {
@@ -400,7 +401,7 @@ private:
 
     static void process_slices(pybind11::tuple const & tuple,
                                std::vector<sshape_type> & slices,
-                               size_t ndim)
+                               ssize_t ndim)
     {
         namespace py = pybind11;
 
@@ -424,15 +425,16 @@ private:
         // copy slices from the back until an ellipsis
         if (ellipsis_flag)
         {
-            for (size_t size = 0; size < tuple.size(); size++)
+            ssize_t const tuple_size = tuple.size();
+            for (ssize_t offset = 0; offset < tuple_size; ++offset)
             {
-                auto it = tuple.end() - size - 1;
+                auto it = tuple.end() - offset - 1;
 
                 if (py::isinstance<py::ellipsis>(*it))
                 {
                     break;
                 }
-                auto & slice_out = slices[ndim - size - 1];
+                auto & slice_out = slices[ndim - offset - 1];
                 const auto slice_in = (*it).cast<py::slice>();
 
                 copy_slice(slice_out, slice_in);
@@ -446,7 +448,7 @@ private:
     {
         TypeBroadcast<T>::check_shape(arr_out, slices, arr_in);
 
-        const size_t nghost = arr_out.nghost();
+        const ssize_t nghost = arr_out.nghost();
         if (0 != nghost)
         {
             arr_out.set_nghost(0);

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -481,9 +481,9 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 "matmul_fast",
                 [](wrapped_type const & self,
                    wrapped_type const & other,
-                   size_t tile_x,
-                   size_t tile_y,
-                   size_t tile_z)
+                   ssize_t tile_x,
+                   ssize_t tile_y,
+                   ssize_t tile_z)
                 { return self.matmul_fast(other, tile_x, tile_y, tile_z); },
                 py::arg("other"),
                 py::arg("tile_x") = 16,
@@ -537,9 +537,9 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 "imatmul_fast",
                 [](wrapped_type & self,
                    wrapped_type const & other,
-                   size_t tile_x,
-                   size_t tile_y,
-                   size_t tile_z)
+                   ssize_t tile_x,
+                   ssize_t tile_y,
+                   ssize_t tile_z)
                 { self.imatmul_fast(other, tile_x, tile_y, tile_z); },
                 py::arg("other"),
                 py::arg("tile_x") = 16,

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -321,13 +321,13 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
                 // getter
                 DECL_MM_EXECUTE_TYPED_ARRAY_METHOD(nghost),
                 // setter
-                [](wrapped_type & self, size_t size)
+                [](wrapped_type & self, ssize_t nghost)
                 {
                     execute_callback_with_typed_array(
                         self,
-                        [size](auto & array)
+                        [nghost](auto & array)
                         {
-                            return array.set_nghost(size);
+                            return array.set_nghost(nghost);
                         });
                 })
             .def_property_readonly("nbody", DECL_MM_EXECUTE_TYPED_ARRAY_METHOD(nbody))

--- a/cpp/solvcon/inout/gmsh.hpp
+++ b/cpp/solvcon/inout/gmsh.hpp
@@ -172,7 +172,7 @@ private:
         std::getline(stream, line);
         auto nnode = std::stoul(line);
 
-        m_nds.remake(small_vector<size_t>{nnode, 3}, 0);
+        m_nds.remake(small_vector<ssize_t>{static_cast<ssize_t>(nnode), 3}, 0);
 
         while (std::getline(stream, line) && line.find('$') == std::string::npos)
         {
@@ -196,10 +196,10 @@ private:
         auto nelement = std::stoul(line);
         std::vector<uint_type> usnds;
 
-        m_cltpn.remake(small_vector<size_t>{nelement}, 0);
-        m_elgrp.remake(small_vector<size_t>{nelement}, 0);
-        m_elgeo.remake(small_vector<size_t>{nelement}, 0);
-        m_eldim.remake(small_vector<size_t>{nelement}, 0);
+        m_cltpn.remake(small_vector<ssize_t>{static_cast<ssize_t>(nelement)}, 0);
+        m_elgrp.remake(small_vector<ssize_t>{static_cast<ssize_t>(nelement)}, 0);
+        m_elgeo.remake(small_vector<ssize_t>{static_cast<ssize_t>(nelement)}, 0);
+        m_eldim.remake(small_vector<ssize_t>{static_cast<ssize_t>(nelement)}, 0);
 
         uint_type idx = 0;
 
@@ -254,7 +254,7 @@ private:
         usnds.erase(remove, usnds.end());
 
         // put used node id to m_ndmap
-        m_ndmap.remake(small_vector<size_t>{usnds.size()}, -1);
+        m_ndmap.remake(small_vector<ssize_t>{static_cast<ssize_t>(usnds.size())}, -1);
         for (size_t i = 0; i < usnds.size(); ++i)
         {
             m_ndmap(usnds[i]) = i;

--- a/cpp/solvcon/inout/plot3d.cpp
+++ b/cpp/solvcon/inout/plot3d.cpp
@@ -23,10 +23,10 @@ Plot3d::Plot3d(const std::string & data)
     std::getline(stream, line);
     nblocks = stoul(line);
 
-    m_x_shape.remake(small_vector<size_t>{nblocks}, 0);
-    m_y_shape.remake(small_vector<size_t>{nblocks}, 0);
-    m_z_shape.remake(small_vector<size_t>{nblocks}, 0);
-    m_blk_sizes.remake(small_vector<size_t>{nblocks}, 0);
+    m_x_shape.remake(small_vector<ssize_t>{static_cast<ssize_t>(nblocks)}, 0);
+    m_y_shape.remake(small_vector<ssize_t>{static_cast<ssize_t>(nblocks)}, 0);
+    m_z_shape.remake(small_vector<ssize_t>{static_cast<ssize_t>(nblocks)}, 0);
+    m_blk_sizes.remake(small_vector<ssize_t>{static_cast<ssize_t>(nblocks)}, 0);
 
     // parsing xyz dimension of each block
     for (auto i = 0; i < nblocks; ++i)
@@ -40,7 +40,7 @@ Plot3d::Plot3d(const std::string & data)
         total_blk_size += m_blk_sizes(i);
     }
 
-    m_nds.remake(small_vector<size_t>{total_blk_size, 3}, 0);
+    m_nds.remake(small_vector<ssize_t>{static_cast<ssize_t>(total_blk_size), 3}, 0);
 
     parseCoordinates(nblocks);
     buildHexahedronElements(nblocks);
@@ -131,7 +131,7 @@ std::shared_ptr<StaticMesh> Plot3d::to_block()
 void Plot3d::build_interior(const std::shared_ptr<StaticMesh> & blk)
 {
     SimpleArray<int_type> m_cltpn;
-    m_cltpn.remake(small_vector<size_t>{m_elems.size()}, 5);
+    m_cltpn.remake(small_vector<ssize_t>{static_cast<ssize_t>(m_elems.size())}, 5);
     blk->cltpn().swap(m_cltpn);
     blk->ndcrd().swap(m_nds);
 

--- a/cpp/solvcon/linalg/EigenSystem.hpp
+++ b/cpp/solvcon/linalg/EigenSystem.hpp
@@ -184,8 +184,8 @@ void EigenSystem<T>::run()
         // CGEEV/ZGEEV return eigenvalues as a single complex array and need a
         // real workspace rwork of length 2*n.  Compute into a local complex
         // buffer, then split it into the real m_wr/m_wi parts below.
-        array_type w(static_cast<size_t>(n));
-        real_array_type rwork(static_cast<size_t>(2 * n));
+        array_type w(static_cast<ssize_t>(n));
+        real_array_type rwork(static_cast<ssize_t>(2 * n));
         detail::lapack_geev(
             jobvl, jobvr, n, m_colmajor.data(), lda, w.data(), vl_ptr, ldvl, vr_ptr, ldvr, &work_query, lwork, rwork.data(), &info);
         if (info != 0)
@@ -197,7 +197,7 @@ void EigenSystem<T>::run()
 
         lapack_int_t const lwork_min = 2 * n;
         lwork = std::max<lapack_int_t>(static_cast<lapack_int_t>(work_query.real()), lwork_min);
-        array_type work(static_cast<size_t>(lwork));
+        array_type work(static_cast<ssize_t>(lwork));
         detail::lapack_geev(
             jobvl, jobvr, n, m_colmajor.data(), lda, w.data(), vl_ptr, ldvl, vr_ptr, ldvr, work.data(), lwork, rwork.data(), &info);
         for (lapack_int_t i = 0; i < n; ++i)
@@ -220,7 +220,7 @@ void EigenSystem<T>::run()
         // 4*n minimum when any eigenvectors requested, else 3*n.
         lapack_int_t const lwork_min = (m_do_vl || m_do_vr) ? 4 * n : 3 * n;
         lwork = std::max<lapack_int_t>(static_cast<lapack_int_t>(work_query), lwork_min);
-        array_type work(static_cast<size_t>(lwork));
+        array_type work(static_cast<ssize_t>(lwork));
         detail::lapack_geev(
             jobvl, jobvr, n, m_colmajor.data(), lda, m_wr.data(), m_wi.data(), vl_ptr, ldvl, vr_ptr, ldvr, work.data(), lwork, &info);
     }

--- a/cpp/solvcon/linalg/factorization.hpp
+++ b/cpp/solvcon/linalg/factorization.hpp
@@ -82,9 +82,9 @@ Llt<T>::array_type Llt<T>::forward_substitution(array_type const & l, array_type
         throw std::invalid_argument(oss.str());
     }
 
-    const auto m = static_cast<ssize_t>(l.shape(0));
-    const auto n = static_cast<ssize_t>(b.shape(1));
-    small_vector<size_t> const y_shape{static_cast<size_t>(m), static_cast<size_t>(n)};
+    const auto m = l.shape(0);
+    const auto n = b.shape(1);
+    small_vector<ssize_t> const y_shape{m, n};
     array_type y(y_shape);
     for (ssize_t k = 0; k < n; ++k)
     {
@@ -135,9 +135,9 @@ Llt<T>::array_type Llt<T>::backward_substitution(array_type const & l, array_typ
         throw std::invalid_argument(oss.str());
     }
 
-    const auto m = static_cast<ssize_t>(l.shape(0));
-    const auto n = static_cast<ssize_t>(y.shape(1));
-    small_vector<size_t> const x_shape{static_cast<size_t>(m), static_cast<size_t>(n)};
+    const auto m = l.shape(0);
+    const auto n = y.shape(1);
+    small_vector<ssize_t> const x_shape{m, n};
     array_type x(x_shape);
     for (ssize_t k = 0; k < n; ++k)
     {
@@ -173,8 +173,8 @@ Llt<T>::array_type Llt<T>::factorize(array_type const & a)
         throw std::invalid_argument(oss.str());
     }
 
-    const auto m = static_cast<ssize_t>(a.shape(0));
-    small_vector<size_t> const shape = {static_cast<size_t>(m), static_cast<size_t>(m)};
+    const auto m = a.shape(0);
+    small_vector<ssize_t> const shape = {m, m};
     array_type l(shape, value_type(0));
     const real_type eps = std::numeric_limits<real_type>::epsilon();
     for (ssize_t i = 0; i < m; ++i)
@@ -241,10 +241,10 @@ Llt<T>::array_type Llt<T>::solve(array_type const & a, array_type const & b)
     bool const was_1d = (b.ndim() == 1);
     if (was_1d)
     {
-        array_type const b_2d = b.reshape(small_vector<size_t>{b.shape(0), 1});
+        array_type const b_2d = b.reshape(small_vector<ssize_t>{b.shape(0), 1});
         array_type const y = forward_substitution(l, b_2d);
         array_type const x = backward_substitution(l, y);
-        return x.reshape(small_vector<size_t>{x.shape(0)});
+        return x.reshape(small_vector<ssize_t>{x.shape(0)});
     }
     else
     {

--- a/cpp/solvcon/linalg/kalman_filter.hpp
+++ b/cpp/solvcon/linalg/kalman_filter.hpp
@@ -46,10 +46,10 @@ struct KalmanStateInfo
 {
     using tuple_type = std::tuple<SimpleArray<T>, SimpleArray<T>, SimpleArray<T>, SimpleArray<T>>;
 
-    KalmanStateInfo(size_t observation_size, size_t state_size)
+    KalmanStateInfo(ssize_t observation_size, ssize_t state_size)
     {
-        small_vector<size_t> const xs_shape{observation_size, state_size};
-        small_vector<size_t> const ps_shape{observation_size, state_size, state_size};
+        small_vector<ssize_t> const xs_shape{observation_size, state_size};
+        small_vector<ssize_t> const ps_shape{observation_size, state_size, state_size};
         prior_states = SimpleArray<T>(xs_shape);
         prior_states_covariance = SimpleArray<T>(ps_shape);
         posterior_states = SimpleArray<T>(xs_shape);
@@ -89,9 +89,9 @@ public:
 
 private:
 
-    size_t m_state_size; // state dimension
-    size_t m_measurement_size; // measurement dimension
-    size_t m_control_size; // control dimension
+    ssize_t m_state_size; // state dimension
+    ssize_t m_measurement_size; // measurement dimension
+    ssize_t m_control_size; // control dimension
 
     array_type m_f; // state transition matrix (state_sizexstate_size)
     array_type m_q; // process noise covariance (state_sizexstate_size)
@@ -335,8 +335,8 @@ private:
     void update_covariance(array_type const & k);
 
     // Batch filter
-    void predict_and_update(array_type const & z, KalmanStateInfo<T> & bfs, size_t iter);
-    void predict_and_update(array_type const & z, array_type const & u, KalmanStateInfo<T> & bfs, size_t iter);
+    void predict_and_update(array_type const & z, KalmanStateInfo<T> & bfs, ssize_t iter);
+    void predict_and_update(array_type const & z, array_type const & u, KalmanStateInfo<T> & bfs, ssize_t iter);
 
 }; /* end class KalmanFilter */
 
@@ -601,14 +601,14 @@ void KalmanFilter<T>::update_covariance(array_type const & k)
 template <typename T>
 KalmanStateInfo<T> KalmanFilter<T>::batch_filter(array_type const & zs)
 {
-    size_t const z_m = zs.shape(0);
-    size_t const z_n = zs.shape(1);
-    array_type z(small_vector<size_t>{z_n});
+    ssize_t const z_m = zs.shape(0);
+    ssize_t const z_n = zs.shape(1);
+    array_type z(small_vector<ssize_t>{z_n});
     KalmanStateInfo<T> bfs(z_m, m_state_size);
 
-    for (size_t iter = 0; iter < z_m; ++iter)
+    for (ssize_t iter = 0; iter < z_m; ++iter)
     {
-        for (size_t j = 0; j < z_n; ++j)
+        for (ssize_t j = 0; j < z_n; ++j)
         {
             z(j) = zs(iter, j);
         }
@@ -618,7 +618,7 @@ KalmanStateInfo<T> KalmanFilter<T>::batch_filter(array_type const & zs)
 }
 
 template <typename T>
-void KalmanFilter<T>::predict_and_update(array_type const & z, KalmanStateInfo<T> & bfs, size_t iter)
+void KalmanFilter<T>::predict_and_update(array_type const & z, KalmanStateInfo<T> & bfs, ssize_t iter)
 {
     SimpleArray<T> & prior_state = bfs.prior_states;
     SimpleArray<T> & prior_state_covariance = bfs.prior_states_covariance;
@@ -626,20 +626,20 @@ void KalmanFilter<T>::predict_and_update(array_type const & z, KalmanStateInfo<T
     SimpleArray<T> & posterior_state_covariance = bfs.posterior_states_covariance;
 
     predict();
-    for (size_t j = 0; j < m_state_size; ++j)
+    for (ssize_t j = 0; j < m_state_size; ++j)
     {
         prior_state(iter, j) = m_x(j);
-        for (size_t k = 0; k < m_state_size; ++k)
+        for (ssize_t k = 0; k < m_state_size; ++k)
         {
             prior_state_covariance(iter, j, k) = m_p(j, k);
         }
     }
 
     update(z);
-    for (size_t j = 0; j < m_state_size; ++j)
+    for (ssize_t j = 0; j < m_state_size; ++j)
     {
         posterior_state(iter, j) = m_x(j);
-        for (size_t k = 0; k < m_state_size; ++k)
+        for (ssize_t k = 0; k < m_state_size; ++k)
         {
             posterior_state_covariance(iter, j, k) = m_p(j, k);
         }
@@ -649,29 +649,29 @@ void KalmanFilter<T>::predict_and_update(array_type const & z, KalmanStateInfo<T
 template <typename T>
 KalmanStateInfo<T> KalmanFilter<T>::batch_filter(array_type const & zs, array_type const & us)
 {
-    size_t const z_m = zs.shape(0);
-    size_t const z_n = zs.shape(1);
-    array_type z(small_vector<size_t>{z_n});
+    ssize_t const z_m = zs.shape(0);
+    ssize_t const z_n = zs.shape(1);
+    array_type z(small_vector<ssize_t>{z_n});
     KalmanStateInfo<T> bfs(z_m, m_state_size);
 
     array_type u;
-    size_t u_n = 0;
+    ssize_t u_n = 0;
 
-    size_t const u_m = us.shape(0);
+    ssize_t const u_m = us.shape(0);
     if (u_m != z_m)
     {
         throw std::invalid_argument("KalmanFilter::batch_filter: The number of control inputs must match the number of measurements.");
     }
     u_n = us.shape(1);
-    u = array_type(small_vector<size_t>{u_n});
+    u = array_type(small_vector<ssize_t>{u_n});
 
-    for (size_t iter = 0; iter < z_m; ++iter)
+    for (ssize_t iter = 0; iter < z_m; ++iter)
     {
-        for (size_t j = 0; j < z_n; ++j)
+        for (ssize_t j = 0; j < z_n; ++j)
         {
             z(j) = zs(iter, j);
         }
-        for (size_t j = 0; j < u_n; ++j)
+        for (ssize_t j = 0; j < u_n; ++j)
         {
             u(j) = us(iter, j);
         }
@@ -681,7 +681,7 @@ KalmanStateInfo<T> KalmanFilter<T>::batch_filter(array_type const & zs, array_ty
 }
 
 template <typename T>
-void KalmanFilter<T>::predict_and_update(array_type const & z, array_type const & u, KalmanStateInfo<T> & bfs, size_t iter)
+void KalmanFilter<T>::predict_and_update(array_type const & z, array_type const & u, KalmanStateInfo<T> & bfs, ssize_t iter)
 {
     SimpleArray<T> & prior_state = bfs.prior_states;
     SimpleArray<T> & prior_state_covariance = bfs.prior_states_covariance;
@@ -689,20 +689,20 @@ void KalmanFilter<T>::predict_and_update(array_type const & z, array_type const 
     SimpleArray<T> & posterior_state_covariance = bfs.posterior_states_covariance;
 
     predict(u);
-    for (size_t j = 0; j < m_state_size; ++j)
+    for (ssize_t j = 0; j < m_state_size; ++j)
     {
         prior_state(iter, j) = m_x(j);
-        for (size_t k = 0; k < m_state_size; ++k)
+        for (ssize_t k = 0; k < m_state_size; ++k)
         {
             prior_state_covariance(iter, j, k) = m_p(j, k);
         }
     }
 
     update(z);
-    for (size_t j = 0; j < m_state_size; ++j)
+    for (ssize_t j = 0; j < m_state_size; ++j)
     {
         posterior_state(iter, j) = m_x(j);
-        for (size_t k = 0; k < m_state_size; ++k)
+        for (ssize_t k = 0; k < m_state_size; ++k)
         {
             posterior_state_covariance(iter, j, k) = m_p(j, k);
         }

--- a/cpp/solvcon/linalg/lu_factorization.hpp
+++ b/cpp/solvcon/linalg/lu_factorization.hpp
@@ -137,7 +137,7 @@ private:
     static std::string format_shape(array_type const & arr);
 
     // Validate that a is square and 2D; return its shape for member init.
-    static small_vector<size_t> validate_shape(array_type const & a);
+    static small_vector<ssize_t> validate_shape(array_type const & a);
 
     /**
      * Forward substitution: solve Ly = Pb using the cached factors.
@@ -177,7 +177,7 @@ std::string LuFactorization<T>::format_shape(array_type const & arr)
 }
 
 template <typename T>
-small_vector<size_t> LuFactorization<T>::validate_shape(array_type const & a)
+small_vector<ssize_t> LuFactorization<T>::validate_shape(array_type const & a)
 {
     if (a.ndim() != 2 || a.shape(0) != a.shape(1))
     {
@@ -191,9 +191,9 @@ small_vector<size_t> LuFactorization<T>::validate_shape(array_type const & a)
 template <typename T>
 LuFactorization<T>::LuFactorization(array_type const & a)
     : m_lu(validate_shape(a), value_type{0})
-    , m_piv(small_vector<size_t>{a.shape(0)})
+    , m_piv(small_vector<ssize_t>{a.shape(0)})
 {
-    const auto n = static_cast<ssize_t>(a.shape(0));
+    const auto n = a.shape(0);
 
     // Working copy of the input matrix.  The algorithm modifies m_lu
     // in-place, overwriting it with the combined L and U factors.
@@ -268,8 +268,8 @@ template <typename T>
 typename LuFactorization<T>::array_type LuFactorization<T>::forward_substitution(array_type const & b) const
 {
     const auto m = n();
-    const auto ncols = static_cast<ssize_t>(b.shape(1));
-    small_vector<size_t> const y_shape{static_cast<size_t>(m), static_cast<size_t>(ncols)};
+    const auto ncols = b.shape(1);
+    small_vector<ssize_t> const y_shape{m, ncols};
 
     // Copy b into y so we can apply the permutation in-place.
     array_type y(y_shape);
@@ -311,8 +311,8 @@ template <typename T>
 typename LuFactorization<T>::array_type LuFactorization<T>::backward_substitution(array_type const & y) const
 {
     const auto m = n();
-    const auto ncols = static_cast<ssize_t>(y.shape(1));
-    small_vector<size_t> const x_shape{static_cast<size_t>(m), static_cast<size_t>(ncols)};
+    const auto ncols = y.shape(1);
+    small_vector<ssize_t> const x_shape{m, ncols};
     array_type x(x_shape);
 
     // Solve Ux = y by backward substitution.  U occupies the upper triangle
@@ -343,7 +343,7 @@ typename LuFactorization<T>::array_type LuFactorization<T>::solve(array_type con
             "LuFactorization::solve: b must be 1D or 2D, but got {}D",
             b.ndim()));
     }
-    if (static_cast<ssize_t>(b.shape(0)) != n())
+    if (b.shape(0) != n())
     {
         throw std::invalid_argument(std::format(
             "LuFactorization::solve: dimension mismatch: a.shape[0]={}, b.shape[0]={}",
@@ -356,10 +356,10 @@ typename LuFactorization<T>::array_type LuFactorization<T>::solve(array_type con
     bool const was_1d = (b.ndim() == 1);
     if (was_1d)
     {
-        auto b_2d = b.reshape(small_vector<size_t>{b.shape(0), 1});
+        auto b_2d = b.reshape(small_vector<ssize_t>{b.shape(0), 1});
         auto y = forward_substitution(b_2d);
         auto x = backward_substitution(y);
-        return x.reshape(small_vector<size_t>{x.shape(0)});
+        return x.reshape(small_vector<ssize_t>{x.shape(0)});
     }
     else
     {

--- a/cpp/solvcon/linalg/pymod/wrap_kalman_filter.cpp
+++ b/cpp/solvcon/linalg/pymod/wrap_kalman_filter.cpp
@@ -73,7 +73,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapKalmanFilter
                         array_type b_array;
                         if (b.is_none())
                         {
-                            b_array = array_type(small_vector<size_t>{x.shape(0), 0});
+                            b_array = array_type(small_vector<ssize_t>{x.shape(0), 0});
                         }
                         else
                         {
@@ -102,7 +102,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapKalmanFilter
                         array_type b_array;
                         if (b.is_none())
                         {
-                            b_array = array_type(small_vector<size_t>{x.shape(0), 0});
+                            b_array = array_type(small_vector<ssize_t>{x.shape(0), 0});
                         }
                         else
                         {

--- a/cpp/solvcon/math/blas_compat.cpp
+++ b/cpp/solvcon/math/blas_compat.cpp
@@ -33,9 +33,16 @@ using blas_int_type = __LAPACK_int;
 using blas_int_type = int;
 #endif
 
-static blas_int_type to_blas_int(size_t value, char const * name)
+static blas_int_type to_blas_int(ssize_t value, char const * name)
 {
-    if (value <= static_cast<size_t>(std::numeric_limits<blas_int_type>::max()))
+    if (value < 0)
+    {
+        throw std::out_of_range(
+            std::format("solvcon BLAS wrapper: {}={} must be non-negative",
+                        name,
+                        value));
+    }
+    if (value <= static_cast<ssize_t>(std::numeric_limits<blas_int_type>::max()))
     {
         return static_cast<blas_int_type>(value);
     }
@@ -51,19 +58,19 @@ static CBLAS_TRANSPOSE to_cblas_transpose(bool transpose_matrix)
     return transpose_matrix ? CblasTrans : CblasNoTrans;
 }
 
-float dot_blas(size_t size, float const * lhs, float const * rhs)
+float dot_blas(ssize_t size, float const * lhs, float const * rhs)
 {
     blas_int_type const bsize = to_blas_int(size, "size");
     return cblas_sdot(bsize, lhs, 1, rhs, 1);
 }
 
-double dot_blas(size_t size, double const * lhs, double const * rhs)
+double dot_blas(ssize_t size, double const * lhs, double const * rhs)
 {
     blas_int_type const bsize = to_blas_int(size, "size");
     return cblas_ddot(bsize, lhs, 1, rhs, 1);
 }
 
-Complex<float> dot_blas(size_t size,
+Complex<float> dot_blas(ssize_t size,
                         Complex<float> const * lhs,
                         Complex<float> const * rhs)
 {
@@ -78,7 +85,7 @@ Complex<float> dot_blas(size_t size,
     return result;
 }
 
-Complex<double> dot_blas(size_t size,
+Complex<double> dot_blas(ssize_t size,
                          Complex<double> const * lhs,
                          Complex<double> const * rhs)
 {
@@ -93,8 +100,8 @@ Complex<double> dot_blas(size_t size,
     return result;
 }
 
-void gemv_blas(size_t m,
-               size_t n,
+void gemv_blas(ssize_t m,
+               ssize_t n,
                float const * matrix,
                float const * vector,
                float * result,
@@ -116,8 +123,8 @@ void gemv_blas(size_t m,
                 1);
 }
 
-void gemv_blas(size_t m,
-               size_t n,
+void gemv_blas(ssize_t m,
+               ssize_t n,
                double const * matrix,
                double const * vector,
                double * result,
@@ -139,8 +146,8 @@ void gemv_blas(size_t m,
                 1);
 }
 
-void gemv_blas(size_t m,
-               size_t n,
+void gemv_blas(ssize_t m,
+               ssize_t n,
                Complex<float> const * matrix,
                Complex<float> const * vector,
                Complex<float> * result,
@@ -164,8 +171,8 @@ void gemv_blas(size_t m,
                 1);
 }
 
-void gemv_blas(size_t m,
-               size_t n,
+void gemv_blas(ssize_t m,
+               ssize_t n,
                Complex<double> const * matrix,
                Complex<double> const * vector,
                Complex<double> * result,
@@ -189,9 +196,9 @@ void gemv_blas(size_t m,
                 1);
 }
 
-void gemm_blas(size_t m,
-               size_t n,
-               size_t k,
+void gemm_blas(ssize_t m,
+               ssize_t n,
+               ssize_t k,
                float const * lhs,
                float const * rhs,
                float * result)
@@ -215,9 +222,9 @@ void gemm_blas(size_t m,
                 bn);
 }
 
-void gemm_blas(size_t m,
-               size_t n,
-               size_t k,
+void gemm_blas(ssize_t m,
+               ssize_t n,
+               ssize_t k,
                double const * lhs,
                double const * rhs,
                double * result)
@@ -241,9 +248,9 @@ void gemm_blas(size_t m,
                 bn);
 }
 
-void gemm_blas(size_t m,
-               size_t n,
-               size_t k,
+void gemm_blas(ssize_t m,
+               ssize_t n,
+               ssize_t k,
                Complex<float> const * lhs,
                Complex<float> const * rhs,
                Complex<float> * result)
@@ -269,9 +276,9 @@ void gemm_blas(size_t m,
                 bn);
 }
 
-void gemm_blas(size_t m,
-               size_t n,
-               size_t k,
+void gemm_blas(ssize_t m,
+               ssize_t n,
+               ssize_t k,
                Complex<double> const * lhs,
                Complex<double> const * rhs,
                Complex<double> * result)
@@ -303,32 +310,32 @@ void gemm_blas(size_t m,
         "solvcon BLAS wrapper: CBLAS backend is unavailable");
 }
 
-float dot_blas(size_t, float const *, float const *)
+float dot_blas(ssize_t, float const *, float const *)
 {
     throw_blas_unavailable();
 }
 
-double dot_blas(size_t, double const *, double const *)
+double dot_blas(ssize_t, double const *, double const *)
 {
     throw_blas_unavailable();
 }
 
-Complex<float> dot_blas(size_t,
+Complex<float> dot_blas(ssize_t,
                         Complex<float> const *,
                         Complex<float> const *)
 {
     throw_blas_unavailable();
 }
 
-Complex<double> dot_blas(size_t,
+Complex<double> dot_blas(ssize_t,
                          Complex<double> const *,
                          Complex<double> const *)
 {
     throw_blas_unavailable();
 }
 
-void gemv_blas(size_t,
-               size_t,
+void gemv_blas(ssize_t,
+               ssize_t,
                float const *,
                float const *,
                float *,
@@ -337,8 +344,8 @@ void gemv_blas(size_t,
     throw_blas_unavailable();
 }
 
-void gemv_blas(size_t,
-               size_t,
+void gemv_blas(ssize_t,
+               ssize_t,
                double const *,
                double const *,
                double *,
@@ -347,8 +354,8 @@ void gemv_blas(size_t,
     throw_blas_unavailable();
 }
 
-void gemv_blas(size_t,
-               size_t,
+void gemv_blas(ssize_t,
+               ssize_t,
                Complex<float> const *,
                Complex<float> const *,
                Complex<float> *,
@@ -357,8 +364,8 @@ void gemv_blas(size_t,
     throw_blas_unavailable();
 }
 
-void gemv_blas(size_t,
-               size_t,
+void gemv_blas(ssize_t,
+               ssize_t,
                Complex<double> const *,
                Complex<double> const *,
                Complex<double> *,
@@ -367,14 +374,14 @@ void gemv_blas(size_t,
     throw_blas_unavailable();
 }
 
-void gemm_blas(size_t, size_t, size_t, float const *, float const *, float *)
+void gemm_blas(ssize_t, ssize_t, ssize_t, float const *, float const *, float *)
 {
     throw_blas_unavailable();
 }
 
-void gemm_blas(size_t,
-               size_t,
-               size_t,
+void gemm_blas(ssize_t,
+               ssize_t,
+               ssize_t,
                double const *,
                double const *,
                double *)
@@ -382,9 +389,9 @@ void gemm_blas(size_t,
     throw_blas_unavailable();
 }
 
-void gemm_blas(size_t,
-               size_t,
-               size_t,
+void gemm_blas(ssize_t,
+               ssize_t,
+               ssize_t,
                Complex<float> const *,
                Complex<float> const *,
                Complex<float> *)
@@ -392,9 +399,9 @@ void gemm_blas(size_t,
     throw_blas_unavailable();
 }
 
-void gemm_blas(size_t,
-               size_t,
-               size_t,
+void gemm_blas(ssize_t,
+               ssize_t,
+               ssize_t,
                Complex<double> const *,
                Complex<double> const *,
                Complex<double> *)

--- a/cpp/solvcon/math/blas_compat.hpp
+++ b/cpp/solvcon/math/blas_compat.hpp
@@ -5,66 +5,65 @@
  * BSD 3-Clause License, see COPYING
  */
 
+#include <solvcon/base.hpp>
 #include <solvcon/math/Complex.hpp>
-
-#include <cstddef>
 
 namespace solvcon
 {
 
-float dot_blas(size_t size, float const * lhs, float const * rhs);
-double dot_blas(size_t size, double const * lhs, double const * rhs);
-Complex<float> dot_blas(size_t size,
+float dot_blas(ssize_t size, float const * lhs, float const * rhs);
+double dot_blas(ssize_t size, double const * lhs, double const * rhs);
+Complex<float> dot_blas(ssize_t size,
                         Complex<float> const * lhs,
                         Complex<float> const * rhs);
-Complex<double> dot_blas(size_t size,
+Complex<double> dot_blas(ssize_t size,
                          Complex<double> const * lhs,
                          Complex<double> const * rhs);
-void gemv_blas(size_t m,
-               size_t n,
+void gemv_blas(ssize_t m,
+               ssize_t n,
                float const * matrix,
                float const * vector,
                float * result,
                bool transpose_matrix);
-void gemv_blas(size_t m,
-               size_t n,
+void gemv_blas(ssize_t m,
+               ssize_t n,
                double const * matrix,
                double const * vector,
                double * result,
                bool transpose_matrix);
-void gemv_blas(size_t m,
-               size_t n,
+void gemv_blas(ssize_t m,
+               ssize_t n,
                Complex<float> const * matrix,
                Complex<float> const * vector,
                Complex<float> * result,
                bool transpose_matrix);
-void gemv_blas(size_t m,
-               size_t n,
+void gemv_blas(ssize_t m,
+               ssize_t n,
                Complex<double> const * matrix,
                Complex<double> const * vector,
                Complex<double> * result,
                bool transpose_matrix);
-void gemm_blas(size_t m,
-               size_t n,
-               size_t k,
+void gemm_blas(ssize_t m,
+               ssize_t n,
+               ssize_t k,
                float const * lhs,
                float const * rhs,
                float * result);
-void gemm_blas(size_t m,
-               size_t n,
-               size_t k,
+void gemm_blas(ssize_t m,
+               ssize_t n,
+               ssize_t k,
                double const * lhs,
                double const * rhs,
                double * result);
-void gemm_blas(size_t m,
-               size_t n,
-               size_t k,
+void gemm_blas(ssize_t m,
+               ssize_t n,
+               ssize_t k,
                Complex<float> const * lhs,
                Complex<float> const * rhs,
                Complex<float> * result);
-void gemm_blas(size_t m,
-               size_t n,
-               size_t k,
+void gemm_blas(ssize_t m,
+               ssize_t n,
+               ssize_t k,
                Complex<double> const * lhs,
                Complex<double> const * rhs,
                Complex<double> * result);

--- a/cpp/solvcon/mesh/StaticMesh.hpp
+++ b/cpp/solvcon/mesh/StaticMesh.hpp
@@ -174,7 +174,7 @@ private:
      * index in bndfcs.  The third column is the face index of the related
      * block (if exists).
      */
-    SimpleArray<int_type> m_facn = SimpleArray<int_type>(std::vector<size_t>{0});
+    SimpleArray<int_type> m_facn = SimpleArray<int_type>(small_vector<ssize_t>{0});
 
 public:
 
@@ -186,8 +186,8 @@ public:
 
     StaticMeshBC() = default;
 
-    explicit StaticMeshBC(size_t nbound)
-        : m_facn(SimpleArray<int_type>(std::vector<size_t>{nbound, BFREL}))
+    explicit StaticMeshBC(ssize_t nbound)
+        : m_facn(SimpleArray<int_type>(small_vector<ssize_t>{nbound, BFREL}))
     {
     }
 
@@ -227,7 +227,7 @@ public:
 
     ~StaticMeshBC() = default;
 
-    size_t nbound() const { return m_facn.nbody(); }
+    ssize_t nbound() const { return m_facn.nbody(); }
 
     SimpleArray<int_type> const & facn() const { return m_facn; }
     SimpleArray<int_type> & facn() { return m_facn; }
@@ -276,21 +276,21 @@ public:
         , m_nnode(nnode)
         , m_nface(nface)
         , m_ncell(ncell)
-        , m_ndcrd(std::vector<size_t>{nnode, m_ndim}, 0)
-        , m_fccnd(std::vector<size_t>{nface, m_ndim}, 0)
-        , m_fcnml(std::vector<size_t>{nface, m_ndim}, 0)
-        , m_fcara(std::vector<size_t>{nface}, 0)
-        , m_clcnd(std::vector<size_t>{ncell, m_ndim}, 0)
-        , m_clvol(std::vector<size_t>{ncell}, 0)
-        , m_fctpn(std::vector<size_t>{nface})
-        , m_cltpn(std::vector<size_t>{ncell})
-        , m_clgrp(std::vector<size_t>{ncell})
-        , m_fcnds(std::vector<size_t>{nface, FCMND + 1})
-        , m_fccls(std::vector<size_t>{nface, FCREL})
-        , m_clnds(std::vector<size_t>{ncell, CLMND + 1})
-        , m_clfcs(std::vector<size_t>{ncell, CLMFC + 1})
-        , m_ednds(std::vector<size_t>{0, 2})
-        , m_bndfcs(std::vector<size_t>{0, StaticMeshBC::BFREL})
+        , m_ndcrd(small_vector<ssize_t>{static_cast<ssize_t>(nnode), m_ndim}, 0)
+        , m_fccnd(small_vector<ssize_t>{static_cast<ssize_t>(nface), m_ndim}, 0)
+        , m_fcnml(small_vector<ssize_t>{static_cast<ssize_t>(nface), m_ndim}, 0)
+        , m_fcara(small_vector<ssize_t>{static_cast<ssize_t>(nface)}, 0)
+        , m_clcnd(small_vector<ssize_t>{static_cast<ssize_t>(ncell), m_ndim}, 0)
+        , m_clvol(small_vector<ssize_t>{static_cast<ssize_t>(ncell)}, 0)
+        , m_fctpn(small_vector<ssize_t>{static_cast<ssize_t>(nface)})
+        , m_cltpn(small_vector<ssize_t>{static_cast<ssize_t>(ncell)})
+        , m_clgrp(small_vector<ssize_t>{static_cast<ssize_t>(ncell)})
+        , m_fcnds(small_vector<ssize_t>{static_cast<ssize_t>(nface), FCMND + 1})
+        , m_fccls(small_vector<ssize_t>{static_cast<ssize_t>(nface), FCREL})
+        , m_clnds(small_vector<ssize_t>{static_cast<ssize_t>(ncell), CLMND + 1})
+        , m_clfcs(small_vector<ssize_t>{static_cast<ssize_t>(ncell), CLMFC + 1})
+        , m_ednds(small_vector<ssize_t>{0, 2})
+        , m_bndfcs(small_vector<ssize_t>{0, StaticMeshBC::BFREL})
     {
     }
     StaticMesh() = delete;
@@ -372,7 +372,7 @@ public:
 
 private:
 
-    std::tuple<size_t, size_t, size_t> count_ghost() const;
+    std::tuple<ssize_t, ssize_t, ssize_t> count_ghost() const;
     void fill_ghost();
 
     // Shape data.

--- a/cpp/solvcon/mesh/StaticMesh_boundary.cpp
+++ b/cpp/solvcon/mesh/StaticMesh_boundary.cpp
@@ -22,14 +22,17 @@ namespace solvcon
 void StaticMesh::build_boundary()
 {
     assert(0 == m_nbound); // nothing should touch m_nbound beforehand.
-    for (size_t it = 0; it < fccls().shape(0); ++it)
+    for (ssize_t it = 0; it < fccls().shape(0); ++it)
     {
         if (fccls()(it, 1) < 0)
         {
             m_nbound += 1;
         }
     }
-    SimpleArray<int_type>(std::vector<size_t>{m_nbound, StaticMeshBC::BFREL}, -1).swap(m_bndfcs);
+    SimpleArray<int_type>(
+        small_vector<ssize_t>{static_cast<ssize_t>(m_nbound), StaticMeshBC::BFREL},
+        -1)
+        .swap(m_bndfcs);
 
     std::vector<int_type> allfacn(m_nbound);
     size_t ait = 0;
@@ -73,7 +76,7 @@ void StaticMesh::build_boundary()
 
     if (nleft != 0)
     {
-        StaticMeshBC bnd(static_cast<size_t>(nleft));
+        StaticMeshBC bnd(nleft);
         auto & bfacn = bnd.facn();
         size_t bfit = 0;
         size_t const ibnd = m_bcs.size();
@@ -104,30 +107,30 @@ void StaticMesh::build_ghost()
     m_ngstface = static_cast<uint_type>(std::get<1>(count_ghost_tuple));
     m_ngstcell = static_cast<uint_type>(std::get<2>(count_ghost_tuple));
 
-#define MM_DECL_GHOST_SWAP1(N, T, D1, I)                                  \
-    {                                                                     \
-        SimpleArray<T> arr(std::vector<size_t>{m_ngst##D1 + m_n##D1}, I); \
-        arr.set_nghost(m_ngst##D1);                                       \
-        for (int_type it = 0; it < static_cast<int_type>(m_n##D1); ++it)  \
-        {                                                                 \
-            arr(it) = m_##N(it);                                          \
-        }                                                                 \
-        arr.swap(m_##N);                                                  \
+#define MM_DECL_GHOST_SWAP1(N, T, D1, I)                                                          \
+    {                                                                                             \
+        SimpleArray<T> arr(small_vector<ssize_t>{static_cast<ssize_t>(m_ngst##D1 + m_n##D1)}, I); \
+        arr.set_nghost(m_ngst##D1);                                                               \
+        for (int_type it = 0; it < static_cast<int_type>(m_n##D1); ++it)                          \
+        {                                                                                         \
+            arr(it) = m_##N(it);                                                                  \
+        }                                                                                         \
+        arr.swap(m_##N);                                                                          \
     }
 
-#define MM_DECL_GHOST_SWAP2(N, T, D1, D2, I)                                  \
-    {                                                                         \
-        SimpleArray<T> arr(std::vector<size_t>{m_ngst##D1 + m_n##D1, D2}, I); \
-        arr.set_nghost(m_ngst##D1);                                           \
-        for (int_type it = 0; it < static_cast<int_type>(m_n##D1); ++it)      \
-        {                                                                     \
-            for (int_type jt = 0; jt < static_cast<int_type>(D2); ++jt)       \
-            {                                                                 \
-                arr(it, jt) = m_##N(it, jt);                                  \
-            }                                                                 \
-            arr(it) = m_##N(it);                                              \
-        }                                                                     \
-        arr.swap(m_##N);                                                      \
+#define MM_DECL_GHOST_SWAP2(N, T, D1, D2, I)                                                          \
+    {                                                                                                 \
+        SimpleArray<T> arr(small_vector<ssize_t>{static_cast<ssize_t>(m_ngst##D1 + m_n##D1), D2}, I); \
+        arr.set_nghost(m_ngst##D1);                                                                   \
+        for (int_type it = 0; it < static_cast<int_type>(m_n##D1); ++it)                              \
+        {                                                                                             \
+            for (int_type jt = 0; jt < static_cast<int_type>(D2); ++jt)                               \
+            {                                                                                         \
+                arr(it, jt) = m_##N(it, jt);                                                          \
+            }                                                                                         \
+            arr(it) = m_##N(it);                                                                      \
+        }                                                                                             \
+        arr.swap(m_##N);                                                                              \
     }
 
     // geometry arrays.
@@ -156,21 +159,22 @@ void StaticMesh::build_ghost()
 /**
  * @brief Count the number of ghost entities.
  *
- * @return std::tuple<size_t, size_t, size_t>
+ * @return std::tuple<ssize_t, ssize_t, ssize_t>
  *  ngstnode, ngstface, ngstcell
  */
-std::tuple<size_t, size_t, size_t> StaticMesh::count_ghost() const
+std::tuple<ssize_t, ssize_t, ssize_t> StaticMesh::count_ghost() const
 {
-    size_t ngstface = 0;
-    size_t ngstnode = 0;
+    ssize_t ngstface = 0;
+    ssize_t ngstnode = 0;
     for (size_t ibfc = 0; ibfc < m_nbound; ++ibfc)
     {
         const int_type ifc = m_bndfcs(ibfc, 0);
         const int_type icl = m_fccls(ifc, 0);
-        ngstface += static_cast<size_t>(CellType::by_id(static_cast<uint8_t>(m_cltpn(icl))).nface()) - 1;
+        ssize_t const nface = CellType::by_id(static_cast<uint8_t>(m_cltpn(icl))).nface();
+        ngstface += nface - 1;
         ngstnode += m_clnds(icl, 0) - m_fcnds(ifc, 0);
     }
-    return std::make_tuple(ngstnode, ngstface, static_cast<size_t>(m_nbound));
+    return std::make_tuple(ngstnode, ngstface, static_cast<ssize_t>(m_nbound));
 }
 
 /**
@@ -211,12 +215,12 @@ inline void StaticMesh::fill_ghost()
         {
             m_clnds(igcl, inl) = m_clnds(icl, inl);
         }
-        for (size_t inl = 1; inl <= static_cast<size_t>(m_clnds(icl, 0)); ++inl)
+        for (int_type inl = 1; inl <= m_clnds(icl, 0); ++inl)
         {
             int_type const ind = m_clnds(icl, inl);
             // try to find the node in the boundary face.
             bool mk_found = false;
-            for (size_t inf = 1; inf <= static_cast<size_t>(m_fcnds(ibfc, 0)); ++inf)
+            for (int_type inf = 1; inf <= m_fcnds(ibfc, 0); ++inf)
             {
                 if (ind == m_fcnds(ibfc, inf))
                 {
@@ -251,7 +255,7 @@ inline void StaticMesh::fill_ghost()
         {
             m_clfcs(igcl, ifl) = m_clfcs(icl, ifl); // copy in-face to ghost.
         }
-        for (size_t ifl = 1; ifl <= static_cast<size_t>(m_clfcs(icl, 0)); ++ifl)
+        for (int_type ifl = 1; ifl <= m_clfcs(icl, 0); ++ifl)
         {
             int_type const ifc = m_clfcs(icl, ifl); // the face to be processed.
             if (ifc == ibfc)
@@ -266,7 +270,7 @@ inline void StaticMesh::fill_ghost()
             {
                 m_fcnds(igfc, inf) = m_fcnds(ifc, inf);
             }
-            for (size_t inf = 1; inf <= static_cast<size_t>(m_fcnds(igfc, 0)); ++inf)
+            for (int_type inf = 1; inf <= m_fcnds(igfc, 0); ++inf)
             {
                 int_type const ind = m_fcnds(igfc, inf);
                 if (gstndmap[ind] != static_cast<int_type>(nnode()))
@@ -278,7 +282,7 @@ inline void StaticMesh::fill_ghost()
             igfc -= 1;
         }
         // erase node map record.
-        for (size_t inl = 1; inl <= static_cast<size_t>(m_clnds(icl, 0)); ++inl)
+        for (int_type inl = 1; inl <= m_clnds(icl, 0); ++inl)
         {
             gstndmap[m_clnds(icl, inl)] = nnode();
         }
@@ -508,7 +512,7 @@ inline void StaticMesh::fill_ghost()
     for (int_type icl = -1; icl >= -static_cast<int_type>(ngstcell()); --icl)
     {
         m_clvol(icl) = 0.0;
-        for (size_t it = 1; it <= static_cast<size_t>(m_clfcs(icl, 0)); ++it)
+        for (int_type it = 1; it <= m_clfcs(icl, 0); ++it)
         {
             int_type const ifc = m_clfcs(icl, it);
             // calculate volume associated with each face.

--- a/cpp/solvcon/mesh/StaticMesh_interior.cpp
+++ b/cpp/solvcon/mesh/StaticMesh_interior.cpp
@@ -326,10 +326,10 @@ struct FaceBuilder
         , mface(nface)
         , cltpn(cltpn_in)
         , clnds(clnds_in)
-        , clfcs(small_vector<size_t>{cltpn.nbody(), CLMFC + 1}, -1)
-        , fctpn(small_vector<size_t>{mface}, -1)
-        , fcnds(small_vector<size_t>{mface, FCMND + 1}, -1)
-        , fccls(small_vector<size_t>{mface, FCREL}, -1)
+        , clfcs(shape_type{cltpn.nbody(), CLMFC + 1}, -1)
+        , fctpn(shape_type{static_cast<ssize_t>(mface)}, -1)
+        , fcnds(shape_type{static_cast<ssize_t>(mface), FCMND + 1}, -1)
+        , fccls(shape_type{static_cast<ssize_t>(mface), FCREL}, -1)
         , dedupmap(mface)
     {
         populate();
@@ -400,7 +400,7 @@ struct FaceBuilder
 
         // second pass: scan again to build hash table.
         size_t const ndmfc = *std::max_element(ndnfc.begin(), ndnfc.end());
-        SimpleArray<int_type> ndfcs(small_vector<size_t>{nnode, static_cast<size_t>(ndmfc) + 1});
+        SimpleArray<int_type> ndfcs(shape_type{static_cast<ssize_t>(nnode), static_cast<ssize_t>(ndmfc) + 1});
         for (size_t ind = 0; ind < nnode; ++ind)
         {
             ndfcs(ind, 0) = 0;
@@ -524,19 +524,19 @@ struct FaceBuilder
 
     void rebuild_fctpn(decltype(fctpn) & ofctpn)
     {
-        ofctpn.remake(small_vector<size_t>{nface});
+        ofctpn.remake(shape_type{static_cast<ssize_t>(nface)});
         std::copy(fctpn.vptr(0), fctpn.vptr(nface), ofctpn.vptr(0));
     }
 
     void rebuild_fcnds(decltype(fcnds) & ofcnds)
     {
-        ofcnds.remake(small_vector<size_t>{nface, FCMND+1});
+        ofcnds.remake(shape_type{static_cast<ssize_t>(nface), FCMND+1});
         std::copy(fcnds.vptr(0, 0), fcnds.vptr(nface, 0), ofcnds.vptr(0, 0));
     }
 
     void rebuild_fccls(decltype(fccls) & ofccls)
     {
-        ofccls.remake(small_vector<size_t>{nface, FCREL});
+        ofccls.remake(shape_type{static_cast<ssize_t>(nface), FCREL});
         std::copy(fccls.vptr(0, 0), fccls.vptr(nface, 0), ofccls.vptr(0, 0));
     }
 
@@ -557,9 +557,9 @@ void StaticMesh::build_faces_from_cells()
     fb.rebuild_fctpn(m_fctpn);
     fb.rebuild_fcnds(m_fcnds);
     fb.rebuild_fccls(m_fccls);
-    m_fccnd.remake(small_vector<size_t>{nface(), m_ndim}, 0);
-    m_fcnml.remake(small_vector<size_t>{nface(), m_ndim}, 0);
-    m_fcara.remake(small_vector<size_t>{nface()}, 0);
+    m_fccnd.remake(small_vector<ssize_t>{static_cast<ssize_t>(nface()), m_ndim}, 0);
+    m_fcnml.remake(small_vector<ssize_t>{static_cast<ssize_t>(nface()), m_ndim}, 0);
+    m_fcara.remake(small_vector<ssize_t>{static_cast<ssize_t>(nface())}, 0);
     std::copy(fb.clfcs.vptr(0, 0), fb.clfcs.vptr(m_ncell, 0), m_clfcs.vptr(0, 0));
 }
 
@@ -600,7 +600,7 @@ void StaticMesh::build_edge()
     }
 
     // Build the edge node array and populate.
-    m_ednds.remake(small_vector<size_t>{edges.size(), 2}, 0);
+    m_ednds.remake(small_vector<ssize_t>{static_cast<ssize_t>(edges.size()), 2}, 0);
     for (size_t ied = 0; ied < edges.size(); ++ied)
     {
         etype const edge = edges[ied];

--- a/cpp/solvcon/multidim/euler_ce.cpp
+++ b/cpp/solvcon/multidim/euler_ce.cpp
@@ -30,31 +30,32 @@ EulerCore::EulerCore(
 
 void EulerCore::initialize_arrays()
 {
-    size_t const total = static_cast<size_t>(m_ngstcell) + m_ncell;
+    ssize_t const total = m_ngstcell + m_ncell;
+    ssize_t const ndim = m_ndim;
 
     m_cevol = SimpleArray<real_type>(
-        std::vector<size_t>{total, StaticMesh::CLMFC + 1}, 0);
+        small_vector<ssize_t>{total, StaticMesh::CLMFC + 1}, 0);
     m_cevol.set_nghost(m_ngstcell);
 
     m_cecnd = SimpleArray<real_type>(
-        std::vector<size_t>{
+        small_vector<ssize_t>{
             total,
-            static_cast<size_t>((StaticMesh::CLMFC + 1) * m_ndim)},
+            (StaticMesh::CLMFC + 1) * ndim},
         0);
     m_cecnd.set_nghost(m_ngstcell);
 
     m_sfcnd = SimpleArray<real_type>(
-        std::vector<size_t>{
-            static_cast<size_t>(m_ncell),
+        small_vector<ssize_t>{
+            m_ncell,
             StaticMesh::CLMFC * StaticMesh::FCMND,
-            static_cast<size_t>(m_ndim)},
+            ndim},
         0);
 
     m_sfnml = SimpleArray<real_type>(
-        std::vector<size_t>{
-            static_cast<size_t>(m_ncell),
+        small_vector<ssize_t>{
+            m_ncell,
             StaticMesh::CLMFC * StaticMesh::FCMND,
-            static_cast<size_t>(m_ndim)},
+            ndim},
         0);
 }
 

--- a/cpp/solvcon/multidim/euler_solution.cpp
+++ b/cpp/solvcon/multidim/euler_solution.cpp
@@ -18,14 +18,15 @@ namespace solvcon
 
 void EulerCore::initialize_solution()
 {
-    size_t const total = static_cast<size_t>(m_ngstcell) + m_ncell;
-    auto const neq = static_cast<size_t>(m_neq);
-    size_t const ndim = m_ndim;
+    ssize_t const total = m_ngstcell + m_ncell;
+    ssize_t const neq = m_neq;
+    ssize_t const ndim = m_ndim;
 
-    auto alloc = [this](SimpleArray<real_type> & arr, std::vector<size_t> const & shape)
+    auto alloc = [this](SimpleArray<real_type> & arr,
+                        small_vector<ssize_t> const & shape)
     {
         arr = SimpleArray<real_type>(shape, 0);
-        arr.set_nghost(static_cast<size_t>(m_ngstcell));
+        arr.set_nghost(m_ngstcell);
     };
 
     alloc(m_so0c, {total, neq});

--- a/cpp/solvcon/onedim/Euler1DCore.cpp
+++ b/cpp/solvcon/onedim/Euler1DCore.cpp
@@ -26,11 +26,12 @@ void Euler1DCore::initialize_data(size_t ncoord)
     {
         throw std::invalid_argument("ncoord cannot be even");
     }
+    auto const coord_count = static_cast<ssize_t>(ncoord);
     m_coord = SimpleArray<double>(/*length*/ ncoord);
     m_cfl = SimpleArray<double>(/*length*/ ncoord);
-    m_so0 = SimpleArray<double>(/*shape*/ small_vector<size_t>{ncoord, NVAR});
-    m_so1 = SimpleArray<double>(/*shape*/ small_vector<size_t>{ncoord, NVAR});
-    m_gamma = SimpleArray<double>(/*shape*/ small_vector<size_t>{ncoord}, /*value*/ 1.4);
+    m_so0 = SimpleArray<double>(/*shape*/ small_vector<ssize_t>{coord_count, NVAR});
+    m_so1 = SimpleArray<double>(/*shape*/ small_vector<ssize_t>{coord_count, NVAR});
+    m_gamma = SimpleArray<double>(/*shape*/ small_vector<ssize_t>{coord_count}, /*value*/ 1.4);
 }
 
 SimpleArray<double> Euler1DCore::density() const

--- a/cpp/solvcon/pilot/RBoundary.cpp
+++ b/cpp/solvcon/pilot/RBoundary.cpp
@@ -44,7 +44,7 @@ void RBoundary::build(StaticMesh const & mh, int ibc)
     // the colored ribbon.
     SimpleCollector<uint32_t> ends;
     SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
-    for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+    for (size_t ibnd = 0; ibnd < static_cast<size_t>(bndfcs.shape(0)); ++ibnd)
     {
         if (bndfcs(ibnd, 1) == ibc)
         {

--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -704,7 +704,7 @@ void RDomainWidget::collectSurfaceScalars(
     if (3 == ndim)
     {
         SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
-        size_t const nprim = std::min(bndfcs.shape(0), primitive_scalar.size());
+        size_t const nprim = std::min(static_cast<size_t>(bndfcs.shape(0)), primitive_scalar.size());
         for (size_t ibnd = 0; ibnd < nprim; ++ibnd)
         {
             int32_t const ifc = bndfcs(ibnd, 0);
@@ -744,9 +744,9 @@ void pack_scalar_arrays(
 {
     size_t const nvert = verts.size() / 3;
     size_t const ntri = tris.size() / 3;
-    va = SimpleArray<float>(std::vector<size_t>{nvert, 3});
-    sa = SimpleArray<float>(std::vector<size_t>{nvert});
-    ia = SimpleArray<uint32_t>(std::vector<size_t>{ntri, 3});
+    va = SimpleArray<float>(small_vector<ssize_t>{static_cast<ssize_t>(nvert), 3});
+    sa = SimpleArray<float>(small_vector<ssize_t>{static_cast<ssize_t>(nvert)});
+    ia = SimpleArray<uint32_t>(small_vector<ssize_t>{static_cast<ssize_t>(ntri), 3});
     for (size_t i = 0; i < nvert; ++i)
     {
         va(i, 0) = verts[3 * i + 0];
@@ -1284,9 +1284,9 @@ void RDomainWidget::setSelection(
         {
             size_t const nvert = verts.size() / 3;
             size_t const ntri = tris.size() / 3;
-            SimpleArray<float> va(std::vector<size_t>{nvert, 3});
-            SimpleArray<float> ca(std::vector<size_t>{nvert, 3});
-            SimpleArray<uint32_t> ia(std::vector<size_t>{ntri, 3});
+            SimpleArray<float> va(small_vector<ssize_t>{static_cast<ssize_t>(nvert), 3});
+            SimpleArray<float> ca(small_vector<ssize_t>{static_cast<ssize_t>(nvert), 3});
+            SimpleArray<uint32_t> ia(small_vector<ssize_t>{static_cast<ssize_t>(ntri), 3});
             for (size_t i = 0; i < nvert; ++i)
             {
                 va(i, 0) = verts[3 * i + 0];
@@ -1455,9 +1455,9 @@ int RDomainWidget::addClip(QVector3D const & origin, QVector3D const & normal)
     {
         size_t const nvert = verts.size() / 3;
         size_t const ntri = tris.size() / 3;
-        SimpleArray<float> va(std::vector<size_t>{nvert, 3});
-        SimpleArray<float> ca(std::vector<size_t>{nvert, 3});
-        SimpleArray<uint32_t> ia(std::vector<size_t>{ntri, 3});
+        SimpleArray<float> va(small_vector<ssize_t>{static_cast<ssize_t>(nvert), 3});
+        SimpleArray<float> ca(small_vector<ssize_t>{static_cast<ssize_t>(nvert), 3});
+        SimpleArray<uint32_t> ia(small_vector<ssize_t>{static_cast<ssize_t>(ntri), 3});
         for (size_t i = 0; i < nvert; ++i)
         {
             va(i, 0) = verts[3 * i + 0];

--- a/cpp/solvcon/pilot/RField.cpp
+++ b/cpp/solvcon/pilot/RField.cpp
@@ -31,8 +31,8 @@ RField::RField(
         throw std::invalid_argument("RField: indices must have shape (ntri, 3)");
     }
 
-    size_t const nvert = vertices.shape(0);
-    size_t const ntri = indices.shape(0);
+    size_t const nvert = static_cast<size_t>(vertices.shape(0));
+    size_t const ntri = static_cast<size_t>(indices.shape(0));
     if (0 == nvert || 0 == ntri)
     {
         return;

--- a/cpp/solvcon/pilot/common_detail.hpp
+++ b/cpp/solvcon/pilot/common_detail.hpp
@@ -30,12 +30,16 @@ namespace solvcon
  * @return A SimpleArray of the requested shape over the byte buffer.
  */
 template <typename T>
-SimpleArray<T> makeSimpleArray(QByteArray & qbarr, small_vector<size_t> shape, bool view = false)
+SimpleArray<T> makeSimpleArray(QByteArray & qbarr, small_vector<ssize_t> shape, bool view = false)
 {
     size_t nbytes = sizeof(T);
-    for (size_t v : shape)
+    for (ssize_t v : shape)
     {
-        nbytes *= v;
+        if (v < 0)
+        {
+            throw std::out_of_range("QByteArray shape cannot contain negative dimensions");
+        }
+        nbytes *= static_cast<size_t>(v);
     }
     if (0 == nbytes)
     {
@@ -58,7 +62,7 @@ SimpleArray<T> makeSimpleArray(QByteArray & qbarr, small_vector<size_t> shape, b
         std::copy_n(ptr, nbytes, cbuf->begin());
     }
 
-    return SimpleArray<T>(small_vector<size_t>(shape), cbuf);
+    return SimpleArray<T>(shape, cbuf);
 }
 
 /**

--- a/cpp/solvcon/python/common.hpp
+++ b/cpp/solvcon/python/common.hpp
@@ -176,7 +176,7 @@ std::enable_if_t<is_simple_array_v<S>, pybind11::array> to_ndarray(S && sarr)
 {
     namespace py = pybind11;
     using T = typename std::remove_reference_t<S>::value_type;
-    std::vector<size_t> const shape(sarr.shape().begin(), sarr.shape().end());
+    std::vector<py::ssize_t> const shape(sarr.shape().begin(), sarr.shape().end());
     std::vector<py::ssize_t> stride;
     stride.reserve(sarr.stride().size());
     auto const itemsize = static_cast<py::ssize_t>(sarr.itemsize());

--- a/cpp/solvcon/spacetime/core.cpp
+++ b/cpp/solvcon/spacetime/core.cpp
@@ -34,7 +34,7 @@ Grid::Grid(real_type xmin, real_type xmax, size_t ncelm, ctor_passkey const &)
     }
     // Fill the array for CCE boundary.
     const real_type xspace = (xmax - xmin) / ncelm;
-    array_type xloc(std::vector<size_t>{ncelm + 1});
+    array_type xloc(small_vector<ssize_t>{static_cast<ssize_t>(ncelm + 1)});
     xloc[0] = xmin;
     for (size_t it = 1; it < ncelm; ++it)
     {
@@ -101,9 +101,9 @@ void Grid::init_from_array(array_type const & xloc)
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 Field::Field(std::shared_ptr<Grid> const & grid, Field::value_type time_increment, size_t nvar)
     : m_grid(grid)
-    , m_so0(array_type(std::vector<size_t>{grid->xsize(), nvar}))
-    , m_so1(array_type(std::vector<size_t>{grid->xsize(), nvar}))
-    , m_cfl(array_type(std::vector<size_t>{grid->xsize()}))
+    , m_so0(array_type(small_vector<ssize_t>{static_cast<ssize_t>(grid->xsize()), static_cast<ssize_t>(nvar)}))
+    , m_so1(array_type(small_vector<ssize_t>{static_cast<ssize_t>(grid->xsize()), static_cast<ssize_t>(nvar)}))
+    , m_cfl(array_type(small_vector<ssize_t>{static_cast<ssize_t>(grid->xsize())}))
 {
     set_time_increment(time_increment);
 }

--- a/cpp/solvcon/spacetime/core.hpp
+++ b/cpp/solvcon/spacetime/core.hpp
@@ -820,7 +820,7 @@ inline typename SolverBase<ST, CE, SE>::array_type
 SolverBase<ST, CE, SE>::x(bool odd_plane) const
 {
     const uint_type nselm = static_cast<uint_type>(grid().nselm()) - static_cast<uint_type>(odd_plane);
-    array_type ret(std::vector<size_t>{nselm});
+    array_type ret(small_vector<ssize_t>{static_cast<ssize_t>(nselm)});
     for (uint_type it = 0; it < nselm; ++it) { ret[it] = selm(it, odd_plane).x(); }
     return ret;
 }
@@ -830,7 +830,7 @@ inline typename SolverBase<ST, CE, SE>::array_type
 SolverBase<ST, CE, SE>::xctr(bool odd_plane) const
 {
     const uint_type nselm = static_cast<uint_type>(grid().nselm()) - static_cast<uint_type>(odd_plane);
-    array_type ret(std::vector<size_t>{nselm});
+    array_type ret(small_vector<ssize_t>{static_cast<ssize_t>(nselm)});
     for (uint_type it = 0; it < nselm; ++it) { ret[it] = selm(it, odd_plane).xctr(); }
     return ret;
 }
@@ -844,7 +844,7 @@ SolverBase<ST, CE, SE>::get_so0p(size_t iv, bool odd_plane) const
         throw std::out_of_range("get_so0p(): out of nvar range");
     }
     const uint_type nselm = static_cast<uint_type>(grid().nselm()) - static_cast<uint_type>(odd_plane);
-    array_type ret(std::vector<size_t>{nselm});
+    array_type ret(small_vector<ssize_t>{static_cast<ssize_t>(nselm)});
     for (uint_type it = 0; it < nselm; ++it) { ret[it] = selm(it, odd_plane).so0p(iv); }
     return ret;
 }
@@ -858,7 +858,7 @@ SolverBase<ST, CE, SE>::get_so0(size_t iv, bool odd_plane) const
         throw std::out_of_range("get_so0(): out of nvar range");
     }
     const uint_type nselm = static_cast<uint_type>(grid().nselm()) - static_cast<uint_type>(odd_plane);
-    array_type ret(std::vector<size_t>{nselm});
+    array_type ret(small_vector<ssize_t>{static_cast<ssize_t>(nselm)});
     for (uint_type it = 0; it < nselm; ++it) { ret[it] = selm(it, odd_plane).so0(iv); }
     return ret;
 }
@@ -872,7 +872,7 @@ SolverBase<ST, CE, SE>::get_so1(size_t iv, bool odd_plane) const
         throw std::out_of_range("get_so1(): out of nvar range");
     }
     const uint_type nselm = static_cast<uint_type>(grid().nselm()) - static_cast<uint_type>(odd_plane);
-    array_type ret(std::vector<size_t>{nselm});
+    array_type ret(small_vector<ssize_t>{static_cast<ssize_t>(nselm)});
     for (uint_type it = 0; it < nselm; ++it) { ret[it] = selm(it, odd_plane).so1(iv); }
     return ret;
 }
@@ -922,7 +922,7 @@ inline typename SolverBase<ST, CE, SE>::array_type
 SolverBase<ST, CE, SE>::get_cfl(bool odd_plane) const
 {
     const uint_type nselm = static_cast<uint_type>(grid().nselm()) - static_cast<uint_type>(odd_plane);
-    array_type ret(std::vector<size_t>{nselm});
+    array_type ret(small_vector<ssize_t>{static_cast<ssize_t>(nselm)});
     for (uint_type it = 0; it < nselm; ++it) { ret[it] = selm(it, odd_plane).cfl(); }
     return ret;
 }

--- a/cpp/solvcon/transform/fourier.hpp
+++ b/cpp/solvcon/transform/fourier.hpp
@@ -105,7 +105,7 @@ public:
     static void ifft(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
     {
         size_t const N = in.size();
-        SimpleArray<T1<T2>> in_conj{solvcon::small_vector<size_t>{N}, T1<T2>{0.0, 0.0}};
+        SimpleArray<T1<T2>> in_conj{solvcon::small_vector<ssize_t>{static_cast<ssize_t>(N)}, T1<T2>{0.0, 0.0}};
 
         for (size_t i = 0; i < N; ++i)
         {
@@ -149,10 +149,10 @@ void fft_bluestein(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
     // Calculate a length with power of 2 and at least 2N-1
     const size_t K = detail::next_power_of_two(2 * N - 1);
 
-    SimpleArray<T1<T2>> a{solvcon::small_vector<size_t>{K}, T1<T2>{0.0, 0.0}};
-    SimpleArray<T1<T2>> A{solvcon::small_vector<size_t>{K}, T1<T2>{0.0, 0.0}};
-    SimpleArray<T1<T2>> b{solvcon::small_vector<size_t>{K}, T1<T2>{0.0, 0.0}};
-    SimpleArray<T1<T2>> B{solvcon::small_vector<size_t>{K}, T1<T2>{0.0, 0.0}};
+    SimpleArray<T1<T2>> a{solvcon::small_vector<ssize_t>{static_cast<ssize_t>(K)}, T1<T2>{0.0, 0.0}};
+    SimpleArray<T1<T2>> A{solvcon::small_vector<ssize_t>{static_cast<ssize_t>(K)}, T1<T2>{0.0, 0.0}};
+    SimpleArray<T1<T2>> b{solvcon::small_vector<ssize_t>{static_cast<ssize_t>(K)}, T1<T2>{0.0, 0.0}};
+    SimpleArray<T1<T2>> B{solvcon::small_vector<ssize_t>{static_cast<ssize_t>(K)}, T1<T2>{0.0, 0.0}};
 
     // Calculate a[0], b[0] first, becuase it can avoid a branch in the following
     // for loop!

--- a/cpp/solvcon/universe/bezier.hpp
+++ b/cpp/solvcon/universe/bezier.hpp
@@ -297,7 +297,7 @@ public:
     SimpleArray<T> pack_array() const
     {
         using shape_type = typename SimpleArray<T>::shape_type;
-        SimpleArray<T> ret(shape_type{m_p0->size(), static_cast<size_t>(ndim() * 4)});
+        SimpleArray<T> ret(shape_type{static_cast<ssize_t>(m_p0->size()), ndim() * 4});
         if (ndim() == 3)
         {
             for (size_t i = 0; i < m_p0->size(); ++i)

--- a/cpp/solvcon/universe/coord.hpp
+++ b/cpp/solvcon/universe/coord.hpp
@@ -538,7 +538,10 @@ public:
     SimpleArray<T> pack_array() const
     {
         using shape_type = typename SimpleArray<T>::shape_type;
-        SimpleArray<T> ret(shape_type{m_x.size(), m_ndim}, m_alignment, with_alignment_t{});
+        SimpleArray<T> ret(
+            shape_type{static_cast<ssize_t>(m_x.size()), m_ndim},
+            m_alignment,
+            with_alignment_t{});
         if (m_ndim == 3)
         {
             for (size_t i = 0; i < m_x.size(); ++i)
@@ -1077,7 +1080,7 @@ public:
     SimpleArray<T> pack_array() const
     {
         using shape_type = typename SimpleArray<T>::shape_type;
-        SimpleArray<T> ret(shape_type{m_p0->size(), static_cast<size_t>(ndim() * 2)});
+        SimpleArray<T> ret(shape_type{static_cast<ssize_t>(m_p0->size()), ndim() * 2});
         if (ndim() == 3)
         {
             for (size_t i = 0; i < m_p0->size(); ++i)

--- a/cpp/solvcon/universe/polygon.hpp
+++ b/cpp/solvcon/universe/polygon.hpp
@@ -499,7 +499,7 @@ public:
     SimpleArray<T> pack_array() const
     {
         using shape_type = typename SimpleArray<T>::shape_type;
-        SimpleArray<T> ret(shape_type{m_p0->size(), static_cast<size_t>(ndim() * 4)});
+        SimpleArray<T> ret(shape_type{static_cast<ssize_t>(m_p0->size()), ndim() * 4});
         if (ndim() == 3)
         {
             for (size_t i = 0; i < m_p0->size(); ++i)
@@ -1699,7 +1699,7 @@ public:
     SimpleArray<T> pack_array() const
     {
         using shape_type = typename SimpleArray<T>::shape_type;
-        SimpleArray<T> ret(shape_type{m_p0->size(), static_cast<size_t>(ndim() * 3)});
+        SimpleArray<T> ret(shape_type{static_cast<ssize_t>(m_p0->size()), ndim() * 3});
         if (ndim() == 3)
         {
             for (size_t i = 0; i < m_p0->size(); ++i)

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -38,7 +38,7 @@ TEST(SimpleArray, minmaxsum)
 {
     using namespace solvcon;
 
-    SimpleArray<double> arr_double(small_vector<size_t>{10}, 0);
+    SimpleArray<double> arr_double(small_vector<ssize_t>{10}, 0);
     EXPECT_EQ(arr_double.sum(), 0);
     EXPECT_EQ(arr_double.min(), 0);
     EXPECT_EQ(arr_double.max(), 0);
@@ -51,7 +51,7 @@ TEST(SimpleArray, minmaxsum)
     EXPECT_EQ(arr_double.min(), -2.9);
     EXPECT_EQ(arr_double.max(), 12.7);
 
-    SimpleArray<int> arr_int(small_vector<size_t>{3, 4}, -2);
+    SimpleArray<int> arr_int(small_vector<ssize_t>{3, 4}, -2);
     EXPECT_EQ(arr_int.sum(), -2 * 3 * 4);
     EXPECT_EQ(arr_int.min(), -2);
     EXPECT_EQ(arr_int.max(), -2);
@@ -69,7 +69,7 @@ TEST(SimpleArray, abs)
 {
     using namespace solvcon;
 
-    SimpleArray<double> arr(small_vector<size_t>{10}, -1.0);
+    SimpleArray<double> arr(small_vector<ssize_t>{10}, -1.0);
     EXPECT_EQ(arr.sum(), -10.0);
 
     SimpleArray<double> brr = arr.abs();
@@ -219,7 +219,7 @@ TEST(TakeAlongAxisSimd, basic_int32)
     using namespace solvcon;
 
     // Create a simple array with values [10, 20, 30, 40, 50]
-    SimpleArray<int32_t> data(small_vector<size_t>{5});
+    SimpleArray<int32_t> data(small_vector<ssize_t>{5});
     data[0] = 10;
     data[1] = 20;
     data[2] = 30;
@@ -227,7 +227,7 @@ TEST(TakeAlongAxisSimd, basic_int32)
     data[4] = 50;
 
     // Create indices [2, 0, 4, 1]
-    SimpleArray<uint64_t> indices(small_vector<size_t>{4});
+    SimpleArray<uint64_t> indices(small_vector<ssize_t>{4});
     indices[0] = 2;
     indices[1] = 0;
     indices[2] = 4;
@@ -249,7 +249,7 @@ TEST(TakeAlongAxisSimd, basic_float64)
     using namespace solvcon;
 
     // Create a simple array with float values
-    SimpleArray<double> data(small_vector<size_t>{6});
+    SimpleArray<double> data(small_vector<ssize_t>{6});
     data[0] = 1.5;
     data[1] = 2.5;
     data[2] = 3.5;
@@ -258,7 +258,7 @@ TEST(TakeAlongAxisSimd, basic_float64)
     data[5] = 6.5;
 
     // Create indices [5, 2, 0, 3]
-    SimpleArray<uint64_t> indices(small_vector<size_t>{4});
+    SimpleArray<uint64_t> indices(small_vector<ssize_t>{4});
     indices[0] = 5;
     indices[1] = 2;
     indices[2] = 0;
@@ -281,7 +281,7 @@ TEST(TakeAlongAxisSimd, large_array)
 
     // Create a larger array
     const size_t data_size = 1000;
-    SimpleArray<int64_t> data(small_vector<size_t>{data_size});
+    SimpleArray<int64_t> data(small_vector<ssize_t>{static_cast<ssize_t>(data_size)});
     for (size_t i = 0; i < data_size; ++i)
     {
         data[i] = static_cast<int64_t>(i * 10);
@@ -289,7 +289,7 @@ TEST(TakeAlongAxisSimd, large_array)
 
     // Create indices that sample from the array
     const size_t indices_size = 100;
-    SimpleArray<uint64_t> indices(small_vector<size_t>{indices_size});
+    SimpleArray<uint64_t> indices(small_vector<ssize_t>{static_cast<ssize_t>(indices_size)});
     for (size_t i = 0; i < indices_size; ++i)
     {
         indices[i] = i * 10; // Sample every 10th element
@@ -311,7 +311,7 @@ TEST(TakeAlongAxisSimd, out_of_range)
     using namespace solvcon;
 
     // Create a simple array
-    SimpleArray<int32_t> data(small_vector<size_t>{5});
+    SimpleArray<int32_t> data(small_vector<ssize_t>{5});
     data[0] = 10;
     data[1] = 20;
     data[2] = 30;
@@ -319,7 +319,7 @@ TEST(TakeAlongAxisSimd, out_of_range)
     data[4] = 50;
 
     // Create indices with out-of-range value
-    SimpleArray<uint64_t> indices(small_vector<size_t>{3});
+    SimpleArray<uint64_t> indices(small_vector<ssize_t>{3});
     indices[0] = 2;
     indices[1] = 10; // Out of range
     indices[2] = 1;
@@ -333,7 +333,7 @@ TEST(TakeAlongAxisSimd, empty_indices)
     using namespace solvcon;
 
     // Create a simple array
-    SimpleArray<int32_t> data(small_vector<size_t>{5});
+    SimpleArray<int32_t> data(small_vector<ssize_t>{5});
     data[0] = 10;
     data[1] = 20;
     data[2] = 30;
@@ -341,7 +341,7 @@ TEST(TakeAlongAxisSimd, empty_indices)
     data[4] = 50;
 
     // Create empty indices
-    SimpleArray<uint64_t> indices(small_vector<size_t>{0});
+    SimpleArray<uint64_t> indices(small_vector<ssize_t>{0});
 
     // Call take_along_axis_simd
     SimpleArray<int32_t> result = data.take_along_axis_simd(indices);
@@ -356,14 +356,14 @@ TEST(TakeAlongAxisSimd, sequential_indices)
 
     // Create array [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     const size_t size = 10;
-    SimpleArray<int32_t> data(small_vector<size_t>{size});
+    SimpleArray<int32_t> data(small_vector<ssize_t>{static_cast<ssize_t>(size)});
     for (size_t i = 0; i < size; ++i)
     {
         data[i] = static_cast<int32_t>(i);
     }
 
     // Create sequential indices [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-    SimpleArray<uint64_t> indices(small_vector<size_t>{size});
+    SimpleArray<uint64_t> indices(small_vector<ssize_t>{static_cast<ssize_t>(size)});
     for (size_t i = 0; i < size; ++i)
     {
         indices[i] = i;
@@ -385,7 +385,7 @@ TEST(TakeAlongAxisSimd, single_index_element)
     using namespace solvcon;
 
     // Create a data array with multiple elements
-    SimpleArray<int32_t> data(small_vector<size_t>{10});
+    SimpleArray<int32_t> data(small_vector<ssize_t>{10});
     for (size_t i = 0; i < 10; ++i)
     {
         data[i] = static_cast<int32_t>(i * 10);
@@ -393,7 +393,7 @@ TEST(TakeAlongAxisSimd, single_index_element)
 
     // Create indices array with ONLY 1 ELEMENT (smaller than N_lane=2 on ARM NEON)
     // This should trigger the bug without the fix!
-    SimpleArray<uint64_t> indices(small_vector<size_t>{1});
+    SimpleArray<uint64_t> indices(small_vector<ssize_t>{1});
     indices[0] = 3;
 
     // Call take_along_axis_simd

--- a/gtests/test_nopython_mdspan.cpp
+++ b/gtests/test_nopython_mdspan.cpp
@@ -15,11 +15,11 @@ TEST(SimpleArray, mdspan_1d)
 {
     namespace mm = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<size_t>{6});
+    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{6});
     for (size_t i = 0; i < 6; ++i) { arr(i) = static_cast<double>(i); }
 
     auto ms = arr.as_mdspan<1>();
-    EXPECT_EQ(ms.extent(0), 6u);
+    EXPECT_EQ(ms.extent(0), 6);
     for (size_t i = 0; i < 6; ++i) { EXPECT_EQ(ms[i], arr(i)); }
 
     auto sp = arr.as_span();
@@ -36,12 +36,12 @@ TEST(SimpleArray, mdspan_1d_const)
 {
     namespace mm = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<size_t>{6}, 5.0);
+    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{6}, 5.0);
     const auto & carr = arr;
 
     auto ms = carr.as_mdspan<1>();
     static_assert(std::is_same_v<decltype(ms)::element_type, const double>);
-    EXPECT_EQ(ms.extent(0), 6u);
+    EXPECT_EQ(ms.extent(0), 6);
     for (size_t i = 0; i < 6; ++i) { EXPECT_EQ(ms[i], 5.0); }
 
     auto sp = carr.as_span();
@@ -55,13 +55,13 @@ TEST(SimpleArray, mdspan_1d_ghost)
     namespace mm = solvcon;
 
     // 1D array: 5 total elements, 1 ghost at the front.
-    mm::SimpleArray<double> arr(mm::small_vector<size_t>{5});
+    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{5});
     arr.set_nghost(1);
     for (size_t i = 0; i < 5; ++i) { arr.data(i) = static_cast<double>(i); }
 
     // Both views span all 5 elements via data().
     auto ms = arr.as_mdspan<1>();
-    EXPECT_EQ(ms.extent(0), 5u);
+    EXPECT_EQ(ms.extent(0), 5);
     for (size_t i = 0; i < 5; ++i) { EXPECT_EQ(ms[i], arr.data(i)); }
 
     auto sp = arr.as_span();
@@ -73,7 +73,7 @@ TEST(SimpleArray, mdspan_2d)
 {
     namespace mm = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<size_t>{3, 4});
+    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{3, 4});
     for (size_t i = 0; i < 3; ++i)
     {
         for (size_t j = 0; j < 4; ++j)
@@ -83,8 +83,8 @@ TEST(SimpleArray, mdspan_2d)
     }
 
     auto ms = arr.as_mdspan<2>();
-    EXPECT_EQ(ms.extent(0), 3u);
-    EXPECT_EQ(ms.extent(1), 4u);
+    EXPECT_EQ(ms.extent(0), 3);
+    EXPECT_EQ(ms.extent(1), 4);
     for (size_t i = 0; i < 3; ++i)
     {
         for (size_t j = 0; j < 4; ++j)
@@ -114,7 +114,7 @@ TEST(SimpleArray, mdspan_2d_const)
 {
     namespace mm = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<size_t>{2, 3}, 7.0);
+    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{2, 3}, 7.0);
     const auto & carr = arr;
 
     auto ms = carr.as_mdspan<2>();
@@ -138,13 +138,13 @@ TEST(SimpleArray, mdspan_2d_ghost)
     namespace mm = solvcon;
 
     // shape {5, 4}: 5 rows (1 ghost + 4 body), 4 columns.
-    mm::SimpleArray<double> arr(mm::small_vector<size_t>{5, 4});
+    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{5, 4});
     arr.set_nghost(1);
     for (size_t idx = 0; idx < arr.size(); ++idx) { arr.data(idx) = static_cast<double>(idx); }
 
     auto ms = arr.as_mdspan<2>();
-    EXPECT_EQ(ms.extent(0), 5u);
-    EXPECT_EQ(ms.extent(1), 4u);
+    EXPECT_EQ(ms.extent(0), 5);
+    EXPECT_EQ(ms.extent(1), 4);
 
     // ms origin is data(), so ms[i, j] == data()[i * 4 + j].
     for (size_t i = 0; i < 5; ++i)
@@ -173,7 +173,7 @@ TEST(SimpleArray, mdspan_3d)
 {
     namespace mm = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<size_t>{2, 3, 4});
+    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{2, 3, 4});
     for (size_t i = 0; i < 2; ++i)
     {
         for (size_t j = 0; j < 3; ++j)
@@ -186,9 +186,9 @@ TEST(SimpleArray, mdspan_3d)
     }
 
     auto ms = arr.as_mdspan<3>();
-    EXPECT_EQ(ms.extent(0), 2u);
-    EXPECT_EQ(ms.extent(1), 3u);
-    EXPECT_EQ(ms.extent(2), 4u);
+    EXPECT_EQ(ms.extent(0), 2);
+    EXPECT_EQ(ms.extent(1), 3);
+    EXPECT_EQ(ms.extent(2), 4);
     for (size_t i = 0; i < 2; ++i)
     {
         for (size_t j = 0; j < 3; ++j)
@@ -223,14 +223,14 @@ TEST(SimpleArray, mdspan_3d_ghost)
     namespace mm = solvcon;
 
     // shape {4, 3, 2}: 4 slices (2 ghost + 2 body), 3 rows, 2 columns.
-    mm::SimpleArray<double> arr(mm::small_vector<size_t>{4, 3, 2});
+    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{4, 3, 2});
     arr.set_nghost(2);
     for (size_t idx = 0; idx < arr.size(); ++idx) { arr.data(idx) = static_cast<double>(idx); }
 
     auto ms = arr.as_mdspan<3>();
-    EXPECT_EQ(ms.extent(0), 4u);
-    EXPECT_EQ(ms.extent(1), 3u);
-    EXPECT_EQ(ms.extent(2), 2u);
+    EXPECT_EQ(ms.extent(0), 4);
+    EXPECT_EQ(ms.extent(1), 3);
+    EXPECT_EQ(ms.extent(2), 2);
 
     // ms origin is data(), so ms[i, j, k] == data()[(i * 3 + j) * 2 + k].
     for (size_t i = 0; i < 4; ++i)
@@ -265,7 +265,7 @@ TEST(SimpleArray, mdspan_4d)
 {
     namespace mm = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<size_t>{2, 3, 4, 5});
+    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{2, 3, 4, 5});
     for (size_t i = 0; i < 2; ++i)
     {
         for (size_t j = 0; j < 3; ++j)
@@ -281,10 +281,10 @@ TEST(SimpleArray, mdspan_4d)
     }
 
     auto ms = arr.as_mdspan<4>();
-    EXPECT_EQ(ms.extent(0), 2u);
-    EXPECT_EQ(ms.extent(1), 3u);
-    EXPECT_EQ(ms.extent(2), 4u);
-    EXPECT_EQ(ms.extent(3), 5u);
+    EXPECT_EQ(ms.extent(0), 2);
+    EXPECT_EQ(ms.extent(1), 3);
+    EXPECT_EQ(ms.extent(2), 4);
+    EXPECT_EQ(ms.extent(3), 5);
     for (size_t i = 0; i < 2; ++i)
     {
         for (size_t j = 0; j < 3; ++j)
@@ -325,15 +325,15 @@ TEST(SimpleArray, mdspan_4d_ghost)
     namespace mm = solvcon;
 
     // shape {4, 3, 2, 2}: 4 slices (1 ghost + 3 body), 3 rows, 2 columns, 2 depth.
-    mm::SimpleArray<double> arr(mm::small_vector<size_t>{4, 3, 2, 2});
+    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{4, 3, 2, 2});
     arr.set_nghost(1);
     for (size_t idx = 0; idx < arr.size(); ++idx) { arr.data(idx) = static_cast<double>(idx); }
 
     auto ms = arr.as_mdspan<4>();
-    EXPECT_EQ(ms.extent(0), 4u);
-    EXPECT_EQ(ms.extent(1), 3u);
-    EXPECT_EQ(ms.extent(2), 2u);
-    EXPECT_EQ(ms.extent(3), 2u);
+    EXPECT_EQ(ms.extent(0), 4);
+    EXPECT_EQ(ms.extent(1), 3);
+    EXPECT_EQ(ms.extent(2), 2);
+    EXPECT_EQ(ms.extent(3), 2);
 
     // ms origin is data(), so ms[i, j, k, l] == data()[((i * 3 + j) * 2 + k) * 2 + l].
     for (size_t i = 0; i < 4; ++i)
@@ -374,7 +374,7 @@ TEST(SimpleArray, mdspan_rank_mismatch)
 {
     namespace mm = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<size_t>{3, 4});
+    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{3, 4});
     EXPECT_THROW(arr.as_mdspan<3>(), std::out_of_range);
 }
 
@@ -384,7 +384,7 @@ TEST(SimpleArray, mdspan_non_contiguous)
 
     // Build a 3x4 view whose stride differs from the row-major layout, so the
     // array is neither C- nor F-contiguous over the underlying buffer.
-    mm::small_vector<size_t> shape{3, 4};
+    mm::small_vector<ssize_t> shape{3, 4};
     mm::small_vector<ssize_t> stride{8, 1};
     auto buffer = mm::ConcreteBuffer::construct(3 * 8 * sizeof(double));
     mm::SimpleArray<double> arr(shape, stride, buffer);
@@ -393,10 +393,10 @@ TEST(SimpleArray, mdspan_non_contiguous)
     EXPECT_FALSE(arr.is_c_contiguous());
 
     auto ms = arr.as_mdspan<2>();
-    EXPECT_EQ(ms.extent(0), 3u);
-    EXPECT_EQ(ms.extent(1), 4u);
-    EXPECT_EQ(ms.mapping().stride(0), 8u);
-    EXPECT_EQ(ms.mapping().stride(1), 1u);
+    EXPECT_EQ(ms.extent(0), 3);
+    EXPECT_EQ(ms.extent(1), 4);
+    EXPECT_EQ(ms.mapping().stride(0), 8);
+    EXPECT_EQ(ms.mapping().stride(1), 1);
     for (size_t i = 0; i < 3; ++i)
     {
         for (size_t j = 0; j < 4; ++j)

--- a/gtests/test_nopython_transform.cpp
+++ b/gtests/test_nopython_transform.cpp
@@ -25,9 +25,9 @@ protected:
     static constexpr size_t VN = is_pow_2 ? 1024 : 1000;
 
     solvcon::SimpleArray<solvcon::Complex<T>> signal{
-        solvcon::small_vector<size_t>{VN}, solvcon::Complex<T>{0.0, 0.0}};
+        solvcon::small_vector<ssize_t>{static_cast<ssize_t>(VN)}, solvcon::Complex<T>{0.0, 0.0}};
     solvcon::SimpleArray<solvcon::Complex<T>> out{
-        solvcon::small_vector<size_t>{VN}, solvcon::Complex<T>{0.0, 0.0}};
+        solvcon::small_vector<ssize_t>{static_cast<ssize_t>(VN)}, solvcon::Complex<T>{0.0, 0.0}};
 
     // Set up the test fixture: generate the signal once
     void SetUp() override
@@ -74,9 +74,9 @@ protected:
     std::mt19937 rng{std::random_device{}()};
 
     solvcon::SimpleArray<solvcon::Complex<T>> signal{
-        solvcon::small_vector<size_t>{VN}, solvcon::Complex<T>{0.0, 0.0}};
+        solvcon::small_vector<ssize_t>{static_cast<ssize_t>(VN)}, solvcon::Complex<T>{0.0, 0.0}};
     solvcon::SimpleArray<solvcon::Complex<T>> out{
-        solvcon::small_vector<size_t>{VN}, solvcon::Complex<T>{0.0, 0.0}};
+        solvcon::small_vector<ssize_t>{static_cast<ssize_t>(VN)}, solvcon::Complex<T>{0.0, 0.0}};
 
     void SetUp() override
     {
@@ -108,11 +108,11 @@ protected:
     std::mt19937 rng{std::random_device{}()};
 
     solvcon::SimpleArray<solvcon::Complex<T>> signal{
-        solvcon::small_vector<size_t>{VN}, solvcon::Complex<T>{0.0, 0.0}};
+        solvcon::small_vector<ssize_t>{static_cast<ssize_t>(VN)}, solvcon::Complex<T>{0.0, 0.0}};
     solvcon::SimpleArray<solvcon::Complex<T>> freq_domain{
-        solvcon::small_vector<size_t>{VN}, solvcon::Complex<T>{0.0, 0.0}};
+        solvcon::small_vector<ssize_t>{static_cast<ssize_t>(VN)}, solvcon::Complex<T>{0.0, 0.0}};
     solvcon::SimpleArray<solvcon::Complex<T>> time_domain{
-        solvcon::small_vector<size_t>{VN}, solvcon::Complex<T>{0.0, 0.0}};
+        solvcon::small_vector<ssize_t>{static_cast<ssize_t>(VN)}, solvcon::Complex<T>{0.0, 0.0}};
 
     void SetUp() override
     {

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -282,6 +282,13 @@ class SimpleArrayBasicTC(unittest.TestCase):
         self.assertEqual((12, 2), sarr.reshape((12, 2)).shape)
         self.assertEqual((2, 2, 2, 3), sarr.reshape((2, 2, 2, 3)).shape)
 
+    def test_SimpleArray_negative_shape_raises(self):
+        with self.assertRaisesRegex(
+                IndexError,
+                "SimpleArray: shape dimension must be non-negative"
+        ):
+            solvcon.SimpleArrayFloat64((-1, 2))
+
     def test_SimpleArray_from_numpy_negative_stride(self):
         ndarr = np.arange(2 * 3, dtype='float64').reshape((2, 3))
         view = ndarr[::-1, ::-1]


### PR DESCRIPTION
Previous [discussion](https://github.com/solvcon/solvcon/issues/856#issuecomment-4686103124) points out third-party libraries usually implement array with signed vector, which could avoid unnecessary casting and wierd bugs. 

To unify the type in `SimpleArray` and reduce type casting, this pull request changes shapes and indices to signed vector in SimpleArray.

Related to #856.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
