### PR TITLE
Highlight syntax and ease multiline editing (step 4 of console)

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxHighlighter.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxRules.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RAction.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pilot.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/wrap_pilot.hpp
@@ -57,6 +59,8 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxHighlighter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxRules.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RAction.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/wrap_pilot.cpp
     CACHE FILEPATH "" FORCE

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
@@ -5,7 +5,10 @@
 
 #include <solvcon/pilot/RPythonConsoleDockWidget.hpp>
 
+#include <solvcon/pilot/RPythonSyntaxRules.hpp>
+
 #include <QAbstractItemView>
+#include <QColor>
 #include <QKeyEvent>
 #include <QScrollBar>
 #include <QStandardPaths>
@@ -95,6 +98,45 @@ void RPythonCommandTextEdit::insertCompletion(const QString & completion)
     setTextCursor(tc);
 }
 
+void RPythonCommandTextEdit::highlightMatchingBracket()
+{
+    QList<QTextEdit::ExtraSelection> selections;
+    std::string const text = toPlainText().toStdString();
+    int const pos = textCursor().position();
+
+    auto addSelection = [&](int position)
+    {
+        QTextCursor cursor(document());
+        cursor.setPosition(position);
+        cursor.setPosition(position + 1, QTextCursor::KeepAnchor);
+        QTextEdit::ExtraSelection selection;
+        selection.cursor = cursor;
+        selection.format.setBackground(QColor(180, 180, 255));
+        selections.append(selection);
+    };
+
+    auto tryMatch = [&](int bracket_pos)
+    {
+        if (bracket_pos < 0 || bracket_pos >= static_cast<int>(text.size()))
+        {
+            return;
+        }
+        std::size_t const other = matchBracket(text, static_cast<std::size_t>(bracket_pos));
+        if (syntax_npos == other)
+        {
+            return;
+        }
+        addSelection(bracket_pos);
+        addSelection(static_cast<int>(other));
+    };
+
+    // The cursor sits between two characters; a bracket on either side is a
+    // candidate for matching.
+    tryMatch(pos);
+    tryMatch(pos - 1);
+    setExtraSelections(selections);
+}
+
 // Tab-triggered auto-completion workflow:
 // 1. Tab key extracts the identifier prefix behind the cursor (e.g., "os.pa")
 // 2. The prefix is sent to Python's rlcompleter via the completionRequested signal
@@ -172,7 +214,11 @@ void RPythonCommandTextEdit::keyPressEvent(QKeyEvent * event)
     {
         if (event->modifiers() & Qt::ShiftModifier)
         {
-            this->insertPlainText("\n");
+            // Open the next line at the same indentation, plus one level
+            // after a block-opening colon.
+            std::string const line = textCursor().block().text().toStdString();
+            std::string const indent = nextLineIndent(line);
+            insertPlainText(QString::fromStdString("\n" + indent));
         }
         else
         {
@@ -272,6 +318,13 @@ RPythonConsoleDockWidget::RPythonConsoleDockWidget(const QString & title, QWidge
         m_history.load();
         m_current_command_index = static_cast<int>(m_history.size());
     }
+
+    m_highlighter = new RPythonSyntaxHighlighter(m_command_edit->document());
+    connect(
+        m_command_edit,
+        &RPythonCommandTextEdit::cursorPositionChanged,
+        m_command_edit,
+        &RPythonCommandTextEdit::highlightMatchingBracket);
 
     m_completer_model = new QStringListModel(this);
     m_completer = new QCompleter(m_completer_model, this);

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
@@ -16,6 +16,7 @@
 #include <solvcon/python/common.hpp> // must be first.
 
 #include <solvcon/pilot/RPythonConsoleHistory.hpp>
+#include <solvcon/pilot/RPythonSyntaxHighlighter.hpp>
 
 #include <cstddef>
 #include <string>
@@ -62,6 +63,10 @@ signals:
     void completionRequested(const QString & prefix);
     void searchHistory();
     void searchHistoryReset();
+
+public slots:
+
+    void highlightMatchingBracket();
 
 private slots:
 
@@ -161,6 +166,7 @@ private:
     QCompleter * m_completer = nullptr;
     QStringListModel * m_completer_model = nullptr;
     QString m_completer_root_prefix;
+    RPythonSyntaxHighlighter * m_highlighter = nullptr;
 }; /* end class RPythonConsoleDockWidget */
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/RPythonSyntaxHighlighter.cpp
+++ b/cpp/solvcon/pilot/RPythonSyntaxHighlighter.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RPythonSyntaxHighlighter.hpp>
+
+#include <solvcon/pilot/RPythonSyntaxRules.hpp>
+
+#include <QColor>
+
+namespace solvcon
+{
+
+RPythonSyntaxHighlighter::RPythonSyntaxHighlighter(QTextDocument * parent)
+    : QSyntaxHighlighter(parent)
+{
+    m_keyword_format.setForeground(QColor(0, 0, 180));
+    m_keyword_format.setFontWeight(QFont::Bold);
+    m_builtin_format.setForeground(QColor(0, 110, 110));
+    m_string_format.setForeground(QColor(160, 0, 0));
+    m_comment_format.setForeground(QColor(128, 128, 128));
+    m_comment_format.setFontItalic(true);
+    m_number_format.setForeground(QColor(140, 0, 140));
+}
+
+void RPythonSyntaxHighlighter::highlightBlock(QString const & text)
+{
+    for (SyntaxSpan const & span : tokenizePython(text.toStdString()))
+    {
+        QTextCharFormat const * format = nullptr;
+        switch (span.kind)
+        {
+        case SyntaxTokenKind::Keyword:
+            format = &m_keyword_format;
+            break;
+        case SyntaxTokenKind::Builtin:
+            format = &m_builtin_format;
+            break;
+        case SyntaxTokenKind::String:
+            format = &m_string_format;
+            break;
+        case SyntaxTokenKind::Comment:
+            format = &m_comment_format;
+            break;
+        case SyntaxTokenKind::Number:
+            format = &m_number_format;
+            break;
+        }
+        setFormat(static_cast<int>(span.start), static_cast<int>(span.length), *format);
+    }
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RPythonSyntaxHighlighter.hpp
+++ b/cpp/solvcon/pilot/RPythonSyntaxHighlighter.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+/*
+ * Copyright (c) 2022, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * A Qt syntax highlighter that paints one line of Python in the console
+ * command editor, using the Qt-free rules in RPythonSyntaxRules.
+ *
+ * @ingroup group_domain
+ */
+
+#include <QSyntaxHighlighter>
+#include <QTextCharFormat>
+
+namespace solvcon
+{
+
+/**
+ * Paints Python keywords, builtins, strings, comments, and numbers in a
+ * text document. The lexing lives in tokenizePython so it can be tested
+ * without a display; this class only maps each category to a format.
+ *
+ * @ingroup group_domain
+ */
+class RPythonSyntaxHighlighter
+    : public QSyntaxHighlighter
+{
+    Q_OBJECT
+
+public:
+
+    explicit RPythonSyntaxHighlighter(QTextDocument * parent);
+
+protected:
+
+    void highlightBlock(QString const & text) override;
+
+private:
+
+    QTextCharFormat m_keyword_format;
+    QTextCharFormat m_builtin_format;
+    QTextCharFormat m_string_format;
+    QTextCharFormat m_comment_format;
+    QTextCharFormat m_number_format;
+
+}; /* end class RPythonSyntaxHighlighter */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RPythonSyntaxRules.cpp
+++ b/cpp/solvcon/pilot/RPythonSyntaxRules.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2022, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RPythonSyntaxRules.hpp>
+
+#include <cctype>
+#include <unordered_set>
+
+namespace solvcon
+{
+
+namespace
+{
+
+bool isIdentStart(char ch)
+{
+    return (std::isalpha(static_cast<unsigned char>(ch)) != 0) || ch == '_';
+}
+
+bool isIdentChar(char ch)
+{
+    return (std::isalnum(static_cast<unsigned char>(ch)) != 0) || ch == '_';
+}
+
+bool isDigit(char ch)
+{
+    return std::isdigit(static_cast<unsigned char>(ch)) != 0;
+}
+
+std::unordered_set<std::string> const & keywords()
+{
+    static std::unordered_set<std::string> const set = {
+        "False", "None", "True", "and", "as", "assert", "async", "await", "break", "class", "continue", "def", "del", "elif", "else", "except", "finally", "for", "from", "global", "if", "import", "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try", "while", "with", "yield"};
+    return set;
+}
+
+std::unordered_set<std::string> const & builtins()
+{
+    static std::unordered_set<std::string> const set = {
+        "abs", "dict", "dir", "enumerate", "float", "getattr", "hasattr", "int", "isinstance", "len", "list", "map", "max", "min", "open", "print", "range", "repr", "set", "sorted", "str", "sum", "tuple", "type", "zip"};
+    return set;
+}
+
+} /* end namespace */
+
+std::vector<SyntaxSpan> tokenizePython(std::string const & line)
+{
+    std::vector<SyntaxSpan> spans;
+    std::size_t const size = line.size();
+    std::size_t i = 0;
+    while (i < size)
+    {
+        char const ch = line[i];
+        if (ch == '#')
+        {
+            spans.push_back({i, size - i, SyntaxTokenKind::Comment});
+            break;
+        }
+        if (ch == '\'' || ch == '"')
+        {
+            std::size_t const start = i;
+            ++i;
+            while (i < size)
+            {
+                if (line[i] == '\\' && i + 1 < size)
+                {
+                    i += 2;
+                    continue;
+                }
+                if (line[i] == ch)
+                {
+                    ++i;
+                    break;
+                }
+                ++i;
+            }
+            spans.push_back({start, i - start, SyntaxTokenKind::String});
+            continue;
+        }
+        if (isIdentStart(ch))
+        {
+            std::size_t const start = i;
+            while (i < size && isIdentChar(line[i]))
+            {
+                ++i;
+            }
+            std::string const word = line.substr(start, i - start);
+            if (keywords().count(word) != 0)
+            {
+                spans.push_back({start, i - start, SyntaxTokenKind::Keyword});
+            }
+            else if (builtins().count(word) != 0)
+            {
+                spans.push_back({start, i - start, SyntaxTokenKind::Builtin});
+            }
+            continue;
+        }
+        if (isDigit(ch))
+        {
+            std::size_t const start = i;
+            while (i < size && (isIdentChar(line[i]) || line[i] == '.'))
+            {
+                ++i;
+            }
+            spans.push_back({start, i - start, SyntaxTokenKind::Number});
+            continue;
+        }
+        ++i;
+    }
+    return spans;
+}
+
+std::string nextLineIndent(std::string const & line)
+{
+    std::size_t lead = 0;
+    while (lead < line.size() && (line[lead] == ' ' || line[lead] == '\t'))
+    {
+        ++lead;
+    }
+    std::string indent = line.substr(0, lead);
+
+    std::size_t end = line.size();
+    while (end > 0 && (line[end - 1] == ' ' || line[end - 1] == '\t'))
+    {
+        --end;
+    }
+    if (end > 0 && line[end - 1] == ':')
+    {
+        indent += "    ";
+    }
+    return indent;
+}
+
+std::size_t matchBracket(std::string const & text, std::size_t pos)
+{
+    if (pos >= text.size())
+    {
+        return syntax_npos;
+    }
+
+    std::string const opens = "([{";
+    std::string const closes = ")]}";
+    char const ch = text[pos];
+
+    std::size_t const open_at = opens.find(ch);
+    if (open_at != std::string::npos)
+    {
+        char const close = closes[open_at];
+        int depth = 0;
+        for (std::size_t i = pos; i < text.size(); ++i)
+        {
+            if (text[i] == ch)
+            {
+                ++depth;
+            }
+            else if (text[i] == close)
+            {
+                --depth;
+                if (depth == 0)
+                {
+                    return i;
+                }
+            }
+        }
+        return syntax_npos;
+    }
+
+    std::size_t const close_at = closes.find(ch);
+    if (close_at != std::string::npos)
+    {
+        char const open = opens[close_at];
+        int depth = 0;
+        for (std::size_t i = pos + 1; i-- > 0;)
+        {
+            if (text[i] == ch)
+            {
+                ++depth;
+            }
+            else if (text[i] == open)
+            {
+                --depth;
+                if (depth == 0)
+                {
+                    return i;
+                }
+            }
+        }
+        return syntax_npos;
+    }
+
+    return syntax_npos;
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RPythonSyntaxRules.hpp
+++ b/cpp/solvcon/pilot/RPythonSyntaxRules.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+/*
+ * Copyright (c) 2022, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Qt-free lexical rules for the console editor: single-line Python
+ * tokenizing for syntax highlighting, next-line indentation, and bracket
+ * matching. Kept free of Qt so the logic can be tested without a display.
+ *
+ * @ingroup group_domain
+ */
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace solvcon
+{
+
+/// The lexical category a highlighter paints.
+enum class SyntaxTokenKind
+{
+    Keyword,
+    Builtin,
+    String,
+    Comment,
+    Number
+};
+
+/// A half-open range [start, start + length) of one category on a line.
+struct SyntaxSpan
+{
+    std::size_t start;
+    std::size_t length;
+    SyntaxTokenKind kind;
+};
+
+constexpr std::size_t syntax_npos = static_cast<std::size_t>(-1);
+
+/// Tokenize one line of Python for highlighting. Strings and comments are
+/// single-line, which is enough for a command editor.
+std::vector<SyntaxSpan> tokenizePython(std::string const & line);
+
+/// The indentation that opens the next line: the current line's leading
+/// whitespace, plus one four-space level when the line ends with a colon.
+std::string nextLineIndent(std::string const & line);
+
+/// The index of the bracket matching the one at @p pos, or syntax_npos when
+/// @p pos is not a bracket or has no match. Counts nesting per bracket type
+/// and is not string-aware.
+std::size_t matchBracket(std::string const & text, std::size_t pos);
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -36,7 +36,9 @@ add_executable(
     test_nopython_mdspan.cpp
     test_nopython_multidim.cpp
     test_nopython_pilot_history.cpp
+    test_nopython_pilot_syntax.cpp
     ${SOLVCON_INCLUDE_DIR}/solvcon/pilot/RPythonConsoleHistory.cpp
+    ${SOLVCON_INCLUDE_DIR}/solvcon/pilot/RPythonSyntaxRules.cpp
     ${SOLVCON_TOGGLE_SOURCES}
     ${SOLVCON_BUFFER_SOURCES}
     ${SOLVCON_SERIALIZATION_SOURCES}

--- a/gtests/test_nopython_pilot_syntax.cpp
+++ b/gtests/test_nopython_pilot_syntax.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RPythonSyntaxRules.hpp>
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+using solvcon::matchBracket;
+using solvcon::nextLineIndent;
+using solvcon::syntax_npos;
+using solvcon::SyntaxSpan;
+using solvcon::SyntaxTokenKind;
+using solvcon::tokenizePython;
+
+namespace
+{
+
+bool hasSpan(std::vector<SyntaxSpan> const & spans, std::size_t start, std::size_t length, SyntaxTokenKind kind)
+{
+    for (auto const & span : spans)
+    {
+        if (span.start == start && span.length == length && span.kind == kind)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+} /* end namespace */
+
+TEST(PilotSyntaxTokenize, MarksKeywordStringComment)
+{
+    std::string const line = "for x in y:  # loop";
+    auto const spans = tokenizePython(line);
+    EXPECT_TRUE(hasSpan(spans, 0, 3, SyntaxTokenKind::Keyword)); // for
+    EXPECT_TRUE(hasSpan(spans, 6, 2, SyntaxTokenKind::Keyword)); // in
+    EXPECT_TRUE(hasSpan(spans, 13, 6, SyntaxTokenKind::Comment)); // # loop
+}
+
+TEST(PilotSyntaxTokenize, MarksStringAndBuiltinAndNumber)
+{
+    std::string const line = "print('a', 42)";
+    auto const spans = tokenizePython(line);
+    EXPECT_TRUE(hasSpan(spans, 0, 5, SyntaxTokenKind::Builtin)); // print
+    EXPECT_TRUE(hasSpan(spans, 6, 3, SyntaxTokenKind::String)); // 'a'
+    EXPECT_TRUE(hasSpan(spans, 11, 2, SyntaxTokenKind::Number)); // 42
+}
+
+TEST(PilotSyntaxTokenize, HandlesEscapedQuoteInString)
+{
+    std::string const line = R"(s = 'a\'b')";
+    auto const spans = tokenizePython(line);
+    // The string spans from the opening quote to the final closing quote,
+    // skipping the escaped quote in the middle.
+    EXPECT_TRUE(hasSpan(spans, 4, 6, SyntaxTokenKind::String));
+}
+
+TEST(PilotSyntaxTokenize, DoesNotMarkAKeywordSubstring)
+{
+    // "format" contains "for" but is not the keyword.
+    auto const spans = tokenizePython("format");
+    EXPECT_TRUE(spans.empty());
+}
+
+TEST(PilotSyntaxIndent, KeepsIndentAndOpensAfterColon)
+{
+    EXPECT_EQ(nextLineIndent("    x = 1"), "    ");
+    EXPECT_EQ(nextLineIndent("    if x:"), "        ");
+    EXPECT_EQ(nextLineIndent("for i in range(3):  "), "    ");
+    EXPECT_EQ(nextLineIndent("plain"), "");
+}
+
+TEST(PilotSyntaxBracket, MatchesForwardBackwardAndNested)
+{
+    std::string const text = "f(a, (b, c))";
+    EXPECT_EQ(matchBracket(text, 1), 11u); // outer ( -> last )
+    EXPECT_EQ(matchBracket(text, 11), 1u); // last ) -> outer (
+    EXPECT_EQ(matchBracket(text, 5), 10u); // inner ( -> inner )
+}
+
+TEST(PilotSyntaxBracket, ReturnsNposForUnmatchedOrNonBracket)
+{
+    EXPECT_EQ(matchBracket("(a", 0), syntax_npos);
+    EXPECT_EQ(matchBracket("ab", 0), syntax_npos);
+    EXPECT_EQ(matchBracket("()", 5), syntax_npos);
+}
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Give the command editor the editing comforts of a modern REPL: syntax highlighting, auto-indent, and bracket matching.

RPythonSyntaxRules holds the lexical logic, kept free of Qt so it can be tested without a display. tokenizePython marks keywords, builtins, strings, comments, and numbers on a line; nextLineIndent returns the indentation that opens the next line, one level deeper after a block-opening colon; and matchBracket finds the partner of a bracket, counting nesting per type. RPythonSyntaxHighlighter maps each token category to a text format and paints the editor.

The console dock widget installs the highlighter on the command editor, indents a Shift+Enter continuation to match the current line, and paints the bracket under or before the cursor together with its match as the cursor moves.

A C++ test covers the rules: keyword, string, comment, builtin, and number tokenizing, an escaped quote inside a string, a keyword substring that must not be marked, indentation carried and opened after a colon, and bracket matching forward, backward, nested, and unmatched.

For step 4 of issue #1005.