### PR TITLE
Fix lint error for pr #883

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -2609,7 +2609,7 @@ A detail::SimpleArrayMixinSort<A, T>::take_along_axis(SimpleArray<I> const & ind
     {
         if (*src < 0 || *src > max_idx)
         {
-            size_t offset = src - indices.begin();
+            size_t const offset = src - indices.begin();
             std::string const indices_str = format_flat_index(indices.shape(), offset);
 
             throw std::out_of_range(
@@ -2691,7 +2691,7 @@ A detail::SimpleArrayMixinSort<A, T>::take_along_axis_simd(SimpleArray<I> const 
     I const * oor_ptr = check_index_range(indices, max_idx);
     if (oor_ptr != nullptr)
     {
-        size_t offset = oor_ptr - indices.begin();
+        size_t const offset = oor_ptr - indices.begin();
         std::string const indices_str = format_flat_index(indices.shape(), offset);
 
         const auto err = std::format("SimpleArray::take_along_axis_simd(): "

--- a/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
+++ b/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
@@ -98,7 +98,7 @@ struct TypeBroadcastImpl
             }
         }
 
-        sshape_type sidx_init(arr_out.ndim(), 0);
+        sshape_type const sidx_init(arr_out.ndim(), 0);
 
         copy_idx(arr_out, slices, arr_new, left_shape, sidx_init, static_cast<ssize_t>(arr_out.ndim()) - 1);
     }

--- a/cpp/solvcon/python/common.hpp
+++ b/cpp/solvcon/python/common.hpp
@@ -179,7 +179,7 @@ std::enable_if_t<is_simple_array_v<S>, pybind11::array> to_ndarray(S && sarr)
     std::vector<size_t> const shape(sarr.shape().begin(), sarr.shape().end());
     std::vector<py::ssize_t> stride;
     stride.reserve(sarr.stride().size());
-    py::ssize_t const itemsize = static_cast<py::ssize_t>(sarr.itemsize());
+    auto const itemsize = static_cast<py::ssize_t>(sarr.itemsize());
     for (ssize_t const v : sarr.stride())
     {
         stride.push_back(static_cast<py::ssize_t>(v) * itemsize);


### PR DESCRIPTION
This pull request fixes lint error in [CI runner](https://github.com/solvcon/solvcon/actions/runs/28519678219/job/84540296079), which is caused by pull request #883.
```
  /Users/runner/work/solvcon/solvcon/cpp/solvcon/python/common.hpp:182:5: error: use auto when initializing with a cast to avoid duplicating the type name [modernize-use-auto,-warnings-as-errors]
    182 |     py::ssize_t const itemsize = static_cast<py::ssize_t>(sarr.itemsize());
        |     ^~~~~~~~~~~
        |     auto
  12284 warnings generated.
  Suppressed 12512 warnings (12283 in non-user code, 229 NOLINT).
  Use -header-filter=.* or leave it as default to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
  1 warning treated as error
  make[4]: *** [cpp/solvcon/CMakeFiles/solvcon_primary.dir/buffer/pymod/buffer_pymod.cpp.o] Error 1
  make[4]: *** Waiting for unfinished jobs....
  /Users/runner/work/solvcon/solvcon/cpp/solvcon/python/common.hpp:182:5: error: use auto when initializing with a cast to avoid duplicating the type name [modernize-use-auto,-warnings-as-errors]
    182 |     py::ssize_t const itemsize = static_cast<py::ssize_t>(sarr.itemsize());
  
        |     ^~~~~~~~~~~
        |     auto
  12556 warnings generated.
```
Related to #883.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
