### PR TITLE
Add a Claude CLI backend for the agent

### DIFF
--- a/solvcon/agent/__init__.py
+++ b/solvcon/agent/__init__.py
@@ -13,6 +13,7 @@ headless build.
 
 from . import _core  # noqa: F401
 from . import _backend  # noqa: F401
+from . import _backends_impl  # noqa: F401
 
 # _core.py
 list_of_core = [
@@ -31,13 +32,20 @@ list_of_backend = [
     'get_backend',
 ]
 
+# _backends_impl.py
+list_of_backends_impl = [
+    'SubprocessBackend',
+    'ClaudeCliBackend',
+    'parse_tool_calls',
+]
+
 # TODO: when the Qt dock module exists in solvcon.pilot, point this at its
 # Agent class, guarded by _pilot_core.enable like the airfoil sub-package.
 Agent = None
 
-__all__ = list_of_core + list_of_backend + [  # noqa: F822
-    'Agent',
-]
+__all__ = (  # noqa: F822
+    list_of_core + list_of_backend + list_of_backends_impl + ['Agent']
+)
 
 
 def _load(module, symbol_list):
@@ -47,6 +55,7 @@ def _load(module, symbol_list):
 
 _load(_core, list_of_core)
 _load(_backend, list_of_backend)
+_load(_backends_impl, list_of_backends_impl)
 
 del _load
 

--- a/solvcon/agent/_backends_impl.py
+++ b/solvcon/agent/_backends_impl.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Concrete AI backends over external command-line tools.
+
+This module holds the backends that shell out to an installed AI CLI, plus the
+shared plumbing they need: :class:`SubprocessBackend` (PATH discovery and a
+cancellable child process) and :func:`parse_tool_calls` (turn a model reply
+into Agent Draw command dicts).  Only the Claude CLI backend lives here for
+now; the Codex CLI and an HTTP backend are follow-ups that reuse the same base.
+
+The module imports no Qt and makes no network call at import time.  A backend
+registers itself only as a class instance in the shared registry, so a caller
+lists it and probes :meth:`~solvcon.agent.AgentBackend.available` before use.
+"""
+
+import abc
+import json
+import shutil
+import subprocess
+
+from . import _backend
+
+
+# TODO: solvcon is an application platform for geometry-based computation:
+# editing graphics and geometry, visualizing, meshing, and solving
+# conservation laws.  These instructions frame the agent around the 2D
+# drawing canvas alone; reframe that as one capability among the platform's
+# rather than the agent's whole scope.  Related to #966.
+_INSTRUCTIONS = (
+    "You drive a 2D drawing canvas. Translate the user's request into a JSON "
+    "array of drawing commands. Each command is an object with an \"op\" key "
+    "naming the operation and the operation's arguments as sibling keys. "
+    "Reply with only the JSON array, no prose and no code fences. Use an "
+    "empty array when no drawing is needed."
+)
+
+
+def _tool_op_names(tool_surface):
+    """The set of op names a tool surface advertises via each tool's ``name``.
+
+    Empty when the surface is empty or names nothing (for example when the
+    Agent Draw package is absent), which tells :func:`parse_tool_calls` to skip
+    op validation rather than reject everything.
+    """
+    names = set()
+    for tool in tool_surface or []:
+        if isinstance(tool, dict) and isinstance(tool.get("name"), str):
+            names.add(tool["name"])
+    return names
+
+
+def _strip_code_fences(text):
+    """Drop a surrounding triple-backtick fence (bare or tagged) if present."""
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return text
+    lines = stripped.splitlines()
+    if lines and lines[0].startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    return "\n".join(lines)
+
+
+def _load_json_payload(text):
+    """Parse the first JSON array or object out of a model reply, tolerating a
+    code fence or surrounding prose.  Return the parsed value, or ``None`` when
+    nothing parses."""
+    text = _strip_code_fences(text).strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    for opener, closer in (("[", "]"), ("{", "}")):
+        start = text.find(opener)
+        end = text.rfind(closer)
+        if start != -1 and end > start:
+            try:
+                return json.loads(text[start:end + 1])
+            except json.JSONDecodeError:
+                continue
+    return None
+
+
+def parse_tool_calls(text, tool_surface=None):
+    """Turn a model reply into a list of Agent Draw command dicts.
+
+    Accept a JSON array, or a lone object treated as a one-command array.  Each
+    command must be an object with an ``op``; when ``tool_surface`` names ops,
+    an unknown op is rejected.  Raise :class:`ValueError` on a malformed reply
+    so the backend records it as an error rather than running a bad command.
+    """
+    data = _load_json_payload(text)
+    if data is None:
+        return []
+    if isinstance(data, dict):
+        data = [data]
+    if not isinstance(data, list):
+        raise ValueError("model reply is not a JSON array of commands")
+    valid = _tool_op_names(tool_surface)
+    commands = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            raise ValueError("command is not an object: %r" % (entry,))
+        op = entry.get("op")
+        if not isinstance(op, str):
+            raise ValueError("command needs a string \"op\": %r" % (entry,))
+        if valid and op not in valid:
+            raise ValueError("unknown op %r" % (op,))
+        commands.append(entry)
+    return commands
+
+
+class SubprocessBackend(_backend.AgentBackend):
+    """Base for backends that shell out to an AI CLI found on ``PATH``.
+
+    A subclass sets :attr:`command` to the executable name and implements
+    :meth:`_build_argv` (and, for a non-plain-text CLI, :meth:`_parse_output`).
+    This base owns everything else: PATH discovery, the :meth:`available`
+    check, a cancellable child process, and the whole :meth:`send` flow that
+    turns a run into a :class:`BackendResponse`.  A new CLI backend is thus the
+    two hooks, never a copied error-handling skeleton.  The running process is
+    kept on the instance so a driver thread can :meth:`cancel` a long-running
+    call.
+    """
+
+    #: The executable name a subclass discovers on ``PATH``.
+    command = None
+
+    def __init__(self, timeout=120):
+        self._timeout = timeout
+        self._proc = None
+
+    @property
+    def name(self):
+        """Selector label derived from the CLI, e.g. ``claude (cli)``."""
+        return "%s (cli)" % self.command
+
+    def executable(self):
+        """The resolved path to :attr:`command`, or ``None`` if not on PATH."""
+        return shutil.which(self.command) if self.command else None
+
+    def available(self):
+        return self.executable() is not None
+
+    @abc.abstractmethod
+    def _build_argv(self, exe, prompt):
+        """The argv that runs ``exe`` on the composed ``prompt``."""
+
+    def _parse_output(self, stdout):
+        """Extract the assistant text from CLI ``stdout``.  The default treats
+        stdout as the reply; override for a CLI that wraps it (JSON, etc.)."""
+        return (stdout or "").strip()
+
+    @staticmethod
+    def _compose_prompt(prompt, scene_context, tool_surface):
+        """Fold the instructions, tool surface, scene, and user request into
+        one prompt string for a CLI that takes a single prompt argument."""
+        tools = json.dumps(tool_surface or [], indent=2)
+        return (
+            "%s\n\nAvailable operations (tool definitions):\n%s\n\n"
+            "Current scene:\n%s\n\nUser request:\n%s"
+            % (_INSTRUCTIONS, tools, scene_context, prompt))
+
+    def send(self, prompt, scene_context, tool_surface):
+        exe = self.executable()
+        if exe is None:
+            return _backend.BackendResponse(
+                error="%s not found on PATH" % self.command)
+        composed = self._compose_prompt(prompt, scene_context, tool_surface)
+        try:
+            code, out, err = self._communicate(self._build_argv(exe, composed))
+        except subprocess.TimeoutExpired:
+            return _backend.BackendResponse(
+                error="%s timed out" % self.command)
+        except OSError as exc:
+            return _backend.BackendResponse(
+                error="%s failed: %s" % (self.command, exc))
+        if code != 0:
+            return _backend.BackendResponse(
+                error="%s exit %d: %s"
+                % (self.command, code, (err or "").strip()))
+        text = self._parse_output(out)
+        try:
+            commands = parse_tool_calls(text, tool_surface)
+        except ValueError as exc:
+            return _backend.BackendResponse(text=text, error=str(exc))
+        return _backend.BackendResponse(text=text, commands=commands)
+
+    def cancel(self):
+        """Terminate the in-flight child, if any.  Safe to call from another
+        thread while :meth:`send` blocks in :meth:`_communicate`."""
+        proc = self._proc
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
+
+    def _communicate(self, argv):
+        """Run ``argv``, returning ``(returncode, stdout, stderr)``.
+
+        The child is held on ``self._proc`` so :meth:`cancel` can reach it, and
+        killed if it outruns the timeout (then the timeout propagates)."""
+        proc = subprocess.Popen(
+            argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        self._proc = proc
+        try:
+            out, err = proc.communicate(timeout=self._timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+            raise
+        finally:
+            self._proc = None
+        return proc.returncode, out, err
+
+
+class ClaudeCliBackend(SubprocessBackend):
+    """Backend over Anthropic's ``claude`` command-line tool.
+
+    It runs the CLI in print mode with JSON output, folds the tool surface and
+    scene context into the prompt, and parses the model's JSON reply into
+    Agent Draw commands.  No API key lives here: the CLI owns authentication.
+    """
+
+    command = "claude"
+
+    def _build_argv(self, exe, prompt):
+        return [exe, "-p", prompt, "--output-format", "json"]
+
+    def _parse_output(self, stdout):
+        """Pull the assistant text out of ``claude --output-format json``
+        output, falling back to the raw text when it is not that envelope."""
+        stdout = (stdout or "").strip()
+        try:
+            payload = json.loads(stdout)
+        except json.JSONDecodeError:
+            return stdout
+        if isinstance(payload, dict):
+            result = payload.get("result")
+            return result if isinstance(result, str) else stdout
+        return stdout
+
+
+_backend.register(ClaudeCliBackend())
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_backends_impl.py
+++ b/tests/test_agent_backends_impl.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Tests for the concrete CLI backends and tool-call parsing.
+
+GUI-free and process-free: PATH discovery is patched and the child process is
+replaced, so no real ``claude`` CLI runs.  These exercise the parsing
+contract, PATH-based availability, and the ``send`` pipeline.
+"""
+
+import json
+import os
+import subprocess
+import unittest
+from unittest import mock
+
+from solvcon.agent import (
+    BackendResponse,
+    ClaudeCliBackend,
+    SubprocessBackend,
+    get_backend,
+    parse_tool_calls,
+)
+
+
+_WHICH = "solvcon.agent._backends_impl.shutil.which"
+
+_TOOLS = [
+    {"name": "add_circle", "description": "add a circle"},
+    {"name": "add_line", "description": "add a line"},
+]
+
+
+class ParseToolCallsTC(unittest.TestCase):
+    def test_plain_json_array(self):
+        text = '[{"op": "add_circle", "r": 1.0}]'
+        self.assertEqual(
+            parse_tool_calls(text, _TOOLS),
+            [{"op": "add_circle", "r": 1.0}])
+
+    def test_lone_object_becomes_one_command(self):
+        commands = parse_tool_calls('{"op": "add_line"}', _TOOLS)
+        self.assertEqual(commands, [{"op": "add_line"}])
+
+    def test_strips_code_fence(self):
+        text = '```json\n[{"op": "add_circle"}]\n```'
+        self.assertEqual(parse_tool_calls(text, _TOOLS),
+                         [{"op": "add_circle"}])
+
+    def test_extracts_array_from_surrounding_prose(self):
+        text = 'Sure! Here you go:\n[{"op": "add_circle"}]\nThanks.'
+        self.assertEqual(parse_tool_calls(text, _TOOLS),
+                         [{"op": "add_circle"}])
+
+    def test_empty_array_is_empty(self):
+        self.assertEqual(parse_tool_calls("[]", _TOOLS), [])
+
+    def test_no_json_yields_empty(self):
+        self.assertEqual(parse_tool_calls("I cannot help.", _TOOLS), [])
+
+    def test_unknown_op_rejected(self):
+        with self.assertRaises(ValueError):
+            parse_tool_calls('[{"op": "delete_universe"}]', _TOOLS)
+
+    def test_missing_op_rejected(self):
+        with self.assertRaises(ValueError):
+            parse_tool_calls('[{"r": 1.0}]', _TOOLS)
+
+    def test_non_string_op_raises_valueerror_not_typeerror(self):
+        # An unhashable op (list/object) must not blow past the ValueError
+        # contract into a set-membership TypeError, or send() would crash
+        # instead of recording an error.
+        with self.assertRaises(ValueError):
+            parse_tool_calls('[{"op": {"nested": 1}}]', _TOOLS)
+        with self.assertRaises(ValueError):
+            parse_tool_calls('[{"op": ["a", "b"]}]', _TOOLS)
+
+    def test_no_tool_surface_skips_op_validation(self):
+        # With no advertised ops (e.g. Agent Draw absent) any op is accepted,
+        # so the pipeline still runs rather than rejecting everything.
+        commands = parse_tool_calls('[{"op": "anything"}]', [])
+        self.assertEqual(commands, [{"op": "anything"}])
+
+
+class SubprocessBackendDiscoveryTC(unittest.TestCase):
+    def test_available_true_when_on_path(self):
+        backend = ClaudeCliBackend()
+        with mock.patch(_WHICH, lambda name: "/usr/bin/" + name):
+            self.assertTrue(backend.available())
+            self.assertEqual(backend.executable(), "/usr/bin/claude")
+
+    def test_available_false_when_absent(self):
+        backend = ClaudeCliBackend()
+        with mock.patch(_WHICH, lambda name: None):
+            self.assertFalse(backend.available())
+
+    def test_command_none_never_resolves(self):
+        # A subclass that names no executable is never available even though
+        # which() would answer for a real name.
+        class Nameless(SubprocessBackend):
+            def _build_argv(self, exe, prompt):
+                return [exe]
+
+        with mock.patch(_WHICH, lambda name: "/usr/bin/" + str(name)):
+            self.assertIsNone(Nameless().executable())
+            self.assertFalse(Nameless().available())
+
+
+class ClaudeCliSendTC(unittest.TestCase):
+    def setUp(self):
+        self.backend = ClaudeCliBackend()
+        patcher = mock.patch(_WHICH, lambda name: "/usr/bin/" + name)
+        self.which = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _envelope(self, result_text):
+        return json.dumps({"type": "result", "result": result_text})
+
+    def test_send_parses_commands(self):
+        reply = self._envelope('[{"op": "add_circle", "r": 2.0}]')
+        self.backend._communicate = lambda argv: (0, reply, "")
+        response = self.backend.send("draw a circle", "empty world", _TOOLS)
+        self.assertIsInstance(response, BackendResponse)
+        self.assertIsNone(response.error)
+        self.assertEqual(response.commands, [{"op": "add_circle", "r": 2.0}])
+
+    def test_send_not_on_path_is_error(self):
+        with mock.patch(_WHICH, lambda name: None):
+            response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertIsNotNone(response.error)
+        self.assertEqual(response.commands, [])
+
+    def test_send_nonzero_exit_is_error(self):
+        self.backend._communicate = lambda argv: (1, "", "boom")
+        response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertIn("boom", response.error)
+        self.assertEqual(response.commands, [])
+
+    def test_send_timeout_is_error(self):
+        def _timeout(argv):
+            raise subprocess.TimeoutExpired(argv, 120)
+        self.backend._communicate = _timeout
+        response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertIn("timed out", response.error)
+
+    def test_send_unknown_op_reports_error_without_commands(self):
+        reply = self._envelope('[{"op": "delete_universe"}]')
+        self.backend._communicate = lambda argv: (0, reply, "")
+        response = self.backend.send("wreck it", "scene", _TOOLS)
+        self.assertIsNotNone(response.error)
+        self.assertEqual(response.commands, [])
+
+    def test_send_unhashable_op_is_error_not_crash(self):
+        # A malformed reply must come back as an error result, never an
+        # unhandled exception out of send().
+        reply = self._envelope('[{"op": {"nested": 1}}]')
+        self.backend._communicate = lambda argv: (0, reply, "")
+        response = self.backend.send("break it", "scene", _TOOLS)
+        self.assertIsNotNone(response.error)
+        self.assertEqual(response.commands, [])
+
+    def test_send_passes_prompt_and_json_flags(self):
+        seen = {}
+
+        def _capture(argv):
+            seen["argv"] = argv
+            return 0, self._envelope("[]"), ""
+
+        self.backend._communicate = _capture
+        self.backend.send("hello", "one shape", _TOOLS)
+        argv = seen["argv"]
+        self.assertEqual(argv[0], "/usr/bin/claude")
+        self.assertIn("-p", argv)
+        self.assertIn("--output-format", argv)
+        self.assertIn("json", argv)
+        prompt = argv[argv.index("-p") + 1]
+        self.assertIn("hello", prompt)
+        self.assertIn("one shape", prompt)
+        self.assertIn("add_circle", prompt)  # tool surface folded in
+
+
+class RegistrationTC(unittest.TestCase):
+    def test_claude_registers_on_import(self):
+        backend = get_backend("claude (cli)")
+        self.assertIsNotNone(backend)
+        self.assertIsInstance(backend, ClaudeCliBackend)
+
+
+_REAL = "SOLVCON_TEST_REAL_CLAUDE"
+
+
+@unittest.skipUnless(os.environ.get(_REAL),
+                     "set %s=1 to hit the installed claude CLI" % _REAL)
+class ClaudeCliRealTC(unittest.TestCase):
+    """Opt-in end-to-end test against the installed claude CLI.
+
+    Skipped by default so CI stays hermetic and free; a local run with
+    ``SOLVCON_TEST_REAL_CLAUDE=1`` makes a real, billed CLI call to confirm
+    the flags, the JSON envelope, and parsing hold against the live tool.  It
+    hands a hand-written tool surface in place of Agent Draw's, so the package
+    need not be present.
+    """
+
+    def setUp(self):
+        self.backend = ClaudeCliBackend()
+        if not self.backend.available():
+            self.skipTest("claude CLI not found on PATH")
+
+    def test_draws_a_circle_end_to_end(self):
+        response = self.backend.send(
+            "Add exactly one circle of radius 1 at the origin.",
+            "empty world with 0 shapes", _TOOLS)
+        # A real reply must parse cleanly into circle-drawing commands; a
+        # broken flag, envelope, or parser would surface as an error or an
+        # empty batch here.
+        self.assertIsNone(response.error)
+        self.assertTrue(response.commands)
+        ops = {tool["name"] for tool in _TOOLS}
+        for command in response.commands:
+            self.assertIn(command.get("op"), ops)
+        self.assertIn("add_circle",
+                      [command["op"] for command in response.commands])
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Add a Claude CLI backend for solvcon agent.

To try it manually against an installed claude CLI, build the extension and run a short snippet (a hand-written tool surface stands in for Agent Draw's, which is not yet on master):

    from solvcon.agent import ClaudeCliBackend
    tools = [{"name": "add_circle", "description": "Add a circle."}]
    backend = ClaudeCliBackend()
    print(backend.available())
    resp = backend.send("draw three circles in a row", "empty world", tools)
    print(resp.error, resp.commands)

The unit tests mock the CLI so CI stays hermetic and free. An opt-in end-to-end test hits the real claude CLI only when SOLVCON_TEST_REAL_CLAUDE is set, so you can verify the flags, JSON envelope, and parsing against the live tool locally:

    SOLVCON_TEST_REAL_CLAUDE=1 make pytest PYTEST_OPTS="tests/test_agent_backends_impl.py::ClaudeCliRealTC"

Next todo: Integrate the Claude backend into the agent session.

Related to #966.
