### PR TITLE
Finish the model migration and delete the menu handles (steps 6, 7, 8, 9 of menu model)

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -76,14 +76,6 @@ void RManager::reset()
     }
     m_core.reset();
     m_mainWindow = nullptr;
-    m_fileMenu = nullptr;
-    m_editMenu = nullptr;
-    m_viewMenu = nullptr;
-    m_oneMenu = nullptr;
-    m_meshMenu = nullptr;
-    m_canvasMenu = nullptr;
-    m_profilingMenu = nullptr;
-    m_windowMenu = nullptr;
     m_menuModel = nullptr;
     m_pycon = nullptr;
     m_mdiArea = nullptr;
@@ -328,16 +320,16 @@ void RManager::setUpMenu()
 
     // Seed the bar from one weighted table, the single source of truth for
     // its order. The weight bands leave room to slot a menu between two
-    // others without renumbering. The members hold the model's menus until
-    // the getters become adapters over the model.
-    m_fileMenu = m_menuModel->menu("File", 0);
-    m_editMenu = m_menuModel->menu("Edit", 10);
-    m_viewMenu = m_menuModel->menu("View", 20);
-    m_oneMenu = m_menuModel->menu("One", 30);
-    m_meshMenu = m_menuModel->menu("Mesh", 40);
-    m_canvasMenu = m_menuModel->menu("Canvas", 50);
-    m_profilingMenu = m_menuModel->menu("Profiling", 60);
-    m_windowMenu = m_menuModel->menu("Window", 70);
+    // others without renumbering. Consumers reach these menus through the
+    // model by path.
+    m_menuModel->menu("File", 0);
+    m_menuModel->menu("Edit", 10);
+    m_menuModel->menu("View", 20);
+    m_menuModel->menu("One", 30);
+    m_menuModel->menu("Mesh", 40);
+    m_menuModel->menu("Canvas", 50);
+    m_menuModel->menu("Profiling", 60);
+    m_menuModel->menu("Window", 70);
 
     setUpEditMenuItems();
     // Code for controlling camera is not exposed to Python yet.

--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -223,6 +223,17 @@ void RManager::setDrawTool(std::string const & name)
     }
     m_draw_tool = name;
     applyDrawTool();
+    // Keep the draw-tool action group in step, so scripting setDrawTool from
+    // the console checks the matching radio item and toolbox button. The
+    // action group's triggered wiring is unaffected because setChecked emits
+    // toggled, not triggered.
+    if (m_menuModel)
+    {
+        if (QAction * action = m_menuModel->action("draw.tool." + name))
+        {
+            action->setChecked(true);
+        }
+    }
 }
 
 void RManager::applyDrawTool()

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -80,15 +80,6 @@ public:
     template <typename... Args>
     QMdiSubWindow * addSubWindow(Args &&... args);
 
-    QMenu * fileMenu() { return m_fileMenu; }
-    QMenu * editMenu() { return m_editMenu; }
-    QMenu * viewMenu() { return m_viewMenu; }
-    QMenu * oneMenu() { return m_oneMenu; }
-    QMenu * meshMenu() { return m_meshMenu; }
-    QMenu * canvasMenu() { return m_canvasMenu; }
-    QMenu * profilingMenu() { return m_profilingMenu; }
-    QMenu * windowMenu() { return m_windowMenu; }
-
     /// The live model of the menu bar, addressable by path from Python.
     RMenuModel * menuModel() { return m_menuModel; }
 
@@ -133,15 +124,6 @@ private:
     std::unique_ptr<QCoreApplication> m_core = nullptr;
 
     QMainWindow * m_mainWindow = nullptr;
-
-    QMenu * m_fileMenu = nullptr;
-    QMenu * m_editMenu = nullptr;
-    QMenu * m_viewMenu = nullptr;
-    QMenu * m_oneMenu = nullptr;
-    QMenu * m_meshMenu = nullptr;
-    QMenu * m_canvasMenu = nullptr;
-    QMenu * m_profilingMenu = nullptr;
-    QMenu * m_windowMenu = nullptr;
 
     /// Live menu model owned by the widget tree (parented to the main window).
     RMenuModel * m_menuModel = nullptr;

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -864,14 +864,6 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 {
                     return self.mainWindow();
                 })
-            .def_property_readonly("fileMenu", &wrapped_type::fileMenu)
-            .def_property_readonly("editMenu", &wrapped_type::editMenu)
-            .def_property_readonly("viewMenu", &wrapped_type::viewMenu)
-            .def_property_readonly("oneMenu", &wrapped_type::oneMenu)
-            .def_property_readonly("meshMenu", &wrapped_type::meshMenu)
-            .def_property_readonly("canvasMenu", &wrapped_type::canvasMenu)
-            .def_property_readonly("profilingMenu", &wrapped_type::profilingMenu)
-            .def_property_readonly("windowMenu", &wrapped_type::windowMenu)
             .def_property_readonly(
                 "menu_model",
                 [](wrapped_type & self)

--- a/solvcon/pilot/_burgers1d.py
+++ b/solvcon/pilot/_burgers1d.py
@@ -78,11 +78,13 @@ class Burgers1DApp(_base_app.OneDimBaseApp):
         """
         Set menu item for GUI.
         """
-        self._add_menu_item(
-            menu=self._mgr.oneMenu,
+        self.add_action(
+            "One",
             text="Burgers equation",
             tip="One-dimensional Burgers equation problem",
             func=self.run,
+            id="one.burgers",
+            weight=20,
         )
 
     def get_region_solver_config(self):

--- a/solvcon/pilot/_canvas_gui.py
+++ b/solvcon/pilot/_canvas_gui.py
@@ -29,8 +29,11 @@ class Canvas(_gui_common.PilotFeature):
         self._blank_worlds = []
 
     def populate_menu(self):
+        # Group the geometry samples under their own submenu, leaving the
+        # working items at the Canvas top level.
+        self._mgr.menu_model.menu("Canvas/Samples", weight=20)
         self.add_action(
-            "Canvas",
+            "Canvas/Samples",
             text="Sample: Create ICCAD-2013",
             tip="Create ICCAD-2013 polygon examples",
             func=self.mesh_iccad_2013,
@@ -38,7 +41,7 @@ class Canvas(_gui_common.PilotFeature):
             weight=10,
         )
         self.add_action(
-            "Canvas",
+            "Canvas/Samples",
             text="Sample: Bezier S-curve",
             tip="Draw a sample S-shaped cubic Bezier curve with control "
                 "points",
@@ -47,7 +50,7 @@ class Canvas(_gui_common.PilotFeature):
             weight=20,
         )
         self.add_action(
-            "Canvas",
+            "Canvas/Samples",
             text="Sample: Bezier Arch",
             tip="Draw a sample arch-shaped cubic Bezier curve with control "
                 "points",
@@ -56,7 +59,7 @@ class Canvas(_gui_common.PilotFeature):
             weight=30,
         )
         self.add_action(
-            "Canvas",
+            "Canvas/Samples",
             text="Sample: Bezier Loop",
             tip="Draw a sample loop-like cubic Bezier curve with control "
                 "points",
@@ -65,7 +68,7 @@ class Canvas(_gui_common.PilotFeature):
             weight=40,
         )
         self.add_action(
-            "Canvas",
+            "Canvas/Samples",
             text="Sample: Ellipse",
             tip="Draw a sample ellipse (a=2, b=1)",
             func=self._ellipse,
@@ -73,7 +76,7 @@ class Canvas(_gui_common.PilotFeature):
             weight=50,
         )
         self.add_action(
-            "Canvas",
+            "Canvas/Samples",
             text="Sample: Parabola",
             tip="Draw a sample parabola (y = 0.5*x^2)",
             func=self._parabola,
@@ -81,7 +84,7 @@ class Canvas(_gui_common.PilotFeature):
             weight=60,
         )
         self.add_action(
-            "Canvas",
+            "Canvas/Samples",
             text="Sample: Hyperbola",
             tip="Draw a sample hyperbola (both branches)",
             func=self._hyperbola,
@@ -89,7 +92,7 @@ class Canvas(_gui_common.PilotFeature):
             weight=70,
         )
 
-        self._mgr.menu_model.place_separator("Canvas", weight=75)
+        self._mgr.menu_model.place_separator("Canvas", weight=30)
         self.add_action(
             "Canvas",
             text="Create blank 2D canvas",

--- a/solvcon/pilot/_canvas_gui.py
+++ b/solvcon/pilot/_canvas_gui.py
@@ -29,67 +29,84 @@ class Canvas(_gui_common.PilotFeature):
         self._blank_worlds = []
 
     def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="Sample: Create ICCAD-2013",
             tip="Create ICCAD-2013 polygon examples",
             func=self.mesh_iccad_2013,
+            id="canvas.sample.iccad2013",
+            weight=10,
         )
-
-        tip = "Draw a sample S-shaped cubic Bezier curve with control points"
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="Sample: Bezier S-curve",
-            tip=tip,
+            tip="Draw a sample S-shaped cubic Bezier curve with control "
+                "points",
             func=self._bezier_s_curve,
+            id="canvas.sample.bezier_s",
+            weight=20,
         )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="Sample: Bezier Arch",
             tip="Draw a sample arch-shaped cubic Bezier curve with control "
                 "points",
             func=self._bezier_arch,
+            id="canvas.sample.bezier_arch",
+            weight=30,
         )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="Sample: Bezier Loop",
             tip="Draw a sample loop-like cubic Bezier curve with control "
                 "points",
             func=self._bezier_loop,
+            id="canvas.sample.bezier_loop",
+            weight=40,
         )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="Sample: Ellipse",
             tip="Draw a sample ellipse (a=2, b=1)",
             func=self._ellipse,
+            id="canvas.sample.ellipse",
+            weight=50,
         )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="Sample: Parabola",
             tip="Draw a sample parabola (y = 0.5*x^2)",
             func=self._parabola,
+            id="canvas.sample.parabola",
+            weight=60,
         )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="Sample: Hyperbola",
             tip="Draw a sample hyperbola (both branches)",
             func=self._hyperbola,
+            id="canvas.sample.hyperbola",
+            weight=70,
         )
 
-        self._mgr.canvasMenu.addSeparator()
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self._mgr.menu_model.place_separator("Canvas", weight=75)
+        self.add_action(
+            "Canvas",
             text="Create blank 2D canvas",
             tip="Open an empty 2D canvas with the Painter toolbox for "
                 "drawing shapes",
             func=self._create_blank_2d_canvas,
+            id="canvas.blank_2d",
+            weight=80,
         )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="View: Open canvas in 2D",
             tip="Show the current canvas world in a strictly-2D QPainter "
                 "widget; the same world also drives the 3D view",
             func=self._open_2d,
+            id="canvas.open_2d",
+            weight=90,
         )
 
     def _create_blank_2d_canvas(self):

--- a/solvcon/pilot/_euler1d.py
+++ b/solvcon/pilot/_euler1d.py
@@ -16,11 +16,13 @@ class Euler1DApp(_base_app.OneDimBaseApp):
         """
         Set menu item for GUI.
         """
-        self._add_menu_item(
-            menu=self._mgr.oneMenu,
+        self.add_action(
+            "One",
             text="Euler solver",
             tip="One-dimensional shock-tube problem with Euler solver",
             func=self.run,
+            id="one.euler",
+            weight=10,
         )
 
     def init_solver_config(self):

--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -50,6 +50,7 @@ class _Controller(metaclass=_Singleton):
         # Do not construct any Qt member objects before calling launch(), or
         # Windows may "exited with code -1073740791."
         self._rmgr = None
+        self._built = False
         self.mesh_sample_dialog = None
         self.gmsh_dialog = None
         self.svg_dialog = None
@@ -77,7 +78,13 @@ class _Controller(metaclass=_Singleton):
 
     def build(self, name="pilot", size=(1000, 600)):
         """Assemble the window, features, and menu bar without the event
-        loop, so the fully built bar can be exercised from a test."""
+        loop, so the fully built bar can be exercised from a test.
+
+        Idempotent: the bar is populated once, so a second call (for example
+        from another test) returns the already-built manager unchanged.
+        """
+        if self._built:
+            return self._rmgr
         self._rmgr = _pcore.RManager.instance
         self._rmgr.setUp()
         self._rmgr.windowTitle = name
@@ -106,6 +113,7 @@ class _Controller(metaclass=_Singleton):
         self.openprofiledata = _profiling.Profiling(mgr=self._rmgr)
         self.runprofiling = _profiling.RunProfiling(mgr=self._rmgr)
         self.populate_menu()
+        self._built = True
         return self._rmgr
 
     def _mesh_sample_dialog_entries(self):

--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -14,7 +14,6 @@ from . import airfoil
 
 if _pcore.enable:
     from PySide6.QtGui import QAction
-    from PySide6.QtWidgets import QMenu
     from . import _gui_common
     from . import _mesh
     from . import _mesh_info
@@ -51,7 +50,6 @@ class _Controller(metaclass=_Singleton):
         # Do not construct any Qt member objects before calling launch(), or
         # Windows may "exited with code -1073740791."
         self._rmgr = None
-        self.panels_menu = None
         self.mesh_sample_dialog = None
         self.gmsh_dialog = None
         self.svg_dialog = None
@@ -73,27 +71,28 @@ class _Controller(metaclass=_Singleton):
         return None if self._rmgr is None else getattr(self._rmgr, name)
 
     def launch(self, name="pilot", size=(1000, 600)):
+        self.build(name=name, size=size)
+        self._rmgr.show()
+        return self._rmgr.exec()
+
+    def build(self, name="pilot", size=(1000, 600)):
+        """Assemble the window, features, and menu bar without the event
+        loop, so the fully built bar can be exercised from a test."""
         self._rmgr = _pcore.RManager.instance
         self._rmgr.setUp()
         self._rmgr.windowTitle = name
         self._rmgr.resize(w=size[0], h=size[1])
 
-        # Add the "Panels" submenu as the first item in the View menu.
-        view = self._rmgr.viewMenu
-        self.panels_menu = QMenu("Panels", self._rmgr.mainWindow)
-        actions = view.actions()
-        if actions:
-            view.insertMenu(actions[0], self.panels_menu)
-        else:
-            view.addMenu(self.panels_menu)
+        # Declare the Panels submenu first on the View menu; features place
+        # their toggles under the "View/Panels" path.
+        self._rmgr.menu_model.menu("View/Panels", weight=0)
 
         self.gmsh_dialog = _mesh.GmshFileDialog(mgr=self._rmgr)
         self.svg_dialog = _svg_gui.SVGFileDialog(mgr=self._rmgr)
         self.sample_mesh = _mesh.SampleMesh(mgr=self._rmgr)
         self.mesh_style_status = _mesh.MeshStyleStatus(mgr=self._rmgr)
         self.mesh_info = _mesh_info.MeshInfo(
-            mgr=self._rmgr, menu=self.panels_menu,
-            style_status=self.mesh_style_status)
+            mgr=self._rmgr, style_status=self.mesh_style_status)
         self.oblique_shock = _oblique.ObliqueShockMesh(mgr=self._rmgr)
         self.oblique_solver = _oblique.ObliqueShockSolver(mgr=self._rmgr)
         self.naca4airfoil = airfoil.Naca4Airfoil(mgr=self._rmgr)
@@ -102,14 +101,12 @@ class _Controller(metaclass=_Singleton):
         self.eulerone = _euler1d.Euler1DApp(mgr=self._rmgr)
         self.burgers = _burgers1d.Burgers1DApp(mgr=self._rmgr)
         self.linear_wave = _linear_wave.LinearWave1DApp(mgr=self._rmgr)
-        self.painter = _painter_gui.Painter(mgr=self._rmgr,
-                                            menu=self.panels_menu)
+        self.painter = _painter_gui.Painter(mgr=self._rmgr)
         self.canvas = _canvas_gui.Canvas(mgr=self._rmgr, painter=self.painter)
         self.openprofiledata = _profiling.Profiling(mgr=self._rmgr)
         self.runprofiling = _profiling.RunProfiling(mgr=self._rmgr)
         self.populate_menu()
-        self._rmgr.show()
-        return self._rmgr.exec()
+        return self._rmgr
 
     def _mesh_sample_dialog_entries(self):
         """Every example mesh as ``(category, label, tip, func)``, in menu

--- a/solvcon/pilot/_linear_wave.py
+++ b/solvcon/pilot/_linear_wave.py
@@ -34,11 +34,13 @@ class LinearWave1DApp(_base_app.OneDimBaseApp):
         """
         Set menu item for GUI.
         """
-        self._add_menu_item(
-            menu=self._mgr.oneMenu,
+        self.add_action(
+            "One",
             text="Linear Wave",
             tip="",
             func=self.run,
+            id="one.linear_wave",
+            weight=30,
         )
 
     def init_solver_config(self):

--- a/solvcon/pilot/_mesh.py
+++ b/solvcon/pilot/_mesh.py
@@ -293,11 +293,13 @@ class SampleMeshDialog(_gui_common.PilotFeature):
         self._tree = None
 
     def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.meshMenu,
+        self.add_action(
+            "Mesh",
             text="Sample mesh dialog",
             tip="Choose an example mesh to create",
             func=self.open_dialog,
+            id="mesh.sample_dialog",
+            weight=10,
         )
 
     def open_dialog(self):
@@ -432,11 +434,13 @@ class GmshFileDialog(_gui_common.PilotFeature):
         self._diag.open(self, QtCore.SLOT('on_finished()'))
 
     def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.fileMenu,
+        self.add_action(
+            "File",
             text="Open Gmsh file",
             tip="Open Gmsh file",
             func=self.run,
+            id="file.gmsh",
+            weight=10,
         )
 
     @QtCore.Slot()

--- a/solvcon/pilot/_mesh.py
+++ b/solvcon/pilot/_mesh.py
@@ -399,7 +399,7 @@ class MeshStyleStatus(QtCore.QObject):
     def populate_menu(self):
         """Add the View > Mesh styles submenu of independent check items."""
         window = self._mgr.mainWindow
-        submenu = QtWidgets.QMenu("Mesh styles", window)
+        submenu = self._mgr.menu_model.menu("View/Mesh styles")
         for name, label in self.STYLES:
             act = QtGui.QAction(label, window)
             act.setCheckable(True)
@@ -410,7 +410,6 @@ class MeshStyleStatus(QtCore.QObject):
             self._actions[name] = act
             submenu.addAction(act)
         self.changed.connect(self._sync_menu)
-        self._mgr.viewMenu.addMenu(submenu)
 
     def _sync_menu(self):
         """Match the menu check marks to the active viewer's styles."""

--- a/solvcon/pilot/_mesh_info.py
+++ b/solvcon/pilot/_mesh_info.py
@@ -7,7 +7,6 @@
 import numpy as np
 
 from PySide6.QtCore import Qt, QTimer
-from PySide6.QtGui import QAction
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QDockWidget,
                                QTreeWidget, QTreeWidgetItem, QFrame)
 
@@ -227,13 +226,12 @@ class MeshInfoTree(QWidget):
 class MeshInfo(_gui_common.PilotFeature):
     """Mesh information panel, toggled from the View "Panels" submenu.
 
-    The caller supplies the ``menu`` group the toggle item is added to. When
-    on, the panel shows the active sub-window's mesh and follows the active
+    The toggle item is placed under the "View/Panels" path. When on, the
+    panel shows the active sub-window's mesh and follows the active
     sub-window; sub-windows without a mesh show "No mesh loaded".
     """
 
     def __init__(self, *args, **kw):
-        self._menu = kw.pop('menu')
         self._status = kw.pop('style_status')
         super().__init__(*args, **kw)
         self._action = None
@@ -241,11 +239,10 @@ class MeshInfo(_gui_common.PilotFeature):
         self._panel = None
 
     def populate_menu(self):
-        self._action = QAction("Mesh", self._mainWindow)
-        self._action.setStatusTip("Toggle the mesh information panel")
-        self._action.setCheckable(True)
+        self._action = self.add_action(
+            "View/Panels", "Mesh", "Toggle the mesh information panel", None,
+            id="panel.mesh_info", weight=10, checkable=True)
         self._action.toggled.connect(self._on_toggled)
-        self._menu.addAction(self._action)
 
     def _on_toggled(self, checked):
         """Show or hide the panel."""

--- a/solvcon/pilot/_oblique.py
+++ b/solvcon/pilot/_oblique.py
@@ -129,12 +129,14 @@ class ObliqueShockSolver(_gui_common.PilotFeature):
         super(ObliqueShockSolver, self).__init__(*args, **kw)
 
     def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.meshMenu,
+        self.add_action(
+            "Mesh",
             text="(WIP) Oblique-shock solution (density)",
             tip="March the oblique-shock Euler solver and draw the density "
                 "as a 2D color field",
             func=self._run,
+            id="mesh.oblique_solver",
+            weight=20,
         )
 
     def _run(self):

--- a/solvcon/pilot/_painter_gui.py
+++ b/solvcon/pilot/_painter_gui.py
@@ -5,7 +5,7 @@
 Painter toolbox for the 2D canvas.
 """
 
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 from . import _gui_common
 from ._pilot_core import draw_tool_names, default_draw_tool_name
@@ -35,19 +35,17 @@ class Painter(_gui_common.PilotFeature):
     }
 
     def __init__(self, *args, **kw):
-        self._menu = kw.pop('menu', None)
         super(Painter, self).__init__(*args, **kw)
         self._action = None
         self._dock = None
         self._buttons = {}
 
     def populate_menu(self):
-        """Add a checkable "Painter" toggle to the supplied Panels menu."""
-        self._action = QtGui.QAction("Painter", self._mainWindow)
-        self._action.setStatusTip("Toggle the Painter toolbox")
-        self._action.setCheckable(True)
+        """Add a checkable "Painter" toggle under the View/Panels path."""
+        self._action = self.add_action(
+            "View/Panels", "Painter", "Toggle the Painter toolbox", None,
+            id="panel.painter", weight=20, checkable=True)
         self._action.toggled.connect(self._on_toggled)
-        self._menu.addAction(self._action)
 
     def _on_toggled(self, checked):
         """Show or hide the toolbox dock from the menu toggle."""

--- a/solvcon/pilot/_painter_gui.py
+++ b/solvcon/pilot/_painter_gui.py
@@ -39,13 +39,49 @@ class Painter(_gui_common.PilotFeature):
         self._action = None
         self._dock = None
         self._buttons = {}
+        self._tool_group = None
+        self._tool_actions = {}
 
     def populate_menu(self):
-        """Add a checkable "Painter" toggle under the View/Panels path."""
+        """Add the Painter toggle and the draw-tool radio group."""
         self._action = self.add_action(
             "View/Panels", "Painter", "Toggle the Painter toolbox", None,
             id="panel.painter", weight=20, checkable=True)
         self._action.toggled.connect(self._on_toggled)
+        self._build_tool_actions()
+
+    def _build_tool_actions(self):
+        """One exclusive checkable action per draw tool, the single source of
+        truth shared by the Canvas/Draw tool radio items and the toolbox
+        buttons. Each action routes its own trigger to the manager.
+
+        Idempotent: the tools are declared once on the model, so a second
+        Painter reuses the existing actions instead of duplicating them.
+        """
+        if self._tool_actions:
+            return
+        model = self._mgr.menu_model
+        model.menu("Canvas/Draw tool", weight=10)
+        # Held by the model under a group id so the selection is queryable.
+        self._tool_group = model.group("draw.tool")
+        self._tool_group.setExclusive(True)
+        mgr = self._mgr
+        weight = 10
+        created = False
+        for tool in draw_tool_names():
+            act = model.action("draw.tool." + tool)
+            if act is None:
+                label = self.TOOL_LABELS.get(tool, tool.title())
+                act = self.add_action(
+                    "Canvas/Draw tool", label, f"Draw with the {label} tool",
+                    lambda t=tool: mgr.setDrawTool(t),
+                    id="draw.tool." + tool, weight=weight, checkable=True)
+                self._tool_group.addAction(act)
+                created = True
+            self._tool_actions[tool] = act
+            weight += 10
+        if created:
+            self._tool_actions[default_draw_tool_name()].setChecked(True)
 
     def _on_toggled(self, checked):
         """Show or hide the toolbox dock from the menu toggle."""
@@ -56,25 +92,23 @@ class Painter(_gui_common.PilotFeature):
             self._dock.hide()
 
     def _ensure_dock(self):
-        """Create the dock and its tool buttons once, lazily."""
+        """Create the dock once, its buttons views of the tool actions."""
         if self._dock is not None:
             return
+        # A standalone Painter (used in tests) reaches the dock without
+        # populate_menu, so make sure the tool actions exist first.
+        self._build_tool_actions()
         dock = QtWidgets.QDockWidget("Painter", self._mainWindow)
         dock.setAllowedAreas(
             QtCore.Qt.LeftDockWidgetArea | QtCore.Qt.RightDockWidgetArea)
 
         body = QtWidgets.QWidget(dock)
         layout = QtWidgets.QVBoxLayout(body)
-        group = QtWidgets.QButtonGroup(body)
-        group.setExclusive(True)
-
         for tool in draw_tool_names():
             button = QtWidgets.QToolButton(body)
-            button.setText(self.TOOL_LABELS.get(tool, tool.title()))
-            button.setCheckable(True)
-            button.clicked.connect(
-                lambda checked=False, t=tool: self._select_tool(t))
-            group.addButton(button)
+            # The default action drives the button and reflects its checked
+            # state, so a menu radio and a button stay one selection.
+            button.setDefaultAction(self._tool_actions[tool])
             layout.addWidget(button)
             self._buttons[tool] = button
 
@@ -87,20 +121,12 @@ class Painter(_gui_common.PilotFeature):
         self._dock = dock
 
     def present(self):
-        """
-        Show the toolbox dock and reset the focused canvas to the Pan tool.
-        """
+        """Show the toolbox dock and reset the focused canvas to the default
+        tool; the action group updates every surface."""
         self._ensure_dock()
-        default_tool = default_draw_tool_name()
-        self._buttons[default_tool].setChecked(True)
-        self._select_tool(default_tool)
+        self._mgr.setDrawTool(default_draw_tool_name())
         self._dock.show()
         self._dock.raise_()
-
-    def _select_tool(self, tool):
-        """Set the selected tool; the manager applies it to the focused
-        canvas and re-applies it as focus moves between canvases."""
-        self._mgr.setDrawTool(tool)
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/pilot/_profiling.py
+++ b/solvcon/pilot/_profiling.py
@@ -46,11 +46,13 @@ class Profiling(_gui_common.PilotFeature):
         self._diag.setWindowTitle("Open profiling file")
 
     def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.profilingMenu,
+        self.add_action(
+            "Profiling",
             text="Open profiling result",
             tip="Open JSON file of profiling result",
             func=self.open_profiling_result,
+            id="profiling.open",
+            weight=10,
         )
 
     def open_profiling_result(self):
@@ -191,11 +193,13 @@ class RunProfiling(_gui_common.PilotFeature):
         self.prof_opt = {}
 
     def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.profilingMenu,
+        self.add_action(
+            "Profiling",
             text="Profiling script",
             tip="Run profiling from script",
             func=self.load_profile_util,
+            id="profiling.run",
+            weight=20,
         )
 
     def load_profile_util(self):

--- a/solvcon/pilot/_svg_gui.py
+++ b/solvcon/pilot/_svg_gui.py
@@ -35,11 +35,13 @@ class SVGFileDialog(_gui_common.PilotFeature):
         self._diag.open(self, QtCore.SLOT('on_finished()'))
 
     def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.fileMenu,
+        self.add_action(
+            "File",
             text="Open SVG file",
             tip="Open SVG file",
             func=self.run,
+            id="file.svg",
+            weight=20,
         )
 
     @QtCore.Slot()

--- a/tests/test_pilot_bar.py
+++ b/tests/test_pilot_bar.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot import _gui
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+BUILTINS = ["File", "Edit", "View", "One", "Mesh", "Canvas", "Profiling",
+            "Window"]
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class BarStructureTC(unittest.TestCase):
+    def test_full_bar_is_assembled_from_the_model(self):
+        mgr = _gui.controller.build()
+        model = mgr.menu_model
+
+        # The eight built-in menus keep their declared order. Other tests may
+        # append scratch menus to the shared singleton, so filter to these.
+        bar = [a.text() for a in mgr.mainWindow.menuBar().actions()]
+        self.assertEqual([t for t in bar if t in BUILTINS], BUILTINS)
+
+        # A known feature item lands under its intended path and id.
+        self.assertIsNotNone(model.action("mesh.sample_dialog"))
+        self.assertIn("Sample mesh dialog",
+                      [a.text() for a in model.menu("Mesh").actions()])
+
+        # Panels sits first in View and holds the two dock toggles.
+        view = [a.text() for a in model.menu("View").actions()]
+        self.assertEqual(view[0], "Panels")
+        panels = [a.text() for a in model.menu("View/Panels").actions()]
+        self.assertEqual(panels, ["Mesh", "Painter"])
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_draw_tool.py
+++ b/tests/test_pilot_draw_tool.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot import _gui
+    from solvcon.pilot._pilot_core import draw_tool_names
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class DrawToolTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.model = self.mgr.menu_model
+        self.painter = _gui.controller.painter
+
+    def test_one_radio_item_per_registered_tool(self):
+        items = [a.text()
+                 for a in self.model.menu("Canvas/Draw tool").actions()]
+        self.assertEqual(len(items), len(draw_tool_names()))
+
+    def test_samples_moved_under_their_own_submenu(self):
+        samples = [a.text()
+                   for a in self.model.menu("Canvas/Samples").actions()]
+        self.assertEqual(len(samples), 7)
+        # The samples no longer sit at the Canvas top level.
+        top = [a.text() for a in self.model.menu("Canvas").actions()
+               if not a.isSeparator()]
+        self.assertNotIn("Sample: Parabola", top)
+
+    def test_menu_radio_drives_manager_and_toolbox(self):
+        self.painter._ensure_dock()
+        self.model.action("draw.tool.line").trigger()
+        self.assertEqual(self.mgr.drawTool, "line")
+        # The toolbox button is a view of the same action.
+        self.assertTrue(
+            self.painter._buttons["line"].defaultAction().isChecked())
+        self.assertFalse(
+            self.painter._buttons["pan"].defaultAction().isChecked())
+
+    def test_console_set_draw_tool_checks_the_menu(self):
+        self.mgr.setDrawTool("rectangle")
+        group = self.model.group("draw.tool")
+        self.assertEqual(group.checkedAction().objectName(),
+                         "draw.tool.rectangle")
+        # The group is exclusive, so the previous choice clears.
+        self.assertFalse(self.model.action("draw.tool.line").isChecked())
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_mesh_info.py
+++ b/tests/test_pilot_mesh_info.py
@@ -12,7 +12,7 @@ try:
     from solvcon.pilot import _mesh_info
     from solvcon.pilot._mesh import MeshStyleStatus
     from PySide6.QtCore import Qt
-    from PySide6.QtWidgets import QApplication, QMenu
+    from PySide6.QtWidgets import QApplication
 except ImportError:
     pilot = None
 
@@ -107,8 +107,6 @@ class MakeMeshInfoTC(unittest.TestCase):
 class MeshInfoTC(unittest.TestCase):
     def setUp(self):
         self.mgr = pilot.RManager.instance.setUp()
-        # The "Panels" group is owned by the caller, not by MeshInfo.
-        self.menu = QMenu("Panels", self.mgr.mainWindow)
         # The View menu and the panel share one MeshStyleStatus.
         self.status = MeshStyleStatus(mgr=self.mgr)
 
@@ -125,10 +123,11 @@ class MeshInfoTC(unittest.TestCase):
     def test_panel_shows_active_mesh(self):
         widget = self.mgr.add3DWidget()
         widget.updateMesh(_make_sample_mesh())
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+        feature = _mesh_info.MeshInfo(mgr=self.mgr,
                                       style_status=self.status)
         feature.populate_menu()
-        self.assertIn(feature._action, self.menu.actions())
+        panels = self.mgr.menu_model.menu("View/Panels")
+        self.assertIn(feature._action, panels.actions())
         feature._action.setChecked(True)
         sections = _tree_sections(feature._panel._tree)
         self.assertEqual(sections["Counts"]["cell"], "3")
@@ -137,7 +136,7 @@ class MeshInfoTC(unittest.TestCase):
     def test_boundary_toggle_drives_viewer(self):
         widget = self.mgr.add3DWidget()
         widget.updateMesh(_make_sample_mesh())
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+        feature = _mesh_info.MeshInfo(mgr=self.mgr,
                                       style_status=self.status)
         feature.populate_menu()
         feature._action.setChecked(True)
@@ -163,7 +162,7 @@ class MeshInfoTC(unittest.TestCase):
     def test_style_toggle_drives_viewer(self):
         widget = self.mgr.add3DWidget()
         widget.updateMesh(_make_sample_mesh())
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+        feature = _mesh_info.MeshInfo(mgr=self.mgr,
                                       style_status=self.status)
         feature.populate_menu()
         feature._action.setChecked(True)
@@ -197,7 +196,7 @@ class MeshInfoTC(unittest.TestCase):
     def test_menu_and_panel_stay_linked(self):
         widget = self.mgr.add3DWidget()
         widget.updateMesh(_make_sample_mesh())
-        panel_feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+        panel_feature = _mesh_info.MeshInfo(mgr=self.mgr,
                                             style_status=self.status)
         panel_feature.populate_menu()
         panel_feature._action.setChecked(True)
@@ -240,7 +239,7 @@ class MeshInfoTC(unittest.TestCase):
 
     def test_panel_without_mesh(self):
         self.mgr.add3DWidget()  # fresh viewer becomes current, no mesh
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+        feature = _mesh_info.MeshInfo(mgr=self.mgr,
                                       style_status=self.status)
         feature.populate_menu()
         feature._action.setChecked(True)
@@ -251,7 +250,7 @@ class MeshInfoTC(unittest.TestCase):
     def test_panel_updates_on_menu_load(self):
         # Loading from a menu creates and activates the viewer before
         # updateMesh runs, so the refresh is deferred to the event loop.
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+        feature = _mesh_info.MeshInfo(mgr=self.mgr,
                                       style_status=self.status)
         feature.populate_menu()
         feature._action.setChecked(True)

--- a/tests/test_pilot_mesh_info.py
+++ b/tests/test_pilot_mesh_info.py
@@ -216,7 +216,7 @@ class MeshInfoTC(unittest.TestCase):
     def test_overlay_toggles_drive_viewer(self):
         widget = self.mgr.add3DWidget()
         widget.updateMesh(_make_sample_mesh())
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+        feature = _mesh_info.MeshInfo(mgr=self.mgr,
                                       style_status=self.status)
         feature.populate_menu()
         feature._action.setChecked(True)


### PR DESCRIPTION
Moving the last imperative surfaces onto the shared menu model and then deleting the per-menu handles the model made redundant. Every flat feature, every dock toggle, and the whole draw-tool selection now reach the bar by path and weight through the model, and the draw tools become one exclusive action group that every surface shares. By the end no code addresses a menu by getter: the eight `QMenu*` members, their getters, and their pybind11 bindings are gone. The visible bar is unchanged throughout.

## Step 6: migrate the flat features onto add_action

Give every non-toggle `populate_menu` an explicit path, id, and weight through `add_action` instead of a bare menu handle: the Gmsh and SVG file dialogs, the sample-mesh dialog and the oblique-shock solver, the three 1D apps, the two profiling items, and the Canvas samples and working items with their separator. The bar is unchanged; its order now comes from the weights rather than the call sequence.

## Step 7: place the dock toggles under the View/Panels path

Convert the Painter and MeshInfo toggles to `add_action` and drop the `menu=` constructor injection: both place their checkable item under `View/Panels`, the submenu the controller now declares at weight 0 so it stays first in the View menu.

Split the controller's launch into a `build()` that assembles the window, features, and bar without the event loop, so the finished bar can be exercised from a test, and `launch()` runs `build()` then the loop. A bar-structure test builds the whole controller and asserts the built-in menus and their order, a feature item under its path, and the two dock toggles under `View/Panels`. The mesh-info tests are rewritten to reach the toggle through the menu model instead of constructing and injecting their own Panels menu, and master's new `test_overlay_toggles_drive_viewer` is reconciled to build its toggle the same way.

## Step 8: drive the draw tools from one action group

Make the draw tools an exclusive `QActionGroup` held by the model: one checkable action per registered tool, surfaced as `Canvas/Draw tool` radio items, and the Painter toolbox buttons become `QToolButton` default-action views of the same actions, so every surface shows one selection and `present()` no longer hand-syncs button state. `setDrawTool` stays the programmatic entry point and now checks the matching action, so scripting it from the console updates the menu and the buttons. The seven geometry samples move under `Canvas/Samples`, leaving the working items at the Canvas top level. The controller's `build()` is made idempotent so a second call does not duplicate the bar.

The tests assert one radio item per registered tool, that a menu radio drives the manager's draw tool and the toolbox button state, that scripting `setDrawTool` checks the group's action, and that the geometry samples moved under `Canvas/Samples`.

## Step 9: reach the last submenu through the model and delete the handles

The mesh-style status was the last consumer of a per-menu getter. Create its `View/Mesh styles` submenu through the menu model instead of the `viewMenu` handle, so nothing outside the model addresses a menu by getter anymore.

Then remove the eight `QMenu*` members, their getters, and their pybind11 bindings. `setUpMenu` declares the top-level menus on the model without storing handles, and `reset()` no longer nulls them. Every menu is now reached by path through the model.

For steps 6, 7, 8, 9 of issue #989.