### PR TITLE
Drive the menu bar from the model (steps 3, 4, 5 of menu model)

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -5,6 +5,7 @@
 
 #include <solvcon/pilot/RManager.hpp> // Must be the first include.
 
+#include <functional>
 #include <stdexcept>
 #include <vector>
 
@@ -16,6 +17,7 @@
 #include <QMenu>
 #include <QAction>
 #include <QActionGroup>
+#include <QKeySequence>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -110,6 +112,17 @@ RDomainWidget * RManager::add3DWidget()
         layout->setContentsMargins(0, 0, 0, 0);
         viewer = new RDomainWidget(/*parent*/ host);
         layout->addWidget(viewer);
+        // Associate the Escape reset shortcut with this viewer; a
+        // Qt::WidgetShortcut fires only while a widget it was added to has
+        // focus. The hidden RHI primer is created elsewhere and never reaches
+        // here, so it stays unbound.
+        if (m_menuModel)
+        {
+            if (QAction * reset = m_menuModel->action("camera.reset"))
+            {
+                viewer->addAction(reset);
+            }
+        }
         auto * subwin = this->addSubWindow(host);
         subwin->resize(400, 300);
     }
@@ -359,127 +372,98 @@ void RManager::setUpCameraControllersMenuItems() const
         }
     };
 
-    auto * use_pan_camera = new RAction(
-        QString("Pan / zoom camera (2D)"),
-        QString("Pan and zoom the domain in the plane"),
-        [set_mode]()
-        { set_mode("pan"); });
+    struct CameraMode
+    {
+        char const * id;
+        QString text;
+        QString tip;
+        std::string mode;
+    };
+    std::vector<CameraMode> const modes = {
+        {"camera.mode_orbit", QString("Orbit camera (3D)"), QString("Orbit the domain around its center"), "orbit"},
+        {"camera.mode_fps", QString("First-person camera (3D)"), QString("Fly through the domain in first person"), "fps"},
+        {"camera.mode_pan", QString("Pan / zoom camera (2D)"), QString("Pan and zoom the domain in the plane"), "pan"},
+    };
 
-    auto * use_fps_camera = new RAction(
-        QString("First-person camera (3D)"),
-        QString("Fly through the domain in first person"),
-        [set_mode]()
-        { set_mode("fps"); });
-
-    auto * use_orbit_camera = new RAction(
-        QString("Orbit camera (3D)"),
-        QString("Orbit the domain around its center"),
-        [set_mode]()
-        { set_mode("orbit"); });
-
-    auto * cameraGroup = new QActionGroup(m_mainWindow);
-    cameraGroup->addAction(use_orbit_camera);
-    cameraGroup->addAction(use_fps_camera);
-    cameraGroup->addAction(use_pan_camera);
-
-    use_orbit_camera->setCheckable(true);
-    use_fps_camera->setCheckable(true);
-    use_pan_camera->setCheckable(true);
-    use_orbit_camera->setChecked(true);
-
-    auto * cameraMenu = m_viewMenu->addMenu(QString("Camera"));
-    cameraMenu->addAction(use_orbit_camera);
-    cameraMenu->addAction(use_fps_camera);
-    cameraMenu->addAction(use_pan_camera);
+    // The group owns the exclusive mode, held by the model under a group id
+    // so Python can query the checked action.
+    auto * cameraGroup = m_menuModel->group("camera.mode");
+    int weight = 10;
+    for (auto const & item : modes)
+    {
+        auto * action = new RAction(
+            item.text, item.tip, [set_mode, mode = item.mode]()
+            { set_mode(mode); },
+            m_menuModel);
+        action->setObjectName(item.id);
+        action->setCheckable(true);
+        cameraGroup->addAction(action);
+        m_menuModel->place("View/Camera", action, weight);
+        weight += 10;
+    }
+    if (QAction * orbit = m_menuModel->action("camera.mode_orbit"))
+    {
+        orbit->setChecked(true);
+    }
 }
 
 void RManager::setUpCameraMovementMenuItems() const
 {
-    constexpr float pan_step = 40.0f;
-    constexpr float rotate_step = 30.0f;
-    constexpr float zoom_step = 1.0f;
+    static constexpr float pan_step = 40.0f;
+    static constexpr float rotate_step = 30.0f;
+    static constexpr float zoom_step = 1.0f;
 
-    auto * reset_camera = new RAction(
-        QString("Reset (esc)"),
-        QString("Reset (esc)"),
-        createCameraMovementItemHandler([](RDomainWidget * viewer)
-                                        { viewer->fitCameraToScene(); }));
+    struct CameraMove
+    {
+        char const * id;
+        QString text;
+        std::function<void(RDomainWidget *)> act;
+    };
+    // The keyboard hints the labels used to carry were wrong: those keys are
+    // handled in RDomainWidget::keyPressEvent with different behavior, so they
+    // are dropped here rather than advertised.
+    std::vector<CameraMove> const moves = {
+        {"camera.reset", QString("Reset camera"), [](RDomainWidget * v)
+         { v->fitCameraToScene(); }},
+        {"camera.move_up", QString("Move camera up"), [](RDomainWidget * v)
+         { v->panCamera(0.0f, pan_step); }},
+        {"camera.move_down", QString("Move camera down"), [](RDomainWidget * v)
+         { v->panCamera(0.0f, -pan_step); }},
+        {"camera.move_right", QString("Move camera right"), [](RDomainWidget * v)
+         { v->panCamera(-pan_step, 0.0f); }},
+        {"camera.move_left", QString("Move camera left"), [](RDomainWidget * v)
+         { v->panCamera(pan_step, 0.0f); }},
+        {"camera.move_forward", QString("Move camera forward"), [](RDomainWidget * v)
+         { v->zoomCamera(zoom_step); }},
+        {"camera.move_backward", QString("Move camera backward"), [](RDomainWidget * v)
+         { v->zoomCamera(-zoom_step); }},
+        {"camera.yaw_positive", QString("Rotate camera positive yaw"), [](RDomainWidget * v)
+         { v->rotateCamera(rotate_step, 0.0f); }},
+        {"camera.yaw_negative", QString("Rotate camera negative yaw"), [](RDomainWidget * v)
+         { v->rotateCamera(-rotate_step, 0.0f); }},
+        {"camera.pitch_positive", QString("Rotate camera positive pitch"), [](RDomainWidget * v)
+         { v->rotateCamera(0.0f, rotate_step); }},
+        {"camera.pitch_negative", QString("Rotate camera negative pitch"), [](RDomainWidget * v)
+         { v->rotateCamera(0.0f, -rotate_step); }},
+    };
 
-    auto * move_camera_up = new RAction(
-        QString("Move camera up (W/UP)"),
-        QString("Move camera up (W/UP)"),
-        createCameraMovementItemHandler([](RDomainWidget * viewer)
-                                        { viewer->panCamera(0.0f, pan_step); }));
+    int weight = 10;
+    for (auto const & item : moves)
+    {
+        auto * action = new RAction(
+            item.text, item.text, createCameraMovementItemHandler(item.act), m_menuModel);
+        action->setObjectName(item.id);
+        m_menuModel->place("View/Camera move", action, weight);
+        weight += 10;
+    }
 
-    auto * move_camera_down = new RAction(
-        QString("Move camera down (S/DOWN)"),
-        QString("Move camera down (S/DOWN)"),
-        createCameraMovementItemHandler([](RDomainWidget * viewer)
-                                        { viewer->panCamera(0.0f, -pan_step); }));
-
-    auto * move_camera_right = new RAction(
-        QString("Move camera right (D/RIGHT)"),
-        QString("Move camera right (D/RIGHT)"),
-        createCameraMovementItemHandler([](RDomainWidget * viewer)
-                                        { viewer->panCamera(-pan_step, 0.0f); }));
-
-    auto * move_camera_left = new RAction(
-        QString("Move camera left (A/LEFT)"),
-        QString("Move camera left (A/LEFT)"),
-        createCameraMovementItemHandler([](RDomainWidget * viewer)
-                                        { viewer->panCamera(pan_step, 0.0f); }));
-
-    auto * move_camera_forward = new RAction(
-        QString("Move camera forward (Ctrl+W/UP)"),
-        QString("Move camera forward (Ctrl+W/UP)"),
-        createCameraMovementItemHandler([](RDomainWidget * viewer)
-                                        { viewer->zoomCamera(zoom_step); }));
-
-    auto * move_camera_backward = new RAction(
-        QString("Move camera backward (Ctrl+S/DOWN)"),
-        QString("Move camera backward (Ctrl+S/DOWN)"),
-        createCameraMovementItemHandler([](RDomainWidget * viewer)
-                                        { viewer->zoomCamera(-zoom_step); }));
-
-    auto * rotate_camera_positive_yaw = new RAction(
-        QString("Rotate camera positive yaw"),
-        QString("Rotate camera positive yaw"),
-        createCameraMovementItemHandler([](RDomainWidget * viewer)
-                                        { viewer->rotateCamera(rotate_step, 0.0f); }));
-
-    auto * rotate_camera_negative_yaw = new RAction(
-        QString("Rotate camera negative yaw"),
-        QString("Rotate camera negative yaw"),
-        createCameraMovementItemHandler([](RDomainWidget * viewer)
-                                        { viewer->rotateCamera(-rotate_step, 0.0f); }));
-
-    auto * rotate_camera_positive_pitch = new RAction(
-        QString("Rotate camera positive pitch"),
-        QString("Rotate camera positive pitch"),
-        createCameraMovementItemHandler([](RDomainWidget * viewer)
-                                        { viewer->rotateCamera(0.0f, rotate_step); }));
-
-    auto * rotate_camera_negative_pitch = new RAction(
-        QString("Rotate camera negative pitch"),
-        QString("Rotate camera negative pitch"),
-        createCameraMovementItemHandler([](RDomainWidget * viewer)
-                                        { viewer->rotateCamera(0.0f, -rotate_step); }));
-
-    reset_camera->setShortcut(QKeySequence(Qt::Key_Escape));
-    reset_camera->setShortcutContext(Qt::WidgetShortcut);
-
-    auto cameraMoveSubmenu = m_viewMenu->addMenu("Camera move");
-    cameraMoveSubmenu->addAction(reset_camera);
-    cameraMoveSubmenu->addAction(move_camera_up);
-    cameraMoveSubmenu->addAction(move_camera_down);
-    cameraMoveSubmenu->addAction(move_camera_right);
-    cameraMoveSubmenu->addAction(move_camera_left);
-    cameraMoveSubmenu->addAction(move_camera_forward);
-    cameraMoveSubmenu->addAction(move_camera_backward);
-    cameraMoveSubmenu->addAction(rotate_camera_positive_yaw);
-    cameraMoveSubmenu->addAction(rotate_camera_negative_yaw);
-    cameraMoveSubmenu->addAction(rotate_camera_positive_pitch);
-    cameraMoveSubmenu->addAction(rotate_camera_negative_pitch);
+    // Escape resets the camera; add3DWidget attaches this action to each
+    // viewer so its Qt::WidgetShortcut context can fire.
+    if (QAction * reset = m_menuModel->action("camera.reset"))
+    {
+        reset->setShortcut(QKeySequence(Qt::Key_Escape));
+        reset->setShortcutContext(Qt::WidgetShortcut);
+    }
 }
 
 std::function<void()> RManager::createCameraMovementItemHandler(const std::function<void(RDomainWidget *)> & func) const

--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -299,44 +299,51 @@ void RManager::setUpMenu()
     // NOTE: All menus need to be populated or Windows may crash with
     // "exited with code -1073740791".  The reason is not yet clarified.
 
-    // The live menu model shares the same bar; consumers migrate onto it in
-    // later steps. Parent it to the main window so the widget tree owns it.
+    // Parent the model to the main window so the widget tree owns it.
     m_menuModel = new RMenuModel(m_mainWindow, m_mainWindow);
 
-    m_fileMenu = m_mainWindow->menuBar()->addMenu(QString("File"));
-    m_editMenu = m_mainWindow->menuBar()->addMenu(QString("Edit"));
+    // Seed the bar from one weighted table, the single source of truth for
+    // its order. The weight bands leave room to slot a menu between two
+    // others without renumbering. The members hold the model's menus until
+    // the getters become adapters over the model.
+    m_fileMenu = m_menuModel->menu("File", 0);
+    m_editMenu = m_menuModel->menu("Edit", 10);
+    m_viewMenu = m_menuModel->menu("View", 20);
+    m_oneMenu = m_menuModel->menu("One", 30);
+    m_meshMenu = m_menuModel->menu("Mesh", 40);
+    m_canvasMenu = m_menuModel->menu("Canvas", 50);
+    m_profilingMenu = m_menuModel->menu("Profiling", 60);
+    m_windowMenu = m_menuModel->menu("Window", 70);
+
     setUpEditMenuItems();
-    m_viewMenu = m_mainWindow->menuBar()->addMenu(QString("View"));
-    {
-        // Code for controlling camera is not exposed to Python yet
-        setUpCameraControllersMenuItems();
-        setUpCameraMovementMenuItems();
-    }
-    m_oneMenu = m_mainWindow->menuBar()->addMenu(QString("One"));
-    m_meshMenu = m_mainWindow->menuBar()->addMenu(QString("Mesh"));
-    m_canvasMenu = m_mainWindow->menuBar()->addMenu(QString("Canvas"));
-    m_profilingMenu = m_mainWindow->menuBar()->addMenu(QString("Profiling"));
-    m_windowMenu = m_mainWindow->menuBar()->addMenu(QString("Window"));
+    // Code for controlling camera is not exposed to Python yet.
+    setUpCameraControllersMenuItems();
+    setUpCameraMovementMenuItems();
 }
 
 void RManager::setUpEditMenuItems() const
 {
+    // Parent the actions to the model so they die with it instead of leaking.
     auto * undo_action = new RAction(
         QString("Undo"),
         QString("Undo the last change on the focused 2D canvas"),
         [this]()
-        { undoCanvas(); });
+        { undoCanvas(); },
+        m_menuModel);
+    undo_action->setObjectName("edit.undo");
     undo_action->setShortcut(QKeySequence::Undo);
 
     auto * redo_action = new RAction(
         QString("Redo"),
         QString("Redo the last undone change on the focused 2D canvas"),
         [this]()
-        { redoCanvas(); });
+        { redoCanvas(); },
+        m_menuModel);
+    redo_action->setObjectName("edit.redo");
     redo_action->setShortcut(QKeySequence::Redo);
 
-    m_editMenu->addAction(undo_action);
-    m_editMenu->addAction(redo_action);
+    m_menuModel->place("Edit", undo_action, 10);
+    m_menuModel->place("Edit", redo_action, 20);
 }
 
 void RManager::setUpCameraControllersMenuItems() const

--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -9,15 +9,13 @@ Graphical-user interface code
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
 
 
-import sys
-import importlib
-
 from . import _pilot_core as _pcore
 from . import airfoil
 
 if _pcore.enable:
     from PySide6.QtGui import QAction
     from PySide6.QtWidgets import QMenu
+    from . import _gui_common
     from . import _mesh
     from . import _mesh_info
     from . import _oblique
@@ -125,21 +123,6 @@ class _Controller(metaclass=_Singleton):
     def populate_menu(self):
         wm = self._rmgr
 
-        def _addAction(menu, text, tip, func, checkable=False, checked=False):
-            act = QAction(text, wm.mainWindow)
-            act.setStatusTip(tip)
-            act.setCheckable(checkable)
-            if checkable:
-                act.setChecked(checked)
-            if callable(func):
-                act.triggered.connect(lambda *a: func())
-            elif func:
-                modname, funcname = func.rsplit('.', maxsplit=1)
-                mod = importlib.import_module(modname)
-                func = getattr(mod, funcname)
-                act.triggered.connect(lambda *a: func())
-            menu.addAction(act)
-
         self.gmsh_dialog.populate_menu()
         self.svg_dialog.populate_menu()
         self.mesh_info.populate_menu()
@@ -154,22 +137,22 @@ class _Controller(metaclass=_Singleton):
         self.openprofiledata.populate_menu()
         self.runprofiling.populate_menu()
 
-        if sys.platform != 'darwin':
-            _addAction(
-                menu=wm.fileMenu,
-                text="Exit",
-                tip="Exit the application",
-                func=lambda: wm.quit(),
-            )
-
-        _addAction(
-            menu=wm.windowMenu,
-            text="Console",
-            tip="Open / Close Console",
-            func=wm.toggleConsole,
-            checkable=True,
-            checked=True,
-        )
+        # An explicit QuitRole lets macOS relocate Exit into the application
+        # menu, so no platform special case is needed.
+        wm.menu_model.place(
+            "File",
+            _gui_common.build_action(
+                wm.mainWindow, "Exit", "Exit the application",
+                lambda: wm.quit(), id="file.exit",
+                menu_role=QAction.MenuRole.QuitRole),
+            100)
+        wm.menu_model.place(
+            "Window",
+            _gui_common.build_action(
+                wm.mainWindow, "Console", "Open / Close Console",
+                wm.toggleConsole, id="window.console",
+                checkable=True, checked=True),
+            50)
 
 
 controller = _Controller()

--- a/solvcon/pilot/_gui_common.py
+++ b/solvcon/pilot/_gui_common.py
@@ -6,6 +6,31 @@ from . import _pilot_core as _pcore
 from PySide6 import QtCore, QtGui
 
 
+def build_action(parent, text, tip, func, *, id=None, checkable=False,
+                 checked=False, shortcut=None, menu_role=None):
+    """Build a QAction from one description, the single item builder.
+
+    The id becomes the action's objectName (its handle in the menu model and
+    in tests). A checkable action carries its initial check state; ``func``,
+    when given, runs on trigger. A checkable feature that needs the toggled
+    state wires ``toggled`` on the returned action itself.
+    """
+    act = QtGui.QAction(text, parent)
+    if id:
+        act.setObjectName(id)
+    act.setStatusTip(tip)
+    if shortcut is not None:
+        act.setShortcut(shortcut)
+    if menu_role is not None:
+        act.setMenuRole(menu_role)
+    if checkable:
+        act.setCheckable(True)
+        act.setChecked(checked)
+    if func is not None:
+        act.triggered.connect(lambda *a: func())
+    return act
+
+
 class PilotFeature(QtCore.QObject):
     """
     Base class to house common GUI code for prototyping pilot features.
@@ -41,6 +66,21 @@ class PilotFeature(QtCore.QObject):
         """
         return self._mgr.mainWindow
 
+    def add_action(self, path, text, tip, func, *, id, weight=50,
+                   checkable=False, checked=False, shortcut=None,
+                   menu_role=None):
+        """Build an action and place it in the menu at ``path`` by ``weight``.
+
+        This is the one Python item builder over the shared placement: it
+        returns the live action so a toggle feature can wire its own reverse
+        connections.
+        """
+        act = build_action(self._mainWindow, text, tip, func, id=id,
+                           checkable=checkable, checked=checked,
+                           shortcut=shortcut, menu_role=menu_role)
+        self._mgr.menu_model.place(path, act, weight)
+        return act
+
     def _add_menu_item(self, menu, text, tip, func):
         """
         Add an item to the corresponding menu.
@@ -53,10 +93,7 @@ class PilotFeature(QtCore.QObject):
 
         :return: None
         """
-        act = QtGui.QAction(text, self._mainWindow)
-        act.setStatusTip(tip)
-        act.triggered.connect(func)
-        menu.addAction(act)
+        menu.addAction(build_action(self._mainWindow, text, tip, func))
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_camera_menu.py
+++ b/tests/test_pilot_camera_menu.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from PySide6 import QtWidgets
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class CameraMenuTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.model = self.mgr.menu_model
+
+    def test_camera_move_items_are_data(self):
+        items = [a.text()
+                 for a in self.model.menu("View/Camera move").actions()]
+        self.assertEqual(items[0], "Reset camera")
+        self.assertEqual(len(items), 11)
+        # The false "(key)" hints are gone from every label.
+        for text in items:
+            self.assertNotIn("(", text)
+
+    def test_reset_carries_the_escape_shortcut(self):
+        reset = self.model.action("camera.reset")
+        self.assertIsNotNone(reset)
+        self.assertEqual(reset.shortcut().toString(), "Esc")
+
+    def test_camera_mode_group_is_exclusive_and_defaults_to_orbit(self):
+        group = self.model.group("camera.mode")
+        self.assertEqual(len(group.actions()), 3)
+        self.assertTrue(group.isExclusive())
+        checked = group.checkedAction()
+        self.assertIsNotNone(checked)
+        self.assertEqual(checked.objectName(), "camera.mode_orbit")
+
+    def test_reset_attaches_to_each_new_viewer(self):
+        reset = self.model.action("camera.reset")
+        before = len(reset.associatedObjects())
+        viewer = self.mgr.add3DWidget()
+        self.assertIsNotNone(viewer)
+        after = reset.associatedObjects()
+        # The new viewer joins the reset action so its widget-context shortcut
+        # can fire; without this association the Escape binding stays inert.
+        self.assertEqual(len(after), before + 1)
+        self.assertIsInstance(after[-1], QtWidgets.QWidget)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_menu_model.py
+++ b/tests/test_pilot_menu_model.py
@@ -3,6 +3,7 @@
 
 
 import os
+import itertools
 import unittest
 
 import solvcon
@@ -15,6 +16,11 @@ except ImportError:
 
 GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
 
+# A fresh tag per test keeps each test's menus and ids from colliding on the
+# shared RManager singleton, whose menu model now owns the real bar; clearing
+# the model would delete the built-in menus other tests rely on.
+_TAG = itertools.count()
+
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
                  "GUI is not available in GitHub Actions")
@@ -22,9 +28,7 @@ class MenuModelTC(unittest.TestCase):
     def setUp(self):
         self.mgr = pilot.RManager.instance.setUp()
         self.model = self.mgr.menu_model
-        # The model persists on the singleton across tests; start each test
-        # from a bar holding only the built-in menus.
-        self.model.clear()
+        self.tag = "m%d_" % next(_TAG)
 
     def _top_level(self):
         return [a.text() for a in self.mgr.mainWindow.menuBar().actions()]
@@ -32,61 +36,60 @@ class MenuModelTC(unittest.TestCase):
     def _children(self, menu):
         return [a.text() for a in menu.actions()]
 
+    def _mine(self, *names):
+        wanted = {self.tag + n for n in names}
+        return [t for t in self._top_level() if t in wanted]
+
     def test_menu_creates_top_level_node(self):
-        menu = self.model.menu("Alpha")
-        self.assertEqual(menu.title(), "Alpha")
-        self.assertIn("Alpha", self._top_level())
+        menu = self.model.menu(self.tag + "Alpha")
+        self.assertEqual(menu.title(), self.tag + "Alpha")
+        self.assertIn(self.tag + "Alpha", self._top_level())
 
     def test_menu_is_idempotent(self):
-        first = self.model.menu("Alpha")
-        second = self.model.menu("Alpha")
+        first = self.model.menu(self.tag + "Alpha")
+        second = self.model.menu(self.tag + "Alpha")
         # The same path resolves to the same menu, not a duplicate on the bar.
         self.assertEqual(first, second)
-        self.assertEqual(self._top_level().count("Alpha"), 1)
+        self.assertEqual(self._top_level().count(self.tag + "Alpha"), 1)
 
     def test_menu_creates_ancestors_on_demand(self):
-        leaf = self.model.menu("Beta/Gamma")
+        leaf = self.model.menu(self.tag + "Beta/Gamma")
         self.assertEqual(leaf.title(), "Gamma")
-        self.assertIn("Beta", self._top_level())
-        parent = self.model.menu("Beta")
+        self.assertIn(self.tag + "Beta", self._top_level())
+        parent = self.model.menu(self.tag + "Beta")
         self.assertIn("Gamma", self._children(parent))
 
     def test_node_weight_orders_the_bar(self):
         # Declare out of order; the weights, not arrival, fix the bar order.
-        self.model.menu("Later", weight=40)
-        self.model.menu("Early", weight=10)
-        self.model.menu("Middle", weight=25)
-        top = [t for t in self._top_level() if t in ("Early", "Middle",
-                                                     "Later")]
-        self.assertEqual(top, ["Early", "Middle", "Later"])
+        self.model.menu(self.tag + "Later", weight=40)
+        self.model.menu(self.tag + "Early", weight=10)
+        self.model.menu(self.tag + "Middle", weight=25)
+        self.assertEqual(self._mine("Later", "Early", "Middle"),
+                         [self.tag + "Early", self.tag + "Middle",
+                          self.tag + "Later"])
 
     def test_equal_weight_keeps_arrival_order(self):
-        self.model.menu("Uno", weight=10)
-        self.model.menu("Dos", weight=10)
-        self.model.menu("Tres", weight=10)
-        top = [t for t in self._top_level() if t in ("Uno", "Dos", "Tres")]
-        self.assertEqual(top, ["Uno", "Dos", "Tres"])
+        self.model.menu(self.tag + "Uno", weight=10)
+        self.model.menu(self.tag + "Dos", weight=10)
+        self.model.menu(self.tag + "Tres", weight=10)
+        self.assertEqual(self._mine("Uno", "Dos", "Tres"),
+                         [self.tag + "Uno", self.tag + "Dos",
+                          self.tag + "Tres"])
 
     def test_submenu_weight_orders_children(self):
-        self.model.menu("Root", weight=90)
-        self.model.menu("Root/Second", weight=20)
-        self.model.menu("Root/First", weight=10)
-        parent = self.model.menu("Root")
+        self.model.menu(self.tag + "Root", weight=90)
+        self.model.menu(self.tag + "Root/Second", weight=20)
+        self.model.menu(self.tag + "Root/First", weight=10)
+        parent = self.model.menu(self.tag + "Root")
         self.assertEqual(self._children(parent), ["First", "Second"])
 
     def test_reweight_moves_an_existing_node(self):
-        self.model.menu("A", weight=10)
-        self.model.menu("B", weight=20)
+        self.model.menu(self.tag + "A", weight=10)
+        self.model.menu(self.tag + "B", weight=20)
         # Re-declaring with a larger weight repositions the same node.
-        self.model.menu("A", weight=30)
-        top = [t for t in self._top_level() if t in ("A", "B")]
-        self.assertEqual(top, ["B", "A"])
-
-    def test_clear_removes_model_menus(self):
-        self.model.menu("Temp")
-        self.assertIn("Temp", self._top_level())
-        self.model.clear()
-        self.assertNotIn("Temp", self._top_level())
+        self.model.menu(self.tag + "A", weight=30)
+        self.assertEqual(self._mine("A", "B"),
+                         [self.tag + "B", self.tag + "A"])
 
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
@@ -95,7 +98,8 @@ class MenuPlacementTC(unittest.TestCase):
     def setUp(self):
         self.mgr = pilot.RManager.instance.setUp()
         self.model = self.mgr.menu_model
-        self.model.clear()
+        self.tag = "p%d_" % next(_TAG)
+        self.box = self.tag + "Box"
 
     def _act(self, text, oid):
         act = QtGui.QAction(text, self.mgr.mainWindow)
@@ -106,53 +110,55 @@ class MenuPlacementTC(unittest.TestCase):
         return [a.text() for a in self.model.menu(path).actions()]
 
     def test_place_orders_items_by_weight(self):
-        self.model.place("Box", self._act("Later", "b.later"), weight=40)
-        self.model.place("Box", self._act("Early", "b.early"), weight=10)
-        self.model.place("Box", self._act("Middle", "b.middle"), weight=25)
-        self.assertEqual(self._items("Box"), ["Early", "Middle", "Later"])
+        self.model.place(self.box, self._act("Later", "b.later"), weight=40)
+        self.model.place(self.box, self._act("Early", "b.early"), weight=10)
+        self.model.place(self.box, self._act("Middle", "b.middle"), weight=25)
+        self.assertEqual(self._items(self.box), ["Early", "Middle", "Later"])
 
     def test_place_equal_weight_keeps_arrival_order(self):
-        self.model.place("Box", self._act("First", "b.1"), weight=10)
-        self.model.place("Box", self._act("Second", "b.2"), weight=10)
-        self.model.place("Box", self._act("Third", "b.3"), weight=10)
-        self.assertEqual(self._items("Box"), ["First", "Second", "Third"])
+        self.model.place(self.box, self._act("First", "b.1"), weight=10)
+        self.model.place(self.box, self._act("Second", "b.2"), weight=10)
+        self.model.place(self.box, self._act("Third", "b.3"), weight=10)
+        self.assertEqual(self._items(self.box), ["First", "Second", "Third"])
 
     def test_items_and_submenu_interleave_by_weight(self):
-        self.model.place("Box", self._act("Top", "b.top"), weight=5)
-        self.model.menu("Box/Sub", weight=10)
-        self.model.place("Box", self._act("Bottom", "b.bottom"), weight=20)
-        self.assertEqual(self._items("Box"), ["Top", "Sub", "Bottom"])
+        self.model.place(self.box, self._act("Top", "b.top"), weight=5)
+        self.model.menu(self.box + "/Sub", weight=10)
+        self.model.place(self.box, self._act("Bottom", "b.bottom"), weight=20)
+        self.assertEqual(self._items(self.box), ["Top", "Sub", "Bottom"])
 
     def test_action_id_round_trip(self):
-        act = self._act("Named", "box.named")
-        self.model.place("Box", act, weight=10)
-        self.assertEqual(self.model.action("box.named"), act)
-        self.assertIsNone(self.model.action("box.missing"))
+        act = self._act("Named", self.tag + "named")
+        self.model.place(self.box, act, weight=10)
+        self.assertEqual(self.model.action(self.tag + "named"), act)
+        self.assertIsNone(self.model.action(self.tag + "missing"))
 
     def test_remove_takes_item_out(self):
-        self.model.place("Box", self._act("Gone", "box.gone"), weight=10)
-        self.assertIn("Gone", self._items("Box"))
-        self.model.remove("box.gone")
-        self.assertIsNone(self.model.action("box.gone"))
-        self.assertNotIn("Gone", self._items("Box"))
+        self.model.place(self.box, self._act("Gone", self.tag + "gone"),
+                         weight=10)
+        self.assertIn("Gone", self._items(self.box))
+        self.model.remove(self.tag + "gone")
+        self.assertIsNone(self.model.action(self.tag + "gone"))
+        self.assertNotIn("Gone", self._items(self.box))
 
     def test_remove_finds_item_in_a_submenu(self):
-        self.model.place("Box/Sub", self._act("Deep", "box.deep"), weight=10)
-        self.assertIn("Deep", self._items("Box/Sub"))
-        self.model.remove("box.deep")
-        self.assertNotIn("Deep", self._items("Box/Sub"))
+        self.model.place(self.box + "/Sub",
+                         self._act("Deep", self.tag + "deep"), weight=10)
+        self.assertIn("Deep", self._items(self.box + "/Sub"))
+        self.model.remove(self.tag + "deep")
+        self.assertNotIn("Deep", self._items(self.box + "/Sub"))
 
     def test_place_separator(self):
-        self.model.place("Box", self._act("A", "box.a"), weight=10)
-        self.model.place_separator("Box", weight=15)
-        self.model.place("Box", self._act("B", "box.b"), weight=20)
-        actions = self.model.menu("Box").actions()
+        self.model.place(self.box, self._act("A", "box.a"), weight=10)
+        self.model.place_separator(self.box, weight=15)
+        self.model.place(self.box, self._act("B", "box.b"), weight=20)
+        actions = self.model.menu(self.box).actions()
         self.assertTrue(actions[1].isSeparator())
         self.assertEqual([actions[0].text(), actions[2].text()], ["A", "B"])
 
     def test_group_is_created_once(self):
-        first = self.model.group("modes")
-        second = self.model.group("modes")
+        first = self.model.group(self.tag + "modes")
+        second = self.model.group(self.tag + "modes")
         self.assertEqual(first, second)
 
 


### PR DESCRIPTION
Move the whole pilot menu bar off imperative Qt calls and onto the shared menu model. The bar order, the camera menu, and the Exit and Console actions all become data placed through the model by path and weight, on both the C++ and the Python side. Behavior is preserved end to end, with two real fixes folded in: the Escape camera reset now actually fires, and Exit, Undo, Redo, and the camera actions no longer leak.

## Step 3: seed the pilot menu bar from the model

Build the bar from one weighted table in `setUpMenu` instead of a run of imperative `addMenu` calls, so the bar order lives in a single declared place. The eight top-level menus are created through the model, and the Edit items route through `place()` with stable ids and a parent, which also stops the undo and redo actions from leaking. The bar and its items are identical to before.

The menu-model tests now own no destructive `clear()` of the shared singleton, whose model owns the real bar from this step on. Each test namespaces its own menus and ids instead.

## Step 4: express the camera menu as data and make Escape reset fire

Reduce the eleven copied camera-movement blocks and the three mode blocks to two tables walked in a loop, each row registered by id and placed under `View/Camera move` or `View/Camera`. The mode set keeps its exclusive group, now held by the model under a group id so Python can query the checked mode.

Drop the `(W/UP)` style key hints from the labels: those keys are handled in `RDomainWidget::keyPressEvent` with different behavior, so the labels were describing keys the items do not own. The reset item keeps its real Escape shortcut, which Qt renders on its own.

Make that Escape reset actually fire: `add3DWidget` associates the reset action with each new viewer, the missing link a `Qt::WidgetShortcut` needs. The hidden RHI primer is created elsewhere and never reaches `add3DWidget`, so it stays unbound. The actions are parented to the model instead of leaking.

The tests assert the eleven movement items and their labels carry no key hints, the reset item owns the Escape shortcut, the mode group is exclusive and defaults to orbit, and each new viewer joins the reset action so its widget-context shortcut can fire.

## Step 5: route Exit and Console through the model with a Python builder

Introduce `build_action`, the single description-to-QAction builder, and `PilotFeature.add_action` over the menu model's `place()`, returning the live action so a toggle feature can wire its own reverse connections. `_add_menu_item` is reimplemented on the same builder, so existing call signatures keep working.

Replace the controller's private `_addAction` with the shared builder and the menu model. Exit gains an explicit `QuitRole`, so macOS relocates it into the application menu and the platform special case goes away; Console keeps its checkable state. The unused `sys` and `importlib` imports go with them.

## Notes

- No behavior change to the visible menu bar: contents and order match the prior imperative setup.
- Bug fixes folded in: the Escape camera reset fires now, and Exit, Undo, Redo, and the camera actions are parented to the model rather than leaked.
- Test surface: `tests/test_pilot_menu_model.py` reworked to avoid clearing the shared singleton, and `tests/test_pilot_camera_menu.py` added for the camera menu data and the Escape association.

For steps 3, 4, 5 of issue #989.