### PR TITLE
Implement ordering comparison operators for SimpleArray

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -741,11 +741,34 @@ public:
         return A(*static_cast<A const *>(this)).idiv(scalar);
     }
 
+private:
+
+    // Element-wise comparison kernel shared by eq/ne/lt/le/gt/ge. The array
+    // overload requires matching shapes; both produce a bool per element.
+    template <typename Cmp>
+    SimpleArray<bool> compare_with(A const & other, Cmp cmp, char const * op) const;
+    template <typename Cmp>
+    SimpleArray<bool> compare_with(value_type scalar, Cmp cmp) const;
+
+public:
+
     SimpleArray<bool> eq(A const & other) const;
     SimpleArray<bool> eq(value_type scalar) const;
 
     SimpleArray<bool> ne(A const & other) const;
     SimpleArray<bool> ne(value_type scalar) const;
+
+    SimpleArray<bool> lt(A const & other) const;
+    SimpleArray<bool> lt(value_type scalar) const;
+
+    SimpleArray<bool> le(A const & other) const;
+    SimpleArray<bool> le(value_type scalar) const;
+
+    SimpleArray<bool> gt(A const & other) const;
+    SimpleArray<bool> gt(value_type scalar) const;
+
+    SimpleArray<bool> ge(A const & other) const;
+    SimpleArray<bool> ge(value_type scalar) const;
 
     A & iadd(A const & other)
     {
@@ -2251,15 +2274,18 @@ private:
 }; /* end class SimpleArray */
 
 template <typename A, typename T>
-SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::eq(A const & other) const
+template <typename Cmp>
+SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::compare_with(
+    A const & other, Cmp cmp, char const * op) const
 {
     auto const * athis = static_cast<A const *>(this);
     if (athis->shape() != other.shape())
     {
-        throw std::invalid_argument(
-            std::format("SimpleArray::eq(): shape mismatch: this={} other={}",
-                        format_shape(athis->shape()),
-                        format_shape(other.shape())));
+        throw std::invalid_argument(std::format(
+            "SimpleArray::{}(): shape mismatch: this={} other={}",
+            op,
+            format_shape(athis->shape()),
+            format_shape(other.shape())));
     }
     SimpleArray<bool> ret(athis->shape());
     const value_type * ptr = athis->begin();
@@ -2268,72 +2294,103 @@ SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::eq(A const & other)
     bool * ret_ptr = ret.begin();
     while (ptr < end)
     {
-        *ret_ptr = (*ptr == *other_ptr);
+        *ret_ptr = cmp(*ptr, *other_ptr);
         ++ptr;
         ++other_ptr;
         ++ret_ptr;
     }
     return ret;
+}
+
+template <typename A, typename T>
+template <typename Cmp>
+SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::compare_with(
+    value_type scalar, Cmp cmp) const
+{
+    auto const * athis = static_cast<A const *>(this);
+    SimpleArray<bool> ret(athis->shape());
+    const value_type * ptr = athis->begin();
+    const value_type * const end = athis->end();
+    bool * ret_ptr = ret.begin();
+    while (ptr < end)
+    {
+        *ret_ptr = cmp(*ptr, scalar);
+        ++ptr;
+        ++ret_ptr;
+    }
+    return ret;
+}
+
+template <typename A, typename T>
+SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::eq(A const & other) const
+{
+    return compare_with(other, std::equal_to<>{}, "eq");
 }
 
 template <typename A, typename T>
 SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::eq(value_type scalar) const
 {
-    auto const * athis = static_cast<A const *>(this);
-    SimpleArray<bool> ret(athis->shape());
-    const value_type * ptr = athis->begin();
-    const value_type * const end = athis->end();
-    bool * ret_ptr = ret.begin();
-    while (ptr < end)
-    {
-        *ret_ptr = (*ptr == scalar);
-        ++ptr;
-        ++ret_ptr;
-    }
-    return ret;
+    return compare_with(scalar, std::equal_to<>{});
 }
 
 template <typename A, typename T>
 SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::ne(A const & other) const
 {
-    auto const * athis = static_cast<A const *>(this);
-    if (athis->shape() != other.shape())
-    {
-        throw std::invalid_argument(
-            std::format("SimpleArray::ne(): shape mismatch: this={} other={}",
-                        format_shape(athis->shape()),
-                        format_shape(other.shape())));
-    }
-    SimpleArray<bool> ret(athis->shape());
-    const value_type * ptr = athis->begin();
-    const value_type * const end = athis->end();
-    const value_type * other_ptr = other.begin();
-    bool * ret_ptr = ret.begin();
-    while (ptr < end)
-    {
-        *ret_ptr = (*ptr != *other_ptr);
-        ++ptr;
-        ++other_ptr;
-        ++ret_ptr;
-    }
-    return ret;
+    return compare_with(other, std::not_equal_to<>{}, "ne");
 }
 
 template <typename A, typename T>
 SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::ne(value_type scalar) const
 {
-    auto const * athis = static_cast<A const *>(this);
-    SimpleArray<bool> ret(athis->shape());
-    const value_type * ptr = athis->begin();
-    const value_type * const end = athis->end();
-    bool * ret_ptr = ret.begin();
-    while (ptr < end)
-    {
-        *ret_ptr = (*ptr != scalar);
-        ++ptr;
-        ++ret_ptr;
-    }
-    return ret;
+    return compare_with(scalar, std::not_equal_to<>{});
+}
+
+template <typename A, typename T>
+SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::lt(A const & other) const
+{
+    return compare_with(other, std::less<>{}, "lt");
+}
+
+template <typename A, typename T>
+SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::lt(value_type scalar) const
+{
+    return compare_with(scalar, std::less<>{});
+}
+
+template <typename A, typename T>
+SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::le(A const & other) const
+{
+    return compare_with(other, std::less_equal<>{}, "le");
+}
+
+template <typename A, typename T>
+SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::le(value_type scalar) const
+{
+    return compare_with(scalar, std::less_equal<>{});
+}
+
+template <typename A, typename T>
+SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::gt(A const & other) const
+{
+    return compare_with(other, std::greater<>{}, "gt");
+}
+
+template <typename A, typename T>
+SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::gt(value_type scalar) const
+{
+    return compare_with(scalar, std::greater<>{});
+}
+
+template <typename A, typename T>
+SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::ge(A const & other) const
+{
+    return compare_with(other, std::greater_equal<>{}, "ge");
+}
+
+template <typename A, typename T>
+SimpleArray<bool> detail::SimpleArrayMixinCalculators<A, T>::ge(value_type scalar) const
+{
+    return compare_with(scalar, std::greater_equal<>{});
 }
 
 /**

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -392,7 +392,89 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 "__ne__",
                 [](wrapped_type const & self, value_type scalar)
                 { return self.ne(scalar); },
-                py::is_operator())
+                py::is_operator());
+
+        // Ordering comparisons are undefined for complex numbers, matching
+        // numpy. Leaving the operators unbound lets Python raise TypeError
+        // for <, <=, >, >= just as numpy does for a complex ndarray.
+        if constexpr (!is_complex_v<value_type>)
+        {
+            (*this)
+                .def(
+                    "lt",
+                    [](wrapped_type const & self, wrapped_type const & other)
+                    { return self.lt(other); })
+                .def(
+                    "lt",
+                    [](wrapped_type const & self, value_type scalar)
+                    { return self.lt(scalar); })
+                .def(
+                    "le",
+                    [](wrapped_type const & self, wrapped_type const & other)
+                    { return self.le(other); })
+                .def(
+                    "le",
+                    [](wrapped_type const & self, value_type scalar)
+                    { return self.le(scalar); })
+                .def(
+                    "gt",
+                    [](wrapped_type const & self, wrapped_type const & other)
+                    { return self.gt(other); })
+                .def(
+                    "gt",
+                    [](wrapped_type const & self, value_type scalar)
+                    { return self.gt(scalar); })
+                .def(
+                    "ge",
+                    [](wrapped_type const & self, wrapped_type const & other)
+                    { return self.ge(other); })
+                .def(
+                    "ge",
+                    [](wrapped_type const & self, value_type scalar)
+                    { return self.ge(scalar); })
+                .def(
+                    "__lt__",
+                    [](wrapped_type const & self, wrapped_type const & other)
+                    { return self.lt(other); },
+                    py::is_operator())
+                .def(
+                    "__lt__",
+                    [](wrapped_type const & self, value_type scalar)
+                    { return self.lt(scalar); },
+                    py::is_operator())
+                .def(
+                    "__le__",
+                    [](wrapped_type const & self, wrapped_type const & other)
+                    { return self.le(other); },
+                    py::is_operator())
+                .def(
+                    "__le__",
+                    [](wrapped_type const & self, value_type scalar)
+                    { return self.le(scalar); },
+                    py::is_operator())
+                .def(
+                    "__gt__",
+                    [](wrapped_type const & self, wrapped_type const & other)
+                    { return self.gt(other); },
+                    py::is_operator())
+                .def(
+                    "__gt__",
+                    [](wrapped_type const & self, value_type scalar)
+                    { return self.gt(scalar); },
+                    py::is_operator())
+                .def(
+                    "__ge__",
+                    [](wrapped_type const & self, wrapped_type const & other)
+                    { return self.ge(other); },
+                    py::is_operator())
+                .def(
+                    "__ge__",
+                    [](wrapped_type const & self, value_type scalar)
+                    { return self.ge(scalar); },
+                    py::is_operator());
+        }
+
+        (*this)
             .def("matmul", &wrapped_type::matmul)
             .def("matmul_blas", &wrapped_type::matmul_blas)
             .def(

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -2,6 +2,7 @@
 # BSD 3-Clause License, see COPYING
 
 
+import operator
 import unittest
 
 import numpy as np
@@ -3860,6 +3861,141 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         self.assertTrue(sarr != None)  # noqa: E711
         self.assertFalse(sarr == "not an array")
         self.assertTrue(sarr != "not an array")
+
+    def _check_order_method(self, op_name, nfunc):
+        def _check_1d(type):
+            narr1 = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=type)
+            narr2 = np.array([1, 0, 3, 9, 5, 0, 9, 8], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+            nres = nfunc(narr1, narr2)
+            sres = getattr(sarr1, op_name)(sarr2)
+            self.assertEqual(sres.ndarray.dtype, np.bool_)
+            np.testing.assert_array_equal(sres.ndarray, nres)
+
+        def _check_2d(type):
+            narr1 = np.array([[1, 2, 3, 4],
+                              [5, 6, 7, 8],
+                              [9, 10, 11, 12]], dtype=type)
+            narr2 = np.array([[1, 0, 3, 9],
+                              [5, 0, 9, 8],
+                              [9, 0, 11, 20]], dtype=type)
+            sarr1 = self.type_convertor(type)(array=narr1)
+            sarr2 = self.type_convertor(type)(array=narr2)
+            nres = nfunc(narr1, narr2)
+            sres = getattr(sarr1, op_name)(sarr2)
+            self.assertEqual(sres.ndarray.dtype, np.bool_)
+            np.testing.assert_array_equal(sres.ndarray, nres)
+
+        def _check_scalar(type):
+            narr1 = np.array([1, 2, 3, 4, 5, 3, 7, 3], dtype=type)
+            scalar = 3
+            sarr1 = self.type_convertor(type)(array=narr1)
+            nres = nfunc(narr1, scalar)
+            sres = getattr(sarr1, op_name)(scalar)
+            self.assertEqual(sres.ndarray.dtype, np.bool_)
+            np.testing.assert_array_equal(sres.ndarray, nres)
+
+        types = ('int8', 'int16', 'int32', 'int64', 'uint8', 'uint16',
+                 'uint32', 'uint64', 'float32', 'float64')
+
+        for type in types:
+            _check_1d(type)
+            _check_2d(type)
+            _check_scalar(type)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"SimpleArray::" + op_name + r"\(\): shape mismatch: "
+            r"this=\(8\) other=\(3\)"
+        ):
+            sarr1 = solvcon.SimpleArrayInt32(array=np.arange(8, dtype='int32'))
+            sarr2 = solvcon.SimpleArrayInt32(array=np.arange(3, dtype='int32'))
+            getattr(sarr1, op_name)(sarr2)
+
+    def test_lt(self):
+        """Test element-wise less-than like numpy"""
+        self._check_order_method('lt', np.less)
+
+    def test_le(self):
+        """Test element-wise less-than-or-equal like numpy"""
+        self._check_order_method('le', np.less_equal)
+
+    def test_gt(self):
+        """Test element-wise greater-than like numpy"""
+        self._check_order_method('gt', np.greater)
+
+    def test_ge(self):
+        """Test element-wise greater-than-or-equal like numpy"""
+        self._check_order_method('ge', np.greater_equal)
+
+    def _check_order_operator(self, pyop, nfunc):
+        narr1 = np.array([1, 2, 3, 3], dtype='int32')
+        narr2 = np.array([1, 0, 3, 9], dtype='int32')
+        sarr1 = solvcon.SimpleArrayInt32(array=narr1)
+        sarr2 = solvcon.SimpleArrayInt32(array=narr2)
+
+        sres = pyop(sarr1, sarr2)
+        self.assertEqual(sres.ndarray.dtype, np.bool_)
+        np.testing.assert_array_equal(sres.ndarray, nfunc(narr1, narr2))
+
+        sres_scalar = pyop(sarr1, 3)
+        self.assertEqual(sres_scalar.ndarray.dtype, np.bool_)
+        np.testing.assert_array_equal(
+            sres_scalar.ndarray, nfunc(narr1, 3))
+
+    def test_lt_operator(self):
+        """< performs element-wise comparison like numpy"""
+        self._check_order_operator(operator.lt, np.less)
+
+    def test_le_operator(self):
+        """<= performs element-wise comparison like numpy"""
+        self._check_order_operator(operator.le, np.less_equal)
+
+    def test_gt_operator(self):
+        """> performs element-wise comparison like numpy"""
+        self._check_order_operator(operator.gt, np.greater)
+
+    def test_ge_operator(self):
+        """>= performs element-wise comparison like numpy"""
+        self._check_order_operator(operator.ge, np.greater_equal)
+
+    def test_order_operator_float_nan(self):
+        """NaN compares false in every direction, like numpy."""
+        narr1 = np.array([1.0, np.nan, 3.0, np.nan], dtype='float64')
+        narr2 = np.array([2.0, 1.0, 3.0, np.nan], dtype='float64')
+        sarr1 = solvcon.SimpleArrayFloat64(array=narr1)
+        sarr2 = solvcon.SimpleArrayFloat64(array=narr2)
+
+        for pyop, nfunc in (
+            (operator.lt, np.less),
+            (operator.le, np.less_equal),
+            (operator.gt, np.greater),
+            (operator.ge, np.greater_equal),
+        ):
+            sres = pyop(sarr1, sarr2)
+            np.testing.assert_array_equal(sres.ndarray, nfunc(narr1, narr2))
+
+    def test_order_operator_complex_unsupported(self):
+        """Ordering is undefined for complex, matching numpy
+
+        numpy raises TypeError for <, <=, >, >= on complex arrays. Leaving
+        those operators unbound makes SimpleArray behave the same way, while
+        equality (== and !=) stays element-wise.
+        """
+        narr = np.array([1 + 2j, 3 + 4j], dtype='complex128')
+        sarr = solvcon.SimpleArrayComplex128(array=narr)
+
+        for pyop in (operator.lt, operator.le, operator.gt, operator.ge):
+            with self.assertRaises(TypeError):
+                pyop(sarr, sarr)
+
+        self.assertFalse(hasattr(sarr, 'lt'))
+        self.assertFalse(hasattr(sarr, 'ge'))
+
+        sres = sarr == sarr
+        self.assertEqual(sres.ndarray.dtype, np.bool_)
+        np.testing.assert_array_equal(sres.ndarray, np.equal(narr, narr))
 
     def test_eye(self):
         """Test eye() static method for creating identity matrices"""


### PR DESCRIPTION
Implement the element-wise ordering comparisons (the lt/le/gt/ge methods and the <, <=, >, >= operators returning a boolean array) for `SimpleArray`, alongside the existing eq and ne. The shared element-wise comparison loop is factored into a single compare_with template, and ordering is left unbound for complex arrays so Python raises TypeError like numpy.

Following the review, the C++-only three-way operator<=> was dropped: whole-array three-way comparison returns a single std::partial_ordering rather than an element-wise array, so it is inconsistent with the other comparison operators.

Related to #1036.