### PR TITLE
Add make run_pilot to build and launch Pilot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,13 @@ pilot_clang_tidy_diff: cmake
 gtest: cmake
 	cmake --build $(BUILD_PATH) --target run_gtest VERBOSE=$(VERBOSE) $(MAKE_PARALLEL)
 
+# Build and launch the pilot GUI. PYTHONPATH is set via RUNENV so the
+# in-tree package is found; CMake resolves the platform binary path.
+.PHONY: run_pilot
+run_pilot: pilot
+	env $(RUNENV) \
+		cmake --build $(BUILD_PATH) --target $@ VERBOSE=$(VERBOSE)
+
 # Pass PYTEST_OPTS to forward arguments to the pytest harness running
 # inside the pilot binary.
 # Example for one file:

--- a/cpp/binary/pilot/CMakeLists.txt
+++ b/cpp/binary/pilot/CMakeLists.txt
@@ -117,6 +117,7 @@ if(APPLE)
     )
 endif()
 
+add_custom_target(run_pilot $<TARGET_FILE:pilot>)
 add_custom_target(run_pilot_pytest $<TARGET_FILE:pilot> --mode=pytest)
 
 if(DO_CLANG_TIDY_DIFF)


### PR DESCRIPTION
Add a make run_pilot target that builds pilot and launches it with PYTHONPATH set, resolving the platform binary path so it works on macOS, Linux, and Windows.
