### PR TITLE
Add call tips and use a non-blocking worker (steps 5, 6 of console)

### DIFF
--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
@@ -8,6 +8,7 @@
 #include <solvcon/pilot/RPythonSyntaxRules.hpp>
 
 #include <QAbstractItemView>
+#include <QApplication>
 #include <QColor>
 #include <QKeyEvent>
 #include <QScrollBar>
@@ -430,6 +431,10 @@ void RPythonConsoleDockWidget::executeCommand()
     m_command_edit->clear();
     m_current_command_index = static_cast<int>(m_history.size());
 
+    // The command runs on the GUI thread, so a slow one freezes the window.
+    // Show a busy cursor for the duration; run_worker in the console offloads
+    // heavy work to a worker thread when responsiveness matters.
+    QApplication::setOverrideCursor(Qt::WaitCursor);
     auto & interp = solvcon::python::Interpreter::instance();
     m_python_redirect.activate();
     interp.exec_code(command);
@@ -439,6 +444,7 @@ void RPythonConsoleDockWidget::executeCommand()
         printCommandStderr(m_python_redirect.stderr_string());
     }
     m_python_redirect.deactivate();
+    QApplication::restoreOverrideCursor();
 }
 
 void RPythonConsoleDockWidget::navigateCommand(int offset)

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
@@ -13,6 +13,7 @@
 #include <QScrollBar>
 #include <QStandardPaths>
 #include <QTextBlock>
+#include <QToolTip>
 #include <QVBoxLayout>
 
 namespace solvcon
@@ -82,6 +83,40 @@ QString RPythonCommandTextEdit::completionPrefix() const
         prefix = prefix.mid(1);
     }
     return prefix;
+}
+
+QString RPythonCommandTextEdit::callableExpression() const
+{
+    QTextCursor const tc = textCursor();
+    QString const block_text = tc.block().text();
+    int const pos = tc.positionInBlock();
+
+    // The cursor sits just past the '(' that triggered the tip; the callable
+    // is the identifier chain immediately before that '('.
+    if (pos < 2 || block_text[pos - 1] != '(')
+    {
+        return QString();
+    }
+    int const end = pos - 1;
+    int start = end - 1;
+    while (start >= 0)
+    {
+        QChar const ch = block_text[start];
+        if (ch.isLetterOrNumber() || ch == '_' || ch == '.')
+        {
+            --start;
+        }
+        else
+        {
+            break;
+        }
+    }
+    QString expr = block_text.mid(start + 1, end - start - 1);
+    while (expr.startsWith('.'))
+    {
+        expr = expr.mid(1);
+    }
+    return expr;
 }
 
 void RPythonCommandTextEdit::insertCompletion(const QString & completion)
@@ -236,6 +271,15 @@ void RPythonCommandTextEdit::keyPressEvent(QKeyEvent * event)
     else
     {
         QTextEdit::keyPressEvent(event);
+        // A '(' just typed after a callable asks for its signature tip.
+        if (event->text() == "(")
+        {
+            QString const expr = callableExpression();
+            if (!expr.isEmpty())
+            {
+                callTipRequested(expr);
+            }
+        }
     }
 }
 
@@ -330,6 +374,7 @@ RPythonConsoleDockWidget::RPythonConsoleDockWidget(const QString & title, QWidge
     m_completer = new QCompleter(m_completer_model, this);
     m_command_edit->setCompleter(m_completer);
     connect(m_command_edit, &RPythonCommandTextEdit::completionRequested, this, &RPythonConsoleDockWidget::handleCompletionRequest);
+    connect(m_command_edit, &RPythonCommandTextEdit::callTipRequested, this, &RPythonConsoleDockWidget::handleCallTipRequest);
     connect(m_command_edit, &QTextEdit::textChanged, this, &RPythonConsoleDockWidget::updateCompletionPrefix);
 }
 
@@ -532,6 +577,19 @@ void RPythonConsoleDockWidget::handleCompletionRequest(const QString & prefix)
     cr.setWidth(
         m_completer->popup()->sizeHintForColumn(0) + m_completer->popup()->verticalScrollBar()->sizeHint().width());
     m_completer->complete(cr);
+}
+
+void RPythonConsoleDockWidget::handleCallTipRequest(const QString & expression)
+{
+    auto & interp = solvcon::python::Interpreter::instance();
+    std::string const tip = interp.get_call_tip(expression.toStdString());
+    if (tip.empty())
+    {
+        return;
+    }
+
+    QPoint const anchor = m_command_edit->mapToGlobal(m_command_edit->cursorRect().bottomRight());
+    QToolTip::showText(anchor, QString::fromStdString(tip), m_command_edit);
 }
 
 // Called on every textChanged signal while the popup is visible. As the user

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
@@ -53,6 +53,7 @@ public:
     void setCompleter(QCompleter * completer);
     QCompleter * completer() const { return m_completer; }
     QString completionPrefix() const;
+    QString callableExpression() const;
 
     void keyPressEvent(QKeyEvent * event) override;
 
@@ -63,6 +64,7 @@ signals:
     void completionRequested(const QString & prefix);
     void searchHistory();
     void searchHistoryReset();
+    void callTipRequested(const QString & expression);
 
 public slots:
 
@@ -142,6 +144,7 @@ public slots:
 
 private slots:
     void handleCompletionRequest(const QString & prefix);
+    void handleCallTipRequest(const QString & expression);
     void updateCompletionPrefix();
 
 private:

--- a/cpp/solvcon/python/common.cpp
+++ b/cpp/solvcon/python/common.cpp
@@ -206,6 +206,29 @@ std::vector<std::string> Interpreter::get_completions(std::string const & text)
     return result;
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+std::string Interpreter::get_call_tip(std::string const & text)
+{
+    std::string result;
+    try
+    {
+        pybind11::gil_scoped_acquire const gil;
+        // NOLINTNEXTLINE(misc-const-correctness)
+        pybind11::object mod_sys = pybind11::module_::import("solvcon.system");
+        pybind11::object const py_result = mod_sys.attr("get_call_tip")(text);
+        result = py_result.cast<std::string>();
+    }
+    catch (const pybind11::error_already_set & e)
+    {
+        std::cerr << e.what() << std::endl;
+    }
+    catch (const std::exception & e)
+    {
+        std::cerr << "get_call_tip error: " << e.what() << std::endl;
+    }
+    return result;
+}
+
 PythonStreamRedirect & PythonStreamRedirect::activate()
 {
     if (is_enabled())

--- a/cpp/solvcon/python/common.hpp
+++ b/cpp/solvcon/python/common.hpp
@@ -500,6 +500,7 @@ public:
     int enter_main();
     void exec_code(std::string const & code);
     std::vector<std::string> get_completions(std::string const & text);
+    std::string get_call_tip(std::string const & text);
 
 private:
 

--- a/solvcon/apputil.py
+++ b/solvcon/apputil.py
@@ -16,6 +16,8 @@ Tools to run applications
 
 import code
 import importlib
+import inspect
+import re
 import rlcompleter
 
 
@@ -24,12 +26,20 @@ __all__ = [
     'AppEnvironment',
     'get_current_appenv',
     'get_completions',
+    'get_call_tip',
     'run_code',
     'stop_code',
     'build_pilot_namespace',
     'format_banner',
     'install_pilot_namespace',
 ]
+
+
+# A dotted identifier chain such as ``range`` or ``mgr.add3DWidget``. The
+# call tip only introspects such an expression, never one that calls or
+# subscripts, so evaluating it cannot run arbitrary user code.
+_IDENTIFIER_CHAIN = re.compile(
+    r'[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$')
 
 
 # All environment objects of this process.
@@ -157,6 +167,40 @@ def get_completions(text):
         completions.append(c)
         i += 1
     return completions
+
+
+def get_call_tip(expr):
+    """
+    A signature and docstring summary for the callable named by ``expr``.
+
+    ``expr`` is a dotted identifier chain such as ``range`` or
+    ``mgr.add3DWidget``. It is resolved against the current namespace, so,
+    like the introspective completion, it can touch live objects. It is
+    never evaluated when it is anything other than an identifier chain, so
+    a call or subscript cannot run arbitrary code. Returns an empty string
+    when the expression does not resolve to a callable.
+    """
+    expr = expr.strip()
+    if not _IDENTIFIER_CHAIN.match(expr):
+        return ''
+    aenv = get_current_appenv()
+    namespace = {'__builtins__': __builtins__}
+    namespace.update(aenv.globals)
+    try:
+        obj = eval(expr, namespace)
+    except Exception:
+        return ''
+    if not callable(obj):
+        return ''
+    try:
+        signature = str(inspect.signature(obj))
+    except (TypeError, ValueError):
+        signature = '(...)'
+    tip = expr + signature
+    doc = inspect.getdoc(obj)
+    if doc:
+        tip += '\n' + doc.strip().split('\n\n')[0]
+    return tip
 
 
 def run_code(source):

--- a/solvcon/apputil.py
+++ b/solvcon/apputil.py
@@ -15,6 +15,7 @@ Tools to run applications
 
 
 import code
+import concurrent.futures
 import importlib
 import inspect
 import re
@@ -28,11 +29,16 @@ __all__ = [
     'get_completions',
     'get_call_tip',
     'run_code',
+    'run_worker',
     'stop_code',
     'build_pilot_namespace',
     'format_banner',
     'install_pilot_namespace',
 ]
+
+
+# A lazily created single-thread pool that backs run_worker.
+_worker_pool = None
 
 
 # A dotted identifier chain such as ``range`` or ``mgr.add3DWidget``. The
@@ -208,6 +214,23 @@ def run_code(source):
     return aenv.run_code(source)
 
 
+def run_worker(func, *args, **kwargs):
+    """
+    Run ``func`` on a background worker thread and return its Future.
+
+    A command in the console runs on the GUI thread, so heavy work freezes
+    the window until it returns; the console cannot interrupt a running
+    command in-process. Hand such work to this helper instead: the solver
+    core releases the GIL while it computes, so the GUI stays responsive.
+    Poll the returned :class:`concurrent.futures.Future` for the result.
+    """
+    global _worker_pool
+    if _worker_pool is None:
+        _worker_pool = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix='solvcon-console-worker')
+    return _worker_pool.submit(func, *args, **kwargs)
+
+
 def stop_code(appenvobj=None):
     if None is appenvobj:
         environ.clear()
@@ -249,6 +272,7 @@ def build_pilot_namespace(mgr):
         'show_mesh': show_mesh,
         'viewers': viewers,
         'meshes': meshes,
+        'run_worker': run_worker,
     }
     entries = [
         ('mgr', 'the running pilot manager'),
@@ -257,6 +281,7 @@ def build_pilot_namespace(mgr):
         ('show_mesh(m)', 'open a mesh in a fresh 3D viewer'),
         ('viewers()', 'list the open 3D viewers'),
         ('meshes()', 'list the loaded meshes'),
+        ('run_worker(f)', 'run f on a worker thread; returns a Future'),
         ('sc', 'the solvcon package'),
     ]
     return handles, entries

--- a/solvcon/system.py
+++ b/solvcon/system.py
@@ -22,6 +22,7 @@ __all__ = [
     'enter_main',
     'exec_code',
     'get_completions',
+    'get_call_tip',
 ]
 
 
@@ -143,5 +144,13 @@ def get_completions(text):
     except Exception as e:
         sys.stderr.write("get_completions error: {}\n".format(e))
         return []
+
+
+def get_call_tip(text):
+    try:
+        return apputil.get_call_tip(text)
+    except Exception as e:
+        sys.stderr.write("get_call_tip error: {}\n".format(e))
+        return ''
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -197,6 +197,60 @@ class HousekeepingTC(unittest.TestCase):
         self.assertNotIn(name, apputil.environ)
 
 
+class CallTipTC(unittest.TestCase):
+    """
+    The call tip that the console shows when a ``(`` is typed.
+
+    Driven through solvcon.apputil directly, so it runs headlessly.
+    """
+
+    def setUp(self):
+        from solvcon.apputil import AppEnvironment
+        self.env = AppEnvironment("tip_{}".format(id(self)))
+
+    def test_builtin_signature_and_docstring(self):
+        from solvcon import apputil
+        tip = apputil.get_call_tip('range')
+        self.assertTrue(tip.startswith('range('))
+        self.assertIn('range', tip)
+
+    def test_seeded_callable_signature_and_first_paragraph(self):
+        from solvcon import apputil
+
+        def greet(name, count=1):
+            """Say hello to someone.
+
+            This second paragraph must not appear in the tip.
+            """
+            return name
+
+        self.env.seed(greet=greet)
+        tip = apputil.get_call_tip('greet')
+        self.assertIn('greet(name, count=1)', tip)
+        self.assertIn('Say hello to someone.', tip)
+        self.assertNotIn('second paragraph', tip)
+
+    def test_non_callable_returns_empty(self):
+        from solvcon import apputil
+        self.env.seed(value=42)
+        self.assertEqual(apputil.get_call_tip('value'), '')
+
+    def test_unknown_name_returns_empty(self):
+        from solvcon import apputil
+        self.assertEqual(apputil.get_call_tip('does_not_exist'), '')
+
+    def test_call_expression_is_not_evaluated(self):
+        from solvcon import apputil
+
+        def boom():
+            raise AssertionError("the call tip must not invoke the callable")
+
+        self.env.seed(boom=boom)
+        # 'boom()' is not a bare identifier chain, so it is rejected before
+        # any evaluation and boom is never called.
+        self.assertEqual(apputil.get_call_tip('boom()'), '')
+
+
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class SetupProcessTC(unittest.TestCase):
 

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -151,6 +151,7 @@ class PilotNamespaceTC(unittest.TestCase):
         self.assertIsNone(g['viewer'])
         self.assertIsNone(g['mesh'])
         self.assertTrue(callable(g['show_mesh']))
+        self.assertTrue(callable(g['run_worker']))
         self.assertIn('mgr', banner)
         self.assertIn('show_mesh(m)', banner)
 
@@ -249,6 +250,32 @@ class CallTipTC(unittest.TestCase):
         # 'boom()' is not a bare identifier chain, so it is rejected before
         # any evaluation and boom is never called.
         self.assertEqual(apputil.get_call_tip('boom()'), '')
+
+
+class WorkerTC(unittest.TestCase):
+    """The worker-thread helper for heavy console work."""
+
+    def test_runs_off_the_calling_thread(self):
+        import threading
+        from solvcon import apputil
+        caller = threading.get_ident()
+        future = apputil.run_worker(threading.get_ident)
+        self.assertNotEqual(future.result(timeout=5), caller)
+
+    def test_returns_the_result(self):
+        from solvcon import apputil
+        future = apputil.run_worker(lambda a, b: a + b, 2, 3)
+        self.assertEqual(future.result(timeout=5), 5)
+
+    def test_propagates_exceptions_through_the_future(self):
+        from solvcon import apputil
+
+        def boom():
+            raise ValueError("worker failed")
+
+        future = apputil.run_worker(boom)
+        with self.assertRaises(ValueError):
+            future.result(timeout=5)
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")


### PR DESCRIPTION
The final two steps to improve the pilot's Python console. The console gains a call tip that appears when you type an open parenthesis after a callable, and it stops silently freezing on slow work: it shows a busy cursor while a command runs and seeds a `run_worker` helper that submits heavy work to a background thread. Both build on the read-eval-print loop and curated namespace from the earlier, already-merged steps.

## Step 5: show a call tip on an open parenthesis

Keep the introspective rlcompleter path and add a call tip: when a `(` is typed after a callable, the console shows the callable's signature and the first line of its docstring.

`get_call_tip` resolves the identifier chain before the paren against the current namespace and formats `inspect.signature` plus the first paragraph of the docstring. It reflects real runtime state the way completion does, but it refuses to evaluate anything other than a dotted identifier, so a call or subscript in the text cannot run arbitrary code. The C++ side reaches it through `Interpreter::get_call_tip`, and the command editor extracts the callable before the `(` it just inserted and shows the tip in a tooltip at the cursor.

## Step 6: show a busy state and add a worker-thread helper

A console command runs on the GUI thread, so a slow one freezes the window, and an in-process console cannot interrupt a running command. Be honest about it and give a way around it.

The console shows a busy cursor while a command runs. `run_worker` submits a callable to a background worker thread and returns its `Future`, so heavy solver work, which releases the GIL in the C++ core while it computes, runs without blocking the GUI event loop. It is seeded into the console namespace and listed in the banner next to the other handles.

For steps 5, 6 of issue #1005.