### PR TITLE
Make REPL and curate namespace (steps 1, 2 of console)

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -185,6 +185,26 @@ R2DWidget * RManager::currentR2DWidget()
     return dynamic_cast<R2DWidget *>(subwin->widget());
 }
 
+std::vector<RDomainWidget *> RManager::list3DWidgets()
+{
+    std::vector<RDomainWidget *> widgets;
+    if (m_mdiArea == nullptr)
+    {
+        return widgets;
+    }
+
+    // A 3D viewer sits inside a host container subwindow, so resolve it
+    // through domainWidgetOf rather than casting the subwindow's widget.
+    for (auto subwin : m_mdiArea->subWindowList())
+    {
+        if (auto * viewer = domainWidgetOf(subwin))
+        {
+            widgets.push_back(viewer);
+        }
+    }
+    return widgets;
+}
+
 std::vector<R2DWidget *> RManager::list2DWidgets()
 {
     std::vector<R2DWidget *> widgets;

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -63,6 +63,7 @@ public:
     R2DWidget * add2DWidget();
     RDomainWidget * currentR3DWidget();
     R2DWidget * currentR2DWidget();
+    std::vector<RDomainWidget *> list3DWidgets();
     std::vector<R2DWidget *> list2DWidgets();
 
     /// Name of the active canvas drawing tool.

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
@@ -278,10 +278,22 @@ void RPythonConsoleDockWidget::executeCommand()
     }
 
     commitCommand(command);
-    ++m_last_command_serial;
 
-    const auto formatted_command = std::format("[{}] {}\n\n", m_last_command_serial, command);
-    writeToHistory(formatted_command);
+    // Echo the submitted command with the interpreter's prompts: ">>> " for
+    // the first line and "... " for each continuation line, so the transcript
+    // reads like a read-eval-print loop.
+    {
+        QStringList const lines = QString::fromStdString(command).split('\n');
+        QString echo;
+        for (int i = 0; i < lines.size(); ++i)
+        {
+            echo += (0 == i) ? ">>> " : "... ";
+            echo += lines[i];
+            echo += '\n';
+        }
+        echo += '\n';
+        writeToHistory(echo.toStdString());
+    }
 
     m_command_edit->clear();
     m_current_command_index = static_cast<int>(m_committed_commands.size());

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
@@ -144,7 +144,6 @@ private:
     std::deque<std::string> m_committed_commands;
     size_t m_committed_commands_size_limit = 1024;
     int m_current_command_index = 0;
-    int m_last_command_serial = 0;
 
     python::PythonStreamRedirect m_python_redirect;
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -828,6 +828,12 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                     return self.currentR2DWidget();
                 })
             .def(
+                "list3DWidgets",
+                [](wrapped_type & self)
+                {
+                    return self.list3DWidgets();
+                })
+            .def(
                 "list2DWidgets",
                 [](wrapped_type & self)
                 {

--- a/solvcon/apputil.py
+++ b/solvcon/apputil.py
@@ -14,6 +14,7 @@ Tools to run applications
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
 
 
+import code
 import importlib
 import rlcompleter
 
@@ -32,28 +33,71 @@ __all__ = [
 environ = {}
 
 
+class _ConsoleInterpreter(code.InteractiveConsole):
+    """
+    A :class:`code.InteractiveConsole` bound to an application namespace.
+
+    The console compiles in ``"single"`` mode, so a bare expression is
+    auto-displayed and bound to ``_`` the way the standard read-eval-print
+    loop does. Exceptions are formatted against the user's own input by
+    :meth:`showtraceback` and :meth:`showsyntaxerror`, not the host stack.
+
+    ``exit()`` or ``quit()`` typed in the console raises :exc:`SystemExit`,
+    which would tear down the interpreter that the pilot embeds. Guard it
+    here so the console reports the request without ending the process.
+    """
+    def push(self, line):
+        try:
+            return super().push(line)
+        except SystemExit:
+            self.write("SystemExit: use the window controls to quit.\n")
+            self.resetbuffer()
+            return False
+
+
 class AppEnvironment:
     """
     Collects the environment for an application.
 
+    The read-eval-print loop uses a single namespace, so :ivar:`globals`
+    and :ivar:`locals` are the same dict: names bound by executed code and
+    names injected by the pilot are both visible to the interpreter.
+
     :ivar globals:
-        The global namespace of the application.
+        The namespace of the application.
     :ivar locals:
-        The local namespace of the application.
+        An alias of :ivar:`globals`.
     """
     def __init__(self, name):
-        self.globals = {
+        namespace = {
             # Give the application an alias of the top package.
             'sc': importlib.import_module('solvcon'),
             'appenv': self,
         }
-        self.locals = {}
+        self.globals = namespace
+        self.locals = namespace
         self.name = name
+        self.console = _ConsoleInterpreter(namespace)
         # Each run of the application appends a new environment.
         environ[name] = self
 
-    def run_code(self, code):
-        exec(code, self.globals, self.locals)
+    def run_code(self, source):
+        """
+        Feed a possibly multi-line command to the persistent interpreter.
+
+        Each line drives ``push()``, which returns whether more input is
+        needed to complete the statement. A block left open after the last
+        line is closed with a blank line, the way a blank line ends a
+        compound statement in the interactive interpreter.
+
+        :return: True when the interpreter is still waiting for more input.
+        """
+        more = False
+        for line in source.split('\n'):
+            more = self.console.push(line)
+        if more:
+            more = self.console.push('')
+        return more
 
 
 def get_appenv(name=None):
@@ -100,9 +144,9 @@ def get_completions(text):
     return completions
 
 
-def run_code(code):
+def run_code(source):
     aenv = get_current_appenv()
-    aenv.run_code(code)
+    return aenv.run_code(source)
 
 
 def stop_code(appenvobj=None):

--- a/solvcon/apputil.py
+++ b/solvcon/apputil.py
@@ -26,6 +26,9 @@ __all__ = [
     'get_completions',
     'run_code',
     'stop_code',
+    'build_pilot_namespace',
+    'format_banner',
+    'install_pilot_namespace',
 ]
 
 
@@ -77,9 +80,23 @@ class AppEnvironment:
         self.globals = namespace
         self.locals = namespace
         self.name = name
+        self.namespace_refreshers = []
         self.console = _ConsoleInterpreter(namespace)
         # Each run of the application appends a new environment.
         environ[name] = self
+
+    def seed(self, **handles):
+        """Install curated handles into the interpreter namespace."""
+        self.globals.update(handles)
+
+    def add_namespace_refresher(self, refresh):
+        """
+        Register a callback that refreshes the namespace before each command.
+
+        The callback receives the namespace dict. Use it for handles whose
+        value tracks live session state, such as the current viewer.
+        """
+        self.namespace_refreshers.append(refresh)
 
     def run_code(self, source):
         """
@@ -92,6 +109,8 @@ class AppEnvironment:
 
         :return: True when the interpreter is still waiting for more input.
         """
+        for refresh in self.namespace_refreshers:
+            refresh(self.globals)
         more = False
         for line in source.split('\n'):
             more = self.console.push(line)
@@ -118,13 +137,9 @@ get_appenv(name='master')
 
 
 def get_current_appenv():
-    has_key = False
-    for k in reversed(environ):
-        has_key = True
-        break
-    if not has_key:
+    if not environ:
         raise KeyError("No AppEnviron is available")
-    return environ[k]
+    return environ[next(reversed(environ))]
 
 
 def get_completions(text):
@@ -153,9 +168,84 @@ def stop_code(appenvobj=None):
     if None is appenvobj:
         environ.clear()
     else:
-        indices = [i for i, o in enumerate(environ) if o == appenvobj]
-        indices = reversed(indices)
-        for i in indices:
-            del environ[i]
+        names = [name for name, env in environ.items() if env is appenvobj]
+        for name in names:
+            del environ[name]
+
+
+def build_pilot_namespace(mgr):
+    """
+    Curated console handles and their descriptions for the pilot.
+
+    Duck-typed on the pilot manager (``mgr``) so it can be exercised with a
+    stand-in in the tests. Returns ``(handles, entries)`` where ``handles``
+    is a name-to-object dict to seed the namespace and ``entries`` is an
+    ordered list of ``(name, description)`` for the banner.
+    """
+    def show_mesh(m):
+        """Open a mesh in a fresh 3D viewer and return the viewer."""
+        w = mgr.add3DWidget()
+        w.updateMesh(m)
+        w.showAxis(True)
+        return w
+
+    def viewers():
+        """List the open 3D viewers."""
+        return list(mgr.list3DWidgets())
+
+    def meshes():
+        """List the meshes currently loaded in the 3D viewers."""
+        return [w.mesh for w in mgr.list3DWidgets() if w.mesh is not None]
+
+    viewer = mgr.currentR3DWidget()
+    handles = {
+        'mgr': mgr,
+        'viewer': viewer,
+        'mesh': None if viewer is None else viewer.mesh,
+        'show_mesh': show_mesh,
+        'viewers': viewers,
+        'meshes': meshes,
+    }
+    entries = [
+        ('mgr', 'the running pilot manager'),
+        ('viewer', 'the current 3D viewer (or None)'),
+        ('mesh', 'the current mesh (or None)'),
+        ('show_mesh(m)', 'open a mesh in a fresh 3D viewer'),
+        ('viewers()', 'list the open 3D viewers'),
+        ('meshes()', 'list the loaded meshes'),
+        ('sc', 'the solvcon package'),
+    ]
+    return handles, entries
+
+
+def _refresh_pilot_namespace(mgr, namespace):
+    viewer = mgr.currentR3DWidget()
+    namespace['viewer'] = viewer
+    namespace['mesh'] = None if viewer is None else viewer.mesh
+
+
+def format_banner(entries):
+    """Format ``(name, description)`` entries as an aligned banner."""
+    width = max(len(name) for name, _ in entries)
+    lines = ["solvcon pilot console. Handles in scope:"]
+    for name, desc in entries:
+        lines.append("  {}  {}".format(name.ljust(width), desc))
+    return "\n".join(lines) + "\n"
+
+
+def install_pilot_namespace(mgr, appenv):
+    """
+    Seed the console namespace from the pilot manager and keep it fresh.
+
+    The dynamic handles (``viewer``, ``mesh``) are refreshed before each
+    command so they track the focused viewer.
+
+    :return: The banner text listing the curated handles.
+    """
+    handles, entries = build_pilot_namespace(mgr)
+    appenv.seed(**handles)
+    appenv.add_namespace_refresher(
+        lambda namespace: _refresh_pilot_namespace(mgr, namespace))
+    return format_banner(entries)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -9,6 +9,7 @@ Graphical-user interface code
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
 
 
+from .. import apputil
 from . import _pilot_core as _pcore
 from . import airfoil
 
@@ -113,8 +114,15 @@ class _Controller(metaclass=_Singleton):
         self.openprofiledata = _profiling.Profiling(mgr=self._rmgr)
         self.runprofiling = _profiling.RunProfiling(mgr=self._rmgr)
         self.populate_menu()
+        self._seed_console_namespace()
         self._built = True
         return self._rmgr
+
+    def _seed_console_namespace(self):
+        """Curate the console namespace and greet with a banner."""
+        appenv = apputil.get_current_appenv()
+        banner = apputil.install_pilot_namespace(self._rmgr, appenv)
+        self._rmgr.pycon.writeToHistory(banner)
 
     def _mesh_sample_dialog_entries(self):
         """Every example mesh as ``(category, label, tip, func)``, in menu

--- a/solvcon/system.py
+++ b/solvcon/system.py
@@ -11,7 +11,6 @@ import builtins
 import sys
 import os
 import argparse
-import traceback
 import warnings
 
 import solvcon
@@ -132,13 +131,10 @@ def enter_main(argv):
 
 
 def exec_code(code):
-    try:
-        apputil.run_code(code)
-    except Exception as e:
-        sys.stdout.write("code:\n{}\n".format(code))
-        sys.stdout.write("{}: {}\n".format(type(e).__name__, str(e)))
-        sys.stdout.write("traceback:\n")
-        traceback.print_stack()
+    # The persistent interpreter reports a user exception through its own
+    # showtraceback/showsyntaxerror, which format the traceback against the
+    # console input. Do not wrap it in the host call stack.
+    return apputil.run_code(code)
 
 
 def get_completions(text):

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -17,11 +17,84 @@ class PilotTC(unittest.TestCase):
     def test_import(self):
         self.assertTrue(hasattr(solvcon.pilot, "mgr"))
 
-    @unittest.skip("headless testing is not ready")
+
+class PythonConsoleBackendTC(unittest.TestCase):
+    """
+    The persistent read-eval-print backend behind the pilot console.
+
+    These drive ``solvcon.apputil`` and ``solvcon.system`` directly, so
+    they run headlessly and do not need the Qt pilot to be built.
+    """
+
+    def setUp(self):
+        from solvcon.apputil import AppEnvironment
+        self.env = AppEnvironment("test_{}".format(id(self)))
+
+    def _run(self, source):
+        """Run source in the test environment, capturing stdout and stderr."""
+        import io
+        from contextlib import redirect_stdout, redirect_stderr
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            more = self.env.run_code(source)
+        return more, out.getvalue(), err.getvalue()
+
     def test_pycon(self):
-        self.assertTrue(pilot.mgr.pycon.python_redirect)
-        pilot.mgr.pycon.python_redirect = False
-        self.assertFalse(pilot.mgr.pycon.python_redirect)
+        # A bare expression auto-displays and binds to _, the way a
+        # read-eval-print loop behaves, rather than printing nothing.
+        import builtins
+        more, out, err = self._run('21 + 21')
+        self.assertFalse(more)
+        self.assertEqual(out.strip(), '42')
+        self.assertEqual(builtins._, 42)
+        _, out, err = self._run('_ + 8')
+        self.assertEqual(out.strip(), '50')
+
+    def test_assignment_is_silent(self):
+        more, out, err = self._run('answer = 42')
+        self.assertFalse(more)
+        self.assertEqual(out, '')
+        _, out, err = self._run('answer')
+        self.assertEqual(out.strip(), '42')
+
+    def test_multiline_reports_more_then_runs(self):
+        import io
+        from contextlib import redirect_stdout
+        self.assertTrue(self.env.console.push('for i in range(3):'))
+        self.assertTrue(self.env.console.push('    print(i)'))
+        out = io.StringIO()
+        with redirect_stdout(out):
+            self.assertFalse(self.env.console.push(''))
+        self.assertEqual(out.getvalue(), '0\n1\n2\n')
+
+    def test_exception_reports_user_traceback(self):
+        _, out, err = self._run('raise ValueError("boom")')
+        self.assertIn('ValueError: boom', err)
+        self.assertIn('File "<console>"', err)
+        # The host call stack must not leak into the user-facing report.
+        self.assertNotIn('apputil', err)
+
+    def test_syntax_error_reports_offending_line(self):
+        _, out, err = self._run('def bad(:')
+        self.assertIn('SyntaxError', err)
+        self.assertIn('bad(', err)
+
+    def test_exit_does_not_kill_process(self):
+        # exit()/quit() raises SystemExit; the console swallows it so the
+        # embedded interpreter that hosts the pilot keeps running.
+        more, out, err = self._run('raise SystemExit(2)')
+        self.assertFalse(more)
+
+    def test_exec_code_entry_point_drives_the_console(self):
+        # The C++ widget calls solvcon.system.exec_code; it must feed the
+        # same persistent interpreter and auto-display the result.
+        import io
+        from contextlib import redirect_stdout
+        from solvcon import system
+        out = io.StringIO()
+        with redirect_stdout(out):
+            system.exec_code('6 * 7')
+        self.assertEqual(out.getvalue().strip(), '42')
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -97,6 +97,106 @@ class PythonConsoleBackendTC(unittest.TestCase):
         self.assertEqual(out.getvalue().strip(), '42')
 
 
+class _FakeViewer:
+    """A stand-in for a 3D viewer widget."""
+
+    def __init__(self):
+        self.mesh = None
+        self.axis = False
+
+    def updateMesh(self, mesh):
+        self.mesh = mesh
+
+    def showAxis(self, shown):
+        self.axis = shown
+
+
+class _FakeManager:
+    """A duck-typed stand-in for the pilot manager."""
+
+    def __init__(self):
+        self._viewers = []
+
+    def add3DWidget(self):
+        viewer = _FakeViewer()
+        self._viewers.append(viewer)
+        return viewer
+
+    def currentR3DWidget(self):
+        return self._viewers[-1] if self._viewers else None
+
+    def list3DWidgets(self):
+        return list(self._viewers)
+
+
+class PilotNamespaceTC(unittest.TestCase):
+    """
+    The curated console namespace and banner.
+
+    Driven with a stand-in manager, so it runs headlessly and does not
+    need the Qt pilot.
+    """
+
+    def setUp(self):
+        from solvcon.apputil import AppEnvironment
+        self.env = AppEnvironment("ns_{}".format(id(self)))
+        self.mgr = _FakeManager()
+
+    def test_curated_handles_are_seeded(self):
+        from solvcon import apputil
+        banner = apputil.install_pilot_namespace(self.mgr, self.env)
+        g = self.env.globals
+        self.assertIs(g['mgr'], self.mgr)
+        self.assertIn('sc', g)
+        self.assertIsNone(g['viewer'])
+        self.assertIsNone(g['mesh'])
+        self.assertTrue(callable(g['show_mesh']))
+        self.assertIn('mgr', banner)
+        self.assertIn('show_mesh(m)', banner)
+
+    def test_show_mesh_opens_a_viewer(self):
+        from solvcon import apputil
+        apputil.install_pilot_namespace(self.mgr, self.env)
+        sentinel = object()
+        viewer = self.env.globals['show_mesh'](sentinel)
+        self.assertIs(viewer.mesh, sentinel)
+        self.assertTrue(viewer.axis)
+        self.assertEqual(self.env.globals['viewers'](), [viewer])
+        self.assertEqual(self.env.globals['meshes'](), [sentinel])
+
+    def test_refresher_tracks_the_current_viewer(self):
+        from solvcon import apputil
+        apputil.install_pilot_namespace(self.mgr, self.env)
+        # No viewer is open yet, so a command leaves the handles empty.
+        self.env.run_code('pass')
+        self.assertIsNone(self.env.globals['viewer'])
+        # Opening a viewer must be reflected on the next command, not stay
+        # stale at the value captured when the namespace was seeded.
+        sentinel = object()
+        self.mgr.add3DWidget().updateMesh(sentinel)
+        self.env.run_code('pass')
+        self.assertIs(self.env.globals['mesh'], sentinel)
+
+
+class HousekeepingTC(unittest.TestCase):
+    """The two latent bugs in the environment bookkeeping."""
+
+    def test_get_current_appenv_returns_the_latest(self):
+        from solvcon import apputil
+        first = apputil.AppEnvironment("hk_first_{}".format(id(self)))
+        latest = apputil.AppEnvironment("hk_latest_{}".format(id(self)))
+        self.assertIsNot(first, latest)
+        self.assertIs(apputil.get_current_appenv(), latest)
+
+    def test_stop_code_removes_the_named_environment(self):
+        from solvcon import apputil
+        name = "hk_stop_{}".format(id(self))
+        env = apputil.AppEnvironment(name)
+        self.assertIn(name, apputil.environ)
+        apputil.stop_code(env)
+        self.assertNotIn(name, apputil.environ)
+
+
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class SetupProcessTC(unittest.TestCase):
 


### PR DESCRIPTION
This turns the pilot's Python console from a one-shot `exec()` of each submission into a real read-eval-print loop, then seeds that loop with the handles a scientist actually reaches for and greets the session with a banner that lists them. The console now behaves like a standard interpreter: it carries state across submissions, auto-displays bare expressions, binds `_`, drives the `>>> ` and `... ` prompts, and survives `exit()`. On top of that it opens with `mgr`, `viewer`, `mesh`, and a few helpers already in scope, with `viewer` and `mesh` kept current as the focus changes. Two latent bookkeeping bugs in the same module are fixed along the way.

The UI does not change.  There are still two text boxes for output and input, respectively.  I will use more console to learn how to improve the UI.

## Step 1: make the pilot console a read-eval-print loop

Replace the per-submission `exec()` with a per-environment `code.InteractiveConsole`, so the console behaves like the standard read-eval-print loop instead of a fresh exec of each command.

`AppEnvironment` now owns one interpreter bound to a single namespace, shared by globals and locals, so names injected by the pilot and names bound by executed code are both visible. `run_code` feeds a command line by line through `push()`, which reports whether more input is needed and drives the `>>> ` and `... ` prompts. Compiling in `single` mode auto-displays a bare expression and binds it to `_`, and exceptions are formatted by the interpreter's own `showtraceback` and `showsyntaxerror` against the console input rather than the host call stack that `traceback.print_stack()` printed. `SystemExit` from `exit()` or `quit()` is caught so it cannot tear down the interpreter the pilot embeds.

The console dock widget echoes a submitted command with the two prompts so the transcript reads like a real interpreter session.

The console test is un-skipped and rebuilt around the backend: the bare expression auto-display and `_` binding, the multiline more-input report, the user traceback, the guarded `SystemExit`, and the `exec_code` entry point the C++ side calls.

## Step 2: curate the console namespace and fix bookkeeping

Seed the console with the handles a scientist reaches for and greet with a banner that lists them, so the live session is discoverable without knowing to walk the pilot module.

`install_pilot_namespace` seeds the namespace with `mgr` (the running manager), `viewer` (the current 3D viewer), `mesh` (its mesh), and the helpers `show_mesh(m)`, `viewers()`, and `meshes()`. `viewer` and `mesh` track the focused viewer through a namespace refresher that runs before each command, so they never go stale at the value captured when the console opened. The builder is duck-typed on the manager, and the banner is written to the transcript when the pilot builds its window. `RManager` gains `list3DWidgets`, the 3D counterpart of `list2DWidgets`, resolved through `domainWidgetOf` because a 3D viewer sits inside a host container.

Fix the two latent bookkeeping bugs in the same module: `get_current_appenv` walked the environment dict only to take the last key, and `stop_code` compared a dict key against the environment object and deleted by integer index, so it never removed anything.

Tests drive the curation with a stand-in manager and cover the seeded handles, `show_mesh` opening a viewer, the refresher tracking the current viewer, and both bookkeeping fixes.

For steps 1 and 2 of issue #1005.