### PR TITLE
Consolidate the toggle store, migrate off the facades, and bind it to the pilot menu (steps 5, 6, 7 of toggle)

### DIFF
--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
@@ -288,7 +288,7 @@ RPythonConsoleDockWidget::RPythonConsoleDockWidget(const QString & title, QWidge
     : QDockWidget(title, parent, flags)
     , m_history_edit(new RPythonHistoryTextEdit)
     , m_command_edit(new RPythonCommandTextEdit)
-    , m_python_redirect(Toggle::instance().fixed().get_python_redirect())
+    , m_python_redirect(Toggle::instance().get<bool>("python_redirect", true))
 {
     auto * container = new QWidget;
     auto * layout = new QVBoxLayout;

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -1034,7 +1034,7 @@ void initialize_pilot(pybind11::module & mod)
         wrap_pilot(mod);
     };
 
-    if (Toggle::instance().solid().use_pyside())
+    if (build_config::use_pyside)
     {
         try
         {

--- a/cpp/solvcon/python/common.hpp
+++ b/cpp/solvcon/python/common.hpp
@@ -530,12 +530,12 @@ public:
 
     PythonStreamRedirect & set_enabled(bool enabled)
     {
-        Toggle::instance().fixed().set_python_redirect(enabled);
+        Toggle::instance().set_bool("python_redirect", enabled);
         return *this;
     }
 
     // FIXME: NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-    bool is_enabled() const { return Toggle::instance().fixed().get_python_redirect(); }
+    bool is_enabled() const { return Toggle::instance().get<bool>("python_redirect", true); }
     bool is_disabled() const { return !is_enabled(); }
 
     PythonStreamRedirect & activate();

--- a/cpp/solvcon/toggle/CMakeLists.txt
+++ b/cpp/solvcon/toggle/CMakeLists.txt
@@ -4,6 +4,7 @@
 cmake_minimum_required(VERSION 4.0.1)
 
 set(SOLVCON_TOGGLE_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/build_config.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/toggle.hpp
     CACHE FILEPATH "" FORCE)
 

--- a/cpp/solvcon/toggle/build_config.hpp
+++ b/cpp/solvcon/toggle/build_config.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+/*
+ * Copyright (c) 2022, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Compile-time build switches for the toggle system.
+ *
+ * A build switch is decided once when the library is built, so it is an
+ * inline constexpr the optimizer can fold away, not a runtime toggle in the
+ * table. A genuine build switch (for example a future GPU backend flag)
+ * belongs here rather than in the runtime store.
+ *
+ * @ingroup group_core
+ */
+
+namespace solvcon
+{
+
+namespace build_config
+{
+
+/// Whether the pilot uses PySide for its Python integration.
+inline constexpr bool use_pyside = true;
+
+} /* end namespace build_config */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
@@ -756,6 +756,14 @@ void wrap_Toggle(pybind11::module & mod)
         .value("Ops", ToggleCategory::Ops)
         .value("Experiment", ToggleCategory::Experiment);
 
+    // Release every change callback held by the global store at interpreter
+    // shutdown, while Python is still alive, so a callback holding a Python
+    // object (for example a pilot menu bridge) is not freed after
+    // finalization when the store's static destructor runs.
+    py::module_::import("atexit").attr("register")(
+        py::cpp_function([]()
+                         { Toggle::instance().clear_change_observers(); }));
+
     WrapSolidToggle::commit(mod, "SolidToggle", "SolidToggle");
     WrapFixedToggle::commit(mod, "FixedToggle", "FixedToggle");
     WrapHierarchicalToggleAccess::commit(mod, "HierarchicalToggleAccess", "HierarchicalToggleAccess");

--- a/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
@@ -448,17 +448,6 @@ void declare_toggle(Toggle & self, std::string const & key, T const & value)
     self.declare<T>(key, value);
 }
 
-void warn_deprecated_getter(char const * name)
-{
-    PyErr_WarnEx(
-        PyExc_DeprecationWarning,
-        std::format("Toggle.{} returns a silent sentinel on a missing or wrong-typed "
-                    "key and is deprecated; use get(key, default) or at(key)",
-                    name)
-            .c_str(),
-        1);
-}
-
 } /* end namespace detail */
 
 WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const * pydoc)
@@ -629,27 +618,8 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
         //
         ;
 
-    // The type-specific getters return a silent sentinel on a missing or
-    // wrong-typed key. They are kept for compatibility but deprecated in
-    // favor of get(key, default) and at(key); each emits a
-    // DeprecationWarning.
-#define MM_PYTHON_TOGGLE_DEPRECATED_GET(MTYPE)             \
-    (*this).def(                                           \
-        "get_" #MTYPE,                                     \
-        [](wrapped_type & self, std::string const & key)   \
-        {                                                  \
-            detail::warn_deprecated_getter("get_" #MTYPE); \
-            return self.get_##MTYPE(key);                  \
-        },                                                 \
-        py::arg("key"));
-    MM_PYTHON_TOGGLE_DEPRECATED_GET(bool)
-    MM_PYTHON_TOGGLE_DEPRECATED_GET(int8)
-    MM_PYTHON_TOGGLE_DEPRECATED_GET(int16)
-    MM_PYTHON_TOGGLE_DEPRECATED_GET(int32)
-    MM_PYTHON_TOGGLE_DEPRECATED_GET(int64)
-    MM_PYTHON_TOGGLE_DEPRECATED_GET(real)
-    MM_PYTHON_TOGGLE_DEPRECATED_GET(string)
-#undef MM_PYTHON_TOGGLE_DEPRECATED_GET
+    // The type-specific sentinel getters (get_bool, get_int8, ...) have been
+    // removed in favor of get(key, default) and at(key).
 
     // Static properties.
     (*this)

--- a/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
@@ -16,6 +16,24 @@ namespace solvcon
 namespace python
 {
 
+namespace detail
+{
+
+// If child is a hierarchical access (a subkey view holding a raw table
+// pointer), tie its lifetime to parent so chaining off a temporary does not
+// dangle. A plain leaf value is returned unchanged, since it cannot carry a
+// keep_alive reference.
+inline pybind11::object tie_subkey_owner(pybind11::object child, pybind11::handle parent)
+{
+    if (pybind11::isinstance<HierarchicalToggleAccess>(child))
+    {
+        pybind11::detail::keep_alive_impl(child, parent);
+    }
+    return child;
+}
+
+} /* end namespace detail */
+
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSolidToggle
     : public WrapBase<WrapSolidToggle, SolidToggle>
 {
@@ -135,7 +153,18 @@ WrapHierarchicalToggleAccess::WrapHierarchicalToggleAccess(pybind11::module & mo
     // Dynamic properties.  Number of the properties can be freely changed
     // during runtime.
     (*this)
-        .def("__getattr__", getattr)
+        .def(
+            "__getattr__",
+            [](py::object const & self_obj, std::string const & key)
+            {
+                auto & self = self_obj.cast<wrapped_type &>();
+                // A subkey access holds a raw table pointer, so a chained
+                // access off a temporary must keep its owner alive.
+                // __getattr__ may also return a plain value (a leaf toggle),
+                // which cannot carry a keep_alive reference, so tie the parent
+                // only when the result is itself an access.
+                return detail::tie_subkey_owner(getattr(self, key), self_obj);
+            })
         .def("__setattr__", setattr)
         .def("get_bool", &wrapped_type::get_bool, py::arg("key"))
         .def("set_bool", &wrapped_type::set_bool, py::arg("key"), py::arg("value"))
@@ -151,7 +180,7 @@ WrapHierarchicalToggleAccess::WrapHierarchicalToggleAccess(pybind11::module & mo
         .def("set_real", &wrapped_type::set_real, py::arg("key"), py::arg("value"))
         .def("get_string", &wrapped_type::get_string, py::arg("key"))
         .def("set_string", &wrapped_type::set_string, py::arg("key"), py::arg("value"))
-        .def("get_subkey", &wrapped_type::get_subkey, py::arg("key"))
+        .def("get_subkey", &wrapped_type::get_subkey, py::arg("key"), py::keep_alive<0, 1>())
         .def("add_subkey", &wrapped_type::add_subkey, py::arg("key"))
         //
         ;
@@ -347,6 +376,13 @@ struct Toggle2Python
 
         for (auto const & fk : keys)
         {
+            // python_redirect and show_axis are declared toggles but are
+            // reported under the "fixed" section by the compatibility facade,
+            // so skip them here to avoid listing them twice.
+            if ("python_redirect" == fk || "show_axis" == fk)
+            {
+                continue;
+            }
             std::vector<std::string> const hk = split(fk);
             DynamicToggleIndex const index = table.get_index(fk);
             py::dict d = ret;
@@ -498,6 +534,7 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
         .def("declare_int64", &detail::declare_toggle<int64_t>, py::arg("key"), py::arg("default"))
         .def("declare_real", &detail::declare_toggle<double>, py::arg("key"), py::arg("default"))
         .def("declare_string", &detail::declare_toggle<std::string>, py::arg("key"), py::arg("default"))
+        .def("category", &wrapped_type::category, py::arg("key"))
         .def(
             "on_change",
             [](wrapped_type & self, std::string const & key, py::function const & callback)
@@ -534,13 +571,15 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
             py::arg("callback"))
         .def(
             "__getattr__",
-            [](wrapped_type & self, std::string const & key)
+            [](py::object const & self_obj, std::string const & key)
             {
+                auto & self = self_obj.cast<wrapped_type &>();
                 HierarchicalToggleAccess access(self.dynamic());
                 py::object ret;
                 if (access.get_index(key).type != DynamicToggleIndex::TYPE_NONE) // dynamic
                 {
-                    ret = WrapHierarchicalToggleAccess::getattr(access, key);
+                    // Tie a returned subkey access to the owning Toggle.
+                    ret = detail::tie_subkey_owner(WrapHierarchicalToggleAccess::getattr(access, key), self_obj);
                 }
                 else if (key == "show_axis") // fixed
                 {
@@ -585,7 +624,7 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
         .def("set_int64", &wrapped_type::set_int64, py::arg("key"), py::arg("value"))
         .def("set_real", &wrapped_type::set_real, py::arg("key"), py::arg("value"))
         .def("set_string", &wrapped_type::set_string, py::arg("key"), py::arg("value"))
-        .def("get_subkey", &wrapped_type::get_subkey, py::arg("key"))
+        .def("get_subkey", &wrapped_type::get_subkey, py::arg("key"), py::keep_alive<0, 1>())
         .def("add_subkey", &wrapped_type::add_subkey, py::arg("key"))
         //
         ;
@@ -621,26 +660,35 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
         //
         ;
 
-    // Instance properties.
+    // Instance properties. The solid and fixed facades and the hierarchical
+    // access are lightweight views; keep_alive ties each returned view to the
+    // owning Toggle so the store it reads through never dangles.
+    // def_property_readonly does not accept a keep_alive policy, so wrap the
+    // getters that return a table-referencing view in a py::cpp_function that
+    // carries keep_alive<0, 1> (tie the view to the owning Toggle).
     (*this)
         .def_property_readonly(
             "solid",
-            [](wrapped_type & self) -> auto &
+            [](wrapped_type & self)
             {
                 return self.solid();
             })
         .def_property_readonly(
             "fixed",
-            [](wrapped_type & self) -> auto &
-            {
-                return self.fixed();
-            })
+            py::cpp_function(
+                [](wrapped_type & self)
+                {
+                    return self.fixed();
+                },
+                py::keep_alive<0, 1>()))
         .def_property_readonly(
             "dynamic",
-            [](wrapped_type & self)
-            {
-                return HierarchicalToggleAccess(self.dynamic());
-            })
+            py::cpp_function(
+                [](wrapped_type & self)
+                {
+                    return HierarchicalToggleAccess(self.dynamic());
+                },
+                py::keep_alive<0, 1>()))
         //
         ;
 }
@@ -732,6 +780,11 @@ void wrap_Toggle(pybind11::module & mod)
     py::class_<ToggleSubscription>(mod, "ToggleSubscription")
         .def("unsubscribe", &ToggleSubscription::reset)
         .def_property_readonly("active", &ToggleSubscription::active);
+
+    py::enum_<ToggleCategory>(mod, "ToggleCategory")
+        .value("Release", ToggleCategory::Release)
+        .value("Ops", ToggleCategory::Ops)
+        .value("Experiment", ToggleCategory::Experiment);
 
     WrapSolidToggle::commit(mod, "SolidToggle", "SolidToggle");
     WrapFixedToggle::commit(mod, "FixedToggle", "FixedToggle");

--- a/cpp/solvcon/toggle/toggle.cpp
+++ b/cpp/solvcon/toggle/toggle.cpp
@@ -40,11 +40,6 @@ Toggle & Toggle::instance()
     return o;
 }
 
-SolidToggle::SolidToggle()
-    : m_use_pyside(true)
-{
-}
-
 // NOLINTNEXTLINE(bugprone-throwing-static-initialization,fuchsia-statically-constructed-objects,readability-redundant-string-init,cert-err58-cpp)
 std::string const DynamicToggleTable::sentinel_string = "";
 
@@ -162,6 +157,7 @@ void DynamicToggleTable::clear()
 {
     std::scoped_lock const guard(m_mutex);
     m_key2index.clear();
+    m_categories.clear();
     m_column_bool.clear();
     m_column_int8.clear();
     m_column_int16.clear();

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -16,6 +16,7 @@
 #include <solvcon/buffer/buffer.hpp>
 #include <solvcon/profiling/profile.hpp>
 #include <solvcon/profiling/RadixTree.hpp>
+#include <solvcon/toggle/build_config.hpp>
 
 #include <algorithm>
 #include <atomic>
@@ -36,6 +37,23 @@ namespace solvcon
 {
 
 int setenv(const char * name, const char * value, int overwrite);
+
+/**
+ * Lifecycle category of a toggle (Fowler's feature-flag categories).
+ *
+ * The category enforces nothing by itself; it records the expected lifetime
+ * so a lint or test can flag, for example, a release toggle that outlived its
+ * feature. Ops and UI settings are long-lived; a release toggle is removed
+ * once its feature lands.
+ *
+ * @ingroup group_core
+ */
+enum class ToggleCategory : uint8_t
+{
+    Release,
+    Ops,
+    Experiment,
+}; /* end enum class ToggleCategory */
 
 template <typename T>
 class ToggleRef;
@@ -450,14 +468,22 @@ public:
     uint64_t generation() const { return m_generation.load(std::memory_order_relaxed); }
 
     /**
-     * Create a toggle with a default and return a handle to it.
+     * Create a toggle with a default and a category, and return a handle.
      *
      * Re-declaring an existing key of the same type is idempotent and
      * returns a handle to the existing register. A conflicting type is an
      * error.
      */
     template <typename T>
-    ToggleRef<T> declare(std::string const & key, T const & default_value);
+    ToggleRef<T> declare(std::string const & key, T const & default_value, ToggleCategory category = ToggleCategory::Ops);
+
+    /// The category recorded for a key, or Ops if the key was never declared.
+    ToggleCategory category(std::string const & key) const
+    {
+        std::scoped_lock const guard(m_mutex);
+        auto it = m_categories.find(key);
+        return (it != m_categories.end()) ? it->second : ToggleCategory::Ops;
+    }
 
     /// Resolve an existing key to a handle; an invalid handle if it is
     /// missing or has a different type.
@@ -494,6 +520,7 @@ private:
 
     DynamicToggleTable(DynamicToggleTable const & other, std::scoped_lock<std::mutex> const &)
         : m_key2index(other.m_key2index)
+        , m_categories(other.m_categories)
         , m_column_bool(other.m_column_bool)
         , m_column_int8(other.m_column_int8)
         , m_column_int16(other.m_column_int16)
@@ -531,6 +558,7 @@ private:
 
     mutable std::mutex m_mutex;
     keymap_type m_key2index;
+    std::unordered_map<std::string, ToggleCategory> m_categories;
     ToggleRegisterColumn<bool> m_column_bool;
     ToggleRegisterColumn<int8_t> m_column_int8;
     ToggleRegisterColumn<int16_t> m_column_int16;
@@ -685,9 +713,10 @@ ToggleRegisterColumn<T> const & DynamicToggleTable::column() const
 }
 
 template <typename T>
-ToggleRef<T> DynamicToggleTable::declare(std::string const & key, T const & default_value)
+ToggleRef<T> DynamicToggleTable::declare(std::string const & key, T const & default_value, ToggleCategory category)
 {
     std::scoped_lock const guard(m_mutex);
+    m_categories[key] = category;
     auto it = m_key2index.find(key);
     if (it != m_key2index.end())
     {
@@ -741,19 +770,12 @@ T DynamicToggleTable::at(std::string const & key) const
     throw std::out_of_range(std::format("Toggle::at: key \"{}\" is missing or has a different type", key));
 }
 
-#define MM_TOGGLE_SOLID_BOOL(NAME)         \
-public:                                    \
-    bool NAME() const { return m_##NAME; } \
-                                           \
-private:                                   \
-    bool m_##NAME;
-
 /**
- * Toggles whose values are determined at compile time and read-only
- * during the process lifetime.
+ * Compatibility facade for the former compile-time solid toggles.
  *
- * Each accessor (for example use_pyside) returns a bool member that has
- * an address and cannot be optimized out, unlike a macro or constexpr.
+ * The one solid toggle, use_pyside, is now an inline constexpr build switch
+ * (see build_config.hpp) that the optimizer folds away. This stateless
+ * facade keeps the old accessor working until its callers move.
  *
  * @ingroup group_core
  */
@@ -762,27 +784,19 @@ class SolidToggle
 
 public:
 
-    SolidToggle();
-
-    MM_TOGGLE_SOLID_BOOL(use_pyside)
+    // Kept as an instance method for API compatibility with the old facade.
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    bool use_pyside() const { return build_config::use_pyside; }
 
 }; /* end class SolidToggle */
 
-#define MM_TOGGLE_FIXED_BOOL(NAME, DEFAULT)      \
-public:                                          \
-    bool get_##NAME() const { return m_##NAME; } \
-    void set_##NAME(bool v) { m_##NAME = v; }    \
-                                                 \
-private:                                         \
-    bool m_##NAME = DEFAULT;
-
 /**
- * Toggles whose names are fixed at compile time but whose bool values
- * can change at runtime.
+ * Compatibility facade for the former fixed toggles.
  *
- * Access needs no table lookup because the member addresses are known
- * to the compiler and linker (for example python_redirect and
- * show_axis).
+ * python_redirect and show_axis are now ordinary declared toggles in the
+ * store, so they gain change notification and serialization. This facade
+ * reads and writes them through the store (with their startup defaults),
+ * keeping the old get_/set_ accessors working until their callers move.
  *
  * @ingroup group_core
  */
@@ -791,8 +805,19 @@ class FixedToggle
 
 public:
 
-    MM_TOGGLE_FIXED_BOOL(python_redirect, true)
-    MM_TOGGLE_FIXED_BOOL(show_axis, false)
+    explicit FixedToggle(DynamicToggleTable & table)
+        : m_table(&table)
+    {
+    }
+
+    bool get_python_redirect() const { return m_table->get<bool>("python_redirect", true); }
+    void set_python_redirect(bool v) { m_table->set_bool("python_redirect", v); }
+    bool get_show_axis() const { return m_table->get<bool>("show_axis", false); }
+    void set_show_axis(bool v) { m_table->set_bool("show_axis", v); }
+
+private:
+
+    DynamicToggleTable * m_table = nullptr;
 
 }; /* end class FixedToggle */
 
@@ -852,10 +877,10 @@ public:
 
     ~Toggle() = default;
 
-    SolidToggle const & solid() const { return m_solid; }
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    SolidToggle solid() const { return SolidToggle{}; }
 
-    FixedToggle const & fixed() const { return m_fixed; }
-    FixedToggle & fixed() { return m_fixed; }
+    FixedToggle fixed() { return FixedToggle(m_dynamic_table); }
 
     DynamicToggleTable const & dynamic() const { return m_dynamic_table; }
     DynamicToggleTable & dynamic() { return m_dynamic_table; }
@@ -866,7 +891,11 @@ public:
     DynamicToggleIndex get_dynamic_index(std::string const & key) const { return m_dynamic_table.get_index(key); }
 
     template <typename T>
-    ToggleRef<T> declare(std::string const & key, T const & default_value) { return m_dynamic_table.declare<T>(key, default_value); }
+    ToggleRef<T> declare(std::string const & key, T const & default_value, ToggleCategory category = ToggleCategory::Ops)
+    {
+        return m_dynamic_table.declare<T>(key, default_value, category);
+    }
+    ToggleCategory category(std::string const & key) const { return m_dynamic_table.category(key); }
     template <typename T>
     ToggleRef<T> ref(std::string const & key) { return m_dynamic_table.ref<T>(key); }
     template <typename T>
@@ -905,11 +934,16 @@ public:
 
 private:
 
-    Toggle() = default;
+    // The formerly fixed toggles are now ordinary declared toggles with
+    // startup defaults and a category, so they carry notification and
+    // serialization like any other toggle.
+    Toggle()
+    {
+        m_dynamic_table.declare<bool>("python_redirect", true, ToggleCategory::Ops);
+        m_dynamic_table.declare<bool>("show_axis", false, ToggleCategory::Ops);
+    }
     Toggle(Toggle const &) = default;
 
-    SolidToggle m_solid;
-    FixedToggle m_fixed;
     DynamicToggleTable m_dynamic_table;
 
 }; /* end class Toggle */

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -516,6 +516,15 @@ public:
         return ToggleSubscription(m_observers, key, id);
     }
 
+    // Drop every change callback. Used at interpreter shutdown so a callback
+    // holding a Python object is released while the interpreter is still
+    // alive, not when this store is destroyed after finalization.
+    void clear_observers()
+    {
+        std::scoped_lock const guard(m_observers->mutex);
+        m_observers->map.clear();
+    }
+
 private:
 
     DynamicToggleTable(DynamicToggleTable const & other, std::scoped_lock<std::mutex> const &)
@@ -888,6 +897,7 @@ public:
     {
         return m_dynamic_table.on_change(key, std::move(callback));
     }
+    void clear_change_observers() { m_dynamic_table.clear_observers(); }
 
     // The type-specific sentinel getters are gone; use get<T>/at<T>. The
     // set_TYPE writers remain as the mutating entry point that fires on_change.

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -822,47 +822,28 @@ private:
 }; /* end class FixedToggle */
 
 /**
- * The toggle system for solvcon. There are 3 types of toggles:
+ * The toggle system for solvcon.
  *
- * 1. solid toggles: managed by SolidToggle class. It is the toggles whose value
- *    is determined during compile time. The value is read-only (const) through
- *    out the program lifecycle (the process).
+ * All toggles now live in one store, the DynamicToggleTable of typed
+ * registers. A toggle is created and named once with declare<T>(key, default,
+ * category); a hot path binds a typed handle (ref<T>) and reads it with a
+ * single atomic load; the UI edits it by key and subscribes with on_change.
  *
- *    The solid toggles have address and can be referenced. They cannot be
- *    optimized out (unlike macros and constexpr). It could add overhead when
- *    used in tight loops. The overhead may usually be too low to be noticed,
- *    but sometimes one needs to be careful about it.
+ * Two access styles read the same store:
  *
- * 2. fixed toggles: managed by FixedToggle class. It is the toggles whose name
- *    is determined during compile time. The value can be changed during
- *    runtime.
- *
- *    Because the names are determined during compile time, when accessing the
- *    toggles, no table lookup is needed. The address of the toggle variables
- *    has been determined by the compiler and linker.
- *
- *    The runtime cost of fixed toggles is the same as solid toggles. It may
- *    be used in tight loops. Just becareful about the potential runtime
- *    overhead.
- *
- * 3. dynamic toggles: managed by DynamicToggleTable. The toggles are
- *    hierarchical and the names and values can be added, removed, and modified
- *    during runtime. The value needs to use limited data types: bool, int8,
- *    int16, int32, int64, real, and string. It is intentional not to support
- *    unsigned integers.
- *
- *    Accessing dynamic toggles requires table lookup and string comparison. It
- *    is slow but flexible.
- *
- *    To access the dynamic toggles from C++, the data type of the toggle
- *    The hierarchical access (from C++) uses ".", like:
- *
- *      tg.get_int8("top_level.second_level.key_name")
- *
- *    In Python, the wrapper can determine the type dynamically, and the
- *    hierarchical access may use attribute syntax:
+ * 1. Typed evaluation by key: get<T>(key, default) returns the caller default
+ *    on a missing or wrong-typed key, and at<T>(key) throws. From Python the
+ *    wrapper infers the type and the hierarchy uses dotted keys or attribute
+ *    syntax, for example:
  *
  *      tg.top_level.second_level.key_name = value
+ *
+ * 2. Hoisted handles: ToggleRef<T> resolves the key once and reads the atomic
+ *    register with no map lookup, for tight loops.
+ *
+ * The former solid and fixed toggles are compatibility facades: use_pyside is
+ * an inline constexpr build switch (see build_config.hpp), and python_redirect
+ * and show_axis are ordinary declared toggles in the store.
  *
  * @ingroup group_core
  */
@@ -908,19 +889,14 @@ public:
         return m_dynamic_table.on_change(key, std::move(callback));
     }
 
-    bool get_bool(std::string const & key) const { return m_dynamic_table.get_bool(key); }
+    // The type-specific sentinel getters are gone; use get<T>/at<T>. The
+    // set_TYPE writers remain as the mutating entry point that fires on_change.
     void set_bool(std::string const & key, bool value) { m_dynamic_table.set_bool(key, value); }
-    int8_t get_int8(std::string const & key) const { return m_dynamic_table.get_int8(key); }
     void set_int8(std::string const & key, int8_t value) { m_dynamic_table.set_int8(key, value); }
-    int16_t get_int16(std::string const & key) const { return m_dynamic_table.get_int16(key); }
     void set_int16(std::string const & key, int16_t value) { m_dynamic_table.set_int16(key, value); }
-    int32_t get_int32(std::string const & key) const { return m_dynamic_table.get_int32(key); }
     void set_int32(std::string const & key, int32_t value) { m_dynamic_table.set_int32(key, value); }
-    int64_t get_int64(std::string const & key) const { return m_dynamic_table.get_int64(key); }
     void set_int64(std::string const & key, int64_t value) { m_dynamic_table.set_int64(key, value); }
-    double get_real(std::string const & key) const { return m_dynamic_table.get_real(key); }
     void set_real(std::string const & key, double value) { m_dynamic_table.set_real(key, value); }
-    std::string const & get_string(std::string const & key) const { return m_dynamic_table.get_string(key); }
     void set_string(std::string const & key, std::string const & value) { m_dynamic_table.set_string(key, value); }
     HierarchicalToggleAccess get_subkey(std::string const & key) { return m_dynamic_table.get_subkey(key); }
     void add_subkey(std::string const & key) { m_dynamic_table.add_subkey(key); }

--- a/gtests/test_nopython_toggle.cpp
+++ b/gtests/test_nopython_toggle.cpp
@@ -113,6 +113,23 @@ TEST(ToggleRefTest, declare_idempotent_and_type_conflict)
     EXPECT_THROW(table.declare<bool>("n", true), std::invalid_argument);
 }
 
+TEST(ToggleCategoryTest, records_and_defaults)
+{
+    DynamicToggleTable table;
+    table.declare<int32_t>("release_flag", 0, ToggleCategory::Release);
+    table.declare<int32_t>("ops_flag", 0, ToggleCategory::Ops);
+    table.declare<int32_t>("exp_flag", 0, ToggleCategory::Experiment);
+
+    EXPECT_EQ(table.category("release_flag"), ToggleCategory::Release);
+    EXPECT_EQ(table.category("ops_flag"), ToggleCategory::Ops);
+    EXPECT_EQ(table.category("exp_flag"), ToggleCategory::Experiment);
+    // An undeclared key reports the Ops default.
+    EXPECT_EQ(table.category("missing"), ToggleCategory::Ops);
+    // A clear forgets categories.
+    table.clear();
+    EXPECT_EQ(table.category("release_flag"), ToggleCategory::Ops);
+}
+
 TEST(ToggleOnChangeTest, fires_once_per_real_change)
 {
     DynamicToggleTable table;

--- a/solvcon/core.py
+++ b/solvcon/core.py
@@ -89,6 +89,8 @@ list_of_toggle = [
     'CallProfilerProbe',
     'HierarchicalToggleAccess',
     'Toggle',
+    'ToggleCategory',
+    'ToggleSubscription',
     'METAL_BUILT',
     'metal_running',
 ]

--- a/solvcon/pilot/_gui_common.py
+++ b/solvcon/pilot/_gui_common.py
@@ -3,17 +3,70 @@
 
 
 from . import _pilot_core as _pcore
+from ..core import Toggle
 from PySide6 import QtCore, QtGui
 
 
+class ToggleActionBridge(QtCore.QObject):
+    """Two-way binding between a checkable QAction and a store toggle.
+
+    The action's ``toggled`` writes the toggle; the toggle's ``on_change``
+    re-checks the action. The change is delivered on the UI thread through a
+    queued signal, so a change from a solver thread is safe. The store's no-op
+    guard (a set to the value already stored fires no ``on_change``) plus Qt
+    emitting ``toggled`` only on a real change together stop the echo, so the
+    old ``blockSignals`` guard is not needed.
+
+    The bridge is parented to its action, so it and its subscription live
+    exactly as long as the action.
+    """
+
+    _store_changed = QtCore.Signal(bool)
+
+    def __init__(self, action, key):
+        super().__init__(action)
+        self._action = action
+        self._key = key
+        tg = Toggle.instance
+        tg.declare_bool(key, action.isChecked())
+        action.setChecked(tg.get(key, action.isChecked()))
+        action.toggled.connect(self._on_action_toggled)
+        # Deliver a store change to the UI thread, then re-check the action.
+        self._store_changed.connect(action.setChecked,
+                                    QtCore.Qt.QueuedConnection)
+        self._token = tg.on_change(key, self._on_store_changed)
+        # Drop the subscription when the action goes away, so a later store
+        # change never calls back into a destroyed widget.
+        action.destroyed.connect(self._release)
+
+    def _release(self, *args):
+        self._token = None
+
+    def _on_action_toggled(self, checked):
+        if self._token is None:
+            return
+        Toggle.instance.set_bool(self._key, checked)
+
+    def _on_store_changed(self):
+        if self._token is None:
+            return
+        tg = Toggle.instance
+        self._store_changed.emit(tg.get(self._key, self._action.isChecked()))
+
+
 def build_action(parent, text, tip, func, *, id=None, checkable=False,
-                 checked=False, shortcut=None, menu_role=None):
+                 checked=False, shortcut=None, menu_role=None,
+                 toggle_key=None):
     """Build a QAction from one description, the single item builder.
 
     The id becomes the action's objectName (its handle in the menu model and
     in tests). A checkable action carries its initial check state; ``func``,
     when given, runs on trigger. A checkable feature that needs the toggled
     state wires ``toggled`` on the returned action itself.
+
+    When ``toggle_key`` is given, the action is bound two-way to that store
+    toggle through a ToggleActionBridge, so its state persists, round-trips to
+    JSON, and can be observed by a solver or a second widget.
     """
     act = QtGui.QAction(text, parent)
     if id:
@@ -28,6 +81,8 @@ def build_action(parent, text, tip, func, *, id=None, checkable=False,
         act.setChecked(checked)
     if func is not None:
         act.triggered.connect(lambda *a: func())
+    if toggle_key is not None:
+        ToggleActionBridge(act, toggle_key)
     return act
 
 
@@ -68,16 +123,19 @@ class PilotFeature(QtCore.QObject):
 
     def add_action(self, path, text, tip, func, *, id, weight=50,
                    checkable=False, checked=False, shortcut=None,
-                   menu_role=None):
+                   menu_role=None, toggle_key=None):
         """Build an action and place it in the menu at ``path`` by ``weight``.
 
         This is the one Python item builder over the shared placement: it
         returns the live action so a toggle feature can wire its own reverse
-        connections.
+        connections. When ``toggle_key`` is given, the action is bound two-way
+        to that store toggle (see build_action), so RMenuModel stays the
+        placement layer and the Toggle store owns the value.
         """
         act = build_action(self._mainWindow, text, tip, func, id=id,
                            checkable=checkable, checked=checked,
-                           shortcut=shortcut, menu_role=menu_role)
+                           shortcut=shortcut, menu_role=menu_role,
+                           toggle_key=toggle_key)
         self._mgr.menu_model.place(path, act, weight)
         return act
 

--- a/solvcon/toggle.py
+++ b/solvcon/toggle.py
@@ -12,6 +12,33 @@ import json
 from . import core
 
 
+def _set_value(node, key, value):
+    """Create or update one toggle, inferring its type from the JSON value."""
+    # bool must be checked before int: in Python, bool is a subclass of int.
+    if isinstance(value, bool):
+        node.set_bool(key, value)
+    elif isinstance(value, int):
+        node.set_int64(key, value)
+    elif isinstance(value, float):
+        node.set_real(key, value)
+    elif isinstance(value, str):
+        node.set_string(key, value)
+    else:
+        raise TypeError(
+            'cannot load toggle "%s" of unsupported type %s'
+            % (key, type(value).__name__))
+
+
+def _load_tree(node, tree):
+    """Walk a nested dict, creating subkeys and typed leaf toggles."""
+    for key, value in tree.items():
+        if isinstance(value, dict):
+            node.add_subkey(key)
+            _load_tree(getattr(node, key), value)
+        else:
+            _set_value(node, key, value)
+
+
 def load(data, toggle_instance=None):
     tg = toggle_instance
     if tg is None:
@@ -21,19 +48,12 @@ def load(data, toggle_instance=None):
     pdata = json.loads(data)
     if len(pdata) != 2:
         raise ValueError("input data must be 2 but get %d" % len(pdata))
-    # pfixed = pdata[0].get('fixed', {})
-    pdynamic = pdata[1].get('dynamic', {})
 
-    # Get the apps sub-section
-    papps = pdynamic.get('apps', {})
-    tg.add_subkey('apps')
-    ta = tg.apps
-
-    # App euler1d
-    ta.add_subkey('euler1d')
-    thisapp = ta.euler1d
-    thispdata = papps.get('euler1d', {})
-    thisapp.set_bool('use_sub', thispdata.get('use_sub', False))
+    # Fixed toggles are now ordinary declared toggles; apply them by name.
+    for name, value in pdata[0].get('fixed', {}).items():
+        _set_value(tg, name, value)
+    # Walk the dynamic tree generically for any app, not just euler1d.
+    _load_tree(tg, pdata[1].get('dynamic', {}))
 
     return tg
 

--- a/tests/test_pilot_toggle_action.py
+++ b/tests/test_pilot_toggle_action.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot import _gui
+    from solvcon.pilot import _gui_common
+    from PySide6 import QtCore, QtWidgets
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class ToggleActionBridgeTC(unittest.TestCase):
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.tg = solvcon.Toggle.instance
+        # A unique key per test isolates the shared global store.
+        self.KEY = "pilot.test.toggle_action." + self._testMethodName
+        self.tg.declare_bool(self.KEY, False)
+        self.tg.set_bool(self.KEY, False)
+        self.act = _gui_common.build_action(
+            self.mgr.mainWindow, "Flag", "A test toggle", None,
+            id="test.flag", checkable=True, checked=False,
+            toggle_key=self.KEY)
+
+    def tearDown(self):
+        # Destroy the action so its bridge unsubscribes from the store.
+        self.act.deleteLater()
+        self.act = None
+        QtWidgets.QApplication.sendPostedEvents(
+            None, QtCore.QEvent.Type.DeferredDelete)
+
+    def _drain(self):
+        QtWidgets.QApplication.processEvents()
+
+    def test_declares_toggle_with_default(self):
+        self.assertEqual(self.tg.get(self.KEY, True), False)
+
+    def test_menu_toggle_writes_the_store(self):
+        self.act.setChecked(True)
+        self.assertEqual(self.tg.get(self.KEY, False), True)
+        self.act.setChecked(False)
+        self.assertEqual(self.tg.get(self.KEY, True), False)
+
+    def test_store_set_rechecks_without_echo(self):
+        # Count notifications independently: a store-side change must fire
+        # on_change exactly once. The re-check it triggers writes the same
+        # value back, which the no-op guard drops, so there is no echo.
+        fires = []
+        token = self.tg.on_change(self.KEY, lambda: fires.append(1))
+
+        self.act.setChecked(False)  # ensure a real change below
+        fires.clear()
+
+        self.tg.set_bool(self.KEY, True)
+        self._drain()  # deliver the queued setChecked on the UI thread
+
+        self.assertTrue(self.act.isChecked())
+        self.assertEqual(len(fires), 1)
+        del token
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -4,9 +4,7 @@
 
 import os
 import unittest
-import math
 import json
-import warnings
 
 import solvcon
 
@@ -50,12 +48,13 @@ class ToggleTC(unittest.TestCase):
         self.assertEqual(tg.dynamic_keys(), [])
 
         tg.set_bool("test_bool", True)
-        self.assertTrue(tg.get_bool("test_bool"))
+        self.assertTrue(tg.get("test_bool", False))
         self.assertEqual(tg.dynamic_keys(), ["test_bool"])
 
         tg1 = tg.clone()
         self.assertEqual(tg.dynamic_keys(), tg1.dynamic_keys())
-        self.assertEqual(tg.get_bool("test_bool"), tg1.get_bool("test_bool"))
+        self.assertEqual(tg.get("test_bool", False),
+                         tg1.get("test_bool", False))
 
 
 class ToggleDynamicTC(unittest.TestCase):
@@ -67,49 +66,44 @@ class ToggleDynamicTC(unittest.TestCase):
 
         # Add a key of Boolean.
         tg.set_bool("test_bool", True)
-        self.assertTrue(tg.get_bool("test_bool"))
+        self.assertTrue(tg.get("test_bool", False))
         # Make sure the key appears.
         self.assertEqual(tg.dynamic_keys(), ["test_bool"])
-        # Test sentinel.
-        self.assertEqual(tg.get_bool("test_no_bool"), False)
+        # A missing key returns the caller default and at() raises.
+        self.assertEqual(tg.get("test_no_bool", False), False)
+        with self.assertRaises(KeyError):
+            tg.at("test_no_bool")
 
         # Add a key of int8.
         tg.set_int8("test_int8", 23)
-        self.assertEqual(tg.get_int8("test_int8"), 23)
+        self.assertEqual(tg.get("test_int8", 0), 23)
         # Make sure the key appears
         self.assertEqual(sorted(tg.dynamic_keys()),
                          ["test_bool", "test_int8"])
-        # Test sentinel.
-        self.assertEqual(tg.get_int8("test_no_int8"), 0)
+        self.assertEqual(tg.get("test_no_int8", 0), 0)
 
         # Add a key of int16.
         tg.set_int16("test_int16", -46)
-        self.assertEqual(tg.get_int16("test_int16"), -46)
+        self.assertEqual(tg.get("test_int16", 0), -46)
         # Make sure the key appears
         self.assertEqual(sorted(tg.dynamic_keys()),
                          ["test_bool", "test_int16", "test_int8"])
-        # Test sentinel.
-        self.assertEqual(tg.get_int16("test_no_int16"), 0)
 
         # Add a key of int32.
         tg.set_int32("test_int32", 842)
-        self.assertEqual(tg.get_int32("test_int32"), 842)
+        self.assertEqual(tg.get("test_int32", 0), 842)
         # Make sure the key appears
         self.assertEqual(sorted(tg.dynamic_keys()),
                          ["test_bool", "test_int16", "test_int32",
                           "test_int8"])
-        # Test sentinel.
-        self.assertEqual(tg.get_int32("test_no_int32"), 0)
 
         # Add a key of int64.
         tg.set_int64("test_int64", -9912)
-        self.assertEqual(tg.get_int64("test_int64"), -9912)
+        self.assertEqual(tg.get("test_int64", 0), -9912)
         # Make sure the key appears
         self.assertEqual(sorted(tg.dynamic_keys()),
                          ["test_bool", "test_int16", "test_int32",
                           "test_int64", "test_int8"])
-        # Test sentinel.
-        self.assertEqual(tg.get_int64("test_no_int64"), 0)
 
         # Clear dynamic keys (and the values).
         tg.dynamic_clear()
@@ -117,20 +111,17 @@ class ToggleDynamicTC(unittest.TestCase):
 
         # Add a key of real.
         tg.set_real("test_real", 2.87)
-        self.assertEqual(tg.get_real("test_real"), 2.87)
+        self.assertEqual(tg.get("test_real", 0.0), 2.87)
         # Make sure the key appears
         self.assertEqual(sorted(tg.dynamic_keys()), ["test_real"])
-        # Test sentinel.
-        self.assertTrue(math.isnan(tg.get_real("test_no_real")))
 
         # Add a key of string.
         tg.set_string("test_string", "a random line")
-        self.assertEqual(tg.get_string("test_string"), "a random line")
+        self.assertEqual(tg.get("test_string", ""), "a random line")
         # Make sure the key appears
         self.assertEqual(sorted(tg.dynamic_keys()),
                          ["test_real", "test_string"])
-        # Test sentinel.
-        self.assertEqual(tg.get_string("test_no_string"), "")
+        self.assertEqual(tg.get("test_no_string", ""), "")
 
         # Clear dynamic keys (and the values) the second time.
         tg.dynamic_clear()
@@ -141,24 +132,24 @@ class ToggleDynamicTC(unittest.TestCase):
         tg.dynamic_clear()
         self.assertEqual(tg.dynamic_keys(), [])
 
-        # Test sentinel.
-        self.assertEqual(tg.get_bool("test_bool"), False)
+        # A missing key returns the caller default.
+        self.assertEqual(tg.get("test_bool", False), False)
 
         # Add a key of Boolean.
         tg.set_bool("test_bool", True)
-        self.assertTrue(tg.get_bool("test_bool"))
+        self.assertTrue(tg.get("test_bool", False))
         # Make sure the key appears.
         self.assertEqual(tg.dynamic_keys(), ["test_bool"])
 
         # Fatigue test.
         tg.set_bool("test_bool", False)
-        self.assertFalse(tg.get_bool("test_bool"))
+        self.assertFalse(tg.get("test_bool", True))
         tg.set_bool("test_bool", True)
-        self.assertTrue(tg.get_bool("test_bool"))
+        self.assertTrue(tg.get("test_bool", False))
         tg.set_bool("test_bool", False)
-        self.assertFalse(tg.get_bool("test_bool"))
+        self.assertFalse(tg.get("test_bool", True))
         tg.set_bool("test_bool", True)
-        self.assertTrue(tg.get_bool("test_bool"))
+        self.assertTrue(tg.get("test_bool", False))
 
         tg.dynamic_clear()
 
@@ -246,7 +237,7 @@ class ToggleHierarchicalTC(unittest.TestCase):
         self.assertIsInstance(tg.level1p.level2p,
                               solvcon.HierarchicalToggleAccess)
         tg.level1p.set_bool("test_bool", True)
-        self.assertEqual(tg.get_bool('level1p.test_bool'), True)
+        self.assertEqual(tg.get('level1p.test_bool', False), True)
         tg.set_int32('level1p.level2p.test_int32', -2132)
         self.assertEqual(tg.level1p.level2p.test_int32, -2132)
         self.assertEqual(sorted(tg.dynamic_keys()),
@@ -332,17 +323,12 @@ class ToggleTypedAccessTC(unittest.TestCase):
         tg.declare_int32("t.count", 100)
         self.assertEqual(tg.get("t.count", 0), 42)
 
-    def test_deprecated_getter_warns(self):
+    def test_sentinel_getters_removed(self):
         tg = solvcon.Toggle.instance.clone()
-        tg.dynamic_clear()
-        tg.set_bool("t.flag", True)
-
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            value = tg.get_bool("t.flag")
-        self.assertTrue(value)
-        self.assertEqual(len(caught), 1)
-        self.assertTrue(issubclass(caught[0].category, DeprecationWarning))
+        # The old silent-sentinel getters no longer exist on Toggle.
+        self.assertFalse(hasattr(tg, "get_bool"))
+        self.assertFalse(hasattr(tg, "get_int32"))
+        self.assertFalse(hasattr(tg, "get_string"))
 
 
 class ToggleOnChangeTC(unittest.TestCase):

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -310,6 +310,19 @@ class ToggleTypedAccessTC(unittest.TestCase):
         with self.assertRaises(KeyError):
             tg.at("t.missing")
 
+    def test_category(self):
+        tg = solvcon.Toggle.instance.clone()
+        # The startup toggles are declared with the Ops category.
+        self.assertEqual(tg.category("python_redirect"),
+                         solvcon.ToggleCategory.Ops)
+        tg.dynamic_clear()
+        tg.declare_int32("t.count", 1)
+        self.assertEqual(tg.category("t.count"),
+                         solvcon.ToggleCategory.Ops)
+        # An undeclared key reports the default category.
+        self.assertEqual(tg.category("t.missing"),
+                         solvcon.ToggleCategory.Ops)
+
     def test_declare_is_idempotent(self):
         tg = solvcon.Toggle.instance.clone()
         tg.dynamic_clear()
@@ -499,19 +512,27 @@ class ToggleLoadTC(unittest.TestCase):
             toggle_instance=solvcon.Toggle.instance.clone())
         self.assertEqual(tg.apps.euler1d.use_sub, True)
 
-    @unittest.skip("the lifecycle issue may cause segfault")
     def test_load_bad_lifecycle(self):
+        # Chaining subkey access off a temporary Toggle used to dangle the raw
+        # table pointer the access holds and could segfault. keep_alive now
+        # keeps the owning Toggle alive through the whole chain.
         fixture = '''[{"fixed": {"show_axis": false}},
-{"dynamic": {"apps": {"euler1d": {"use_sub": false}}}}]'''
-        # TODO: Need to fix this later. It may be wrong lifecycle handling with
-        # WrapHierarchicalToggleAccess.
-        with self.assertRaisesRegex(
-                AttributeError,
-                r'Cannot get non-existing key "apps.euler1d"'
-        ):
-            solvcon.toggle.load(
-                fixture,
-                toggle_instance=solvcon.Toggle.instance.clone()).apps.euler1d
+{"dynamic": {"apps": {"euler1d": {"use_sub": true}}}}]'''
+        value = solvcon.toggle.load(
+            fixture,
+            toggle_instance=solvcon.Toggle.instance.clone()
+        ).apps.euler1d.use_sub
+        self.assertEqual(value, True)
+
+    def test_load_generic_app(self):
+        # load walks the dynamic tree for any app, not just euler1d.
+        fixture = '''[{"fixed": {}},
+{"dynamic": {"apps": {"myapp": {"count": 7, "name": "hi"}}}}]'''
+        tg = solvcon.toggle.load(
+            fixture,
+            toggle_instance=solvcon.Toggle.instance.clone())
+        self.assertEqual(tg.apps.myapp.count, 7)
+        self.assertEqual(tg.apps.myapp.name, "hi")
 
 
 class CommandLineInfoTC(unittest.TestCase):


### PR DESCRIPTION
This branch continues the toggle redesign on top of the concurrency guard and change-notification hook. It folds the last two parallel storage mechanisms (the compile-time solid toggle and the fixed-name toggle) onto the one store, migrates the remaining callers off the compatibility facades and retires the deprecated getters, and then gives the pilot a reusable way to back a checkable menu action with a store toggle through a Qt bridge. The end state is a single storage model with one read contract that a widget or a solver can subscribe to, wired end to end into the GUI menu.

## Step 5: consolidate the classes onto one store

Fold the three parallel storage mechanisms into one. The single solid toggle, `use_pyside`, becomes an inline `constexpr` build switch in `build_config.hpp` that the optimizer folds away, with `SolidToggle` reduced to a stateless facade over it. `python_redirect` and `show_axis` become declared toggles created at `Toggle` construction with startup defaults and a category, so they gain change notification and serialization like any other toggle, and `FixedToggle` becomes a facade that reads and writes them through the store; `to_python` still reports them under the "fixed" section and skips them in the dynamic section, so the serialization format is unchanged. A `ToggleCategory` (release, ops, experiment) is recorded per key at declare time for a later lint or test to flag a stale release toggle; it enforces nothing by itself. This step also fixes a `HierarchicalToggleAccess` lifetime bug (a subkey access holds a raw table pointer, so a returned access is now tied to its owner with `keep_alive`; a leaf read returns a plain value and cannot carry the reference, so the owner is tied only when the result is itself an access), which un-skips `test_load_bad_lifecycle`. It also makes `solvcon.toggle.load` generic, walking the JSON tree and inferring the type of each value for any app rather than only euler1d.

## Step 6: migrate call sites off the facades

With the store unified, move the remaining readers off the solid and fixed facades and retire the deprecated getters. `wrap_pilot` reads `use_pyside` directly from `build_config` instead of `Toggle::instance().solid()`, so the branch folds at compile time. The Python stream redirect and the console dock read and write `python_redirect` through the typed store (`get<bool>(key, default)` and `set_bool`) instead of `Toggle::instance().fixed()`, so they observe the same value as everything else and pick up change notification. The silent-sentinel getters are removed: the Python `get_bool`/`get_int8`/.../`get_string` on `Toggle` (deprecated in an earlier step) and the unused C++ `Toggle::get_TYPE` forwards. Callers use `get<T>(key, default)` or `at<T>(key)`, while the `set_TYPE` writers stay as the mutating entry point; the lower-level `get_TYPE` on the dynamic access and the table remain, since the type-dispatched read still uses them. Tests that encoded the old sentinel behavior now assert the typed contract, and the `Toggle` class documentation is rewritten around the one-store model.

## Step 7: bind the pilot menu to the store

Give the pilot a reusable way to back a checkable menu action with a store toggle. `build_action` and `PilotFeature.add_action` gain an optional `toggle_key`; when set, the action is bound two-way to that toggle through a `ToggleActionBridge` so the action's `toggled` writes the toggle and the toggle's `on_change` re-checks the action. `RMenuModel` stays the placement layer while the store owns the value, so the state persists, round-trips to JSON, and can be observed by a solver or a second widget. The bridge is the change hook's Qt bridge: `on_change` fires a queued signal to `setChecked`, so a change from a solver thread lands on the UI thread. The store's no-op guard plus Qt emitting `toggled` only on a real change break the echo, so no `blockSignals` dance is needed; the bridge is parented to its action and drops its subscription when the action is destroyed, so a later change never calls back into a dead widget. `Toggle.clear_change_observers` is added and registered with `atexit`, so a callback holding a Python object is released while the interpreter is still alive rather than when the store's static is destroyed after finalization.

For steps 5, 6, 7 of issue #1022.