### PR TITLE
Geometric slice and clip of the mesh (item 14 of basic mesh visualization)

### DIFF
--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -1231,6 +1231,220 @@ void RDomainWidget::clearMeasurements()
     update();
 }
 
+int RDomainWidget::addClip(QVector3D const & origin, QVector3D const & normal)
+{
+    m_scene.removeDrawable(m_clip);
+    m_clip = nullptr;
+    if (nullptr == m_mesh)
+    {
+        return 0;
+    }
+    StaticMesh const & mh = *m_mesh;
+    uint32_t const ndim = mh.ndim();
+    QVector3D const n = normal.normalized();
+    auto coord = [&mh, ndim](int32_t ind, uint32_t dm) -> float
+    { return (dm < ndim) ? static_cast<float>(mh.ndcrd(ind, dm)) : 0.0f; };
+    auto side = [&](QVector3D const & p) -> float
+    { return QVector3D::dotProduct(p - origin, n); };
+
+    std::vector<float> verts;
+    std::vector<float> cols;
+    std::vector<uint32_t> tris;
+    auto add_polygon = [&](auto node, int32_t nnd)
+    {
+        for (int32_t k = 1; k + 1 < nnd; ++k)
+        {
+            int32_t const tri[3] = {node(0), node(k), node(k + 1)};
+            uint32_t const base = static_cast<uint32_t>(verts.size() / 3);
+            for (int32_t const ind : tri)
+            {
+                verts.push_back(coord(ind, 0));
+                verts.push_back(coord(ind, 1));
+                verts.push_back(coord(ind, 2));
+                cols.push_back(0.55f);
+                cols.push_back(0.62f);
+                cols.push_back(0.75f);
+            }
+            tris.push_back(base + 0);
+            tris.push_back(base + 1);
+            tris.push_back(base + 2);
+        }
+    };
+
+    int kept = 0;
+    if (3 == ndim)
+    {
+        SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
+        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        {
+            int32_t const ifc = bndfcs(ibnd, 0);
+            QVector3D const centroid(
+                static_cast<float>(mh.fccnd(ifc, 0)),
+                static_cast<float>(mh.fccnd(ifc, 1)),
+                static_cast<float>(mh.fccnd(ifc, 2)));
+            if (side(centroid) <= 0.0f)
+            {
+                add_polygon(
+                    [&mh, ifc](int32_t k)
+                    { return mh.fcnds(ifc, k + 1); },
+                    mh.fcnds(ifc, 0));
+                ++kept;
+            }
+        }
+    }
+    else
+    {
+        for (uint32_t icl = 0; icl < mh.ncell(); ++icl)
+        {
+            QVector3D const centroid(
+                static_cast<float>(mh.clcnd(icl, 0)),
+                static_cast<float>(mh.clcnd(icl, 1)),
+                0.0f);
+            if (side(centroid) <= 0.0f)
+            {
+                add_polygon(
+                    [&mh, icl](int32_t k)
+                    { return mh.clnds(icl, k + 1); },
+                    mh.clnds(icl, 0));
+                ++kept;
+            }
+        }
+    }
+
+    if (!verts.empty())
+    {
+        size_t const nvert = verts.size() / 3;
+        size_t const ntri = tris.size() / 3;
+        SimpleArray<float> va(std::vector<size_t>{nvert, 3});
+        SimpleArray<float> ca(std::vector<size_t>{nvert, 3});
+        SimpleArray<uint32_t> ia(std::vector<size_t>{ntri, 3});
+        for (size_t i = 0; i < nvert; ++i)
+        {
+            va(i, 0) = verts[3 * i + 0];
+            va(i, 1) = verts[3 * i + 1];
+            va(i, 2) = verts[3 * i + 2];
+            ca(i, 0) = cols[3 * i + 0];
+            ca(i, 1) = cols[3 * i + 1];
+            ca(i, 2) = cols[3 * i + 2];
+        }
+        for (size_t t = 0; t < ntri; ++t)
+        {
+            ia(t, 0) = tris[3 * t + 0];
+            ia(t, 1) = tris[3 * t + 1];
+            ia(t, 2) = tris[3 * t + 2];
+        }
+        auto clip = std::make_unique<RField>(va, ca, ia);
+        if (clip->hasGeometry())
+        {
+            m_clip = clip.get();
+            m_scene.addDrawable(std::move(clip));
+        }
+    }
+    update();
+    return kept;
+}
+
+int RDomainWidget::addSlice(QVector3D const & origin, QVector3D const & normal)
+{
+    m_scene.removeDrawable(m_slice);
+    m_slice = nullptr;
+    if (nullptr == m_mesh)
+    {
+        return 0;
+    }
+    StaticMesh const & mh = *m_mesh;
+    uint32_t const ndim = mh.ndim();
+    QVector3D const n = normal.normalized();
+    auto pos = [&mh, ndim](int32_t ind) -> QVector3D
+    {
+        return QVector3D(
+            static_cast<float>(mh.ndcrd(ind, 0)),
+            static_cast<float>(mh.ndcrd(ind, 1)),
+            (3 == ndim) ? static_cast<float>(mh.ndcrd(ind, 2)) : 0.0f);
+    };
+    auto side = [&](QVector3D const & p) -> float
+    { return QVector3D::dotProduct(p - origin, n); };
+
+    std::vector<QVector3D> segments;
+    for (uint32_t icl = 0; icl < mh.ncell(); ++icl)
+    {
+        int32_t const nnd = mh.clnds(icl, 0);
+        std::vector<int32_t> nd(static_cast<size_t>(nnd));
+        for (int32_t k = 0; k < nnd; ++k)
+        {
+            nd[k] = mh.clnds(icl, k + 1);
+        }
+
+        // Candidate edges: the polygon rim in 2D, every node pair in 3D (exact
+        // for a simplex, an over-set for a hex but the crossings stay on real
+        // faces).
+        std::vector<QVector3D> cuts;
+        auto try_edge = [&](int32_t ia, int32_t ib)
+        {
+            QVector3D const pa = pos(ia);
+            QVector3D const pb = pos(ib);
+            float const sa = side(pa);
+            float const sb = side(pb);
+            if (sa * sb < 0.0f)
+            {
+                float const t = sa / (sa - sb);
+                cuts.push_back(pa + t * (pb - pa));
+            }
+        };
+        if (3 == ndim)
+        {
+            for (int32_t a = 0; a < nnd; ++a)
+            {
+                for (int32_t b = a + 1; b < nnd; ++b)
+                {
+                    try_edge(nd[a], nd[b]);
+                }
+            }
+        }
+        else
+        {
+            for (int32_t k = 0; k < nnd; ++k)
+            {
+                try_edge(nd[k], nd[(k + 1) % nnd]);
+            }
+        }
+
+        if (2 == cuts.size())
+        {
+            segments.push_back(cuts[0]);
+            segments.push_back(cuts[1]);
+        }
+        else if (cuts.size() > 2)
+        {
+            // Close the crossing points into a loop to outline the cut face.
+            for (size_t k = 0; k < cuts.size(); ++k)
+            {
+                segments.push_back(cuts[k]);
+                segments.push_back(cuts[(k + 1) % cuts.size()]);
+            }
+        }
+    }
+
+    auto slice = std::make_unique<RSegments>(segments);
+    slice->setColor(QVector4D(0.10f, 0.10f, 0.10f, 1.0f));
+    if (slice->hasGeometry())
+    {
+        m_slice = slice.get();
+        m_scene.addDrawable(std::move(slice));
+    }
+    update();
+    return static_cast<int>(segments.size() / 2);
+}
+
+void RDomainWidget::clearFilters()
+{
+    m_scene.removeDrawable(m_clip);
+    m_scene.removeDrawable(m_slice);
+    m_clip = nullptr;
+    m_slice = nullptr;
+    update();
+}
+
 void RDomainWidget::fitCameraToScene()
 {
     m_scene.fitCameraToScene(viewportAspect());

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -161,6 +161,18 @@ public:
     /// Remove the measurement ruler.
     void clearMeasurements();
 
+    /// Clip the mesh by a plane, keeping the side the normal points away from
+    /// (the near half, toward the normal, is removed). Returns the number of
+    /// surface primitives kept.
+    int addClip(QVector3D const & origin, QVector3D const & normal);
+
+    /// Slice the mesh by a plane, drawing the cross-section outline where the
+    /// plane cuts the cells. Returns the number of segments drawn.
+    int addSlice(QVector3D const & origin, QVector3D const & normal);
+
+    /// Remove the slice and clip filters.
+    void clearFilters();
+
     // Color the mesh cells by a categorical attribute through the qualitative
     // colormap with a legend: element type, cell group, or boundary set. Each
     // replaces the field with a per-cell-colored surface; clearCellColoring
@@ -347,6 +359,8 @@ private:
     RDrawable * m_selection = nullptr; ///< Highlight of the picked entity.
     RDrawable * m_ruler = nullptr; ///< The measurement ruler segments.
     RDrawable * m_cube_axes = nullptr; ///< The bounding-box cube-axes grid.
+    RDrawable * m_clip = nullptr; ///< The clipped surface drawable.
+    RDrawable * m_slice = nullptr; ///< The slice cross-section outline.
     std::vector<float> m_ticks_x; ///< Cube-axes tick coordinates per axis.
     std::vector<float> m_ticks_y;
     std::vector<float> m_ticks_z;

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -288,6 +288,27 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                 "to p0 and p2.")
             .def("clearMeasurements", &wrapped_type::clearMeasurements)
             .def(
+                "addClip",
+                [](wrapped_type & self, py::sequence origin, py::sequence normal)
+                {
+                    return self.addClip(seq_to_vec3(origin), seq_to_vec3(normal));
+                },
+                py::arg("origin"),
+                py::arg("normal"),
+                "Clip the mesh by a plane; returns the number of surface "
+                "primitives kept.")
+            .def(
+                "addSlice",
+                [](wrapped_type & self, py::sequence origin, py::sequence normal)
+                {
+                    return self.addSlice(seq_to_vec3(origin), seq_to_vec3(normal));
+                },
+                py::arg("origin"),
+                py::arg("normal"),
+                "Slice the mesh by a plane, drawing the cross-section outline; "
+                "returns the number of segments.")
+            .def("clearFilters", &wrapped_type::clearFilters)
+            .def(
                 "colorByCellType",
                 &wrapped_type::colorByCellType,
                 "Color the mesh by the cell element type through a discrete "

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -1284,6 +1284,50 @@ class RDomainWidgetNavMapTC(unittest.TestCase):
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetFilterTC(unittest.TestCase):
+    """Geometric slice and clip of the mesh."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def test_clip_keeps_one_side(self):
+        """A plane at x=1 keeps the two cells whose centroid is left of it and
+        drops the right-hand quad."""
+        widget = pilot.RDomainWidget()
+        widget.updateMesh(_make_2d_mesh())
+        kept = widget.addClip((1.0, 0.5, 0.0), (1.0, 0.0, 0.0))
+        self.assertEqual(kept, 2)
+
+    def test_clip_without_mesh_is_zero(self):
+        """Clipping before a mesh loads keeps nothing, no crash."""
+        widget = pilot.RDomainWidget()
+        self.assertEqual(widget.addClip((0, 0, 0), (1, 0, 0)), 0)
+
+    def test_slice_2d_cuts_cells(self):
+        """A vertical plane cutting the 2D mesh draws cross-section lines."""
+        widget = pilot.RDomainWidget()
+        widget.updateMesh(_make_2d_mesh())
+        self.assertGreater(
+            widget.addSlice((0.9, 0.5, 0.0), (1.0, 0.0, 0.0)), 0)
+
+    def test_slice_3d_cuts_the_tet(self):
+        """A horizontal plane through the tetrahedron outlines the cut."""
+        widget = pilot.RDomainWidget()
+        widget.updateMesh(_make_3d_mesh())
+        self.assertGreater(
+            widget.addSlice((0.0, 0.0, 0.5), (0.0, 0.0, 1.0)), 0)
+
+    def test_clear_filters_is_harmless(self):
+        """Clearing after a slice and clip does not crash."""
+        widget = pilot.RDomainWidget()
+        widget.updateMesh(_make_2d_mesh())
+        widget.addClip((1.0, 0.5, 0.0), (1.0, 0.0, 0.0))
+        widget.addSlice((0.9, 0.5, 0.0), (1.0, 0.0, 0.0))
+        widget.clearFilters()
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class RDomainWidgetCubeAxesTC(unittest.TestCase):
     """Cube-axes grid, tick values, and the figure title."""
 


### PR DESCRIPTION
Add two geometric cuts that reveal a mesh interior without any field coloring.

addClip keeps the surface primitives (2D cells, or 3D boundary faces) whose centroid lies on one side of a plane and drops the rest, drawing the kept side as a shaded surface. addSlice cuts every cell by the plane: it intersects the plane with the cell edges (the polygon rim in 2D, every node pair in 3D) and draws the crossing points as a cross-section outline. Both re-evaluate from the plane on each call, and clearFilters removes them.

addClip and addSlice are bound to Python, taking (origin, normal) sequences and returning the kept-primitive and segment counts. Tests check that a plane keeps the expected cells, that a slice cuts the 2D mesh and the 3D tetrahedron, and that clearing is harmless.

For item 14 of issue #976.