### PR TITLE
Guard the console against blocking stdin reads

### DIFF
--- a/solvcon/apputil.py
+++ b/solvcon/apputil.py
@@ -16,10 +16,13 @@ Tools to run applications
 
 import code
 import concurrent.futures
+import contextlib
 import importlib
 import inspect
+import io
 import re
 import rlcompleter
+import sys
 
 
 __all__ = [
@@ -72,6 +75,25 @@ class _ConsoleInterpreter(code.InteractiveConsole):
             self.write("SystemExit: use the window controls to quit.\n")
             self.resetbuffer()
             return False
+
+
+@contextlib.contextmanager
+def _stdin_at_eof():
+    """
+    Present an exhausted ``sys.stdin`` for the duration of a command.
+
+    The embedded console has no interactive input. A command that reads
+    stdin, such as a bare ``help()`` that starts pydoc's interactive
+    browser, would otherwise block the GUI thread forever waiting for a
+    line that never arrives. An empty stream reads as immediate EOF, so
+    the read ends at once and the command returns.
+    """
+    saved = sys.stdin
+    sys.stdin = io.StringIO()
+    try:
+        yield
+    finally:
+        sys.stdin = saved
 
 
 class AppEnvironment:
@@ -128,10 +150,13 @@ class AppEnvironment:
         for refresh in self.namespace_refreshers:
             refresh(self.globals)
         more = False
-        for line in source.split('\n'):
-            more = self.console.push(line)
-        if more:
-            more = self.console.push('')
+        # The treatment is for the console UI that has I/O in separate text
+        # boxes. After having an alternate terminal UI, it will have stdio.
+        with _stdin_at_eof():
+            for line in source.split('\n'):
+                more = self.console.push(line)
+            if more:
+                more = self.console.push('')
         return more
 
 

--- a/tests/test_apputil.py
+++ b/tests/test_apputil.py
@@ -2,6 +2,9 @@
 # BSD 3-Clause License, see COPYING
 
 
+import contextlib
+import io
+import threading
 import unittest
 
 import solvcon
@@ -43,5 +46,49 @@ class AppenvTC(unittest.TestCase):
         # Try to reset the environment dictionary.
         solvcon.apputil.environ.clear()
         _check(0, basenum=0)
+
+
+class RunCodeStdinTC(unittest.TestCase):
+    """The embedded console has no interactive stdin, so a command that
+    reads it must hit EOF at once rather than block the GUI thread."""
+
+    def setUp(self):
+        self.envbak = solvcon.apputil.environ.copy()
+
+    def tearDown(self):
+        solvcon.apputil.environ.clear()
+        solvcon.apputil.environ = self.envbak.copy()
+
+    def _run_with_timeout(self, source, timeout=10):
+        env = solvcon.apputil.AppEnvironment('stdin-test')
+        done = threading.Event()
+
+        # Run on a daemon thread so a regression that hangs fails the
+        # assertion instead of stalling the whole test process.
+        def _run():
+            with contextlib.redirect_stdout(io.StringIO()):
+                env.run_code(source)
+            done.set()
+        threading.Thread(target=_run, daemon=True).start()
+        self.assertTrue(done.wait(timeout=timeout),
+                        "run_code blocked reading stdin")
+        return env
+
+    def test_help_does_not_hang(self):
+        self._run_with_timeout('help()')
+
+    def test_input_reads_eof(self):
+        env = self._run_with_timeout(
+            'got_eof = False\n'
+            'try:\n'
+            '    input()\n'
+            'except EOFError:\n'
+            '    got_eof = True\n')
+        self.assertTrue(env.globals['got_eof'])
+
+    def test_stdin_restored_after_run(self):
+        saved = solvcon.apputil.sys.stdin
+        self._run_with_timeout('pass')
+        self.assertIs(solvcon.apputil.sys.stdin, saved)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
When running `help()` without argument in the new console that uses `InteractiveConsole`, it hangs the whole pilot.

A bare `help()` in the pilot console starts pydoc's interactive browser, which loops reading `sys.stdin`. The console runs commands on the GUI thread with no interactive input, so the read never returns and the window freezes. `input()` and any other stdin read hang the same way.

Present an exhausted `sys.stdin` while a console command runs, so such a read hits EOF at once and the command returns. The guard lives in the shared `run_code` driver, so it covers the pilot and any other embedding.

It will need improvement after implementing a terminal-based UI that has both stdin and stdout (issue #1023).