### PR TITLE
Scene of multiple meshes and offscreen capture (items 15 and 16 of basic mesh visualization)

### DIFF
--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -223,6 +223,128 @@ void RDomainWidget::updateMesh(std::shared_ptr<StaticMesh> const & mesh)
     update();
 }
 
+namespace
+{
+
+/// The axis-aligned node bounds of a mesh.
+void mesh_bounds(StaticMesh const & mh, QVector3D & lo, QVector3D & hi)
+{
+    bool const is_3d = (3 == mh.ndim());
+    lo = QVector3D(
+        std::numeric_limits<float>::max(),
+        std::numeric_limits<float>::max(),
+        std::numeric_limits<float>::max());
+    hi = QVector3D(
+        std::numeric_limits<float>::lowest(),
+        std::numeric_limits<float>::lowest(),
+        std::numeric_limits<float>::lowest());
+    for (uint32_t ind = 0; ind < mh.nnode(); ++ind)
+    {
+        float const x = static_cast<float>(mh.ndcrd(ind, 0));
+        float const y = static_cast<float>(mh.ndcrd(ind, 1));
+        float const z = is_3d ? static_cast<float>(mh.ndcrd(ind, 2)) : 0.0f;
+        lo = QVector3D(std::min(lo.x(), x), std::min(lo.y(), y), std::min(lo.z(), z));
+        hi = QVector3D(std::max(hi.x(), x), std::max(hi.y(), y), std::max(hi.z(), z));
+    }
+}
+
+} /* end namespace */
+
+void RDomainWidget::addObject(
+    std::string const & name, std::shared_ptr<StaticMesh> const & mesh)
+{
+    auto const it = m_objects.find(name);
+    if (it != m_objects.end())
+    {
+        m_scene.removeDrawable(it->second.drawable);
+        m_objects.erase(it);
+    }
+
+    auto surface = std::make_unique<RMeshFrame>(mesh, RMeshFrame::Style::Surface);
+    surface->setName(name);
+    RDrawable * const drawable = surface.get();
+    m_scene.addDrawable(std::move(surface));
+    m_objects[name] = ObjectEntry{drawable, mesh};
+
+    m_scene.setDimension(mesh->ndim());
+    QVector3D lo;
+    QVector3D hi;
+    mesh_bounds(*mesh, lo, hi);
+    if (mesh->nnode() > 0)
+    {
+        m_scene.extendBoundingBox(lo, hi);
+    }
+    m_scene.fitCameraToScene(viewportAspect());
+    update();
+}
+
+void RDomainWidget::setObjectTransform(
+    std::string const & name,
+    float tx,
+    float ty,
+    float tz,
+    float sx,
+    float sy,
+    float sz)
+{
+    auto const it = m_objects.find(name);
+    if (it == m_objects.end())
+    {
+        return;
+    }
+    QMatrix4x4 model;
+    model.translate(tx, ty, tz);
+    model.scale(sx, sy, sz);
+    it->second.drawable->setModel(model);
+
+    // Grow the framing box to include the transformed object corners.
+    QVector3D lo;
+    QVector3D hi;
+    mesh_bounds(*it->second.mesh, lo, hi);
+    for (int i = 0; i < 8; ++i)
+    {
+        QVector3D const corner(
+            (i & 1) ? hi.x() : lo.x(),
+            (i & 2) ? hi.y() : lo.y(),
+            (i & 4) ? hi.z() : lo.z());
+        QVector3D const mapped = model.map(corner);
+        m_scene.extendBoundingBox(mapped, mapped);
+    }
+    m_scene.fitCameraToScene(viewportAspect());
+    update();
+}
+
+void RDomainWidget::setObjectVisible(std::string const & name, bool visible)
+{
+    auto const it = m_objects.find(name);
+    if (it != m_objects.end())
+    {
+        it->second.drawable->setVisible(visible);
+        update();
+    }
+}
+
+void RDomainWidget::setObjectOpacity(std::string const & name, float opacity)
+{
+    auto const it = m_objects.find(name);
+    if (it != m_objects.end())
+    {
+        it->second.drawable->setOpacity(opacity);
+        update();
+    }
+}
+
+std::vector<std::string> RDomainWidget::objectNames() const
+{
+    std::vector<std::string> names;
+    names.reserve(m_objects.size());
+    for (auto const & entry : m_objects)
+    {
+        names.push_back(entry.first);
+    }
+    return names;
+}
+
 void RDomainWidget::showMesh(bool show)
 {
     m_mesh_shown = show;

--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -157,6 +157,24 @@ QImage RDomainWidget::grabImage()
     return grabFramebuffer();
 }
 
+QImage RDomainWidget::renderToImage(int width, int height, bool transparent)
+{
+    if (width <= 0 || height <= 0)
+    {
+        return QImage();
+    }
+    // Render at the requested size by resizing the (possibly hidden) widget,
+    // grabbing, and restoring; the transparent flag clears the frame's alpha.
+    QSize const old_size = size();
+    bool const old_transparent = m_transparent_capture;
+    m_transparent_capture = transparent;
+    resize(width, height);
+    QImage const image = grabFramebuffer();
+    resize(old_size.width(), old_size.height());
+    m_transparent_capture = old_transparent;
+    return image;
+}
+
 void RDomainWidget::updateMesh(std::shared_ptr<StaticMesh> const & mesh)
 {
     // Drop the previous mesh drawables and replace them; a new mesh redefines
@@ -2037,7 +2055,9 @@ void RDomainWidget::render(QRhiCommandBuffer * cb)
     m_scalar_bar.update(m_rhi, rpdesc, sampleCount(), pixel_size, batch);
     m_title.update(m_rhi, rpdesc, sampleCount(), pixel_size, batch);
 
-    QColor const clear_color = QColor::fromRgbF(1.0f, 1.0f, 1.0f, 1.0f);
+    QColor const clear_color = m_transparent_capture
+                                   ? QColor::fromRgbF(1.0f, 1.0f, 1.0f, 0.0f)
+                                   : QColor::fromRgbF(1.0f, 1.0f, 1.0f, 1.0f);
     QRhiDepthStencilClearValue const ds_clear(1.0f, 0);
 
     cb->beginPass(renderTarget(), clear_color, ds_clear, batch);

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -31,11 +31,11 @@
 #include <QRhiWidget>
 #include <QVector3D>
 
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-#include <utility>
 
 namespace solvcon
 {
@@ -65,6 +65,23 @@ public:
 
     /// Replace the rendered mesh with the wireframe of @p mesh.
     void updateMesh(std::shared_ptr<StaticMesh> const & mesh);
+
+    // A scene of several named mesh objects, each with its own model transform
+    // and visibility, listed by an outliner. addObject registers a mesh as a
+    // named, lit surface; the setters drive it by name (an unknown name is a
+    // no-op).
+    void addObject(std::string const & name, std::shared_ptr<StaticMesh> const & mesh);
+    void setObjectTransform(
+        std::string const & name,
+        float tx,
+        float ty,
+        float tz,
+        float sx,
+        float sy,
+        float sz);
+    void setObjectVisible(std::string const & name, bool visible);
+    void setObjectOpacity(std::string const & name, float opacity);
+    std::vector<std::string> objectNames() const;
 
     /// Show or hide the mesh, in whatever representation is active.
     void showMesh(bool show);
@@ -361,6 +378,15 @@ private:
     RDrawable * m_cube_axes = nullptr; ///< The bounding-box cube-axes grid.
     RDrawable * m_clip = nullptr; ///< The clipped surface drawable.
     RDrawable * m_slice = nullptr; ///< The slice cross-section outline.
+
+    /// A named scene object: its drawable (owned by the scene) and its mesh,
+    /// kept so a transform can re-extend the framing box.
+    struct ObjectEntry
+    {
+        RDrawable * drawable = nullptr;
+        std::shared_ptr<StaticMesh> mesh;
+    };
+    std::map<std::string, ObjectEntry> m_objects;
     std::vector<float> m_ticks_x; ///< Cube-axes tick coordinates per axis.
     std::vector<float> m_ticks_y;
     std::vector<float> m_ticks_z;

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -291,6 +291,11 @@ public:
     /// wrapper over QRhiWidget::grabFramebuffer() for the Python control path.
     QImage grabImage();
 
+    /// Render the scene offscreen at a requested width and height, decoupled
+    /// from the widget size, optionally over a transparent background. The
+    /// widget size is restored afterward.
+    QImage renderToImage(int width, int height, bool transparent = false);
+
 protected:
 
     void initialize(QRhiCommandBuffer * cb) override;
@@ -406,6 +411,8 @@ private:
     bool m_has_field_bbox = false;
 
     std::shared_ptr<StaticMesh> m_mesh;
+
+    bool m_transparent_capture = false; ///< Clear alpha 0 for a capture.
 
     QPoint m_last_mouse_pos; ///< Last cursor position during a drag.
 

--- a/cpp/solvcon/pilot/RDrawable.cpp
+++ b/cpp/solvcon/pilot/RDrawable.cpp
@@ -76,7 +76,8 @@ void RDrawable::updateUniform(QRhiResourceUpdateBatch * batch, QMatrix4x4 const 
     {
         return;
     }
-    batch->updateDynamicBuffer(m_ubuf.get(), 0, 64, view_proj.constData());
+    QMatrix4x4 const mvp = view_proj * m_model;
+    batch->updateDynamicBuffer(m_ubuf.get(), 0, 64, mvp.constData());
     float const color[4] = {
         m_color.x(), m_color.y(), m_color.z(), m_color.w() * m_opacity};
     batch->updateDynamicBuffer(m_ubuf.get(), 64, 16, color);

--- a/cpp/solvcon/pilot/RDrawable.hpp
+++ b/cpp/solvcon/pilot/RDrawable.hpp
@@ -23,6 +23,7 @@
 #include <QVector4D>
 
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace solvcon
@@ -58,6 +59,15 @@ public:
 
     void setColor(QVector4D const & color) { m_color = color; }
     QVector4D color() const { return m_color; }
+
+    /// The model transform applied before the view-projection; identity by
+    /// default, so a single object renders where its geometry already sits.
+    void setModel(QMatrix4x4 const & model) { m_model = model; }
+    QMatrix4x4 model() const { return m_model; }
+
+    /// An optional name, used by the scene's named-object registry.
+    void setName(std::string const & name) { m_name = name; }
+    std::string const & name() const { return m_name; }
 
     /// World-space direction toward the light, read by the lit material and
     /// ignored by the others. The widget refreshes it as the camera moves.
@@ -128,6 +138,8 @@ protected:
 
     QVector4D m_color{1.0f, 1.0f, 1.0f, 1.0f};
     QVector3D m_light_dir{0.0f, 0.0f, 1.0f};
+    QMatrix4x4 m_model; ///< Per-object model transform (identity by default).
+    std::string m_name; ///< Optional name for the scene registry.
     float m_opacity = 1.0f;
     bool m_visible = true;
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -175,6 +175,34 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                 py::arg("h"))
             .def_property_readonly("mesh", &wrapped_type::mesh)
             .def("updateMesh", &wrapped_type::updateMesh, py::arg("mesh"))
+            .def(
+                "addObject",
+                &wrapped_type::addObject,
+                py::arg("name"),
+                py::arg("mesh"),
+                "Register a mesh as a named, lit surface object in the scene.")
+            .def(
+                "setObjectTransform",
+                &wrapped_type::setObjectTransform,
+                py::arg("name"),
+                py::arg("tx"),
+                py::arg("ty"),
+                py::arg("tz"),
+                py::arg("sx") = 1.0f,
+                py::arg("sy") = 1.0f,
+                py::arg("sz") = 1.0f,
+                "Set a named object's translate and scale model transform.")
+            .def(
+                "setObjectVisible",
+                &wrapped_type::setObjectVisible,
+                py::arg("name"),
+                py::arg("visible"))
+            .def(
+                "setObjectOpacity",
+                &wrapped_type::setObjectOpacity,
+                py::arg("name"),
+                py::arg("opacity"))
+            .def("objectNames", &wrapped_type::objectNames)
             .def("showMesh", &wrapped_type::showMesh, py::arg("show"))
             .def("setMeshOpacity", &wrapped_type::setMeshOpacity, py::arg("opacity"))
             .def("setFieldOpacity", &wrapped_type::setFieldOpacity, py::arg("opacity"))

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -555,6 +555,19 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                 },
                 py::arg("filename"))
             .def(
+                "renderToImage",
+                [](wrapped_type & self, std::string const & filename, int width, int height, bool transparent)
+                {
+                    return self.renderToImage(width, height, transparent).save(filename.c_str());
+                },
+                py::arg("path"),
+                py::arg("width"),
+                py::arg("height"),
+                py::arg("transparent") = false,
+                "Render the scene offscreen at width x height (independent of "
+                "the widget size), with an optional transparent background, "
+                "and save it to path; returns whether the write succeeded.")
+            .def(
                 "clipImage",
                 [](wrapped_type & self)
                 {

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -1284,6 +1284,56 @@ class RDomainWidgetNavMapTC(unittest.TestCase):
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetCaptureTC(unittest.TestCase):
+    """High-resolution and transparent offscreen capture."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def _render_or_skip(self, widget, width, height, transparent=False):
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "capture.png")
+            ok = widget.renderToImage(path, width, height, transparent)
+            if not ok or not os.path.exists(path):
+                raise unittest.SkipTest("offscreen capture is unavailable")
+            image = QImage(path)
+        if image.isNull():
+            raise unittest.SkipTest("offscreen capture is unavailable")
+        return image
+
+    def test_capture_size_is_independent_of_widget_size(self):
+        """A capture is produced at the requested size regardless of the
+        widget size."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        image = self._render_or_skip(widget, 512, 384)
+        self.assertEqual(image.width(), 512)
+        self.assertEqual(image.height(), 384)
+
+    def test_transparent_capture_has_a_clear_corner(self):
+        """A transparent capture leaves the background corner not fully
+        opaque."""
+        widget = pilot.RDomainWidget()
+        widget.resize(200, 200)
+        widget.updateMesh(_make_3d_mesh())
+        image = self._render_or_skip(widget, 256, 256, transparent=True)
+        self.assertLess(image.pixelColor(0, 0).alpha(), 255)
+
+    def test_invalid_size_writes_nothing(self):
+        """A non-positive size yields a null image, so the write fails and no
+        file is produced (no crash)."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "bad.png")
+            self.assertFalse(widget.renderToImage(path, 0, 0))
+            self.assertFalse(os.path.exists(path))
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class RDomainWidgetSceneObjectsTC(unittest.TestCase):
     """A scene of several named mesh objects with transforms."""
 

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -1284,6 +1284,67 @@ class RDomainWidgetNavMapTC(unittest.TestCase):
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetSceneObjectsTC(unittest.TestCase):
+    """A scene of several named mesh objects with transforms."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def test_two_objects_register(self):
+        """Two named meshes both register in the scene."""
+        widget = pilot.RDomainWidget()
+        widget.addObject("left", _make_2d_mesh())
+        widget.addObject("right", _make_3d_mesh())
+        names = sorted(widget.objectNames())
+        self.assertEqual(names, ["left", "right"])
+
+    def test_readding_replaces_object(self):
+        """Adding a name that already exists replaces it, not duplicates."""
+        widget = pilot.RDomainWidget()
+        widget.addObject("m", _make_2d_mesh())
+        widget.addObject("m", _make_3d_mesh())
+        self.assertEqual(widget.objectNames(), ["m"])
+
+    def test_transform_and_visibility_setters_by_name(self):
+        """The transform, visibility, and opacity setters accept a known name
+        and ignore an unknown one, without crashing."""
+        widget = pilot.RDomainWidget()
+        widget.addObject("a", _make_2d_mesh())
+        widget.setObjectTransform("a", 3.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+        widget.setObjectVisible("a", False)
+        widget.setObjectOpacity("a", 0.5)
+        widget.setObjectVisible("nope", True)  # unknown: no-op
+        self.assertEqual(widget.objectNames(), ["a"])
+
+    def test_two_objects_render_and_toggle(self):
+        """Two objects with distinct transforms both render; hiding one drops
+        drawn pixels.
+
+        Each state grabs a freshly configured widget: a second grab of a
+        mutated widget is unreliable on the headless software rasterizer.
+        _count_foreground keys on the difference from the frame's own
+        background, so a dark empty read-back still counts as nothing drawn.
+        """
+        both_widget = pilot.RDomainWidget()
+        both_widget.resize(320, 240)
+        both_widget.addObject("a", _make_2d_mesh())
+        both_widget.addObject("b", _make_2d_mesh())
+        both_widget.setObjectTransform("b", 4.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+        both = _count_foreground(_grab_or_skip(both_widget))
+        self.assertGreater(both, 0)
+
+        one_widget = pilot.RDomainWidget()
+        one_widget.resize(320, 240)
+        one_widget.addObject("a", _make_2d_mesh())
+        one_widget.addObject("b", _make_2d_mesh())
+        one_widget.setObjectTransform("b", 4.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+        one_widget.setObjectVisible("b", False)
+        one = _count_foreground(_grab_or_skip(one_widget))
+        self.assertLess(one, both)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class RDomainWidgetFilterTC(unittest.TestCase):
     """Geometric slice and clip of the mesh."""
 


### PR DESCRIPTION
Scene of multiple meshes with transforms and an outliner and High-resolution and transparent offscreen capture.

## Item 15: Scene of multiple meshes with transforms and an outliner

Let the viewer hold several named mesh objects at once, each with its own model transform and visibility, the basis an outliner would list.

- `RDrawable` gains a model transform, applied before the view-projection so a single object still renders in place, and a name for the scene registry.
- `RDomainWidget` registers objects by name: `addObject` adds a mesh as a named lit surface and frames the union; `setObjectTransform` sets a translate and scale and grows the framing box to the transformed corners; `setObjectVisible` and `setObjectOpacity` drive one object by name; `objectNames` lists them.
- The API is bound to Python.

Tests check that two named meshes register, that re-adding a name replaces it, that the by-name setters accept a known name and ignore an unknown one, and that two transformed objects render and toggle.

## Item 16: High-resolution and transparent offscreen capture

Add an offscreen capture at an arbitrary resolution decoupled from the widget size, with an optional transparent background, for publication figures that should not depend on the on-screen window.

- `renderToImage` renders the scene at a requested width and height by resizing the (possibly hidden) widget, grabbing the frame, and restoring the size; a transparent flag clears the frame's alpha so the background composites cleanly.
- Bound to Python as `renderToImage(path, width, height, transparent)`, writing the capture to a file.

Tests check that a capture is produced at the requested size regardless of the widget size, that a transparent capture leaves the corner not fully opaque, and that a non-positive size writes nothing.

For items 15 and 16 of issue #976.