### PR TITLE
Surface with edges and per-object opacity (basic mesh visualization item 2)

### DIFF
--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -175,6 +175,24 @@ void RDomainWidget::applyMeshVisibility()
     }
 }
 
+void RDomainWidget::setMeshOpacity(float opacity)
+{
+    if (nullptr != m_mesh_frame)
+    {
+        m_mesh_frame->setOpacity(opacity);
+        update();
+    }
+}
+
+void RDomainWidget::setFieldOpacity(float opacity)
+{
+    if (nullptr != m_field)
+    {
+        m_field->setOpacity(opacity);
+        update();
+    }
+}
+
 void RDomainWidget::updateColorField(
     SimpleArray<float> const & vertices,
     SimpleArray<float> const & colors,

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -68,6 +68,13 @@ public:
     void showMeshStyle(std::string const & name, bool show);
     bool meshStyleShown(std::string const & name) const;
 
+    /// Set the mesh wireframe opacity, a [0, 1] fraction (1 opaque).
+    void setMeshOpacity(float opacity);
+
+    /// Set the color-field surface opacity, a [0, 1] fraction (1 opaque).
+    /// Lower it to read the wireframe drawn over the shaded surface.
+    void setFieldOpacity(float opacity);
+
     /// Replace the colored field: per-vertex-colored triangles from a vertex
     /// table (nvert, 3), a matching color table (nvert, 3), and a triangle
     /// index table (ntri, 3). Swappable at runtime.

--- a/cpp/solvcon/pilot/RDrawable.cpp
+++ b/cpp/solvcon/pilot/RDrawable.cpp
@@ -45,7 +45,7 @@ void RDrawable::prepare(
     m_pipeline.reset(m_material->buildPipeline(
         rhi, m_srb.get(), rpdesc, vertexInputLayout(), topology(), sample_count,
         /*depth_test*/ true,
-        /*alpha_blend*/ false,
+        /*alpha_blend*/ true,
         depthBias(),
         slopeScaledDepthBias()));
     m_ready = (nullptr != m_pipeline);
@@ -71,7 +71,8 @@ void RDrawable::updateUniform(QRhiResourceUpdateBatch * batch, QMatrix4x4 const 
         return;
     }
     batch->updateDynamicBuffer(m_ubuf.get(), 0, 64, view_proj.constData());
-    float const color[4] = {m_color.x(), m_color.y(), m_color.z(), m_color.w()};
+    float const color[4] = {
+        m_color.x(), m_color.y(), m_color.z(), m_color.w() * m_opacity};
     batch->updateDynamicBuffer(m_ubuf.get(), 64, 16, color);
     float const light[4] = {m_light_dir.x(), m_light_dir.y(), m_light_dir.z(), 0.0f};
     batch->updateDynamicBuffer(m_ubuf.get(), 80, 16, light);

--- a/cpp/solvcon/pilot/RDrawable.hpp
+++ b/cpp/solvcon/pilot/RDrawable.hpp
@@ -62,6 +62,15 @@ public:
     /// ignored by the others. The widget refreshes it as the camera moves.
     void setLightDir(QVector3D const & dir) { m_light_dir = dir; }
 
+    /// Set the drawable opacity, a [0, 1] multiplier on the color alpha.
+    /// 1 is fully opaque, 0 fully transparent. Clamped to the range.
+    void setOpacity(float opacity)
+    {
+        m_opacity = (opacity < 0.0f) ? 0.0f : (opacity > 1.0f) ? 1.0f
+                                                               : opacity;
+    }
+    float opacity() const { return m_opacity; }
+
     /// Create the device resources if they do not exist yet. Idempotent.
     void prepare(
         QRhi * rhi,
@@ -110,6 +119,7 @@ protected:
 
     QVector4D m_color{1.0f, 1.0f, 1.0f, 1.0f};
     QVector3D m_light_dir{0.0f, 0.0f, 1.0f};
+    float m_opacity = 1.0f;
     bool m_visible = true;
 
     std::unique_ptr<QRhiBuffer> m_vbuf;

--- a/cpp/solvcon/pilot/shaders/vcolor.vert
+++ b/cpp/solvcon/pilot/shaders/vcolor.vert
@@ -6,13 +6,13 @@ layout(location = 1) in vec3 vertexColor;
 layout(std140, binding = 0) uniform buf
 {
     mat4 mvp;
-    vec4 color; // unused by the per-vertex-color variant
+    vec4 color; // only the alpha (opacity) is used by this variant
 } ubuf;
 
 layout(location = 0) out vec4 v_color;
 
 void main()
 {
-    v_color = vec4(vertexColor, 1.0);
+    v_color = vec4(vertexColor, ubuf.color.a);
     gl_Position = ubuf.mvp * vec4(position, 1.0);
 }

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -152,6 +152,8 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
             .def_property_readonly("mesh", &wrapped_type::mesh)
             .def("updateMesh", &wrapped_type::updateMesh, py::arg("mesh"))
             .def("showMesh", &wrapped_type::showMesh, py::arg("show"))
+            .def("setMeshOpacity", &wrapped_type::setMeshOpacity, py::arg("opacity"))
+            .def("setFieldOpacity", &wrapped_type::setFieldOpacity, py::arg("opacity"))
             .def(
                 "showMeshStyle",
                 &wrapped_type::showMeshStyle,
@@ -544,8 +546,10 @@ void wrap_pilot(pybind11::module & mod)
         mod,
         "RDomainWidget",
         "Interactive QRhi viewer for 2D and 3D unstructured-mesh domains and "
-        "fields. Drive it with updateMesh / showMesh / showMeshStyle, "
-        "updateColorField, showBoundary, and showAxis; navigate with cameraMode, the "
+        "fields. Drive it with updateMesh / showMesh / showMeshStyle / "
+        "setMeshOpacity, "
+        "updateColorField / setFieldOpacity, "
+        "showBoundary, and showAxis; navigate with cameraMode, the "
         "cameraPosition / cameraTarget / cameraUp pose, rotateCamera / "
         "panCamera / zoomCamera / pinchCamera, and fitCameraToScene; capture "
         "frames with "

--- a/doc/source/pilot/domain.md
+++ b/doc/source/pilot/domain.md
@@ -49,6 +49,26 @@ viewer.showMeshStyle("wireframe", False)  # drop the wireframe over it
 viewer.meshStyleShown("points")           # False
 ```
 
+## Layering and opacity
+
+The wireframe and the colored field are separate layers drawn in the same
+scene, so showing both draws the wireframe over the shaded surface as one
+representation. Each layer takes an adjustable opacity, a fraction from `0`
+(fully transparent) to `1` (fully opaque, the default):
+
+- `setFieldOpacity(alpha)` fades the shaded surface. Lower it to read the
+  wireframe and any structure behind the surface.
+- `setMeshOpacity(alpha)` fades the wireframe.
+
+```python
+viewer.updateMesh(mesh)                    # wireframe layer
+viewer.updateColorField(verts, cols, tris)  # shaded surface layer
+viewer.setFieldOpacity(0.5)                # see the wireframe through it
+```
+
+The opacity is applied on the next frame, so it takes effect immediately in the
+live viewer and in a captured frame.
+
 ## Camera navigation
 
 The viewer has one camera with three modes; each suits a different domain.

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -466,6 +466,55 @@ class RDomainWidgetFieldTC(unittest.TestCase):
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetOpacityTC(unittest.TestCase):
+    """Adjustable per-drawable opacity for the wireframe and the surface."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def test_field_opacity_fades_toward_background(self):
+        """Lowering the field opacity blends the shaded surface toward the
+        white background, so far fewer pixels stay strongly saturated."""
+        vertices, colors, indices = _make_color_field()
+
+        opaque = pilot.RDomainWidget()
+        opaque.resize(320, 240)
+        _update_field(opaque, vertices, colors, indices)
+        strong_opaque = _count_colored(_grab_or_skip(opaque), 100)
+        self.assertGreater(strong_opaque, 0)
+
+        faded = pilot.RDomainWidget()
+        faded.resize(320, 240)
+        _update_field(faded, vertices, colors, indices)
+        faded.setFieldOpacity(0.3)
+        strong_faded = _count_colored(_grab_or_skip(faded), 100)
+        self.assertLess(strong_faded, strong_opaque)
+
+    def test_mesh_opacity_fades_wireframe(self):
+        """A low mesh opacity fades the black wireframe toward white, so its
+        lines fall below the foreground threshold."""
+        opaque = pilot.RDomainWidget()
+        opaque.resize(320, 240)
+        opaque.updateMesh(_make_2d_mesh())
+        shown = _count_foreground(_grab_or_skip(opaque))
+        self.assertGreater(shown, 0)
+
+        faded = pilot.RDomainWidget()
+        faded.resize(320, 240)
+        faded.updateMesh(_make_2d_mesh())
+        faded.setMeshOpacity(0.2)
+        self.assertLess(_count_foreground(_grab_or_skip(faded)), shown)
+
+    def test_set_opacity_without_drawable_is_noop(self):
+        """Setting opacity before a mesh or field exists is a harmless no-op,
+        not a crash."""
+        widget = pilot.RDomainWidget()
+        widget.setMeshOpacity(0.5)
+        widget.setFieldOpacity(0.5)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class RDomainWidgetSceneTC(unittest.TestCase):
     """Scene framing and the fit-to-scene camera (step 4)."""
 


### PR DESCRIPTION
The mesh already draws its surface, wireframe, and points as independent layers, so the standard surface-with-edges inspection view is just the surface and the wireframe shown together. Give each drawable an opacity so a caller can fade an outer surface and read the structure behind it.

RDrawable gains a clamped opacity that scales the color alpha written into the per-object uniform, and its pipeline now enables source-over blending unconditionally so a runtime opacity change takes effect without rebuilding the pipeline; an alpha of 1 keeps the blend an identity, so opaque drawables render unchanged. The per-vertex-color shader reads the uniform alpha so the shaded surface honors the opacity too.

RDomainWidget exposes setMeshOpacity and setFieldOpacity, both bound to Python, and the domain visualizer page documents the layering.

For item 2 of issue #976.