### PR TITLE
Add File menu action to save the 2D canvas as PNG or JPEG

### DIFF
--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -556,9 +556,11 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                 "saveImage",
                 [](wrapped_type & self, std::string const & filename)
                 {
-                    self.grabImage().save(filename.c_str());
+                    return self.grabImage().save(filename.c_str());
                 },
-                py::arg("filename"))
+                py::arg("filename"),
+                "Grab the current on-screen frame and save it to filename; "
+                "returns whether the write succeeded.")
             .def(
                 "renderToImage",
                 [](wrapped_type & self, std::string const & filename, int width, int height, bool transparent)
@@ -625,9 +627,15 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapR2DWidget
                  {
                      QClipboard * clipboard = QGuiApplication::clipboard();
                      clipboard->setPixmap(self.grab()); })
-            .def("saveImage", [](wrapped_type & self, std::string const & filename)
-                 { self.grab().save(filename.c_str()); },
-                 py::arg("filename"))
+            .def(
+                "saveImage",
+                [](wrapped_type & self, std::string const & filename)
+                {
+                    return self.grab().save(filename.c_str());
+                },
+                py::arg("filename"),
+                "Grab the current on-screen frame and save it to filename; "
+                "returns whether the write succeeded.")
             //
             ;
     }

--- a/solvcon/pilot/_canvas_gui.py
+++ b/solvcon/pilot/_canvas_gui.py
@@ -5,6 +5,10 @@
 Canvas GUI feature for pilot.
 """
 
+import os
+
+from PySide6 import QtCore, QtWidgets
+
 from .. import core
 from ..plot import curve, plane_layer
 
@@ -12,7 +16,101 @@ from . import _gui_common
 
 __all__ = [
     'Canvas',
+    'Save2DCanvasDialog',
 ]
+
+_PNG_FILTER = "PNG image (*.png)"
+_JPG_FILTER = "JPEG image (*.jpg *.jpeg)"
+_ALLOWED_EXTS = (".png", ".jpg", ".jpeg")
+
+
+def resolve_save_path(path, name_filter):
+    """Force ``path`` to a png/jpg extension from the chosen name filter.
+
+    Returns the resolved path, or ``None`` when the result is not png/jpg.
+    """
+    if not path:
+        return None
+    root, ext = os.path.splitext(path)
+    ext = ext.lower()
+    filt = (name_filter or "").lower()
+    if "png" in filt:
+        if ext != ".png":
+            path = root + ".png"
+    elif "jpg" in filt or "jpeg" in filt:
+        if ext not in (".jpg", ".jpeg"):
+            path = root + ".jpg"
+    elif ext not in _ALLOWED_EXTS:
+        return None
+    return path
+
+
+class Save2DCanvasDialog(_gui_common.PilotFeature):
+    """
+    File-menu action that saves the focused 2D canvas via ``saveImage``.
+    """
+
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self._diag = QtWidgets.QFileDialog(self._mainWindow)
+        self._diag.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
+        self._diag.setFileMode(QtWidgets.QFileDialog.AnyFile)
+        self._diag.setNameFilters([_PNG_FILTER, _JPG_FILTER])
+        self._diag.setDefaultSuffix("png")
+        self._diag.setWindowTitle("Save 2D canvas")
+        self._diag.filterSelected.connect(self._on_filter_selected)
+
+    def populate_menu(self):
+        self.add_action(
+            "File",
+            text="Save 2D canvas",
+            tip="Save the focused 2D canvas as a PNG or JPEG image",
+            func=self.run,
+            id="file.save_2d_canvas",
+            weight=30,
+        )
+
+    def run(self):
+        if self._mgr.currentR2DWidget() is None:
+            self._pycon.writeToHistory(
+                "Save 2D canvas: no focused 2D canvas\n")
+            return False
+        self._on_filter_selected(self._diag.selectedNameFilter())
+        self._diag.open(self, QtCore.SLOT("on_finished()"))
+        return True
+
+    def _on_filter_selected(self, name_filter):
+        filt = (name_filter or "").lower()
+        if "jpg" in filt or "jpeg" in filt:
+            self._diag.setDefaultSuffix("jpg")
+        else:
+            self._diag.setDefaultSuffix("png")
+
+    @QtCore.Slot()
+    def on_finished(self):
+        selected = self._diag.selectedFiles()
+        if not selected:
+            return
+        path = resolve_save_path(selected[0], self._diag.selectedNameFilter())
+        if path is None:
+            self._pycon.writeToHistory(
+                "Save 2D canvas: only png or jpg is allowed\n")
+            return
+        self._save_current(path)
+
+    def _save_current(self, path):
+        widget = self._mgr.currentR2DWidget()
+        if widget is None:
+            self._pycon.writeToHistory(
+                "Save 2D canvas: no focused 2D canvas\n")
+            return False
+        ok = widget.saveImage(path)
+        if ok:
+            self._pycon.writeToHistory(f"Save 2D canvas: wrote {path}\n")
+        else:
+            self._pycon.writeToHistory(
+                f"Save 2D canvas: failed to write {path}\n")
+        return ok
 
 
 class Canvas(_gui_common.PilotFeature):

--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -68,6 +68,7 @@ class _Controller(metaclass=_Singleton):
         self.linear_wave = None
         self.painter = None
         self.canvas = None
+        self.save_2d_canvas = None
         self.openprofiledata = None
         self.runprofiling = None
 
@@ -114,6 +115,7 @@ class _Controller(metaclass=_Singleton):
         self.linear_wave = _linear_wave.LinearWave1DApp(mgr=self._rmgr)
         self.painter = _painter_gui.Painter(mgr=self._rmgr)
         self.canvas = _canvas_gui.Canvas(mgr=self._rmgr, painter=self.painter)
+        self.save_2d_canvas = _canvas_gui.Save2DCanvasDialog(mgr=self._rmgr)
         self.openprofiledata = _profiling.Profiling(mgr=self._rmgr)
         self.runprofiling = _profiling.RunProfiling(mgr=self._rmgr)
         self.populate_menu()
@@ -141,6 +143,7 @@ class _Controller(metaclass=_Singleton):
 
         self.gmsh_dialog.populate_menu()
         self.svg_dialog.populate_menu()
+        self.save_2d_canvas.populate_menu()
         self.mesh_info.populate_menu()
         self.entity_tree.populate_menu()
         self.painter.populate_menu()

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -260,7 +260,7 @@ class R2DWidgetScreenshotTC(unittest.TestCase):
         self.widget.resetView()
         with tempfile.TemporaryDirectory() as folder:
             path = os.path.join(folder, "widget.png")
-            self.widget.saveImage(path)
+            self.assertTrue(self.widget.saveImage(path))
             with open(path, 'rb') as stream:
                 data = stream.read()
         self.assertEqual(data[:8], _PNG_MAGIC)
@@ -278,7 +278,7 @@ class R2DWidgetScreenshotTC(unittest.TestCase):
         current.resetView()
         with tempfile.TemporaryDirectory() as folder:
             path = os.path.join(folder, "current.png")
-            current.saveImage(path)
+            self.assertTrue(current.saveImage(path))
             with open(path, 'rb') as stream:
                 data = stream.read()
         self.assertEqual(data[:8], _PNG_MAGIC)
@@ -301,7 +301,7 @@ class R2DWidgetScreenshotTC(unittest.TestCase):
         listed.resetView()
         with tempfile.TemporaryDirectory() as folder:
             path = os.path.join(folder, "listed.png")
-            listed.saveImage(path)
+            self.assertTrue(listed.saveImage(path))
             with open(path, 'rb') as stream:
                 data = stream.read()
         self.assertEqual(data[:8], _PNG_MAGIC)
@@ -320,6 +320,72 @@ class R2DWidgetScreenshotTC(unittest.TestCase):
         self.assertFalse(pixmap.isNull())
         self.assertGreater(pixmap.width(), 0)
         self.assertGreater(pixmap.height(), 0)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class Save2DCanvasDialogTC(unittest.TestCase):
+    """File -> Save 2D canvas dialog and path resolution."""
+
+    def test_resolve_save_path_forces_png_or_jpg(self):
+        from solvcon.pilot._canvas_gui import (
+            resolve_save_path, _PNG_FILTER, _JPG_FILTER)
+        self.assertEqual(
+            resolve_save_path("/tmp/a", _PNG_FILTER), "/tmp/a.png")
+        self.assertEqual(
+            resolve_save_path("/tmp/a.bmp", _PNG_FILTER), "/tmp/a.png")
+        self.assertEqual(
+            resolve_save_path("/tmp/a", _JPG_FILTER), "/tmp/a.jpg")
+        self.assertEqual(
+            resolve_save_path("/tmp/a.png", _JPG_FILTER), "/tmp/a.jpg")
+        self.assertEqual(
+            resolve_save_path("/tmp/a.jpeg", _JPG_FILTER), "/tmp/a.jpeg")
+        self.assertEqual(resolve_save_path("/tmp/a.png", ""), "/tmp/a.png")
+        self.assertIsNone(resolve_save_path("/tmp/a.bmp", ""))
+        self.assertIsNone(resolve_save_path("", _PNG_FILTER))
+
+    def test_menu_action_is_registered(self):
+        from solvcon.pilot import _gui
+        mgr = _gui.controller.build()
+        act = mgr.menu_model.action("file.save_2d_canvas")
+        self.assertIsNotNone(act)
+        self.assertEqual(act.text(), "Save 2D canvas")
+        self.assertIn(
+            "Save 2D canvas",
+            [a.text() for a in mgr.menu_model.menu("File").actions()])
+
+    def test_run_without_canvas_skips_dialog(self):
+        """Without a focused 2D canvas, run must not open the save dialog."""
+        from solvcon.pilot import _canvas_gui
+        mgr = pilot.RManager.instance.setUp()
+        # RManager is a process-wide singleton; earlier tests may leave a
+        # focused 2D subwindow, so clear the MDI before asserting the guard.
+        mgr.mdiArea.closeAllSubWindows()
+        feature = _canvas_gui.Save2DCanvasDialog(mgr=mgr)
+        opened = []
+        feature._diag.open = lambda *a, **k: opened.append(True)
+        self.assertIsNone(mgr.currentR2DWidget())
+        self.assertFalse(feature.run())
+        self.assertEqual(opened, [])
+
+    def test_save_current_reports_write_result(self):
+        """Menu save path returns saveImage's bool and only writes on
+        success."""
+        from solvcon.pilot import _canvas_gui
+        mgr = pilot.RManager.instance.setUp()
+        widget = mgr.add2DWidget()
+        widget.updateWorld(_build_world())
+        widget.resetView()
+        feature = _canvas_gui.Save2DCanvasDialog(mgr=mgr)
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "out.png")
+            self.assertTrue(feature._save_current(path))
+            self.assertTrue(os.path.isfile(path))
+            with open(path, 'rb') as stream:
+                data = stream.read()
+            bad = os.path.join(folder, "missing", "out.png")
+            self.assertFalse(feature._save_current(bad))
+            self.assertFalse(os.path.isfile(bad))
+        self.assertEqual(data[:8], _PNG_MAGIC)
 
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,

--- a/tests/test_pilot_bar.py
+++ b/tests/test_pilot_bar.py
@@ -35,6 +35,9 @@ class BarStructureTC(unittest.TestCase):
         self.assertIsNotNone(model.action("mesh.sample_dialog"))
         self.assertIn("Sample mesh dialog",
                       [a.text() for a in model.menu("Mesh").actions()])
+        self.assertIsNotNone(model.action("file.save_2d_canvas"))
+        self.assertIn("Save 2D canvas",
+                      [a.text() for a in model.menu("File").actions()])
 
         # Panels sits first in View and holds the three dock toggles.
         view = [a.text() for a in model.menu("View").actions()]


### PR DESCRIPTION
Add a File → Save 2D canvas action that opens a PNG/JPEG save dialog and writes the focused R2DWidget via saveImage, returning and reporting the write result.

Related to #896.
