### PR TITLE
Add typed handles and typed evaluation to the dynamic toggle store (steps 1, 2 of toggle)

### DIFF
--- a/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
@@ -403,6 +403,28 @@ private:
 
 } /* end namespace detail */
 
+namespace detail
+{
+
+template <typename T>
+void declare_toggle(Toggle & self, std::string const & key, T const & value)
+{
+    self.declare<T>(key, value);
+}
+
+void warn_deprecated_getter(char const * name)
+{
+    PyErr_WarnEx(
+        PyExc_DeprecationWarning,
+        std::format("Toggle.{} returns a silent sentinel on a missing or wrong-typed "
+                    "key and is deprecated; use get(key, default) or at(key)",
+                    name)
+            .c_str(),
+        1);
+}
+
+} /* end namespace detail */
+
 WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const * pydoc)
     : base_type(mod, pyname, pydoc)
 {
@@ -444,6 +466,38 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
             },
             py::arg("key"),
             py::arg("default"))
+        .def(
+            "get",
+            [](wrapped_type & self, std::string const & key, py::object & obj)
+            {
+                HierarchicalToggleAccess access(self.dynamic());
+                if (access.get_index(key).type != DynamicToggleIndex::TYPE_NONE)
+                {
+                    return WrapHierarchicalToggleAccess::getattr(access, key);
+                }
+                return obj;
+            },
+            py::arg("key"),
+            py::arg("default"))
+        .def(
+            "at",
+            [](wrapped_type & self, std::string const & key)
+            {
+                HierarchicalToggleAccess access(self.dynamic());
+                if (access.get_index(key).type == DynamicToggleIndex::TYPE_NONE)
+                {
+                    throw py::key_error(std::format("Toggle.at: key \"{}\" is missing", key));
+                }
+                return WrapHierarchicalToggleAccess::getattr(access, key);
+            },
+            py::arg("key"))
+        .def("declare_bool", &detail::declare_toggle<bool>, py::arg("key"), py::arg("default"))
+        .def("declare_int8", &detail::declare_toggle<int8_t>, py::arg("key"), py::arg("default"))
+        .def("declare_int16", &detail::declare_toggle<int16_t>, py::arg("key"), py::arg("default"))
+        .def("declare_int32", &detail::declare_toggle<int32_t>, py::arg("key"), py::arg("default"))
+        .def("declare_int64", &detail::declare_toggle<int64_t>, py::arg("key"), py::arg("default"))
+        .def("declare_real", &detail::declare_toggle<double>, py::arg("key"), py::arg("default"))
+        .def("declare_string", &detail::declare_toggle<std::string>, py::arg("key"), py::arg("default"))
         .def(
             "__getattr__",
             [](wrapped_type & self, std::string const & key)
@@ -490,24 +544,39 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
             })
         .def("dynamic_keys", &wrapped_type::dynamic_keys)
         .def("dynamic_clear", &wrapped_type::dynamic_clear)
-        .def("get_bool", &wrapped_type::get_bool, py::arg("key"))
         .def("set_bool", &wrapped_type::set_bool, py::arg("key"), py::arg("value"))
-        .def("get_int8", &wrapped_type::get_int8, py::arg("key"))
         .def("set_int8", &wrapped_type::set_int8, py::arg("key"), py::arg("value"))
-        .def("get_int16", &wrapped_type::get_int16, py::arg("key"))
         .def("set_int16", &wrapped_type::set_int16, py::arg("key"), py::arg("value"))
-        .def("get_int32", &wrapped_type::get_int32, py::arg("key"))
         .def("set_int32", &wrapped_type::set_int32, py::arg("key"), py::arg("value"))
-        .def("get_int64", &wrapped_type::get_int64, py::arg("key"))
         .def("set_int64", &wrapped_type::set_int64, py::arg("key"), py::arg("value"))
-        .def("get_real", &wrapped_type::get_real, py::arg("key"))
         .def("set_real", &wrapped_type::set_real, py::arg("key"), py::arg("value"))
-        .def("get_string", &wrapped_type::get_string, py::arg("key"))
         .def("set_string", &wrapped_type::set_string, py::arg("key"), py::arg("value"))
         .def("get_subkey", &wrapped_type::get_subkey, py::arg("key"))
         .def("add_subkey", &wrapped_type::add_subkey, py::arg("key"))
         //
         ;
+
+    // The type-specific getters return a silent sentinel on a missing or
+    // wrong-typed key. They are kept for compatibility but deprecated in
+    // favor of get(key, default) and at(key); each emits a
+    // DeprecationWarning.
+#define MM_PYTHON_TOGGLE_DEPRECATED_GET(MTYPE)             \
+    (*this).def(                                           \
+        "get_" #MTYPE,                                     \
+        [](wrapped_type & self, std::string const & key)   \
+        {                                                  \
+            detail::warn_deprecated_getter("get_" #MTYPE); \
+            return self.get_##MTYPE(key);                  \
+        },                                                 \
+        py::arg("key"));
+    MM_PYTHON_TOGGLE_DEPRECATED_GET(bool)
+    MM_PYTHON_TOGGLE_DEPRECATED_GET(int8)
+    MM_PYTHON_TOGGLE_DEPRECATED_GET(int16)
+    MM_PYTHON_TOGGLE_DEPRECATED_GET(int32)
+    MM_PYTHON_TOGGLE_DEPRECATED_GET(int64)
+    MM_PYTHON_TOGGLE_DEPRECATED_GET(real)
+    MM_PYTHON_TOGGLE_DEPRECATED_GET(string)
+#undef MM_PYTHON_TOGGLE_DEPRECATED_GET
 
     // Static properties.
     (*this)

--- a/cpp/solvcon/toggle/toggle.cpp
+++ b/cpp/solvcon/toggle/toggle.cpp
@@ -58,7 +58,7 @@ std::string const DynamicToggleTable::sentinel_string = "";
         {                                                                      \
             if (it->second.is_##MTYPE())                                       \
             {                                                                  \
-                return m_vector_##MTYPE.at(it->second.index);                  \
+                return m_column_##MTYPE.at(it->second.index).value;            \
             }                                                                  \
         }                                                                      \
         return SENTINEL;                                                       \
@@ -87,7 +87,7 @@ MM_DECL_DYNGET(std::string const &, string, sentinel_string)
         {                                                                                                                      \
             if (it->second.is_##MTYPE())                                                                                       \
             {                                                                                                                  \
-                m_vector_##MTYPE.at(it->second.index) = value;                                                                 \
+                m_column_##MTYPE.at(it->second.index).value = value;                                                           \
             }                                                                                                                  \
             else                                                                                                               \
             {                                                                                                                  \
@@ -96,9 +96,9 @@ MM_DECL_DYNGET(std::string const &, string, sentinel_string)
         }                                                                                                                      \
         else                                                                                                                   \
         {                                                                                                                      \
-            DynamicToggleIndex const index{static_cast<uint32_t>(m_vector_##MTYPE.size()), DynamicToggleIndex::TYPE_##MTYPEC}; \
+            DynamicToggleIndex const index{static_cast<uint32_t>(m_column_##MTYPE.size()), DynamicToggleIndex::TYPE_##MTYPEC}; \
             m_key2index.insert({key, index});                                                                                  \
-            m_vector_##MTYPE.push_back(value);                                                                                 \
+            m_column_##MTYPE.append(value);                                                                                    \
         }                                                                                                                      \
     }                                                                                                                          \
     void HierarchicalToggleAccess::set_##MTYPE(std::string const & key, CTYPE value)                                           \
@@ -148,13 +148,14 @@ std::vector<std::string> DynamicToggleTable::keys() const
 void DynamicToggleTable::clear()
 {
     m_key2index.clear();
-    m_vector_bool.clear();
-    m_vector_int8.clear();
-    m_vector_int16.clear();
-    m_vector_int32.clear();
-    m_vector_int64.clear();
-    m_vector_real.clear();
-    m_vector_string.clear();
+    m_column_bool.clear();
+    m_column_int8.clear();
+    m_column_int16.clear();
+    m_column_int32.clear();
+    m_column_int64.clear();
+    m_column_real.clear();
+    m_column_string.clear();
+    ++m_generation;
 }
 
 // NOLINTNEXTLINE(modernize-use-equals-default) lack of SOLVCON_METAL

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -19,7 +19,10 @@
 
 #include <cstdint>
 #include <deque>
+#include <format>
+#include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -27,6 +30,9 @@ namespace solvcon
 {
 
 int setenv(const char * name, const char * value, int overwrite);
+
+template <typename T>
+class ToggleRef;
 
 /**
  * A single stored toggle value.
@@ -127,6 +133,33 @@ struct DynamicToggleIndex
     Type type = TYPE_NONE;
 
 }; /* end struct DynamicToggleIndex */
+
+/**
+ * Maps a C++ value type to its DynamicToggleIndex type tag.
+ *
+ * The primary template is left undefined so an unsupported type is a
+ * compile error rather than a silent mismatch.
+ *
+ * @ingroup group_core
+ */
+template <typename T>
+struct ToggleTypeTraits;
+
+#define MM_TOGGLE_TYPE_TRAITS(CTYPE, TAG)               \
+    template <>                                         \
+    struct ToggleTypeTraits<CTYPE>                      \
+    {                                                   \
+        static constexpr DynamicToggleIndex::Type tag = \
+            DynamicToggleIndex::TAG;                    \
+    };
+MM_TOGGLE_TYPE_TRAITS(bool, TYPE_BOOL)
+MM_TOGGLE_TYPE_TRAITS(int8_t, TYPE_INT8)
+MM_TOGGLE_TYPE_TRAITS(int16_t, TYPE_INT16)
+MM_TOGGLE_TYPE_TRAITS(int32_t, TYPE_INT32)
+MM_TOGGLE_TYPE_TRAITS(int64_t, TYPE_INT64)
+MM_TOGGLE_TYPE_TRAITS(double, TYPE_REAL)
+MM_TOGGLE_TYPE_TRAITS(std::string, TYPE_STRING)
+#undef MM_TOGGLE_TYPE_TRAITS
 
 class DynamicToggleTable;
 
@@ -248,7 +281,36 @@ public:
      */
     uint64_t generation() const { return m_generation; }
 
+    /**
+     * Create a toggle with a default and return a handle to it.
+     *
+     * Re-declaring an existing key of the same type is idempotent and
+     * returns a handle to the existing register. A conflicting type is an
+     * error.
+     */
+    template <typename T>
+    ToggleRef<T> declare(std::string const & key, T const & default_value);
+
+    /// Resolve an existing key to a handle; an invalid handle if it is
+    /// missing or has a different type.
+    template <typename T>
+    ToggleRef<T> ref(std::string const & key);
+
+    /// Typed read returning the caller default on a missing or wrong-typed
+    /// key (the OpenFeature contract).
+    template <typename T>
+    T get(std::string const & key, T const & default_value) const;
+
+    /// Strict typed read that throws on a missing or wrong-typed key.
+    template <typename T>
+    T at(std::string const & key) const;
+
 private:
+
+    template <typename T>
+    ToggleRegisterColumn<T> & column();
+    template <typename T>
+    ToggleRegisterColumn<T> const & column() const;
 
     keymap_type m_key2index;
     ToggleRegisterColumn<bool> m_column_bool;
@@ -265,6 +327,194 @@ private:
 inline DynamicToggleIndex HierarchicalToggleAccess::get_index(std::string const & key) const
 {
     return m_table->get_index(rekey(key));
+}
+
+/**
+ * A resolved, typed handle to one toggle register.
+ *
+ * It binds a key to its register once (table, index, and the table
+ * generation at resolution) so a hot path reads the value without touching
+ * the string map again. Because the storage keeps register addresses
+ * stable, the bound pointer survives unrelated toggles being added; because
+ * the handle stamps the table generation, a handle taken before a
+ * dynamic_clear is refused afterward instead of aliasing a reused register.
+ *
+ * @ingroup group_core
+ */
+template <typename T>
+class ToggleRef
+{
+
+public:
+
+    ToggleRef() = default;
+
+    /// True when the handle points at a live register in the current
+    /// generation (not default-constructed and not invalidated by a clear).
+    bool valid() const
+    {
+        return nullptr != m_register && nullptr != m_table && m_table->generation() == m_generation;
+    }
+    explicit operator bool() const { return valid(); }
+
+    T load() const
+    {
+        check();
+        return m_register->value;
+    }
+    void store(T const & value) const
+    {
+        check();
+        m_register->value = value;
+    }
+
+    uint32_t index() const { return m_index; }
+    uint64_t generation() const { return m_generation; }
+
+private:
+
+    friend class DynamicToggleTable;
+
+    ToggleRef(DynamicToggleTable * table, ToggleRegister<T> * reg, uint32_t index, uint64_t generation)
+        : m_table(table)
+        , m_register(reg)
+        , m_index(index)
+        , m_generation(generation)
+    {
+    }
+
+    void check() const
+    {
+        if (!valid())
+        {
+            throw std::out_of_range("ToggleRef: stale or invalid handle");
+        }
+    }
+
+    DynamicToggleTable * m_table = nullptr;
+    ToggleRegister<T> * m_register = nullptr;
+    uint32_t m_index = 0;
+    uint64_t m_generation = 0;
+
+}; /* end class ToggleRef */
+
+template <typename T>
+ToggleRegisterColumn<T> & DynamicToggleTable::column()
+{
+    if constexpr (std::is_same_v<T, bool>)
+    {
+        return m_column_bool;
+    }
+    else if constexpr (std::is_same_v<T, int8_t>)
+    {
+        return m_column_int8;
+    }
+    else if constexpr (std::is_same_v<T, int16_t>)
+    {
+        return m_column_int16;
+    }
+    else if constexpr (std::is_same_v<T, int32_t>)
+    {
+        return m_column_int32;
+    }
+    else if constexpr (std::is_same_v<T, int64_t>)
+    {
+        return m_column_int64;
+    }
+    else if constexpr (std::is_same_v<T, double>)
+    {
+        return m_column_real;
+    }
+    else
+    {
+        return m_column_string;
+    }
+}
+
+template <typename T>
+ToggleRegisterColumn<T> const & DynamicToggleTable::column() const
+{
+    if constexpr (std::is_same_v<T, bool>)
+    {
+        return m_column_bool;
+    }
+    else if constexpr (std::is_same_v<T, int8_t>)
+    {
+        return m_column_int8;
+    }
+    else if constexpr (std::is_same_v<T, int16_t>)
+    {
+        return m_column_int16;
+    }
+    else if constexpr (std::is_same_v<T, int32_t>)
+    {
+        return m_column_int32;
+    }
+    else if constexpr (std::is_same_v<T, int64_t>)
+    {
+        return m_column_int64;
+    }
+    else if constexpr (std::is_same_v<T, double>)
+    {
+        return m_column_real;
+    }
+    else
+    {
+        return m_column_string;
+    }
+}
+
+template <typename T>
+ToggleRef<T> DynamicToggleTable::declare(std::string const & key, T const & default_value)
+{
+    auto it = m_key2index.find(key);
+    if (it != m_key2index.end())
+    {
+        if (it->second.type != ToggleTypeTraits<T>::tag)
+        {
+            throw std::invalid_argument(
+                std::format("Toggle::declare: key \"{}\" already declared with a different type", key));
+        }
+        uint32_t const idx = it->second.index;
+        return ToggleRef<T>(this, &column<T>().at(idx), idx, m_generation);
+    }
+    auto const idx = static_cast<uint32_t>(column<T>().append(default_value));
+    m_key2index.insert({key, DynamicToggleIndex{idx, ToggleTypeTraits<T>::tag}});
+    return ToggleRef<T>(this, &column<T>().at(idx), idx, m_generation);
+}
+
+template <typename T>
+ToggleRef<T> DynamicToggleTable::ref(std::string const & key)
+{
+    auto it = m_key2index.find(key);
+    if (it != m_key2index.end() && it->second.type == ToggleTypeTraits<T>::tag)
+    {
+        uint32_t const idx = it->second.index;
+        return ToggleRef<T>(this, &column<T>().at(idx), idx, m_generation);
+    }
+    return ToggleRef<T>();
+}
+
+template <typename T>
+T DynamicToggleTable::get(std::string const & key, T const & default_value) const
+{
+    auto it = m_key2index.find(key);
+    if (it != m_key2index.end() && it->second.type == ToggleTypeTraits<T>::tag)
+    {
+        return column<T>().at(it->second.index).value;
+    }
+    return default_value;
+}
+
+template <typename T>
+T DynamicToggleTable::at(std::string const & key) const
+{
+    auto it = m_key2index.find(key);
+    if (it != m_key2index.end() && it->second.type == ToggleTypeTraits<T>::tag)
+    {
+        return column<T>().at(it->second.index).value;
+    }
+    throw std::out_of_range(std::format("Toggle::at: key \"{}\" is missing or has a different type", key));
 }
 
 #define MM_TOGGLE_SOLID_BOOL(NAME)         \
@@ -390,6 +640,15 @@ public:
     void dynamic_clear() { m_dynamic_table.clear(); }
     uint64_t dynamic_generation() const { return m_dynamic_table.generation(); }
     DynamicToggleIndex get_dynamic_index(std::string const & key) const { return m_dynamic_table.get_index(key); }
+
+    template <typename T>
+    ToggleRef<T> declare(std::string const & key, T const & default_value) { return m_dynamic_table.declare<T>(key, default_value); }
+    template <typename T>
+    ToggleRef<T> ref(std::string const & key) { return m_dynamic_table.ref<T>(key); }
+    template <typename T>
+    T get(std::string const & key, T const & default_value) const { return m_dynamic_table.get<T>(key, default_value); }
+    template <typename T>
+    T at(std::string const & key) const { return m_dynamic_table.at<T>(key); }
 
     bool get_bool(std::string const & key) const { return m_dynamic_table.get_bool(key); }
     void set_bool(std::string const & key, bool value) { m_dynamic_table.set_bool(key, value); }

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -17,6 +17,8 @@
 #include <solvcon/profiling/profile.hpp>
 #include <solvcon/profiling/RadixTree.hpp>
 
+#include <cstdint>
+#include <deque>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -25,6 +27,59 @@ namespace solvcon
 {
 
 int setenv(const char * name, const char * value, int overwrite);
+
+/**
+ * A single stored toggle value.
+ *
+ * Named after the atomic register of shared-memory theory: a single-value
+ * shared location. For now it boxes a plain value; a later step makes the
+ * scalar read and write atomic without changing this shape.
+ *
+ * @ingroup group_core
+ */
+template <typename T>
+struct ToggleRegister
+{
+    T value;
+}; /* end struct ToggleRegister */
+
+/**
+ * Segmented column of ToggleRegister<T> with stable element addresses.
+ *
+ * Registers append into a std::deque, so a register keeps its address as
+ * the column grows, unlike a reallocating std::vector. A resolved handle
+ * can therefore keep pointing at its register while unrelated toggles are
+ * added. Indices are dense and start at zero, matching the offsets held by
+ * DynamicToggleIndex.
+ *
+ * @ingroup group_core
+ */
+template <typename T>
+class ToggleRegisterColumn
+{
+
+public:
+
+    size_t size() const { return m_registers.size(); }
+
+    ToggleRegister<T> & at(size_t index) { return m_registers.at(index); }
+    ToggleRegister<T> const & at(size_t index) const { return m_registers.at(index); }
+
+    size_t append(T const & value)
+    {
+        size_t const index = m_registers.size();
+        m_registers.emplace_back();
+        m_registers.back().value = value;
+        return index;
+    }
+
+    void clear() { m_registers.clear(); }
+
+private:
+
+    std::deque<ToggleRegister<T>> m_registers;
+
+}; /* end class ToggleRegisterColumn */
 
 /**
  * Index and type tag that locates a dynamic toggle value in its typed
@@ -184,16 +239,26 @@ public:
     std::vector<std::string> keys() const;
     void clear();
 
+    /**
+     * Monotonic stamp bumped on every clear.
+     *
+     * A handle resolved before a clear carries the old generation, so it
+     * can be detected as stale rather than aliasing a register reused
+     * after the clear.
+     */
+    uint64_t generation() const { return m_generation; }
+
 private:
 
     keymap_type m_key2index;
-    std::vector<bool> m_vector_bool;
-    std::vector<int8_t> m_vector_int8;
-    std::vector<int16_t> m_vector_int16;
-    std::vector<int32_t> m_vector_int32;
-    std::vector<int64_t> m_vector_int64;
-    std::vector<double> m_vector_real;
-    std::vector<std::string> m_vector_string;
+    ToggleRegisterColumn<bool> m_column_bool;
+    ToggleRegisterColumn<int8_t> m_column_int8;
+    ToggleRegisterColumn<int16_t> m_column_int16;
+    ToggleRegisterColumn<int32_t> m_column_int32;
+    ToggleRegisterColumn<int64_t> m_column_int64;
+    ToggleRegisterColumn<double> m_column_real;
+    ToggleRegisterColumn<std::string> m_column_string;
+    uint64_t m_generation = 0;
 
 }; /* end class DynamicToggleTable */
 
@@ -323,6 +388,7 @@ public:
 
     std::vector<std::string> dynamic_keys() const { return m_dynamic_table.keys(); }
     void dynamic_clear() { m_dynamic_table.clear(); }
+    uint64_t dynamic_generation() const { return m_dynamic_table.generation(); }
     DynamicToggleIndex get_dynamic_index(std::string const & key) const { return m_dynamic_table.get_index(key); }
 
     bool get_bool(std::string const & key) const { return m_dynamic_table.get_bool(key); }

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
     test_nopython_buffer.cpp
     test_nopython_solvcon.cpp
     test_nopython_inout.cpp
+    test_nopython_toggle.cpp
     test_nopython_radixtree.cpp
     test_nopython_callprofiler.cpp
     test_nopython_serializable.cpp

--- a/gtests/test_nopython_toggle.cpp
+++ b/gtests/test_nopython_toggle.cpp
@@ -1,0 +1,115 @@
+#include <gtest/gtest.h>
+
+#ifdef Py_PYTHON_H
+#error "Python.h should not be included."
+#endif
+
+#include <solvcon/toggle/toggle.hpp>
+
+#include <string>
+
+namespace solvcon
+{
+
+namespace detail
+{
+
+TEST(ToggleRefTest, declare_and_load)
+{
+    DynamicToggleTable table;
+    ToggleRef<int32_t> const r = table.declare<int32_t>("a.n", 42);
+    EXPECT_TRUE(r.valid());
+    EXPECT_TRUE(static_cast<bool>(r));
+    EXPECT_EQ(r.load(), 42);
+
+    r.store(7);
+    EXPECT_EQ(r.load(), 7);
+    EXPECT_EQ(table.get<int32_t>("a.n", 0), 7);
+}
+
+TEST(ToggleRefTest, ref_resolves_existing_only)
+{
+    DynamicToggleTable table;
+    table.declare<bool>("flag", true);
+
+    ToggleRef<bool> const good = table.ref<bool>("flag");
+    EXPECT_TRUE(good.valid());
+    EXPECT_TRUE(good.load());
+
+    // Missing key resolves to an invalid handle.
+    ToggleRef<bool> const missing = table.ref<bool>("nope");
+    EXPECT_FALSE(missing.valid());
+    EXPECT_THROW(missing.load(), std::out_of_range);
+
+    // Wrong type resolves to an invalid handle.
+    ToggleRef<int32_t> const wrong = table.ref<int32_t>("flag");
+    EXPECT_FALSE(wrong.valid());
+}
+
+TEST(ToggleRefTest, get_default_and_at_throw)
+{
+    DynamicToggleTable table;
+    table.declare<double>("r", 2.5);
+
+    EXPECT_DOUBLE_EQ(table.get<double>("r", 9.0), 2.5);
+    EXPECT_DOUBLE_EQ(table.get<double>("missing", 9.0), 9.0);
+    // Wrong-typed read falls back to the default.
+    EXPECT_EQ(table.get<int32_t>("r", 9), 9);
+
+    EXPECT_DOUBLE_EQ(table.at<double>("r"), 2.5);
+    EXPECT_THROW(table.at<double>("missing"), std::out_of_range);
+    EXPECT_THROW(table.at<int32_t>("r"), std::out_of_range);
+}
+
+TEST(ToggleRefTest, handle_survives_unrelated_growth)
+{
+    DynamicToggleTable table;
+    ToggleRef<int32_t> const r = table.declare<int32_t>("first", 111);
+
+    for (int i = 0; i < 10000; ++i)
+    {
+        table.declare<int32_t>("k" + std::to_string(i), i);
+    }
+
+    // The handle stays valid and reads its own value after the column has
+    // grown well past any single chunk.
+    EXPECT_TRUE(r.valid());
+    EXPECT_EQ(r.load(), 111);
+}
+
+TEST(ToggleRefTest, handle_refused_after_clear)
+{
+    DynamicToggleTable table;
+    ToggleRef<bool> const r = table.declare<bool>("flag", true);
+    EXPECT_TRUE(r.valid());
+
+    table.clear();
+
+    EXPECT_FALSE(r.valid());
+    EXPECT_THROW(r.load(), std::out_of_range);
+
+    // A fresh handle after the clear works even at the same index.
+    ToggleRef<bool> const r2 = table.declare<bool>("flag", false);
+    EXPECT_TRUE(r2.valid());
+    EXPECT_FALSE(r2.load());
+}
+
+TEST(ToggleRefTest, declare_idempotent_and_type_conflict)
+{
+    DynamicToggleTable table;
+    ToggleRef<int32_t> const r1 = table.declare<int32_t>("n", 1);
+    // Re-declaring the same type returns a handle to the same register and
+    // does not overwrite the stored value.
+    ToggleRef<int32_t> const r2 = table.declare<int32_t>("n", 99);
+    EXPECT_EQ(r1.index(), r2.index());
+    EXPECT_EQ(r2.load(), 1);
+
+    // A conflicting type is an error.
+    EXPECT_THROW(table.declare<bool>("n", true), std::invalid_argument);
+}
+
+} /* end namespace detail */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -6,6 +6,7 @@ import os
 import unittest
 import math
 import json
+import warnings
 
 import solvcon
 
@@ -275,6 +276,60 @@ class ToggleHierarchicalTC(unittest.TestCase):
                 r'Cannot get non-existing key "level1.non_exist"'
         ):
             self.assertEqual(tg.level1.non_exist, 21)
+
+
+class ToggleTypedAccessTC(unittest.TestCase):
+
+    def test_declare_and_typed_get(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+
+        tg.declare_bool("t.flag", True)
+        tg.declare_int32("t.count", 42)
+        tg.declare_real("t.ratio", 2.5)
+        tg.declare_string("t.name", "hello")
+
+        self.assertEqual(tg.get("t.flag", False), True)
+        self.assertEqual(tg.get("t.count", 0), 42)
+        self.assertEqual(tg.get("t.ratio", 0.0), 2.5)
+        self.assertEqual(tg.get("t.name", ""), "hello")
+
+    def test_get_returns_default_on_missing(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+
+        self.assertEqual(tg.get("nope", 99), 99)
+        self.assertEqual(tg.get("nope", default="fallback"), "fallback")
+
+    def test_at_raises_on_missing(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+
+        tg.declare_int32("t.count", 7)
+        self.assertEqual(tg.at("t.count"), 7)
+        with self.assertRaises(KeyError):
+            tg.at("t.missing")
+
+    def test_declare_is_idempotent(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+
+        tg.declare_int32("t.count", 42)
+        # Re-declaring the same key keeps the stored value.
+        tg.declare_int32("t.count", 100)
+        self.assertEqual(tg.get("t.count", 0), 42)
+
+    def test_deprecated_getter_warns(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+        tg.set_bool("t.flag", True)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            value = tg.get_bool("t.flag")
+        self.assertTrue(value)
+        self.assertEqual(len(caught), 1)
+        self.assertTrue(issubclass(caught[0].category, DeprecationWarning))
 
 
 class ToggleSerializationTC(unittest.TestCase):


### PR DESCRIPTION
The dynamic toggle table stores runtime feature toggles keyed by string. Before this change it had two weaknesses. Its values lived in seven parallel `std::vector`s (one per type), so a stored value moved in memory whenever an unrelated toggle grew a vector past its capacity, which rules out handing a hot path a stable reference. And it could only be read by a string key that re-hashes on every access and returns a silent sentinel (`false`, `0`, `NaN`, `""`) on a missing or wrong-typed key, so a misspelled key read as `false` with no error.

This branch redesigns the store's storage and read contract in two reviewable steps: first stable-address register storage, then the typed handle and typed read API built on top of it. The existing `get`/`set`/`clear`/`keys` surface keeps its behavior, and the old silent-sentinel getters are kept but deprecated.

## Step 1: store dynamic toggles in stable-address registers

Replace the seven per-type value vectors with segmented columns whose element addresses stay put for the column's lifetime.

- `ToggleRegister<T>` boxes a single stored value, named after the atomic register of shared-memory theory. For now it holds a plain value; a later step can make the scalar read and write atomic without changing its shape.
- `ToggleRegisterColumn<T>` is a per-type column backed by a `std::deque`, so an appended register keeps its address as the column grows, unlike a reallocating `std::vector`. Indices are dense and start at zero, matching the offsets held by `DynamicToggleIndex`.
- The existing `get`/`set` route through the columns unchanged in behavior: a get still returns the sentinel on a missing or wrong-typed key; a set still overwrites a matching type, ignores a mismatched one, and appends a new register otherwise.
- A table generation counter is bumped on every `clear`, so a handle taken before a clear can be told from one taken after. Nothing reads it yet; it is the seam the next step builds the handle on. The public `get`/`set`/`clear`/`keys` surface is unchanged.

## Step 2: add typed handles and typed evaluation

Build the resolved handle and the typed read contract on top of the register storage.

- `ToggleRef<T>` binds a key to its register once (table, index, and the table generation at resolution). Because register addresses are stable it keeps reading through unrelated growth, and because it stamps the generation it is refused after a `dynamic_clear` instead of aliasing a reused register. It exposes `valid()`, `load()`, and `store()`.
- `declare<T>(key, default)` creates a toggle and returns a handle. Re-declaring the same type is idempotent and returns a handle to the existing register; a conflicting type throws `std::invalid_argument`.
- `ref<T>(key)` resolves an existing key to a handle, or returns an invalid handle when the key is missing or typed differently.
- `get<T>(key, default)` returns the caller default on a miss or mismatch, and `at<T>(key)` throws `std::out_of_range`, replacing the silent sentinels (the OpenFeature typed contract).
- `ToggleTypeTraits<T>` maps each supported value type to its `DynamicToggleIndex` tag; the primary template is left undefined so an unsupported type is a compile error rather than a silent mismatch.

Python gains `declare_bool` / `declare_int8` / `declare_int16` / `declare_int32` / `declare_int64` / `declare_real` / `declare_string`, a generic `get(key, default)` and `at(key)`, and the old `get_TYPE` sentinel getters now emit a `DeprecationWarning` pointing at `get(key, default)` and `at(key)`.

## Notes

- The register boxing and the generation-stamped handle are deliberately laid down as seams for later work (atomic scalar access, hot-path binding) without changing today's behavior.
- No caller is migrated off the deprecated `get_TYPE` getters in this branch; they still work and only warn.

For steps 1, 2 of issue #1022.