### PR TITLE
Draw the pilot mesh in independent surface, wireframe, and points styles

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -61,6 +61,8 @@ set(SOLVCON_PILOT_SHADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/vcolor.vert
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/texture.vert
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/texture.frag
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/lit.vert
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/lit.frag
     CACHE FILEPATH "" FORCE)
 
 # vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -48,16 +48,29 @@ QImage RDomainWidget::grabImage()
 
 void RDomainWidget::updateMesh(std::shared_ptr<StaticMesh> const & mesh)
 {
-    // Drop the previous mesh wireframe and replace it; a new mesh redefines
+    // Drop the previous mesh drawables and replace them; a new mesh redefines
     // the framing, so the bounding box is recomputed from scratch.
+    m_scene.removeDrawable(m_mesh_surface);
     m_scene.removeDrawable(m_mesh_frame);
+    m_scene.removeDrawable(m_mesh_points);
+    m_mesh_surface = nullptr;
     m_mesh_frame = nullptr;
+    m_mesh_points = nullptr;
 
     m_mesh = mesh;
 
-    auto frame = std::make_unique<RMeshFrame>(mesh);
+    // Build one drawable per representation and switch between them by
+    // visibility; rebuilding on every toggle would be wasteful.
+    auto surface = std::make_unique<RMeshFrame>(mesh, RMeshFrame::Style::Surface);
+    m_mesh_surface = surface.get();
+    m_scene.addDrawable(std::move(surface));
+    auto frame = std::make_unique<RMeshFrame>(mesh, RMeshFrame::Style::Wireframe);
     m_mesh_frame = frame.get();
     m_scene.addDrawable(std::move(frame));
+    auto points = std::make_unique<RMeshFrame>(mesh, RMeshFrame::Style::Points);
+    m_mesh_points = points.get();
+    m_scene.addDrawable(std::move(points));
+    applyMeshVisibility();
 
     StaticMesh const & mh = *mesh;
     m_scene.setDimension(mh.ndim());
@@ -102,10 +115,63 @@ void RDomainWidget::updateMesh(std::shared_ptr<StaticMesh> const & mesh)
 
 void RDomainWidget::showMesh(bool show)
 {
+    m_mesh_shown = show;
+    applyMeshVisibility();
+    update();
+}
+
+void RDomainWidget::showMeshStyle(std::string const & name, bool show)
+{
+    if ("surface" == name)
+    {
+        m_show_surface = show;
+    }
+    else if ("wireframe" == name)
+    {
+        m_show_wireframe = show;
+    }
+    else if ("points" == name)
+    {
+        m_show_points = show;
+    }
+    else
+    {
+        return; // Ignore an unknown name.
+    }
+    applyMeshVisibility();
+    update();
+}
+
+bool RDomainWidget::meshStyleShown(std::string const & name) const
+{
+    if ("surface" == name)
+    {
+        return m_show_surface;
+    }
+    if ("wireframe" == name)
+    {
+        return m_show_wireframe;
+    }
+    if ("points" == name)
+    {
+        return m_show_points;
+    }
+    return false;
+}
+
+void RDomainWidget::applyMeshVisibility()
+{
+    if (nullptr != m_mesh_surface)
+    {
+        m_mesh_surface->setVisible(m_mesh_shown && m_show_surface);
+    }
     if (nullptr != m_mesh_frame)
     {
-        m_mesh_frame->setVisible(show);
-        update();
+        m_mesh_frame->setVisible(m_mesh_shown && m_show_wireframe);
+    }
+    if (nullptr != m_mesh_points)
+    {
+        m_mesh_points->setVisible(m_mesh_shown && m_show_points);
     }
 }
 
@@ -362,9 +428,19 @@ void RDomainWidget::render(QRhiCommandBuffer * cb)
     QMatrix4x4 const view_proj = m_scene.viewProjection(pixel_size, m_rhi);
     QRhiRenderPassDescriptor * const rpdesc = renderTarget()->renderPassDescriptor();
 
+    // A camera-following headlight: the lit surface faces toward the eye read
+    // brightest. Non-lit drawables ignore the direction.
+    QVector3D light_dir = m_scene.camera().position() - m_scene.camera().target();
+    if (light_dir.lengthSquared() <= 0.0f)
+    {
+        light_dir = QVector3D(0.0f, 0.0f, 1.0f);
+    }
+    light_dir.normalize();
+
     for (std::unique_ptr<RDrawable> const & drawable : m_scene.drawables())
     {
         drawable->prepare(m_rhi, rpdesc, sampleCount(), batch);
+        drawable->setLightDir(light_dir);
         drawable->updateUniform(batch, view_proj);
     }
 

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -58,8 +58,15 @@ public:
     /// Replace the rendered mesh with the wireframe of @p mesh.
     void updateMesh(std::shared_ptr<StaticMesh> const & mesh);
 
-    /// Show or hide the mesh wireframe.
+    /// Show or hide the mesh, in whatever representation is active.
     void showMesh(bool show);
+
+    /// Show or hide one mesh style independently of the others, so any
+    /// combination can be drawn at once (a wireframe over a lit surface, say).
+    /// @p name is "surface" (lit shaded), "wireframe" (edges), or "points"
+    /// (nodes); an unknown name is ignored.
+    void showMeshStyle(std::string const & name, bool show);
+    bool meshStyleShown(std::string const & name) const;
 
     /// Replace the colored field: per-vertex-colored triangles from a vertex
     /// table (nvert, 3), a matching color table (nvert, 3), and a triangle
@@ -122,14 +129,28 @@ private:
 
     float viewportAspect() const;
 
+    /// Push the per-style show flags and the overall mesh-shown flag onto the
+    /// three mesh drawables' visibility.
+    void applyMeshVisibility();
+
     QRhi * m_rhi = nullptr; ///< Tracked to detect device changes.
     QRhiRenderPassDescriptor * m_rpdesc = nullptr; ///< Tracked to detect target changes.
     int m_sample_count = 0; ///< Tracked to detect MSAA changes.
 
     RScene m_scene;
     RAxisGizmo m_gizmo;
-    RDrawable * m_mesh_frame = nullptr; ///< Non-owning; lives in the scene.
-    RDrawable * m_field = nullptr; ///< Non-owning; lives in the scene.
+    // Non-owning; the drawables live in the scene. One per mesh representation.
+    RDrawable * m_mesh_surface = nullptr;
+    RDrawable * m_mesh_frame = nullptr;
+    RDrawable * m_mesh_points = nullptr;
+    RDrawable * m_field = nullptr;
+
+    // Per-style show flags; any combination may be on at once. Only the
+    // wireframe is on by default, so a fresh viewer looks unchanged.
+    bool m_show_surface = false;
+    bool m_show_wireframe = true;
+    bool m_show_points = false;
+    bool m_mesh_shown = true; ///< The showMesh toggle, applied atop the styles.
 
     std::shared_ptr<StaticMesh> m_mesh;
 

--- a/cpp/solvcon/pilot/RDrawable.cpp
+++ b/cpp/solvcon/pilot/RDrawable.cpp
@@ -43,7 +43,11 @@ void RDrawable::prepare(
 
     m_material = std::make_unique<RMaterial>(materialKind());
     m_pipeline.reset(m_material->buildPipeline(
-        rhi, m_srb.get(), rpdesc, vertexInputLayout(), topology(), sample_count));
+        rhi, m_srb.get(), rpdesc, vertexInputLayout(), topology(), sample_count,
+        /*depth_test*/ true,
+        /*alpha_blend*/ false,
+        depthBias(),
+        slopeScaledDepthBias()));
     m_ready = (nullptr != m_pipeline);
 }
 
@@ -69,6 +73,8 @@ void RDrawable::updateUniform(QRhiResourceUpdateBatch * batch, QMatrix4x4 const 
     batch->updateDynamicBuffer(m_ubuf.get(), 0, 64, view_proj.constData());
     float const color[4] = {m_color.x(), m_color.y(), m_color.z(), m_color.w()};
     batch->updateDynamicBuffer(m_ubuf.get(), 64, 16, color);
+    float const light[4] = {m_light_dir.x(), m_light_dir.y(), m_light_dir.z(), 0.0f};
+    batch->updateDynamicBuffer(m_ubuf.get(), 80, 16, light);
 }
 
 void RDrawable::draw(QRhiCommandBuffer * cb)

--- a/cpp/solvcon/pilot/RDrawable.hpp
+++ b/cpp/solvcon/pilot/RDrawable.hpp
@@ -19,6 +19,7 @@
 #include <rhi/qrhi.h>
 
 #include <QMatrix4x4>
+#include <QVector3D>
 #include <QVector4D>
 
 #include <memory>
@@ -57,6 +58,10 @@ public:
     void setColor(QVector4D const & color) { m_color = color; }
     QVector4D color() const { return m_color; }
 
+    /// World-space direction toward the light, read by the lit material and
+    /// ignored by the others. The widget refreshes it as the camera moves.
+    void setLightDir(QVector3D const & dir) { m_light_dir = dir; }
+
     /// Create the device resources if they do not exist yet. Idempotent.
     void prepare(
         QRhi * rhi,
@@ -79,8 +84,10 @@ protected:
 
     RDrawable() = default;
 
-    /// std140 layout of the shared uniform block: mat4 mvp + vec4 color.
-    static constexpr int UBUF_SIZE = 64 + 16;
+    /// std140 layout of the shared uniform block: mat4 mvp + vec4 color +
+    /// vec4 lightDir. The trailing light direction is used only by the lit
+    /// material; the other shaders declare a shorter block over the same buffer.
+    static constexpr int UBUF_SIZE = 64 + 16 + 16;
 
     /// The shader variant this drawable renders with.
     virtual RMaterial::Kind materialKind() const = 0;
@@ -95,7 +102,14 @@ protected:
     /// m_vertex_count / m_index_count. Called once from prepare().
     virtual void createGeometry(QRhi * rhi, QRhiResourceUpdateBatch * batch) = 0;
 
+    /// Constant and slope-scaled depth bias for this drawable's pipeline. A
+    /// filled surface returns a positive bias so a coplanar wireframe or point
+    /// cloud drawn over it is not lost to the depth test; the default is none.
+    virtual int depthBias() const { return 0; }
+    virtual float slopeScaledDepthBias() const { return 0.0f; }
+
     QVector4D m_color{1.0f, 1.0f, 1.0f, 1.0f};
+    QVector3D m_light_dir{0.0f, 0.0f, 1.0f};
     bool m_visible = true;
 
     std::unique_ptr<QRhiBuffer> m_vbuf;

--- a/cpp/solvcon/pilot/RMaterial.cpp
+++ b/cpp/solvcon/pilot/RMaterial.cpp
@@ -41,6 +41,10 @@ RMaterial::RMaterial(Kind kind)
         m_vert = loadShader(QStringLiteral(":/solvcon/pilot/shaders/texture.vert.qsb"));
         m_frag = loadShader(QStringLiteral(":/solvcon/pilot/shaders/texture.frag.qsb"));
         break;
+    case Kind::Lit:
+        m_vert = loadShader(QStringLiteral(":/solvcon/pilot/shaders/lit.vert.qsb"));
+        m_frag = loadShader(QStringLiteral(":/solvcon/pilot/shaders/lit.frag.qsb"));
+        break;
     }
 }
 
@@ -52,7 +56,9 @@ QRhiGraphicsPipeline * RMaterial::buildPipeline(
     QRhiGraphicsPipeline::Topology topology,
     int sample_count,
     bool depth_test,
-    bool alpha_blend) const
+    bool alpha_blend,
+    int depth_bias,
+    float slope_scaled_depth_bias) const
 {
     QRhiGraphicsPipeline * pipeline = rhi->newGraphicsPipeline();
     pipeline->setShaderStages({
@@ -66,6 +72,13 @@ QRhiGraphicsPipeline * RMaterial::buildPipeline(
     pipeline->setSampleCount(sample_count);
     pipeline->setDepthTest(depth_test);
     pipeline->setDepthWrite(depth_test);
+    if (0 != depth_bias || 0.0f != slope_scaled_depth_bias)
+    {
+        // Push these fragments away from the eye so coplanar geometry drawn
+        // later (a wireframe or points over a surface) wins the depth test.
+        pipeline->setDepthBias(depth_bias);
+        pipeline->setSlopeScaledDepthBias(slope_scaled_depth_bias);
+    }
     if (alpha_blend)
     {
         QRhiGraphicsPipeline::TargetBlend blend;

--- a/cpp/solvcon/pilot/RMaterial.hpp
+++ b/cpp/solvcon/pilot/RMaterial.hpp
@@ -48,6 +48,7 @@ public:
         FlatColor, ///< One uniform color for the whole primitive.
         VertexColor, ///< A per-vertex color attribute.
         Textured, ///< A sampled texture tinted by the uniform color.
+        Lit, ///< A per-vertex normal shaded by a directional light.
     };
 
     explicit RMaterial(Kind kind);
@@ -71,7 +72,9 @@ public:
         QRhiGraphicsPipeline::Topology topology,
         int sample_count,
         bool depth_test = true,
-        bool alpha_blend = false) const;
+        bool alpha_blend = false,
+        int depth_bias = 0,
+        float slope_scaled_depth_bias = 0.0f) const;
 
     /// Load a baked shader from the Qt resource system.
     static QShader loadShader(QString const & resource_path);

--- a/cpp/solvcon/pilot/RMeshFrame.cpp
+++ b/cpp/solvcon/pilot/RMeshFrame.cpp
@@ -8,53 +8,172 @@
 namespace solvcon
 {
 
-RMeshFrame::RMeshFrame(std::shared_ptr<StaticMesh> const & mesh)
+RMeshFrame::RMeshFrame(std::shared_ptr<StaticMesh> const & mesh, Style style)
+    : m_style(style)
 {
     StaticMesh const & mh = *mesh;
+    if (Style::Surface == m_style)
+    {
+        buildSurface(mh);
+        // A muted steel-blue surface: clearly a solid, and distinct from both
+        // the white background and the black wireframe it can pair with.
+        setColor(QVector4D(0.60f, 0.70f, 0.85f, 1.0f));
+    }
+    else
+    {
+        buildFrame(mh);
+        // A black hairline/point over the white background.
+        setColor(QVector4D(0.0f, 0.0f, 0.0f, 1.0f));
+    }
+}
+
+void RMeshFrame::buildFrame(StaticMesh const & mh)
+{
     uint32_t const nnode = mh.nnode();
     uint32_t const ndim = mh.ndim();
 
-    m_positions.reserve(static_cast<size_t>(nnode) * 3);
+    m_vertices.reserve(static_cast<size_t>(nnode) * 3);
     for (uint32_t ind = 0; ind < nnode; ++ind)
     {
-        m_positions.push_back(static_cast<float>(mh.ndcrd(ind, 0)));
-        m_positions.push_back(static_cast<float>(mh.ndcrd(ind, 1)));
-        m_positions.push_back((3 == ndim) ? static_cast<float>(mh.ndcrd(ind, 2)) : 0.0f);
+        m_vertices.push_back(static_cast<float>(mh.ndcrd(ind, 0)));
+        m_vertices.push_back(static_cast<float>(mh.ndcrd(ind, 1)));
+        m_vertices.push_back((3 == ndim) ? static_cast<float>(mh.ndcrd(ind, 2)) : 0.0f);
     }
 
-    uint32_t const nedge = mh.nedge();
-    m_indices.reserve(static_cast<size_t>(nedge) * 2);
-    for (uint32_t ie = 0; ie < nedge; ++ie)
+    // The point cloud draws the nodes directly; only the wireframe needs edges.
+    if (Style::Wireframe == m_style)
     {
-        m_indices.push_back(static_cast<uint32_t>(mh.ednds(ie, 0)));
-        m_indices.push_back(static_cast<uint32_t>(mh.ednds(ie, 1)));
+        uint32_t const nedge = mh.nedge();
+        m_indices.reserve(static_cast<size_t>(nedge) * 2);
+        for (uint32_t ie = 0; ie < nedge; ++ie)
+        {
+            m_indices.push_back(static_cast<uint32_t>(mh.ednds(ie, 0)));
+            m_indices.push_back(static_cast<uint32_t>(mh.ednds(ie, 1)));
+        }
     }
+}
 
-    // A black hairline over the white background.
-    setColor(QVector4D(0.0f, 0.0f, 0.0f, 1.0f));
+void RMeshFrame::buildSurface(StaticMesh const & mh)
+{
+    uint32_t const ndim = mh.ndim();
+
+    auto node_coord = [&mh, ndim](int32_t ind, uint32_t dim) -> float
+    { return (dim < ndim) ? static_cast<float>(mh.ndcrd(ind, dim)) : 0.0f; };
+
+    // Fan-triangulate a polygon of @p nnd nodes (indexed through @p node),
+    // emitting flat-shaded triangles that all carry @p normal.
+    auto add_polygon =
+        [this, &node_coord](auto node, int32_t nnd, float const normal[3])
+    {
+        for (int32_t k = 1; k + 1 < nnd; ++k)
+        {
+            int32_t const tri[3] = {node(0), node(k), node(k + 1)};
+            uint32_t const base = static_cast<uint32_t>(m_vertices.size() / 6);
+            for (int32_t const ind : tri)
+            {
+                m_vertices.push_back(node_coord(ind, 0));
+                m_vertices.push_back(node_coord(ind, 1));
+                m_vertices.push_back(node_coord(ind, 2));
+                m_vertices.push_back(normal[0]);
+                m_vertices.push_back(normal[1]);
+                m_vertices.push_back(normal[2]);
+            }
+            m_indices.push_back(base + 0);
+            m_indices.push_back(base + 1);
+            m_indices.push_back(base + 2);
+        }
+    };
+
+    if (3 == ndim)
+    {
+        // The visible surface of a 3D domain is its boundary shell; each
+        // boundary face carries an outward normal from the metric.
+        SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
+        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        {
+            int32_t const ifc = bndfcs(ibnd, 0);
+            int32_t const nnd = mh.fcnds(ifc, 0);
+            float const normal[3] = {
+                static_cast<float>(mh.fcnml(ifc, 0)),
+                static_cast<float>(mh.fcnml(ifc, 1)),
+                static_cast<float>(mh.fcnml(ifc, 2))};
+            add_polygon(
+                [&mh, ifc](int32_t k)
+                { return mh.fcnds(ifc, k + 1); },
+                nnd,
+                normal);
+        }
+    }
+    else
+    {
+        // A 2D domain is a flat sheet of cells in the z = 0 plane, facing +z.
+        float const normal[3] = {0.0f, 0.0f, 1.0f};
+        for (uint32_t icl = 0; icl < mh.ncell(); ++icl)
+        {
+            int32_t const nnd = mh.clnds(icl, 0);
+            add_polygon(
+                [&mh, icl](int32_t k)
+                { return mh.clnds(icl, k + 1); },
+                nnd,
+                normal);
+        }
+    }
+}
+
+QRhiGraphicsPipeline::Topology RMeshFrame::topology() const
+{
+    switch (m_style)
+    {
+    case Style::Points:
+        return QRhiGraphicsPipeline::Points;
+    case Style::Surface:
+        return QRhiGraphicsPipeline::Triangles;
+    default:
+        return QRhiGraphicsPipeline::Lines;
+    }
 }
 
 QRhiVertexInputLayout RMeshFrame::vertexInputLayout() const
 {
     QRhiVertexInputLayout layout;
-    layout.setBindings({{3 * sizeof(float)}});
-    layout.setAttributes({{0, 0, QRhiVertexInputAttribute::Float3, 0}});
+    if (Style::Surface == m_style)
+    {
+        layout.setBindings({{6 * sizeof(float)}});
+        layout.setAttributes({
+            {0, 0, QRhiVertexInputAttribute::Float3, 0},
+            {0, 1, QRhiVertexInputAttribute::Float3, 3 * sizeof(float)},
+        });
+    }
+    else
+    {
+        layout.setBindings({{3 * sizeof(float)}});
+        layout.setAttributes({{0, 0, QRhiVertexInputAttribute::Float3, 0}});
+    }
     return layout;
 }
 
 void RMeshFrame::createGeometry(QRhi * rhi, QRhiResourceUpdateBatch * batch)
 {
-    if (0 == m_positions.size() || 0 == m_indices.size())
+    if (0 == m_vertices.size())
     {
         return;
     }
 
-    quint32 const vbytes = static_cast<quint32>(m_positions.size() * sizeof(float));
+    // The surface interleaves a normal after each position; the frame stores
+    // bare positions.
+    size_t const stride = (Style::Surface == m_style) ? 6 : 3;
+    quint32 const vbytes = static_cast<quint32>(m_vertices.size() * sizeof(float));
     m_vbuf.reset(rhi->newBuffer(QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer, vbytes));
     m_vbuf->create();
-    batch->uploadStaticBuffer(m_vbuf.get(), m_positions.data());
-    m_vertex_count = static_cast<quint32>(m_positions.size() / 3);
+    batch->uploadStaticBuffer(m_vbuf.get(), m_vertices.data());
+    m_vertex_count = static_cast<quint32>(m_vertices.size() / stride);
 
+    // The point cloud is a non-indexed draw over every node; the wireframe and
+    // the surface index into their vertices.
+    if (0 == m_indices.size())
+    {
+        return;
+    }
     quint32 const ibytes = static_cast<quint32>(m_indices.size() * sizeof(uint32_t));
     m_ibuf.reset(rhi->newBuffer(QRhiBuffer::Immutable, QRhiBuffer::IndexBuffer, ibytes));
     m_ibuf->create();

--- a/cpp/solvcon/pilot/RMeshFrame.hpp
+++ b/cpp/solvcon/pilot/RMeshFrame.hpp
@@ -7,7 +7,8 @@
 
 /**
  * @file
- * Renders the unstructured-mesh domain as a wireframe drawable.
+ * Renders the unstructured-mesh domain as a wireframe, a point cloud, or a
+ * lit surface.
  *
  * @ingroup group_domain
  */
@@ -24,11 +25,16 @@ namespace solvcon
 {
 
 /**
- * @brief The unstructured-mesh domain rendered as a wireframe.
+ * @brief The unstructured-mesh domain rendered as an edge wireframe, a node
+ * point cloud, or a lit, shaded surface.
  *
- * Edges come from the mesh edge list (StaticMesh::ednds); the node
- * coordinates feed a line-topology vertex buffer. Works for both 2D meshes
- * (drawn in the z = 0 plane) and 3D meshes.
+ * The wireframe draws the mesh edge list (StaticMesh::ednds) as lines and the
+ * point cloud draws the nodes themselves, both over the shared node-coordinate
+ * buffer and flat-colored. The surface instead fills the domain: a 2D mesh
+ * fills its cells in the z = 0 plane facing +z, a 3D mesh draws its boundary
+ * shell with each face's outward normal, every face fan-triangulated into
+ * flat-shaded triangles that the lit material shades two-sided over an ambient
+ * floor. Works for both 2D and 3D meshes.
  *
  * @ingroup group_domain
  */
@@ -38,24 +44,54 @@ class RMeshFrame
 
 public:
 
-    explicit RMeshFrame(std::shared_ptr<StaticMesh> const & mesh);
+    /// Which primitive the geometry is assembled into.
+    enum class Style
+    {
+        Wireframe, ///< Mesh edges as lines.
+        Points, ///< Mesh nodes as points.
+        Surface, ///< Cell or boundary faces as a lit, shaded surface.
+    };
+
+    explicit RMeshFrame(
+        std::shared_ptr<StaticMesh> const & mesh, Style style = Style::Wireframe);
 
 protected:
 
-    RMaterial::Kind materialKind() const override { return RMaterial::Kind::FlatColor; }
+    RMaterial::Kind materialKind() const override
+    {
+        return (Style::Surface == m_style) ? RMaterial::Kind::Lit
+                                           : RMaterial::Kind::FlatColor;
+    }
 
-    QRhiGraphicsPipeline::Topology topology() const override { return QRhiGraphicsPipeline::Lines; }
+    QRhiGraphicsPipeline::Topology topology() const override;
 
     QRhiVertexInputLayout vertexInputLayout() const override;
 
     void createGeometry(QRhi * rhi, QRhiResourceUpdateBatch * batch) override;
 
+    // Sink the surface a touch in depth so a wireframe or point cloud sharing
+    // its plane draws on top instead of z-fighting into it.
+    int depthBias() const override { return (Style::Surface == m_style) ? 2 : 0; }
+    float slopeScaledDepthBias() const override
+    {
+        return (Style::Surface == m_style) ? 1.0f : 0.0f;
+    }
+
 private:
 
+    /// Node positions plus the edge index list, for the wireframe and points.
+    void buildFrame(StaticMesh const & mh);
+    /// Fan-triangulated, per-vertex-normal triangles, for the lit surface.
+    void buildSurface(StaticMesh const & mh);
+
+    Style m_style;
+
     // CPU-side geometry captured at construction; the rhi is not available
-    // until prepare() runs, so the buffers are uploaded then.
-    SimpleCollector<float> m_positions; ///< nnode * 3 (x, y, z).
-    SimpleCollector<uint32_t> m_indices; ///< nedge * 2 node indices.
+    // until prepare() runs, so the buffers are uploaded then. m_vertices holds
+    // 3 floats per vertex (x, y, z) for the wireframe and points, or 6
+    // interleaved (x, y, z, nx, ny, nz) for the lit surface.
+    SimpleCollector<float> m_vertices;
+    SimpleCollector<uint32_t> m_indices;
 
 }; /* end class RMeshFrame */
 

--- a/cpp/solvcon/pilot/shaders/color.vert
+++ b/cpp/solvcon/pilot/shaders/color.vert
@@ -13,5 +13,8 @@ layout(location = 0) out vec4 v_color;
 void main()
 {
     v_color = ubuf.color;
+    // Give the point-topology mesh representation a visible footprint; ignored
+    // when this shader assembles lines.
+    gl_PointSize = 4.0;
     gl_Position = ubuf.mvp * vec4(position, 1.0);
 }

--- a/cpp/solvcon/pilot/shaders/lit.frag
+++ b/cpp/solvcon/pilot/shaders/lit.frag
@@ -1,0 +1,23 @@
+#version 440
+
+layout(location = 0) in vec3 v_normal;
+
+layout(std140, binding = 0) uniform buf
+{
+    mat4 mvp;
+    vec4 color;
+    vec4 lightDir;
+} ubuf;
+
+layout(location = 0) out vec4 fragColor;
+
+void main()
+{
+    vec3 n = normalize(v_normal);
+    vec3 l = normalize(ubuf.lightDir.xyz);
+    // Two-sided Lambert so a facet reads lit regardless of its winding, over a
+    // fixed ambient floor so faces turned away from the light are not black.
+    float ambient = 0.3;
+    float diffuse = (1.0 - ambient) * abs(dot(n, l));
+    fragColor = vec4(ubuf.color.rgb * (ambient + diffuse), ubuf.color.a);
+}

--- a/cpp/solvcon/pilot/shaders/lit.vert
+++ b/cpp/solvcon/pilot/shaders/lit.vert
@@ -1,0 +1,20 @@
+#version 440
+
+layout(location = 0) in vec3 position;
+layout(location = 1) in vec3 normal;
+
+layout(std140, binding = 0) uniform buf
+{
+    mat4 mvp;
+    vec4 color;
+    vec4 lightDir; // xyz: world-space direction toward the light.
+} ubuf;
+
+layout(location = 0) out vec3 v_normal;
+
+void main()
+{
+    // The model transform is identity, so the normal is already world-space.
+    v_normal = normal;
+    gl_Position = ubuf.mvp * vec4(position, 1.0);
+}

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -153,6 +153,18 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
             .def("updateMesh", &wrapped_type::updateMesh, py::arg("mesh"))
             .def("showMesh", &wrapped_type::showMesh, py::arg("show"))
             .def(
+                "showMeshStyle",
+                &wrapped_type::showMeshStyle,
+                py::arg("name"),
+                py::arg("show"),
+                "Show or hide one mesh style (\"surface\", \"wireframe\", or "
+                "\"points\") independently, so any combination can be drawn.")
+            .def(
+                "meshStyleShown",
+                &wrapped_type::meshStyleShown,
+                py::arg("name"),
+                "Whether the named mesh style is currently shown.")
+            .def(
                 "updateColorField",
                 &wrapped_type::updateColorField,
                 py::arg("vertices"),
@@ -532,8 +544,8 @@ void wrap_pilot(pybind11::module & mod)
         mod,
         "RDomainWidget",
         "Interactive QRhi viewer for 2D and 3D unstructured-mesh domains and "
-        "fields. Drive it with updateMesh / showMesh, updateColorField, "
-        "showBoundary, and showAxis; navigate with cameraMode, the "
+        "fields. Drive it with updateMesh / showMesh / showMeshStyle, "
+        "updateColorField, showBoundary, and showAxis; navigate with cameraMode, the "
         "cameraPosition / cameraTarget / cameraUp pose, rotateCamera / "
         "panCamera / zoomCamera / pinchCamera, and fitCameraToScene; capture "
         "frames with "

--- a/doc/source/pilot/domain.md
+++ b/doc/source/pilot/domain.md
@@ -9,8 +9,9 @@ drives them.
 
 ## Showing a domain
 
-- **Mesh wireframe**: `updateMesh(mesh)` draws the unstructured mesh (2D faces
-  or 3D cells) as a wireframe; `showMesh(on)` toggles it.
+- **Mesh**: `updateMesh(mesh)` draws the unstructured mesh (2D cells or the 3D
+  boundary shell); `showMesh(on)` toggles it. Choose which styles are drawn
+  with the mesh styles (see below).
 - **Colored field**: `updateColorField(vertices, colors, indices)` draws
   per-vertex-colored triangles over the domain. The field is swappable at
   runtime: call it again to replace the previous one.
@@ -19,6 +20,34 @@ drives them.
 - **Orientation guide**: `showAxis(on)` shows a small axis triad in the corner,
   two axes for a 2D domain and three for a 3D one, oriented by the camera. It
   is hidden by default.
+
+## Mesh styles
+
+The mesh draws in three styles that toggle **independently**, so any
+combination shows at once, a wireframe over a lit surface for instance. Toggle
+each from the **View > Mesh styles** submenu or the mesh panel's check boxes,
+or from Python with `showMeshStyle(name, on)`; `meshStyleShown(name)` reads a
+style back.
+
+| Menu item | `name` | What it draws |
+| --- | --- | --- |
+| Surface (lit shaded) | `"surface"` | cell or boundary faces as a lit, shaded surface |
+| Wireframe | `"wireframe"` | mesh edges as hairlines (on by default) |
+| Points | `"points"` | mesh nodes as points |
+
+Only the wireframe is on by default, so a freshly loaded mesh looks unchanged.
+The surface is shaded by a camera-following headlight, so faces turned toward
+the eye read brightest and the facets stay legible as the camera moves. A 2D
+domain fills its cells in the plane; a 3D domain shades its boundary shell.
+`showMesh(on)` hides or shows the mesh as a whole, on top of the per-style
+toggles.
+
+```python
+viewer.updateMesh(mesh)                   # wireframe only, the default
+viewer.showMeshStyle("surface", True)     # add the lit shaded surface
+viewer.showMeshStyle("wireframe", False)  # drop the wireframe over it
+viewer.meshStyleShown("points")           # False
+```
 
 ## Camera navigation
 

--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -59,6 +59,7 @@ class _Controller(metaclass=_Singleton):
         self.svg_dialog = None
         self.mesh_info = None
         self.sample_mesh = None
+        self.mesh_style_status = None
         self.oblique_shock = None
         self.oblique_solver = None
         self.naca4airfoil = None
@@ -91,8 +92,10 @@ class _Controller(metaclass=_Singleton):
         self.gmsh_dialog = _mesh.GmshFileDialog(mgr=self._rmgr)
         self.svg_dialog = _svg_gui.SVGFileDialog(mgr=self._rmgr)
         self.sample_mesh = _mesh.SampleMesh(mgr=self._rmgr)
-        self.mesh_info = _mesh_info.MeshInfo(mgr=self._rmgr,
-                                             menu=self.panels_menu)
+        self.mesh_style_status = _mesh.MeshStyleStatus(mgr=self._rmgr)
+        self.mesh_info = _mesh_info.MeshInfo(
+            mgr=self._rmgr, menu=self.panels_menu,
+            style_status=self.mesh_style_status)
         self.oblique_shock = _oblique.ObliqueShockMesh(mgr=self._rmgr)
         self.oblique_solver = _oblique.ObliqueShockSolver(mgr=self._rmgr)
         self.naca4airfoil = airfoil.Naca4Airfoil(mgr=self._rmgr)
@@ -142,6 +145,7 @@ class _Controller(metaclass=_Singleton):
         self.mesh_info.populate_menu()
         self.painter.populate_menu()
         self.mesh_sample_dialog.populate_menu()
+        self.mesh_style_status.populate_menu()
         self.oblique_solver.populate_menu()
         self.eulerone.populate_menu()
         self.burgers.populate_menu()

--- a/solvcon/pilot/_mesh.py
+++ b/solvcon/pilot/_mesh.py
@@ -8,13 +8,14 @@ Show meshes.
 
 import os
 
-from PySide6 import QtCore, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
 from .. import core
 from . import _gui_common
 
 __all__ = [  # noqa: F822
     'SampleMesh',
+    'MeshStyleStatus',
     'GmshFileDialog',
 ]
 
@@ -349,6 +350,74 @@ class SampleMeshDialog(_gui_common.PilotFeature):
         func = item.data(0, QtCore.Qt.UserRole)
         if callable(func):
             func()
+
+
+class MeshStyleStatus(QtCore.QObject):
+    """Shared on/off state of the three mesh styles for the active viewer.
+    """
+
+    # (style name understood by RDomainWidget, human-readable label), in one
+    # canonical order shared by every mesh-style UI.
+    STYLES = (
+        ("surface", "Surface (lit shaded)"),
+        ("wireframe", "Wireframe"),
+        ("points", "Points"),
+    )
+    # The viewer default (wireframe only), reported when no viewer is active.
+    _DEFAULTS = {"surface": False, "wireframe": True, "points": False}
+
+    changed = QtCore.Signal()
+
+    def __init__(self, *args, **kw):
+        self._mgr = kw.pop('mgr')
+        super().__init__(*args, **kw)
+        self._actions = {}
+        mdi = self._mgr.mainWindow.centralWidget()
+        if mdi is not None:
+            # A newly activated viewer brings its own styles; refresh the UIs.
+            mdi.subWindowActivated.connect(lambda _sub: self.changed.emit())
+
+    def is_shown(self, name):
+        """Whether ``name`` is drawn in the active viewer, or its default."""
+        widget = self._mgr.currentR3DWidget()
+        if widget is None:
+            return self._DEFAULTS.get(name, False)
+        return widget.meshStyleShown(name)
+
+    def set_shown(self, name, shown):
+        """Show or hide ``name`` in the active viewer, then refresh the UIs."""
+        widget = self._mgr.currentR3DWidget()
+        if widget is None:
+            self._mgr.pycon.writeToHistory(
+                "No active 3D viewer to toggle the mesh style\n")
+        else:
+            widget.showMeshStyle(name, shown)
+        self.changed.emit()
+
+    def populate_menu(self):
+        """Add the View > Mesh styles submenu of independent check items."""
+        window = self._mgr.mainWindow
+        submenu = QtWidgets.QMenu("Mesh styles", window)
+        for name, label in self.STYLES:
+            act = QtGui.QAction(label, window)
+            act.setCheckable(True)
+            act.setChecked(self.is_shown(name))
+            act.setStatusTip(f"Show or hide the {label.lower()} mesh style")
+            act.toggled.connect(
+                lambda checked, n=name: self.set_shown(n, checked))
+            self._actions[name] = act
+            submenu.addAction(act)
+        self.changed.connect(self._sync_menu)
+        self._mgr.viewMenu.addMenu(submenu)
+
+    def _sync_menu(self):
+        """Match the menu check marks to the active viewer's styles."""
+        for name, act in self._actions.items():
+            shown = self.is_shown(name)
+            if act.isChecked() != shown:
+                blocked = act.blockSignals(True)
+                act.setChecked(shown)
+                act.blockSignals(blocked)
 
 
 class GmshFileDialog(_gui_common.PilotFeature):

--- a/solvcon/pilot/_mesh_info.py
+++ b/solvcon/pilot/_mesh_info.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QDockWidget,
 
 from .. import core
 from . import _gui_common
+from . import _mesh
 
 __all__ = [  # noqa: F822
     'MeshInfo',
@@ -20,12 +21,19 @@ __all__ = [  # noqa: F822
 
 
 class MeshInfoTree(QWidget):
-    """Widget that presents the mesh information tree inside the dock."""
+    """Widget that presents the mesh information tree inside the dock.
+
+    :ivar boundary_toggled:
+        Owner-supplied callback ``boundary_toggled(ibc, checked)`` that routes
+        a boundary set's check-box to the active viewer; ``None`` until wired.
+    :vartype boundary_toggled: callable or None
+    """
 
     # Data roles that route a tree item's check-box toggle; the boundary
-    # index rides in the role after the kind.
+    # index and the style name ride in the roles after the kind.
     _ROLE_KIND = Qt.UserRole
     _ROLE_IBC = Qt.UserRole + 1
+    _ROLE_STYLE = Qt.UserRole + 2
 
     # Map cell type numbers to human-readable names.
     CELL_TYPE_NAME = {
@@ -39,8 +47,12 @@ class MeshInfoTree(QWidget):
         core.StaticMesh.PYRAMID: "pyramid",
     }
 
-    def __init__(self, mh=None, parent=None):
+    def __init__(self, style_status=None, mh=None, parent=None):
         super().__init__(parent)
+        self.style_status = style_status
+        if self.style_status is not None:
+            self.style_status.changed.connect(self.refresh_style_checks)
+        self._style_items = {}
         self._tree = QTreeWidget()
         self._tree.setColumnCount(1)
         self._tree.setHeaderHidden(True)
@@ -50,12 +62,7 @@ class MeshInfoTree(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self._tree)
         self.setLayout(layout)
-        # Called when a check box flips; the owner wires these to the viewer.
-        # ``boundary_toggled(ibc, checked)`` follows a boundary set and
-        # ``mesh_toggled(checked)`` the wireframe.  ``_building`` suppresses
-        # the signal while ``set_mesh`` populates the check boxes.
         self.boundary_toggled = None
-        self.mesh_toggled = None
         self._building = False
         self._tree.itemChanged.connect(self._on_item_changed)
         self.set_mesh(mh)
@@ -126,9 +133,9 @@ class MeshInfoTree(QWidget):
                 QTreeWidgetItem(self._tree, ["No mesh loaded"])
                 return
             root = QTreeWidgetItem(self._tree, [f"StaticMesh ({mh.ndim}D)"])
-            # Keep the display toggles (wireframe, then boundaries) together
-            # at the top, above the read-only information sections.
-            self._add_mesh_toggle(root)
+            # Keep the display toggles (styles, then boundaries) together at
+            # the top, above the read-only information sections.
+            self._add_style_toggles(root)
             self._add_boundary_group(root, mh)
             for section, rows in self.make_mesh_info(mh):
                 group = QTreeWidgetItem(root, [section])
@@ -141,12 +148,35 @@ class MeshInfoTree(QWidget):
         finally:
             self._building = False
 
-    def _add_mesh_toggle(self, root):
-        """Add the wireframe on/off check box (default on)."""
-        item = QTreeWidgetItem(root, ["wireframe"])
-        item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
-        item.setData(0, self._ROLE_KIND, 'mesh')
-        item.setCheckState(0, Qt.Checked)
+    def _add_style_toggles(self, root):
+        """Add the mesh style on-off check boxes.
+
+        Each mirrors the active viewer's style through the shared status, so a
+        fresh viewer shows the wireframe checked and the other two clear.
+        """
+        self._style_items = {}
+        if self.style_status is None:
+            return
+        for name, label in _mesh.MeshStyleStatus.STYLES:
+            item = QTreeWidgetItem(root, [label])
+            item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+            item.setData(0, self._ROLE_KIND, 'style')
+            item.setData(0, self._ROLE_STYLE, name)
+            shown = self.style_status.is_shown(name)
+            item.setCheckState(0, Qt.Checked if shown else Qt.Unchecked)
+            self._style_items[name] = item
+
+    def refresh_style_checks(self):
+        """Match the style check boxes to the active viewer's styles."""
+        if self.style_status is None:
+            return
+        self._building = True
+        try:
+            for name, item in self._style_items.items():
+                shown = self.style_status.is_shown(name)
+                item.setCheckState(0, Qt.Checked if shown else Qt.Unchecked)
+        finally:
+            self._building = False
 
     def _add_boundary_group(self, root, mh):
         """Add the boundary sets as a group of check boxes (default off)."""
@@ -170,8 +200,9 @@ class MeshInfoTree(QWidget):
         kind = item.data(0, self._ROLE_KIND)
         if kind == 'boundary' and self.boundary_toggled is not None:
             self.boundary_toggled(item.data(0, self._ROLE_IBC), checked)
-        elif kind == 'mesh' and self.mesh_toggled is not None:
-            self.mesh_toggled(checked)
+        elif kind == 'style' and self.style_status is not None:
+            self.style_status.set_shown(
+                item.data(0, self._ROLE_STYLE), checked)
 
 
 class MeshInfo(_gui_common.PilotFeature):
@@ -184,6 +215,7 @@ class MeshInfo(_gui_common.PilotFeature):
 
     def __init__(self, *args, **kw):
         self._menu = kw.pop('menu')
+        self._status = kw.pop('style_status')
         super().__init__(*args, **kw)
         self._action = None
         self._dock = None
@@ -209,9 +241,8 @@ class MeshInfo(_gui_common.PilotFeature):
         """Build the dock lazily and follow sub-window activation."""
         if self._panel is not None:
             return
-        self._panel = MeshInfoTree()
+        self._panel = MeshInfoTree(self._status)
         self._panel.boundary_toggled = self._on_boundary_toggled
-        self._panel.mesh_toggled = self._on_mesh_toggled
         self._dock = QDockWidget("mesh")
         self._dock.setWidget(self._panel)
         self._mgr.mainWindow.addDockWidget(Qt.LeftDockWidgetArea,
@@ -233,7 +264,8 @@ class MeshInfo(_gui_common.PilotFeature):
             QTimer.singleShot(0, self._refresh)
 
     def _refresh(self):
-        """Show the active sub-window's mesh."""
+        """Show the active sub-window's mesh. The style boxes read the shared
+        status, so rebuilding the tree already reflects the active viewer."""
         self._panel.set_mesh(self._active_mesh())
 
     def _on_boundary_toggled(self, ibc, checked):
@@ -241,12 +273,6 @@ class MeshInfo(_gui_common.PilotFeature):
         widget = self._mgr.currentR3DWidget()
         if widget is not None:
             widget.showBoundary(ibc, checked)
-
-    def _on_mesh_toggled(self, checked):
-        """Show or hide the wireframe in the active viewer."""
-        widget = self._mgr.currentR3DWidget()
-        if widget is not None:
-            widget.showMesh(checked)
 
     def _mdi_area(self):
         return self._mainWindow.centralWidget()

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -55,6 +55,12 @@ def _make_3d_mesh():
     return mh
 
 
+def _show_only(widget, name):
+    """Draw only the named mesh style, hiding the other two."""
+    for style in ("surface", "wireframe", "points"):
+        widget.showMeshStyle(style, style == name)
+
+
 def _grab_or_skip(widget):
     """Render the widget offscreen and return a QImage.
 
@@ -252,6 +258,132 @@ class RDomainWidgetMeshTC(unittest.TestCase):
         widget.showMesh(True)
         restored = _count_foreground(_grab_or_skip(widget))
         self.assertGreater(restored, hidden)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetStyleTC(unittest.TestCase):
+    """Independently toggling the surface, wireframe, and points styles."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def test_2d_surface_renders_filled(self):
+        """A 2D mesh drawn as a lit surface fills the cells with color, not
+        just the black hairline the wireframe draws."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        _show_only(widget, "surface")
+        self.assertGreater(_count_colored(_grab_or_skip(widget)), 0)
+
+    def test_3d_surface_renders_filled(self):
+        """A 3D mesh drawn as a lit surface shades its boundary faces."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_3d_mesh())
+        _show_only(widget, "surface")
+        widget.fitCameraToScene()
+        self.assertGreater(_count_colored(_grab_or_skip(widget)), 0)
+
+    def test_surface_differs_from_wireframe(self):
+        """The surface fills the interior the wireframe leaves as background,
+        so the two styles rasterize to different frames."""
+        wire = pilot.RDomainWidget()
+        wire.resize(320, 240)
+        wire.updateMesh(_make_2d_mesh())
+        wire_frame = _rgb_array(_grab_or_skip(wire))
+
+        surf = pilot.RDomainWidget()
+        surf.resize(320, 240)
+        surf.updateMesh(_make_2d_mesh())
+        _show_only(surf, "surface")
+        surf_frame = _rgb_array(_grab_or_skip(surf))
+        self.assertTrue((wire_frame != surf_frame).any())
+
+    def test_points_render(self):
+        """A 2D mesh drawn as points marks its nodes: some foreground pixels
+        stand over the background."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        _show_only(widget, "points")
+        self.assertGreater(_count_foreground(_grab_or_skip(widget)), 0)
+
+    def test_show_mesh_hides_active_surface(self):
+        """showMesh(False) hides whichever styles are shown, and
+        showMesh(True) brings them back.
+
+        The count keys on the difference from the frame's own background (as in
+        the wireframe toggle test), so an empty scene that a software
+        rasterizer reads back as a uniformly dark frame still counts as
+        nothing drawn.
+        """
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        _show_only(widget, "surface")
+        shown = _count_foreground(_grab_or_skip(widget))
+        self.assertGreater(shown, 0)
+        widget.showMesh(False)
+        hidden = _count_foreground(_grab_or_skip(widget))
+        self.assertLess(hidden, shown * 0.5)
+        widget.showMesh(True)
+        self.assertGreater(_count_foreground(_grab_or_skip(widget)), hidden)
+
+    def test_styles_toggle_independently(self):
+        """Showing or hiding one style leaves the others as they were."""
+        widget = pilot.RDomainWidget()
+        self.assertTrue(widget.meshStyleShown("wireframe"))
+        self.assertFalse(widget.meshStyleShown("surface"))
+        self.assertFalse(widget.meshStyleShown("points"))
+        widget.showMeshStyle("surface", True)
+        self.assertTrue(widget.meshStyleShown("surface"))
+        self.assertTrue(widget.meshStyleShown("wireframe"))
+        widget.showMeshStyle("wireframe", False)
+        self.assertFalse(widget.meshStyleShown("wireframe"))
+        self.assertTrue(widget.meshStyleShown("surface"))
+
+    def test_unknown_style_is_ignored(self):
+        """An unknown style name toggles nothing and reads back false."""
+        widget = pilot.RDomainWidget()
+        before = [widget.meshStyleShown(n)
+                  for n in ("surface", "wireframe", "points")]
+        widget.showMeshStyle("bogus", True)
+        after = [widget.meshStyleShown(n)
+                 for n in ("surface", "wireframe", "points")]
+        self.assertEqual(before, after)
+        self.assertFalse(widget.meshStyleShown("bogus"))
+
+    def test_wireframe_over_surface_overlays(self):
+        """Adding the wireframe over the lit surface changes the frame: the
+        black edges the surface alone does not draw now appear over the
+        fill."""
+        surf = pilot.RDomainWidget()
+        surf.resize(320, 240)
+        surf.updateMesh(_make_2d_mesh())
+        _show_only(surf, "surface")
+        surf_frame = _rgb_array(_grab_or_skip(surf))
+
+        both = pilot.RDomainWidget()
+        both.resize(320, 240)
+        both.updateMesh(_make_2d_mesh())
+        _show_only(both, "surface")
+        both.showMeshStyle("wireframe", True)
+        both_frame = _rgb_array(_grab_or_skip(both))
+        self.assertTrue((surf_frame != both_frame).any())
+
+    def test_all_styles_off_draws_nothing(self):
+        """Turning every style off empties the scene."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        _show_only(widget, "surface")
+        shown = _count_foreground(_grab_or_skip(widget))
+        self.assertGreater(shown, 0)
+        for name in ("surface", "wireframe", "points"):
+            widget.showMeshStyle(name, False)
+        self.assertLess(_count_foreground(_grab_or_skip(widget)), shown * 0.5)
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")

--- a/tests/test_pilot_mesh_info.py
+++ b/tests/test_pilot_mesh_info.py
@@ -10,6 +10,7 @@ import solvcon
 try:
     from solvcon import pilot
     from solvcon.pilot import _mesh_info
+    from solvcon.pilot._mesh import MeshStyleStatus
     from PySide6.QtCore import Qt
     from PySide6.QtWidgets import QApplication, QMenu
 except ImportError:
@@ -108,6 +109,8 @@ class MeshInfoTC(unittest.TestCase):
         self.mgr = pilot.RManager.instance.setUp()
         # The "Panels" group is owned by the caller, not by MeshInfo.
         self.menu = QMenu("Panels", self.mgr.mainWindow)
+        # The View menu and the panel share one MeshStyleStatus.
+        self.status = MeshStyleStatus(mgr=self.mgr)
 
     def test_current_r3dwidget_exposes_mesh(self):
         # The mesh must be reached through the pybind11 RDomainWidget rather
@@ -122,7 +125,8 @@ class MeshInfoTC(unittest.TestCase):
     def test_panel_shows_active_mesh(self):
         widget = self.mgr.add3DWidget()
         widget.updateMesh(_make_sample_mesh())
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu)
+        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+                                      style_status=self.status)
         feature.populate_menu()
         self.assertIn(feature._action, self.menu.actions())
         feature._action.setChecked(True)
@@ -133,7 +137,8 @@ class MeshInfoTC(unittest.TestCase):
     def test_boundary_toggle_drives_viewer(self):
         widget = self.mgr.add3DWidget()
         widget.updateMesh(_make_sample_mesh())
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu)
+        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+                                      style_status=self.status)
         feature.populate_menu()
         feature._action.setChecked(True)
         # Record the routed (ibc, checked) while still driving the real
@@ -155,31 +160,64 @@ class MeshInfoTC(unittest.TestCase):
         # Each flip routes the set index and its new state to the viewer.
         self.assertEqual(calls, [(0, True), (0, False)])
 
-    def test_wireframe_toggle_drives_viewer(self):
+    def test_style_toggle_drives_viewer(self):
         widget = self.mgr.add3DWidget()
         widget.updateMesh(_make_sample_mesh())
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu)
+        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+                                      style_status=self.status)
         feature.populate_menu()
         feature._action.setChecked(True)
-        calls = []
-        inner = feature._panel.mesh_toggled
+        panel = feature._panel
+        # Wireframe is on by default; surface and points are off.
+        self.assertEqual(panel._style_items["wireframe"].checkState(0),
+                         Qt.Checked)
+        self.assertEqual(panel._style_items["surface"].checkState(0),
+                         Qt.Unchecked)
+        # Toggling a panel check box drives the active viewer's style, one
+        # style at a time without disturbing the others.
+        panel._style_items["surface"].setCheckState(0, Qt.Checked)
+        self.assertTrue(widget.meshStyleShown("surface"))
+        self.assertTrue(widget.meshStyleShown("wireframe"))
+        panel._style_items["wireframe"].setCheckState(0, Qt.Unchecked)
+        self.assertFalse(widget.meshStyleShown("wireframe"))
+        self.assertTrue(widget.meshStyleShown("surface"))
 
-        def record(checked):
-            calls.append(checked)
-            inner(checked)
-        feature._panel.mesh_toggled = record
-        root = feature._panel._tree.topLevelItem(0)
-        item = next(root.child(i) for i in range(root.childCount())
-                    if root.child(i).text(0) == "wireframe")
-        self.assertEqual(item.checkState(0), Qt.Checked)  # default on
-        item.setCheckState(0, Qt.Unchecked)
-        item.setCheckState(0, Qt.Checked)
-        # The wireframe visibility flips reach the viewer in order.
-        self.assertEqual(calls, [False, True])
+    def test_tree_holds_shared_style_status(self):
+        # MeshInfoTree keeps the injected MeshStyleStatus as a public
+        # attribute and reads its style rows from it, rather than owning a
+        # status of its own.
+        widget = self.mgr.add3DWidget()
+        widget.updateMesh(_make_sample_mesh())
+        tree = _mesh_info.MeshInfoTree(style_status=self.status,
+                                       mh=_make_sample_mesh())
+        self.assertIs(tree.style_status, self.status)
+        self.assertEqual(tree._style_items["wireframe"].checkState(0),
+                         Qt.Checked)
+
+    def test_menu_and_panel_stay_linked(self):
+        widget = self.mgr.add3DWidget()
+        widget.updateMesh(_make_sample_mesh())
+        panel_feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+                                            style_status=self.status)
+        panel_feature.populate_menu()
+        panel_feature._action.setChecked(True)
+        # The status object owns the View menu now; build it too.
+        self.status.populate_menu()
+        panel = panel_feature._panel
+        # A toggle from the menu reaches the viewer and the panel check box.
+        self.status._actions["surface"].setChecked(True)
+        self.assertTrue(widget.meshStyleShown("surface"))
+        self.assertEqual(panel._style_items["surface"].checkState(0),
+                         Qt.Checked)
+        # A toggle from the panel reaches the viewer and the menu action.
+        panel._style_items["points"].setCheckState(0, Qt.Checked)
+        self.assertTrue(widget.meshStyleShown("points"))
+        self.assertTrue(self.status._actions["points"].isChecked())
 
     def test_panel_without_mesh(self):
         self.mgr.add3DWidget()  # fresh viewer becomes current, no mesh
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu)
+        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+                                      style_status=self.status)
         feature.populate_menu()
         feature._action.setChecked(True)
         root = feature._panel._tree.topLevelItem(0)
@@ -189,7 +227,8 @@ class MeshInfoTC(unittest.TestCase):
     def test_panel_updates_on_menu_load(self):
         # Loading from a menu creates and activates the viewer before
         # updateMesh runs, so the refresh is deferred to the event loop.
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu)
+        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+                                      style_status=self.status)
         feature.populate_menu()
         feature._action.setChecked(True)
         widget = self.mgr.add3DWidget()


### PR DESCRIPTION
The pilot domain viewer could draw an unstructured mesh only as a wireframe. This PR adds a lit, shaded surface and a node point cloud alongside it, and lets the three styles toggle independently, so any combination shows at once (a wireframe over a lit surface, for instance). The styles are driven from Python, from the **View > Mesh styles** menu, and from the mesh-info panel, all kept in step through one shared status.

Code usage:
```python
from solvcon import pilot

mgr = pilot.RManager.instance.setUp()
viewer = mgr.add3DWidget()

viewer.updateMesh(mesh)                    # wireframe only, the default
viewer.showMeshStyle("surface", True)      # add the lit shaded surface
viewer.showMeshStyle("wireframe", False)   # drop the wireframe over it
viewer.meshStyleShown("points")            # False
```

In the GUI, toggle the styles from **View > Mesh styles** or the mesh panel's check boxes; both stay in sync with the active viewer.

This is for item 1 of issue #976.