### PR TITLE
View presets and projection toggle (item 7 of basic mesh visualization)

### DIFF
--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -787,6 +787,23 @@ void RDomainWidget::fitCameraToScene()
     update();
 }
 
+void RDomainWidget::setView(std::string const & name)
+{
+    m_scene.setViewPreset(name, viewportAspect());
+    update();
+}
+
+void RDomainWidget::setProjection(std::string const & name)
+{
+    m_scene.setProjection(name);
+    update();
+}
+
+std::string RDomainWidget::projection() const
+{
+    return m_scene.projectionName();
+}
+
 void RDomainWidget::setCameraMode(std::string const & name)
 {
     m_scene.camera().setMode(RCameraController::modeFromName(name));

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -144,6 +144,16 @@ public:
     /// Frame the camera so the whole domain is in view.
     void fitCameraToScene();
 
+    /// Point the camera along a named view preset and frame the scene:
+    /// "front", "back", "left", "right", "top", "bottom", the axis names
+    /// "+x".."-z", or "iso".
+    void setView(std::string const & name);
+
+    /// Set the projection independently of the 2D/3D default: "auto",
+    /// "parallel", or "perspective".
+    void setProjection(std::string const & name);
+    std::string projection() const;
+
     /// Show or hide the orientation-guide triad in the corner.
     void showAxis(bool show);
 

--- a/cpp/solvcon/pilot/RScene.cpp
+++ b/cpp/solvcon/pilot/RScene.cpp
@@ -6,6 +6,7 @@
 #include <solvcon/pilot/RScene.hpp> // Must be the first include.
 
 #include <algorithm>
+#include <cmath>
 
 namespace solvcon
 {
@@ -93,6 +94,98 @@ void RScene::fitCameraToScene(float aspect)
     m_camera.fitToBoundingBox(m_bbox_lo, m_bbox_hi, m_ndim, aspect);
 }
 
+void RScene::setProjection(std::string const & name)
+{
+    if ("auto" == name)
+    {
+        m_projection = Projection::Auto;
+    }
+    else if ("parallel" == name)
+    {
+        m_projection = Projection::Parallel;
+    }
+    else if ("perspective" == name)
+    {
+        m_projection = Projection::Perspective;
+    }
+}
+
+std::string RScene::projectionName() const
+{
+    switch (m_projection)
+    {
+    case Projection::Parallel:
+        return "parallel";
+    case Projection::Perspective:
+        return "perspective";
+    default:
+        return "auto";
+    }
+}
+
+void RScene::setViewPreset(std::string const & name, float aspect)
+{
+    if (!m_has_bbox)
+    {
+        return;
+    }
+
+    // The preset direction points from the target toward the eye; the up axis
+    // is +z for the side views and +y when looking down or up the z axis.
+    QVector3D dir;
+    QVector3D up(0.0f, 0.0f, 1.0f);
+    if ("front" == name || "-y" == name)
+    {
+        dir = QVector3D(0.0f, -1.0f, 0.0f);
+    }
+    else if ("back" == name || "+y" == name)
+    {
+        dir = QVector3D(0.0f, 1.0f, 0.0f);
+    }
+    else if ("right" == name || "+x" == name)
+    {
+        dir = QVector3D(1.0f, 0.0f, 0.0f);
+    }
+    else if ("left" == name || "-x" == name)
+    {
+        dir = QVector3D(-1.0f, 0.0f, 0.0f);
+    }
+    else if ("top" == name || "+z" == name)
+    {
+        dir = QVector3D(0.0f, 0.0f, 1.0f);
+        up = QVector3D(0.0f, 1.0f, 0.0f);
+    }
+    else if ("bottom" == name || "-z" == name)
+    {
+        dir = QVector3D(0.0f, 0.0f, -1.0f);
+        up = QVector3D(0.0f, 1.0f, 0.0f);
+    }
+    else if ("iso" == name || "isometric" == name)
+    {
+        dir = QVector3D(1.0f, 1.0f, 1.0f);
+    }
+    else
+    {
+        return; // Ignore an unknown preset.
+    }
+
+    QVector3D const center = (m_bbox_lo + m_bbox_hi) * 0.5f;
+    float radius = boundingRadius();
+    if (radius <= 0.0f)
+    {
+        radius = 1.0f;
+    }
+    float const safe_aspect = (aspect > 0.0f) ? aspect : 1.0f;
+    float const deg2rad = 3.14159265358979323846f / 180.0f;
+    float const half_v = FOV_DEGREES * 0.5f * deg2rad;
+    float const half_h = std::atan(std::tan(half_v) * safe_aspect);
+    float const distance = radius / std::tan(std::min(half_v, half_h)) * 1.1f;
+
+    m_camera.setTarget(center);
+    m_camera.setPosition(center + dir.normalized() * distance);
+    m_camera.setUp(up.normalized());
+}
+
 QMatrix4x4 RScene::viewProjection(QSize pixel_size, QRhi * rhi) const
 {
     QMatrix4x4 clip = (nullptr != rhi) ? rhi->clipSpaceCorrMatrix() : QMatrix4x4();
@@ -111,8 +204,12 @@ QMatrix4x4 RScene::viewProjection(QSize pixel_size, QRhi * rhi) const
         distance = 2.0f * radius;
     }
 
+    bool const use_perspective =
+        (Projection::Perspective == m_projection) ||
+        (Projection::Auto == m_projection && 3 == m_ndim);
+
     QMatrix4x4 proj;
-    if (3 == m_ndim)
+    if (use_perspective)
     {
         proj.perspective(FOV_DEGREES, aspect, 0.01f * radius, distance + 3.0f * radius);
     }

--- a/cpp/solvcon/pilot/RScene.hpp
+++ b/cpp/solvcon/pilot/RScene.hpp
@@ -26,6 +26,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace solvcon
@@ -78,6 +79,25 @@ public:
     void setDimension(uint32_t ndim) { m_ndim = ndim; }
     uint32_t dimension() const { return m_ndim; }
 
+    /// The projection selector. Auto picks orthographic for a 2D domain and
+    /// perspective for a 3D one; the others force the choice.
+    enum class Projection
+    {
+        Auto,
+        Parallel,
+        Perspective,
+    };
+
+    /// Override the projection: "auto", "parallel", or "perspective". An
+    /// unknown name is ignored.
+    void setProjection(std::string const & name);
+    std::string projectionName() const;
+
+    /// Point the camera along an axis-aligned or isometric preset and frame
+    /// the scene: "front", "back", "left", "right", "top", "bottom", the axis
+    /// names "+x".."-z", or "iso". An unknown name is ignored.
+    void setViewPreset(std::string const & name, float aspect);
+
     RCameraController & camera() { return m_camera; }
     RCameraController const & camera() const { return m_camera; }
 
@@ -100,6 +120,7 @@ private:
     QVector3D m_bbox_hi;
     bool m_has_bbox = false;
     uint32_t m_ndim = 0;
+    Projection m_projection = Projection::Auto;
 
     RCameraController m_camera;
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -248,6 +248,25 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                 "cells.")
             .def("showAxis", &wrapped_type::showAxis, py::arg("show"))
             .def("fitCameraToScene", &wrapped_type::fitCameraToScene)
+            .def(
+                "setView",
+                &wrapped_type::setView,
+                py::arg("name"),
+                "Point the camera along a view preset and frame the scene: "
+                "\"front\", \"back\", \"left\", \"right\", \"top\", "
+                "\"bottom\", \"+x\"..\"-z\", or \"iso\".")
+            .def_property(
+                "projection",
+                [](wrapped_type & self)
+                {
+                    return self.projection();
+                },
+                [](wrapped_type & self, std::string const & name)
+                {
+                    self.setProjection(name);
+                },
+                "Projection: \"auto\" (orthographic 2D, perspective 3D), "
+                "\"parallel\", or \"perspective\".")
             .def_property(
                 "cameraMode",
                 [](wrapped_type & self)

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -974,6 +974,78 @@ class RDomainWidgetQualityTC(unittest.TestCase):
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetViewPresetTC(unittest.TestCase):
+    """Axis-aligned view presets and the projection toggle."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def test_projection_round_trip(self):
+        """The projection defaults to auto and takes the forced values."""
+        widget = pilot.RDomainWidget()
+        self.assertEqual(widget.projection, "auto")
+        widget.projection = "parallel"
+        self.assertEqual(widget.projection, "parallel")
+        widget.projection = "perspective"
+        self.assertEqual(widget.projection, "perspective")
+        widget.projection = "auto"
+        self.assertEqual(widget.projection, "auto")
+
+    def test_unknown_projection_is_ignored(self):
+        """An unknown projection name leaves the current one untouched."""
+        widget = pilot.RDomainWidget()
+        widget.projection = "parallel"
+        widget.projection = "bogus"
+        self.assertEqual(widget.projection, "parallel")
+
+    def test_view_preset_frames_3d_mesh(self):
+        """Each preset frames a 3D mesh so it renders in view."""
+        for name in ("front", "top", "right", "iso"):
+            widget = pilot.RDomainWidget()
+            widget.resize(320, 240)
+            widget.updateMesh(_make_3d_mesh())
+            widget.setView(name)
+            self.assertGreater(
+                _count_foreground(_grab_or_skip(widget)), 0,
+                "preset %s drew nothing" % name)
+
+    def test_presets_view_from_different_directions(self):
+        """Front and top presets look from different directions, so they
+        rasterize a 3D mesh to different frames."""
+        front = pilot.RDomainWidget()
+        front.resize(320, 240)
+        front.updateMesh(_make_3d_mesh())
+        front.setView("front")
+        front_frame = _rgb_array(_grab_or_skip(front))
+
+        top = pilot.RDomainWidget()
+        top.resize(320, 240)
+        top.updateMesh(_make_3d_mesh())
+        top.setView("top")
+        top_frame = _rgb_array(_grab_or_skip(top))
+        self.assertTrue((front_frame != top_frame).any())
+
+    def test_projection_toggle_changes_the_frame(self):
+        """Forcing parallel versus perspective changes the rendered frame of a
+        3D mesh."""
+        para = pilot.RDomainWidget()
+        para.resize(320, 240)
+        para.updateMesh(_make_3d_mesh())
+        para.setView("iso")
+        para.projection = "parallel"
+        para_frame = _rgb_array(_grab_or_skip(para))
+
+        persp = pilot.RDomainWidget()
+        persp.resize(320, 240)
+        persp.updateMesh(_make_3d_mesh())
+        persp.setView("iso")
+        persp.projection = "perspective"
+        persp_frame = _rgb_array(_grab_or_skip(persp))
+        self.assertTrue((para_frame != persp_frame).any())
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class RDomainWidgetSceneTC(unittest.TestCase):
     """Scene framing and the fit-to-scene camera (step 4)."""
 


### PR DESCRIPTION
Add axis-aligned and isometric view presets and an explicit parallel-versus-perspective projection toggle, so the projection is no longer tied to the domain dimension.

RScene gains a projection override (auto, parallel, perspective) that viewProjection honors over the per-dimension default, and setViewPreset that points the camera along a named direction ("front", "back", "left", "right", "top", "bottom", the axis names "+x".."-z", or "iso") and frames the scene at a distance sized to the bounding sphere and viewport.

RDomainWidget exposes setView and a projection property, both bound to Python. Tests cover the projection round trip, the preset framing, that two presets view from different directions, and that the projection toggle changes the rendered frame.

For item 7 of issue #976.