### PR TITLE
Make the toggle store thread-safe and observable (steps 3, 4 of toggle)

### DIFF
--- a/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
@@ -499,6 +499,40 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
         .def("declare_real", &detail::declare_toggle<double>, py::arg("key"), py::arg("default"))
         .def("declare_string", &detail::declare_toggle<std::string>, py::arg("key"), py::arg("default"))
         .def(
+            "on_change",
+            [](wrapped_type & self, std::string const & key, py::function const & callback)
+            {
+                // Run the Python callback under the GIL (it may fire from a
+                // solver thread that does not hold it) and never let it
+                // propagate a C++ exception out of the store.
+                // The whole body is wrapped so nothing escapes into the
+                // store's notify loop (which also guards callbacks); the
+                // analysis cannot always see that through the GIL guard.
+                // NOLINTNEXTLINE(bugprone-exception-escape)
+                auto wrapped = [callback]()
+                {
+                    try
+                    {
+                        py::gil_scoped_acquire const acquire;
+                        try
+                        {
+                            callback();
+                        }
+                        catch (py::error_already_set & e)
+                        {
+                            e.discard_as_unraisable("solvcon.Toggle on_change callback");
+                        }
+                    }
+                    // NOLINTNEXTLINE(bugprone-empty-catch)
+                    catch (...)
+                    {
+                    }
+                };
+                return self.on_change(key, std::move(wrapped));
+            },
+            py::arg("key"),
+            py::arg("callback"))
+        .def(
             "__getattr__",
             [](wrapped_type & self, std::string const & key)
             {
@@ -691,6 +725,14 @@ WrapProcessInfo::WrapProcessInfo(pybind11::module & mod, char const * pyname, ch
 
 void wrap_Toggle(pybind11::module & mod)
 {
+    namespace py = pybind11;
+
+    // The RAII subscription token returned by Toggle.on_change. Dropping the
+    // Python handle (or calling unsubscribe) removes the callback.
+    py::class_<ToggleSubscription>(mod, "ToggleSubscription")
+        .def("unsubscribe", &ToggleSubscription::reset)
+        .def_property_readonly("active", &ToggleSubscription::active);
+
     WrapSolidToggle::commit(mod, "SolidToggle", "SolidToggle");
     WrapFixedToggle::commit(mod, "FixedToggle", "FixedToggle");
     WrapHierarchicalToggleAccess::commit(mod, "HierarchicalToggleAccess", "HierarchicalToggleAccess");

--- a/cpp/solvcon/toggle/toggle.cpp
+++ b/cpp/solvcon/toggle/toggle.cpp
@@ -79,33 +79,42 @@ MM_DECL_DYNGET(std::string const &, string, sentinel_string)
 
 /* The macro gives debuggers a hard time. Manually expand it if you need to
  * step in a debugger. */
-#define MM_DECL_DYNSET(CTYPE, MTYPE, MTYPEC)                                                                                   \
-    /* NOLINTNEXTLINE(bugprone-easily-swappable-parameters) */                                                                 \
-    void DynamicToggleTable::set_##MTYPE(std::string const & key, CTYPE value)                                                 \
-    {                                                                                                                          \
-        std::scoped_lock const guard(m_mutex);                                                                                 \
-        auto it = m_key2index.find(key);                                                                                       \
-        if (it != m_key2index.end())                                                                                           \
-        {                                                                                                                      \
-            if (it->second.is_##MTYPE())                                                                                       \
-            {                                                                                                                  \
-                m_column_##MTYPE.at(it->second.index).set(value);                                                              \
-            }                                                                                                                  \
-            else                                                                                                               \
-            {                                                                                                                  \
-                /* do nothing */                                                                                               \
-            }                                                                                                                  \
-        }                                                                                                                      \
-        else                                                                                                                   \
-        {                                                                                                                      \
-            DynamicToggleIndex const index{static_cast<uint32_t>(m_column_##MTYPE.size()), DynamicToggleIndex::TYPE_##MTYPEC}; \
-            m_key2index.insert({key, index});                                                                                  \
-            m_column_##MTYPE.append(value);                                                                                    \
-        }                                                                                                                      \
-    }                                                                                                                          \
-    void HierarchicalToggleAccess::set_##MTYPE(std::string const & key, CTYPE value)                                           \
-    {                                                                                                                          \
-        m_table->set_##MTYPE(rekey(key), value);                                                                               \
+#define MM_DECL_DYNSET(CTYPE, MTYPE, MTYPEC)                                                                                     \
+    /* NOLINTNEXTLINE(bugprone-easily-swappable-parameters) */                                                                   \
+    void DynamicToggleTable::set_##MTYPE(std::string const & key, CTYPE value)                                                   \
+    {                                                                                                                            \
+        bool changed = false;                                                                                                    \
+        {                                                                                                                        \
+            std::scoped_lock const guard(m_mutex);                                                                               \
+            auto it = m_key2index.find(key);                                                                                     \
+            if (it != m_key2index.end())                                                                                         \
+            {                                                                                                                    \
+                if (it->second.is_##MTYPE())                                                                                     \
+                {                                                                                                                \
+                    auto & reg = m_column_##MTYPE.at(it->second.index);                                                          \
+                    if (!value_equal(reg.get(), value))                                                                          \
+                    {                                                                                                            \
+                        reg.set(value);                                                                                          \
+                        changed = true;                                                                                          \
+                    }                                                                                                            \
+                }                                                                                                                \
+            }                                                                                                                    \
+            else                                                                                                                 \
+            {                                                                                                                    \
+                DynamicToggleIndex const idx{static_cast<uint32_t>(m_column_##MTYPE.size()), DynamicToggleIndex::TYPE_##MTYPEC}; \
+                m_key2index.insert({key, idx});                                                                                  \
+                m_column_##MTYPE.append(value);                                                                                  \
+                changed = true;                                                                                                  \
+            }                                                                                                                    \
+        }                                                                                                                        \
+        if (changed)                                                                                                             \
+        {                                                                                                                        \
+            notify(key);                                                                                                         \
+        }                                                                                                                        \
+    }                                                                                                                            \
+    void HierarchicalToggleAccess::set_##MTYPE(std::string const & key, CTYPE value)                                             \
+    {                                                                                                                            \
+        m_table->set_##MTYPE(rekey(key), value);                                                                                 \
     }
 MM_DECL_DYNSET(bool, bool, BOOL)
 MM_DECL_DYNSET(int8_t, int8, INT8)
@@ -161,6 +170,37 @@ void DynamicToggleTable::clear()
     m_column_real.clear();
     m_column_string.clear();
     m_generation.fetch_add(1, std::memory_order_relaxed);
+}
+
+void DynamicToggleTable::notify(std::string const & key) const
+{
+    // Copy the callbacks out under the registry mutex, then run them with no
+    // lock held so a callback may re-enter the store or the registry.
+    std::vector<detail::ToggleChangeObservers::callback_type> callbacks;
+    {
+        std::scoped_lock const guard(m_observers->mutex);
+        auto it = m_observers->map.find(key);
+        if (it != m_observers->map.end())
+        {
+            for (auto const & pr : it->second)
+            {
+                callbacks.push_back(pr.second);
+            }
+        }
+    }
+    for (auto const & callback : callbacks)
+    {
+        try
+        {
+            (*callback)();
+        }
+        // A throwing observer must not corrupt the store or stop the other
+        // observers, so the exception is intentionally swallowed here.
+        // NOLINTNEXTLINE(bugprone-empty-catch)
+        catch (...)
+        {
+        }
+    }
 }
 
 // NOLINTNEXTLINE(modernize-use-equals-default) lack of SOLVCON_METAL

--- a/cpp/solvcon/toggle/toggle.cpp
+++ b/cpp/solvcon/toggle/toggle.cpp
@@ -53,12 +53,13 @@ std::string const DynamicToggleTable::sentinel_string = "";
 #define MM_DECL_DYNGET(CTYPE, MTYPE, SENTINEL)                                 \
     CTYPE DynamicToggleTable::get_##MTYPE(std::string const & key) const       \
     {                                                                          \
+        std::scoped_lock const guard(m_mutex);                                 \
         auto it = m_key2index.find(key);                                       \
         if (it != m_key2index.end())                                           \
         {                                                                      \
             if (it->second.is_##MTYPE())                                       \
             {                                                                  \
-                return m_column_##MTYPE.at(it->second.index).value;            \
+                return m_column_##MTYPE.at(it->second.index).get();            \
             }                                                                  \
         }                                                                      \
         return SENTINEL;                                                       \
@@ -82,12 +83,13 @@ MM_DECL_DYNGET(std::string const &, string, sentinel_string)
     /* NOLINTNEXTLINE(bugprone-easily-swappable-parameters) */                                                                 \
     void DynamicToggleTable::set_##MTYPE(std::string const & key, CTYPE value)                                                 \
     {                                                                                                                          \
+        std::scoped_lock const guard(m_mutex);                                                                                 \
         auto it = m_key2index.find(key);                                                                                       \
         if (it != m_key2index.end())                                                                                           \
         {                                                                                                                      \
             if (it->second.is_##MTYPE())                                                                                       \
             {                                                                                                                  \
-                m_column_##MTYPE.at(it->second.index).value = value;                                                           \
+                m_column_##MTYPE.at(it->second.index).set(value);                                                              \
             }                                                                                                                  \
             else                                                                                                               \
             {                                                                                                                  \
@@ -126,6 +128,7 @@ void HierarchicalToggleAccess::add_subkey(const std::string & key)
 
 void DynamicToggleTable::add_subkey(std::string const & key)
 {
+    std::scoped_lock const guard(m_mutex);
     auto it = m_key2index.find(key);
     if (it == m_key2index.end())
     {
@@ -136,6 +139,7 @@ void DynamicToggleTable::add_subkey(std::string const & key)
 
 std::vector<std::string> DynamicToggleTable::keys() const
 {
+    std::scoped_lock const guard(m_mutex);
     std::vector<std::string> ret;
     ret.reserve(m_key2index.size());
     for (auto const & it : m_key2index)
@@ -147,6 +151,7 @@ std::vector<std::string> DynamicToggleTable::keys() const
 
 void DynamicToggleTable::clear()
 {
+    std::scoped_lock const guard(m_mutex);
     m_key2index.clear();
     m_column_bool.clear();
     m_column_int8.clear();
@@ -155,7 +160,7 @@ void DynamicToggleTable::clear()
     m_column_int64.clear();
     m_column_real.clear();
     m_column_string.clear();
-    ++m_generation;
+    m_generation.fetch_add(1, std::memory_order_relaxed);
 }
 
 // NOLINTNEXTLINE(modernize-use-equals-default) lack of SOLVCON_METAL

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -17,9 +17,12 @@
 #include <solvcon/profiling/profile.hpp>
 #include <solvcon/profiling/RadixTree.hpp>
 
+#include <atomic>
 #include <cstdint>
 #include <deque>
 #include <format>
+#include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -38,25 +41,46 @@ class ToggleRef;
  * A single stored toggle value.
  *
  * Named after the atomic register of shared-memory theory: a single-value
- * shared location. For now it boxes a plain value; a later step makes the
- * scalar read and write atomic without changing this shape.
+ * shared location. A scalar register holds a std::atomic so its read and
+ * write are lock-free and never torn; get and set use memory_order_relaxed
+ * because a toggle publishes nothing but itself.
  *
  * @ingroup group_core
  */
 template <typename T>
 struct ToggleRegister
 {
-    T value;
+    std::atomic<T> value;
+    T get() const { return value.load(std::memory_order_relaxed); }
+    void set(T v) { value.store(v, std::memory_order_relaxed); }
 }; /* end struct ToggleRegister */
 
 /**
- * Segmented column of ToggleRegister<T> with stable element addresses.
+ * String register.
  *
- * Registers append into a std::deque, so a register keeps its address as
- * the column grows, unlike a reallocating std::vector. A resolved handle
- * can therefore keep pointing at its register while unrelated toggles are
- * added. Indices are dense and start at zero, matching the offsets held by
- * DynamicToggleIndex.
+ * A string is not a hot-path value: it is read by the UI and config code
+ * only, never in a tight loop, so it is a plain std::string guarded by the
+ * table mutex rather than an atomic. get returns a reference that is valid
+ * only while no writer mutates the same key.
+ *
+ * @ingroup group_core
+ */
+template <>
+struct ToggleRegister<std::string>
+{
+    std::string value;
+    std::string const & get() const { return value; }
+    void set(std::string v) { value = std::move(v); }
+}; /* end struct ToggleRegister<std::string> */
+
+/**
+ * Column of ToggleRegister<T> with stable register addresses.
+ *
+ * Each register is heap-owned through a unique_ptr, so a register keeps its
+ * address for its lifetime even as the column grows, and a resolved handle
+ * stays valid. The heap box also lets a non-movable atomic register live in
+ * a standard container. Indices are dense and start at zero, matching the
+ * offsets held by DynamicToggleIndex.
  *
  * @ingroup group_core
  */
@@ -66,16 +90,30 @@ class ToggleRegisterColumn
 
 public:
 
+    ToggleRegisterColumn() = default;
+
+    ToggleRegisterColumn(ToggleRegisterColumn const & other)
+    {
+        for (auto const & reg : other.m_registers)
+        {
+            append(reg->get());
+        }
+    }
+    ToggleRegisterColumn(ToggleRegisterColumn &&) = default;
+    ToggleRegisterColumn & operator=(ToggleRegisterColumn const &) = delete;
+    ToggleRegisterColumn & operator=(ToggleRegisterColumn &&) = default;
+    ~ToggleRegisterColumn() = default;
+
     size_t size() const { return m_registers.size(); }
 
-    ToggleRegister<T> & at(size_t index) { return m_registers.at(index); }
-    ToggleRegister<T> const & at(size_t index) const { return m_registers.at(index); }
+    ToggleRegister<T> & at(size_t index) { return *m_registers.at(index); }
+    ToggleRegister<T> const & at(size_t index) const { return *m_registers.at(index); }
 
     size_t append(T const & value)
     {
         size_t const index = m_registers.size();
-        m_registers.emplace_back();
-        m_registers.back().value = value;
+        m_registers.push_back(std::make_unique<ToggleRegister<T>>());
+        m_registers.back()->set(value);
         return index;
     }
 
@@ -83,7 +121,7 @@ public:
 
 private:
 
-    std::deque<ToggleRegister<T>> m_registers;
+    std::deque<std::unique_ptr<ToggleRegister<T>>> m_registers;
 
 }; /* end class ToggleRegisterColumn */
 
@@ -241,6 +279,21 @@ public:
 
     static std::string const sentinel_string; // FIXME: NOLINT(readability-redundant-string-init)
 
+    DynamicToggleTable() = default;
+
+    // The atomic generation and the mutex are not copyable. Delegate to a
+    // private constructor that holds the source lock for the whole deep copy
+    // (the scoped_lock temporary outlives the delegated-to body) and starts a
+    // fresh mutex.
+    DynamicToggleTable(DynamicToggleTable const & other)
+        : DynamicToggleTable(other, std::scoped_lock<std::mutex>(other.m_mutex))
+    {
+    }
+    DynamicToggleTable(DynamicToggleTable &&) = delete;
+    DynamicToggleTable & operator=(DynamicToggleTable const &) = delete;
+    DynamicToggleTable & operator=(DynamicToggleTable &&) = delete;
+    ~DynamicToggleTable() = default;
+
     bool get_bool(std::string const & key) const;
     void set_bool(std::string const & key, bool value);
     int8_t get_int8(std::string const & key) const;
@@ -266,6 +319,7 @@ public:
     // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     DynamicToggleIndex get_index(std::string const & key) const
     {
+        std::scoped_lock const guard(m_mutex);
         auto it = m_key2index.find(key);
         return (it != m_key2index.end()) ? it->second : DynamicToggleIndex{.index = 0, .type = DynamicToggleIndex::TYPE_NONE};
     }
@@ -279,7 +333,7 @@ public:
      * can be detected as stale rather than aliasing a register reused
      * after the clear.
      */
-    uint64_t generation() const { return m_generation; }
+    uint64_t generation() const { return m_generation.load(std::memory_order_relaxed); }
 
     /**
      * Create a toggle with a default and return a handle to it.
@@ -307,11 +361,25 @@ public:
 
 private:
 
+    DynamicToggleTable(DynamicToggleTable const & other, std::scoped_lock<std::mutex> const &)
+        : m_key2index(other.m_key2index)
+        , m_column_bool(other.m_column_bool)
+        , m_column_int8(other.m_column_int8)
+        , m_column_int16(other.m_column_int16)
+        , m_column_int32(other.m_column_int32)
+        , m_column_int64(other.m_column_int64)
+        , m_column_real(other.m_column_real)
+        , m_column_string(other.m_column_string)
+        , m_generation(other.m_generation.load(std::memory_order_relaxed))
+    {
+    }
+
     template <typename T>
     ToggleRegisterColumn<T> & column();
     template <typename T>
     ToggleRegisterColumn<T> const & column() const;
 
+    mutable std::mutex m_mutex;
     keymap_type m_key2index;
     ToggleRegisterColumn<bool> m_column_bool;
     ToggleRegisterColumn<int8_t> m_column_int8;
@@ -320,7 +388,7 @@ private:
     ToggleRegisterColumn<int64_t> m_column_int64;
     ToggleRegisterColumn<double> m_column_real;
     ToggleRegisterColumn<std::string> m_column_string;
-    uint64_t m_generation = 0;
+    std::atomic<uint64_t> m_generation{0};
 
 }; /* end class DynamicToggleTable */
 
@@ -360,12 +428,12 @@ public:
     T load() const
     {
         check();
-        return m_register->value;
+        return m_register->get();
     }
     void store(T const & value) const
     {
         check();
-        m_register->value = value;
+        m_register->set(value);
     }
 
     uint32_t index() const { return m_index; }
@@ -467,6 +535,7 @@ ToggleRegisterColumn<T> const & DynamicToggleTable::column() const
 template <typename T>
 ToggleRef<T> DynamicToggleTable::declare(std::string const & key, T const & default_value)
 {
+    std::scoped_lock const guard(m_mutex);
     auto it = m_key2index.find(key);
     if (it != m_key2index.end())
     {
@@ -476,21 +545,22 @@ ToggleRef<T> DynamicToggleTable::declare(std::string const & key, T const & defa
                 std::format("Toggle::declare: key \"{}\" already declared with a different type", key));
         }
         uint32_t const idx = it->second.index;
-        return ToggleRef<T>(this, &column<T>().at(idx), idx, m_generation);
+        return ToggleRef<T>(this, &column<T>().at(idx), idx, generation());
     }
     auto const idx = static_cast<uint32_t>(column<T>().append(default_value));
     m_key2index.insert({key, DynamicToggleIndex{idx, ToggleTypeTraits<T>::tag}});
-    return ToggleRef<T>(this, &column<T>().at(idx), idx, m_generation);
+    return ToggleRef<T>(this, &column<T>().at(idx), idx, generation());
 }
 
 template <typename T>
 ToggleRef<T> DynamicToggleTable::ref(std::string const & key)
 {
+    std::scoped_lock const guard(m_mutex);
     auto it = m_key2index.find(key);
     if (it != m_key2index.end() && it->second.type == ToggleTypeTraits<T>::tag)
     {
         uint32_t const idx = it->second.index;
-        return ToggleRef<T>(this, &column<T>().at(idx), idx, m_generation);
+        return ToggleRef<T>(this, &column<T>().at(idx), idx, generation());
     }
     return ToggleRef<T>();
 }
@@ -498,10 +568,11 @@ ToggleRef<T> DynamicToggleTable::ref(std::string const & key)
 template <typename T>
 T DynamicToggleTable::get(std::string const & key, T const & default_value) const
 {
+    std::scoped_lock const guard(m_mutex);
     auto it = m_key2index.find(key);
     if (it != m_key2index.end() && it->second.type == ToggleTypeTraits<T>::tag)
     {
-        return column<T>().at(it->second.index).value;
+        return column<T>().at(it->second.index).get();
     }
     return default_value;
 }
@@ -509,10 +580,11 @@ T DynamicToggleTable::get(std::string const & key, T const & default_value) cons
 template <typename T>
 T DynamicToggleTable::at(std::string const & key) const
 {
+    std::scoped_lock const guard(m_mutex);
     auto it = m_key2index.find(key);
     if (it != m_key2index.end() && it->second.type == ToggleTypeTraits<T>::tag)
     {
-        return column<T>().at(it->second.index).value;
+        return column<T>().at(it->second.index).get();
     }
     throw std::out_of_range(std::format("Toggle::at: key \"{}\" is missing or has a different type", key));
 }
@@ -667,13 +739,17 @@ public:
     HierarchicalToggleAccess get_subkey(std::string const & key) { return m_dynamic_table.get_subkey(key); }
     void add_subkey(std::string const & key) { m_dynamic_table.add_subkey(key); }
 
+    // The store holds an atomic and a mutex, so it is not movable or
+    // assignable, and neither is the Toggle that owns it. clone() still copies
+    // through the private copy constructor.
+    Toggle(Toggle &&) = delete;
+    Toggle & operator=(Toggle const &) = delete;
+    Toggle & operator=(Toggle &&) = delete;
+
 private:
 
     Toggle() = default;
     Toggle(Toggle const &) = default;
-    Toggle(Toggle &&) = default;
-    Toggle & operator=(Toggle const &) = default;
-    Toggle & operator=(Toggle &&) = default;
 
     SolidToggle m_solid;
     FixedToggle m_fixed;

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -17,10 +17,13 @@
 #include <solvcon/profiling/profile.hpp>
 #include <solvcon/profiling/RadixTree.hpp>
 
+#include <algorithm>
 #include <atomic>
+#include <bit>
 #include <cstdint>
 #include <deque>
 #include <format>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -199,6 +202,117 @@ MM_TOGGLE_TYPE_TRAITS(double, TYPE_REAL)
 MM_TOGGLE_TYPE_TRAITS(std::string, TYPE_STRING)
 #undef MM_TOGGLE_TYPE_TRAITS
 
+namespace detail
+{
+
+/**
+ * Shared registry of change callbacks, keyed by toggle key.
+ *
+ * It is owned by a shared_ptr so a ToggleSubscription can hold a weak
+ * reference and unsubscribe safely even if the table is gone. Its own mutex
+ * guards the map and is never held while a callback runs.
+ *
+ * @ingroup group_core
+ */
+struct ToggleChangeObservers
+{
+    using callback_type = std::shared_ptr<std::function<void()>>;
+    std::mutex mutex;
+    uint64_t next_id = 0;
+    // The callback is held by shared_ptr so a firing thread can copy the
+    // pointer (a cheap atomic) rather than the std::function itself. Copying
+    // a std::function that wraps a Python callable would touch a Python
+    // refcount without the GIL, from a solver thread that does not hold it.
+    std::unordered_map<std::string, std::vector<std::pair<uint64_t, callback_type>>> map;
+}; /* end struct ToggleChangeObservers */
+
+} /* end namespace detail */
+
+/**
+ * RAII handle for one change subscription.
+ *
+ * Dropping it unsubscribes, so a callback never outlives the widget it
+ * belongs to. It is move-only and tolerates the table being destroyed first
+ * (the weak reference simply expires).
+ *
+ * @ingroup group_core
+ */
+class ToggleSubscription
+{
+
+public:
+
+    ToggleSubscription() = default;
+
+    ToggleSubscription(std::shared_ptr<detail::ToggleChangeObservers> const & observers, std::string key, uint64_t id)
+        : m_observers(observers)
+        , m_key(std::move(key))
+        , m_id(id)
+        , m_active(true)
+    {
+    }
+
+    ToggleSubscription(ToggleSubscription const &) = delete;
+    ToggleSubscription & operator=(ToggleSubscription const &) = delete;
+
+    ToggleSubscription(ToggleSubscription && other) noexcept { swap(other); }
+    ToggleSubscription & operator=(ToggleSubscription && other) noexcept
+    {
+        if (this != &other)
+        {
+            reset();
+            swap(other);
+        }
+        return *this;
+    }
+
+    ~ToggleSubscription() { reset(); }
+
+    bool active() const { return m_active; }
+
+    void reset()
+    {
+        if (!m_active)
+        {
+            return;
+        }
+        m_active = false;
+        if (std::shared_ptr<detail::ToggleChangeObservers> const obs = m_observers.lock())
+        {
+            std::scoped_lock const guard(obs->mutex);
+            auto it = obs->map.find(m_key);
+            if (it != obs->map.end())
+            {
+                auto & subs = it->second;
+                subs.erase(
+                    std::remove_if(subs.begin(), subs.end(), [this](auto const & pr)
+                                   { return pr.first == m_id; }),
+                    subs.end());
+                if (subs.empty())
+                {
+                    obs->map.erase(it);
+                }
+            }
+        }
+    }
+
+private:
+
+    void swap(ToggleSubscription & other) noexcept
+    {
+        m_observers.swap(other.m_observers);
+        m_key.swap(other.m_key);
+        std::swap(m_id, other.m_id);
+        std::swap(m_active, other.m_active);
+    }
+
+    std::weak_ptr<detail::ToggleChangeObservers> m_observers;
+    std::string m_key;
+    uint64_t m_id = 0;
+    bool m_active = false;
+
+}; /* end class ToggleSubscription */
+
 class DynamicToggleTable;
 
 /**
@@ -359,6 +473,23 @@ public:
     template <typename T>
     T at(std::string const & key) const;
 
+    /**
+     * Subscribe to changes of a key.
+     *
+     * The callback runs after the write lock is released, so it may call back
+     * into the store (including set) without deadlock, and firing outside the
+     * lock keeps a Python callback from inverting lock order against the GIL.
+     * A no-op write (setting the value already stored) does not fire. Dropping
+     * the returned token unsubscribes.
+     */
+    [[nodiscard]] ToggleSubscription on_change(std::string const & key, std::function<void()> callback)
+    {
+        std::scoped_lock const guard(m_observers->mutex);
+        uint64_t const id = m_observers->next_id++;
+        m_observers->map[key].emplace_back(id, std::make_shared<std::function<void()>>(std::move(callback)));
+        return ToggleSubscription(m_observers, key, id);
+    }
+
 private:
 
     DynamicToggleTable(DynamicToggleTable const & other, std::scoped_lock<std::mutex> const &)
@@ -379,6 +510,25 @@ private:
     template <typename T>
     ToggleRegisterColumn<T> const & column() const;
 
+    // Fire the change callbacks for a key, called after the write lock is
+    // released. A throwing callback is caught so the store is never corrupted.
+    void notify(std::string const & key) const;
+
+    // Equality used by the no-op-write guard. Doubles compare by bit pattern
+    // so NaN and -0.0 behave sanely under the load-compare-store.
+    template <typename T>
+    static bool value_equal(T const & lhs, T const & rhs)
+    {
+        if constexpr (std::is_same_v<T, double>)
+        {
+            return std::bit_cast<uint64_t>(lhs) == std::bit_cast<uint64_t>(rhs);
+        }
+        else
+        {
+            return lhs == rhs;
+        }
+    }
+
     mutable std::mutex m_mutex;
     keymap_type m_key2index;
     ToggleRegisterColumn<bool> m_column_bool;
@@ -389,6 +539,8 @@ private:
     ToggleRegisterColumn<double> m_column_real;
     ToggleRegisterColumn<std::string> m_column_string;
     std::atomic<uint64_t> m_generation{0};
+    // A fresh registry per table; a clone does not inherit subscriptions.
+    std::shared_ptr<detail::ToggleChangeObservers> m_observers = std::make_shared<detail::ToggleChangeObservers>();
 
 }; /* end class DynamicToggleTable */
 
@@ -721,6 +873,11 @@ public:
     T get(std::string const & key, T const & default_value) const { return m_dynamic_table.get<T>(key, default_value); }
     template <typename T>
     T at(std::string const & key) const { return m_dynamic_table.at<T>(key); }
+
+    [[nodiscard]] ToggleSubscription on_change(std::string const & key, std::function<void()> callback)
+    {
+        return m_dynamic_table.on_change(key, std::move(callback));
+    }
 
     bool get_bool(std::string const & key) const { return m_dynamic_table.get_bool(key); }
     void set_bool(std::string const & key, bool value) { m_dynamic_table.set_bool(key, value); }

--- a/gtests/test_nopython_toggle.cpp
+++ b/gtests/test_nopython_toggle.cpp
@@ -6,7 +6,10 @@
 
 #include <solvcon/toggle/toggle.hpp>
 
+#include <atomic>
 #include <string>
+#include <thread>
+#include <vector>
 
 namespace solvcon
 {
@@ -106,6 +109,118 @@ TEST(ToggleRefTest, declare_idempotent_and_type_conflict)
 
     // A conflicting type is an error.
     EXPECT_THROW(table.declare<bool>("n", true), std::invalid_argument);
+}
+
+TEST(ToggleRefTest, concurrent_readers_and_writers)
+{
+    DynamicToggleTable table;
+    ToggleRef<int64_t> const r = table.declare<int64_t>("counter", 0);
+
+    constexpr int readers = 4;
+    constexpr int writers = 4;
+    constexpr int iters = 20000;
+    std::atomic<bool> start{false};
+    std::vector<std::thread> threads;
+
+    // Readers load through the handle and the typed getter; an atomic
+    // register is never torn, so every read is a value some writer stored.
+    for (int i = 0; i < readers; ++i)
+    {
+        threads.emplace_back(
+            [&]
+            {
+                while (!start.load())
+                {
+                }
+                int64_t sink = 0;
+                for (int k = 0; k < iters; ++k)
+                {
+                    sink += r.load();
+                    sink += table.get<int64_t>("counter", -1);
+                }
+                (void)sink;
+            });
+    }
+    // Writers store through the handle and through the table set path.
+    for (int w = 0; w < writers; ++w)
+    {
+        threads.emplace_back(
+            [&, w]
+            {
+                while (!start.load())
+                {
+                }
+                for (int k = 0; k < iters; ++k)
+                {
+                    r.store(static_cast<int64_t>(k));
+                    table.set_int64("counter", static_cast<int64_t>(w));
+                }
+            });
+    }
+
+    start.store(true);
+    for (auto & t : threads)
+    {
+        t.join();
+    }
+
+    int64_t const final_value = r.load();
+    EXPECT_GE(final_value, 0);
+    EXPECT_LT(final_value, iters);
+    EXPECT_TRUE(r.valid());
+}
+
+TEST(ToggleRefTest, concurrent_declare_and_read)
+{
+    DynamicToggleTable table;
+    ToggleRef<int32_t> const base = table.declare<int32_t>("base", 7);
+
+    std::atomic<bool> start{false};
+    std::atomic<bool> reads_ok{true};
+    std::vector<std::thread> threads;
+
+    // Writers declare distinct new keys, growing the map and columns under
+    // the table mutex.
+    for (int w = 0; w < 4; ++w)
+    {
+        threads.emplace_back(
+            [&, w]
+            {
+                while (!start.load())
+                {
+                }
+                for (int k = 0; k < 2000; ++k)
+                {
+                    table.declare<int32_t>("w" + std::to_string(w) + "_" + std::to_string(k), k);
+                }
+            });
+    }
+    // A reader hammers the base handle while the table grows; its register is
+    // heap-stable, so the lock-free load stays valid and correct.
+    threads.emplace_back(
+        [&]
+        {
+            while (!start.load())
+            {
+            }
+            for (int k = 0; k < 40000; ++k)
+            {
+                if (base.load() != 7)
+                {
+                    reads_ok.store(false);
+                }
+            }
+        });
+
+    start.store(true);
+    for (auto & t : threads)
+    {
+        t.join();
+    }
+
+    EXPECT_TRUE(reads_ok.load());
+    EXPECT_EQ(base.load(), 7);
+    EXPECT_TRUE(base.valid());
 }
 
 } /* end namespace detail */

--- a/gtests/test_nopython_toggle.cpp
+++ b/gtests/test_nopython_toggle.cpp
@@ -7,6 +7,8 @@
 #include <solvcon/toggle/toggle.hpp>
 
 #include <atomic>
+#include <limits>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -109,6 +111,94 @@ TEST(ToggleRefTest, declare_idempotent_and_type_conflict)
 
     // A conflicting type is an error.
     EXPECT_THROW(table.declare<bool>("n", true), std::invalid_argument);
+}
+
+TEST(ToggleOnChangeTest, fires_once_per_real_change)
+{
+    DynamicToggleTable table;
+    table.declare<int32_t>("k", 1);
+
+    int fired = 0;
+    ToggleSubscription const tok = table.on_change("k", [&]
+                                                   { ++fired; });
+    table.set_int32("k", 2); // change
+    table.set_int32("k", 2); // no-op
+    table.set_int32("k", 3); // change
+    EXPECT_EQ(fired, 2);
+}
+
+TEST(ToggleOnChangeTest, double_noop_uses_bit_pattern)
+{
+    DynamicToggleTable table;
+    table.declare<double>("r", 0.0);
+
+    int fired = 0;
+    ToggleSubscription const tok = table.on_change("r", [&]
+                                                   { ++fired; });
+
+    table.set_real("r", 0.0); // same bits -> no fire
+    EXPECT_EQ(fired, 0);
+    table.set_real("r", -0.0); // different bits from +0.0 -> fire
+    EXPECT_EQ(fired, 1);
+
+    double const nan_value = std::numeric_limits<double>::quiet_NaN();
+    table.set_real("r", nan_value); // -0.0 -> NaN -> fire
+    EXPECT_EQ(fired, 2);
+    table.set_real("r", nan_value); // same NaN bits -> no fire
+    EXPECT_EQ(fired, 2);
+}
+
+TEST(ToggleOnChangeTest, coalesced_across_observers_and_reentrant)
+{
+    DynamicToggleTable table;
+    table.declare<int32_t>("k", 0);
+    table.declare<int32_t>("mirror", -1);
+
+    int a = 0;
+    int b = 0;
+    ToggleSubscription const t0 = table.on_change("k", [&]
+                                                  { ++a; });
+    // A reentrant observer writes another key from inside the callback.
+    ToggleSubscription const t1 = table.on_change("k", [&]
+                                                  { ++b; table.set_int32("mirror", table.at<int32_t>("k")); });
+
+    table.set_int32("k", 7);
+    EXPECT_EQ(a, 1);
+    EXPECT_EQ(b, 1);
+    EXPECT_EQ(table.at<int32_t>("mirror"), 7);
+}
+
+TEST(ToggleOnChangeTest, throwing_observer_is_contained)
+{
+    DynamicToggleTable table;
+    table.declare<int32_t>("k", 0);
+
+    int after = 0;
+    ToggleSubscription const t0 = table.on_change("k", []
+                                                  { throw std::runtime_error("boom"); });
+    ToggleSubscription const t1 = table.on_change("k", [&]
+                                                  { ++after; });
+
+    EXPECT_NO_THROW(table.set_int32("k", 1));
+    EXPECT_EQ(after, 1);
+    EXPECT_EQ(table.at<int32_t>("k"), 1);
+}
+
+TEST(ToggleOnChangeTest, dropped_subscription_stops_firing)
+{
+    DynamicToggleTable table;
+    table.declare<int32_t>("k", 0);
+
+    int fired = 0;
+    {
+        ToggleSubscription const tok = table.on_change("k", [&]
+                                                       { ++fired; });
+        table.set_int32("k", 1);
+        EXPECT_EQ(fired, 1);
+    }
+    // Token destroyed at scope exit -> unsubscribed.
+    table.set_int32("k", 2);
+    EXPECT_EQ(fired, 1);
 }
 
 TEST(ToggleRefTest, concurrent_readers_and_writers)

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -332,6 +332,96 @@ class ToggleTypedAccessTC(unittest.TestCase):
         self.assertTrue(issubclass(caught[0].category, DeprecationWarning))
 
 
+class ToggleOnChangeTC(unittest.TestCase):
+
+    def test_fires_on_real_change_only(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+        tg.declare_int32("k", 1)
+
+        seen = []
+        tok = tg.on_change("k", lambda: seen.append(tg.get("k", -1)))
+        self.assertTrue(tok.active)
+        tg.set_int32("k", 2)   # change -> fire
+        tg.set_int32("k", 2)   # no-op -> no fire
+        tg.set_int32("k", 3)   # change -> fire
+        self.assertEqual(seen, [2, 3])
+
+    def test_attribute_set_fires(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+        tg.declare_bool("flag", False)
+
+        seen = []
+        tok = tg.on_change("flag", lambda: seen.append(1))
+        tg.flag = True
+        self.assertEqual(seen, [1])
+        self.assertTrue(tok.active)
+
+    def test_multiple_observers_each_fire_once(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+        tg.declare_int32("k", 0)
+
+        counts = [0, 0]
+
+        def make(i):
+            def cb():
+                counts[i] += 1
+            return cb
+
+        t0 = tg.on_change("k", make(0))
+        t1 = tg.on_change("k", make(1))
+        tg.set_int32("k", 5)
+        self.assertEqual(counts, [1, 1])
+        self.assertTrue(t0.active and t1.active)
+
+    def test_reentrant_callback(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+        tg.declare_int32("k", 0)
+        tg.declare_int32("mirror", -1)
+
+        def mirror():
+            tg.set_int32("mirror", tg.get("k", -1))
+
+        tok = tg.on_change("k", mirror)
+        tg.set_int32("k", 42)
+        self.assertEqual(tg.get("mirror", -1), 42)
+        self.assertTrue(tok.active)
+
+    def test_dropping_token_unsubscribes(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+        tg.declare_int32("k", 0)
+
+        seen = []
+        tok = tg.on_change("k", lambda: seen.append(1))
+        tg.set_int32("k", 1)
+        tok.unsubscribe()
+        tg.set_int32("k", 2)
+        self.assertEqual(seen, [1])
+        self.assertFalse(tok.active)
+
+    def test_throwing_callback_is_contained(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+        tg.declare_int32("k", 0)
+
+        after = []
+
+        def boom():
+            raise ValueError("boom")
+
+        t0 = tg.on_change("k", boom)
+        t1 = tg.on_change("k", lambda: after.append(1))
+        # The throwing observer must not propagate nor stop the other one.
+        tg.set_int32("k", 1)
+        self.assertEqual(after, [1])
+        self.assertEqual(tg.get("k", -1), 1)
+        self.assertTrue(t0.active and t1.active)
+
+
 class ToggleSerializationTC(unittest.TestCase):
 
     def test_to_json(self):


### PR DESCRIPTION
`Toggle::instance()` is a process-global that a solver thread and the UI thread both reach, and until now nothing synchronized it and nothing could subscribe to a change. A dynamic set could grow a value column while another thread read it, the read itself was an unguarded plain load, and the UI could only learn of a change by polling. This branch closes both gaps: it makes the store safe under concurrent access, then adds an observable change hook with a defined contract. It continues the toggle redesign on top of the register storage and typed handles from the earlier steps.

## Step 3: safe under concurrent access

Make the scalar register a `std::atomic` and serialize the rest behind a mutex.

- `ToggleRegister<T>` boxes a `std::atomic` for scalars and exposes get/set with `memory_order_relaxed`, which is sound because a toggle publishes nothing but itself. The `std::string` register stays a plain string guarded by the table mutex, and is documented as not a hot-path value.
- Each register is heap-owned in the column (a `deque` of `unique_ptr`), so a non-movable atomic lives in the container and register addresses stay stable for the handles.
- The key map, structural growth, string access, and clear run under the table mutex. The table generation is a `std::atomic` bumped on clear, so a handle's validity check stays lock-free on the hot path: a `ToggleRef` scalar read is one relaxed atomic load with no lock.
- The store now holds an atomic and a mutex, so it is no longer movable or assignable. `clone()` still deep-copies through a private constructor that holds the source lock for the whole copy.

## Step 4: notify observers when a toggle changes

Add an observable change hook so the UI can stop polling and a solver can be told to re-read.

- `on_change(key, callback)` returns an RAII `ToggleSubscription`; dropping it unsubscribes, so a callback never outlives the widget it belongs to.
- A write fires the callback through one mutating entry point (`set`), and only when the stored value actually changes. The no-op guard compares under the write lock; doubles compare by bit pattern so `NaN` and `-0.0` behave, which also keeps a two-way UI binding from echoing.
- The callback runs after the write lock is released, so it may call back into the store (including `set`) without deadlock, and firing outside the lock keeps a Python callback from inverting lock order against the GIL. A throwing callback is caught so it neither propagates nor stops the other observers.
- Callbacks are held by `shared_ptr` so a firing thread copies a pointer, not the `std::function`; copying a `std::function` that wraps a Python callable would touch a Python refcount without the GIL. The Python binding runs the callback under a reacquired GIL and reports a raising callback through the unraisable hook.

Python gains `on_change(key, callback)` returning a `ToggleSubscription` object (with `unsubscribe()` and an `active` property).

## Notes

- The design was checked clean under ThreadSanitizer for both the concurrent read/write paths and the concurrent notify path.
- The Qt bridge to a queued UI-thread signal is intentionally not here; it lands with the menu wiring that consumes it.

For steps 3, 4 of issue #1022.