### PR TITLE
Add an OpenAI-compatible HTTP backend for the agent

### DIFF
--- a/solvcon/agent/__init__.py
+++ b/solvcon/agent/__init__.py
@@ -36,6 +36,7 @@ list_of_backend = [
 list_of_backends_impl = [
     'SubprocessBackend',
     'ClaudeCliBackend',
+    'OpenAIHttpBackend',
     'parse_tool_calls',
 ]
 

--- a/solvcon/agent/_backend.py
+++ b/solvcon/agent/_backend.py
@@ -15,6 +15,7 @@ default.
 
 import abc
 import dataclasses
+import json
 
 
 @dataclasses.dataclass
@@ -31,7 +32,23 @@ class BackendResponse:
 class AgentBackend(abc.ABC):
     """Interface every AI backend implements: a stable :attr:`name`, an
     :meth:`available` check, and :meth:`send`.  The tiny surface lets a caller
-    drive any backend from a background thread."""
+    drive any backend from a background thread.  Every backend also shares one
+    system instruction and one prompt layout through :meth:`_compose_prompt`,
+    so a CLI and an HTTP backend never drift apart in what they ask the model.
+    """
+
+    # TODO: solvcon is an application platform for geometry-based computation:
+    # editing graphics and geometry, visualizing, meshing, and solving
+    # conservation laws.  These instructions frame the agent around the 2D
+    # drawing canvas alone; reframe that as one capability among the platform's
+    # rather than the agent's whole scope.  Related to #966.
+    _INSTRUCTIONS = (
+        "You drive a 2D drawing canvas. Translate the user's request into a "
+        "JSON array of drawing commands. Each command is an object with an "
+        "\"op\" key naming the operation and the operation's arguments as "
+        "sibling keys. Reply with only the JSON array, no prose and no code "
+        "fences. Use an empty array when no drawing is needed."
+    )
 
     @property
     @abc.abstractmethod
@@ -51,6 +68,17 @@ class AgentBackend(abc.ABC):
         :param tool_surface: the Agent Draw tool definitions the model may
             call.
         """
+
+    @classmethod
+    def _compose_prompt(cls, prompt, scene_context, tool_surface):
+        """Fold the shared instruction, tool surface, scene, and user request
+        into one prompt string, so every backend sends the same thing whether
+        it is a CLI argument or an HTTP message body."""
+        tools = json.dumps(tool_surface or [], indent=2)
+        return (
+            "%s\n\nAvailable operations (tool definitions):\n%s\n\n"
+            "Current scene:\n%s\n\nUser request:\n%s"
+            % (cls._INSTRUCTIONS, tools, scene_context, prompt))
 
 
 _REGISTRY = []

--- a/solvcon/agent/_backends_impl.py
+++ b/solvcon/agent/_backends_impl.py
@@ -3,13 +3,14 @@
 
 
 """
-Concrete AI backends over external command-line tools.
+Concrete AI backends over external CLIs and HTTP APIs.
 
-This module holds the backends that shell out to an installed AI CLI, plus the
-shared plumbing they need: :class:`SubprocessBackend` (PATH discovery and a
-cancellable child process) and :func:`parse_tool_calls` (turn a model reply
-into Agent Draw command dicts).  Only the Claude CLI backend lives here for
-now; the Codex CLI and an HTTP backend are follow-ups that reuse the same base.
+This module holds the backends that talk to an installed AI CLI or an
+OpenAI-compatible HTTP server, plus the shared plumbing they need:
+:class:`SubprocessBackend` (PATH discovery and a cancellable child process),
+:class:`OpenAIHttpBackend` (stdlib ``http.client``, no SDK), and
+:func:`parse_tool_calls` (turn a model reply into Agent Draw command dicts).
+The Codex CLI backend is a follow-up that reuses :class:`SubprocessBackend`.
 
 The module imports no Qt and makes no network call at import time.  A backend
 registers itself only as a class instance in the shared registry, so a caller
@@ -17,25 +18,14 @@ lists it and probes :meth:`~solvcon.agent.AgentBackend.available` before use.
 """
 
 import abc
+import http.client
 import json
+import os
 import shutil
 import subprocess
+import urllib.parse
 
 from . import _backend
-
-
-# TODO: solvcon is an application platform for geometry-based computation:
-# editing graphics and geometry, visualizing, meshing, and solving
-# conservation laws.  These instructions frame the agent around the 2D
-# drawing canvas alone; reframe that as one capability among the platform's
-# rather than the agent's whole scope.  Related to #966.
-_INSTRUCTIONS = (
-    "You drive a 2D drawing canvas. Translate the user's request into a JSON "
-    "array of drawing commands. Each command is an object with an \"op\" key "
-    "naming the operation and the operation's arguments as sibling keys. "
-    "Reply with only the JSON array, no prose and no code fences. Use an "
-    "empty array when no drawing is needed."
-)
 
 
 def _tool_op_names(tool_surface):
@@ -67,8 +57,13 @@ def _strip_code_fences(text):
 
 def _load_json_payload(text):
     """Parse the first JSON array or object out of a model reply, tolerating a
-    code fence or surrounding prose.  Return the parsed value, or ``None`` when
-    nothing parses."""
+    code fence or surrounding prose.
+
+    Return the parsed value, or ``None`` when the reply has no JSON-looking
+    span (plain prose).  Raise :class:`ValueError` when a ``[``/``{`` span is
+    present but does not parse, so a truncated or invalid command batch is not
+    mistaken for an empty one.
+    """
     text = _strip_code_fences(text).strip()
     if not text:
         return None
@@ -76,14 +71,19 @@ def _load_json_payload(text):
         return json.loads(text)
     except json.JSONDecodeError:
         pass
+    saw_span = False
     for opener, closer in (("[", "]"), ("{", "}")):
         start = text.find(opener)
         end = text.rfind(closer)
-        if start != -1 and end > start:
-            try:
-                return json.loads(text[start:end + 1])
-            except json.JSONDecodeError:
-                continue
+        if start == -1 or end <= start:
+            continue
+        saw_span = True
+        try:
+            return json.loads(text[start:end + 1])
+        except json.JSONDecodeError:
+            continue
+    if saw_span or text[0] in "[{":
+        raise ValueError("model reply has malformed JSON")
     return None
 
 
@@ -93,7 +93,9 @@ def parse_tool_calls(text, tool_surface=None):
     Accept a JSON array, or a lone object treated as a one-command array.  Each
     command must be an object with an ``op``; when ``tool_surface`` names ops,
     an unknown op is rejected.  Raise :class:`ValueError` on a malformed reply
-    so the backend records it as an error rather than running a bad command.
+    (including invalid JSON that looks like a command batch) so the backend
+    records it as an error rather than running a bad command.  Plain prose with
+    no JSON yields an empty list.
     """
     data = _load_json_payload(text)
     if data is None:
@@ -156,16 +158,6 @@ class SubprocessBackend(_backend.AgentBackend):
         """Extract the assistant text from CLI ``stdout``.  The default treats
         stdout as the reply; override for a CLI that wraps it (JSON, etc.)."""
         return (stdout or "").strip()
-
-    @staticmethod
-    def _compose_prompt(prompt, scene_context, tool_surface):
-        """Fold the instructions, tool surface, scene, and user request into
-        one prompt string for a CLI that takes a single prompt argument."""
-        tools = json.dumps(tool_surface or [], indent=2)
-        return (
-            "%s\n\nAvailable operations (tool definitions):\n%s\n\n"
-            "Current scene:\n%s\n\nUser request:\n%s"
-            % (_INSTRUCTIONS, tools, scene_context, prompt))
 
     def send(self, prompt, scene_context, tool_surface):
         exe = self.executable()
@@ -246,5 +238,184 @@ class ClaudeCliBackend(SubprocessBackend):
 
 
 _backend.register(ClaudeCliBackend())
+
+
+class OpenAIHttpBackend(_backend.AgentBackend):
+    """Backend over an OpenAI-compatible Chat Completions HTTP API.
+
+    Uses only the stdlib (``http.client`` and ``urllib.parse``); no vendor
+    SDK.  Point ``base_url`` at OpenAI, Ollama's ``/v1`` endpoint, or any
+    compatible server.  Defaults and the optional API key come from the
+    constructor or the ``SOLVCON_OPENAI_BASE_URL``, ``SOLVCON_OPENAI_MODEL``,
+    and ``SOLVCON_OPENAI_API_KEY`` environment variables.  The in-flight
+    connection is kept on the instance so a driver thread can :meth:`cancel`.
+    """
+
+    # Local Ollama's OpenAI-compatible root; override for a remote provider.
+    _DEFAULT_BASE_URL = "http://127.0.0.1:11434/v1"
+    _DEFAULT_MODEL = "qwen2.5vl:7b"
+
+    def __init__(self, base_url=None, model=None, api_key=None, timeout=120):
+        self._base_url = base_url if base_url is not None else self._env_or(
+            "SOLVCON_OPENAI_BASE_URL", self._DEFAULT_BASE_URL)
+        self._model = model if model is not None else self._env_or(
+            "SOLVCON_OPENAI_MODEL", self._DEFAULT_MODEL)
+        self._api_key = api_key if api_key is not None else self._env_or(
+            "SOLVCON_OPENAI_API_KEY", "")
+        self._timeout = timeout
+        self._conn = None
+
+    @staticmethod
+    def _env_or(name, default):
+        """``os.environ[name]`` when set and non-empty, else ``default``."""
+        value = os.environ.get(name)
+        return value if value else default
+
+    @property
+    def name(self):
+        return "openai (http)"
+
+    @property
+    def base_url(self):
+        """API root including the ``/v1`` suffix, with no trailing slash."""
+        return (self._base_url or "").rstrip("/")
+
+    @property
+    def model(self):
+        return self._model
+
+    def available(self):
+        """True when both a base URL and a model name are configured."""
+        return bool(self.base_url) and bool(self._model)
+
+    def send(self, prompt, scene_context, tool_surface):
+        if not self.available():
+            return _backend.BackendResponse(
+                error="openai http backend needs base_url and model")
+        composed = self._compose_prompt(prompt, scene_context, tool_surface)
+        body = {
+            "model": self._model,
+            "stream": False,
+            "messages": [{"role": "user", "content": composed}],
+        }
+        try:
+            status, raw = self._post_chat(body)
+        except TimeoutError:
+            return _backend.BackendResponse(
+                error="openai http timed out")
+        except (OSError, http.client.HTTPException) as exc:
+            return _backend.BackendResponse(
+                error="openai http failed: %s" % exc)
+        if status != 200:
+            detail = (raw or b"").decode("utf-8", errors="replace").strip()
+            return _backend.BackendResponse(
+                error="openai http status %d: %s" % (status, detail))
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            return _backend.BackendResponse(
+                error="openai http bad JSON: %s" % exc)
+        text = self._parse_chat_payload(payload)
+        if text is None:
+            return _backend.BackendResponse(
+                error="openai http response missing assistant text")
+        try:
+            commands = parse_tool_calls(text, tool_surface)
+        except ValueError as exc:
+            return _backend.BackendResponse(text=text, error=str(exc))
+        return _backend.BackendResponse(text=text, commands=commands)
+
+    def cancel(self):
+        """Close the in-flight HTTP connection, if any.  Safe to call from
+        another thread while :meth:`send` blocks in :meth:`_post_chat`."""
+        conn = self._conn
+        if conn is not None:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+    @classmethod
+    def _parse_chat_payload(cls, payload):
+        """Assistant text from a Chat Completions JSON body, or ``None``."""
+        if not isinstance(payload, dict):
+            return None
+        choices = payload.get("choices")
+        if not isinstance(choices, list) or not choices:
+            return None
+        first = choices[0]
+        if not isinstance(first, dict):
+            return None
+        return cls._message_text(first.get("message") or {})
+
+    @staticmethod
+    def _message_text(message):
+        """Assistant text from an OpenAI-style ``message`` object.
+
+        Accept a plain string ``content``, or a list of content parts (the
+        multimodal shape) by joining the text pieces.
+        """
+        if not isinstance(message, dict):
+            return ""
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for part in content:
+                if isinstance(part, str):
+                    parts.append(part)
+                elif isinstance(part, dict):
+                    text = part.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+            return "".join(parts)
+        return ""
+
+    def _post_chat(self, body):
+        """POST ``body`` to ``/chat/completions``; return ``(status, raw)``.
+
+        Builds an ``http.client`` connection from :attr:`base_url`, holds it
+        on ``self._conn`` for :meth:`cancel`, and always clears that slot.
+        """
+        parsed = urllib.parse.urlparse(self.base_url)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise OSError("invalid base_url: %s" % self.base_url)
+        path = parsed.path.rstrip("/") + "/chat/completions"
+        if parsed.query:
+            path = "%s?%s" % (path, parsed.query)
+        host = parsed.hostname
+        if not host:
+            raise OSError("invalid base_url host: %s" % self.base_url)
+        port = parsed.port
+        if port is None:
+            port = 443 if parsed.scheme == "https" else 80
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        if self._api_key:
+            headers["Authorization"] = "Bearer %s" % self._api_key
+        payload = json.dumps(body).encode("utf-8")
+        if parsed.scheme == "https":
+            conn = http.client.HTTPSConnection(
+                host, port, timeout=self._timeout)
+        else:
+            conn = http.client.HTTPConnection(
+                host, port, timeout=self._timeout)
+        self._conn = conn
+        try:
+            conn.request("POST", path, body=payload, headers=headers)
+            response = conn.getresponse()
+            return response.status, response.read()
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+            self._conn = None
+
+
+_backend.register(OpenAIHttpBackend())
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_backends_impl.py
+++ b/tests/test_agent_backends_impl.py
@@ -2,11 +2,12 @@
 # BSD 3-Clause License, see COPYING
 
 
-"""Tests for the concrete CLI backends and tool-call parsing.
+"""Tests for the concrete CLI/HTTP backends and tool-call parsing.
 
-GUI-free and process-free: PATH discovery is patched and the child process is
-replaced, so no real ``claude`` CLI runs.  These exercise the parsing
-contract, PATH-based availability, and the ``send`` pipeline.
+GUI-free by default: PATH discovery is patched, the child process is replaced,
+and HTTP posts are stubbed, so no real ``claude`` CLI or network call runs.
+These exercise the parsing contract, availability checks, and the ``send``
+pipeline.  Opt-in classes hit a live CLI or OpenAI-compatible server.
 """
 
 import json
@@ -18,6 +19,7 @@ from unittest import mock
 from solvcon.agent import (
     BackendResponse,
     ClaudeCliBackend,
+    OpenAIHttpBackend,
     SubprocessBackend,
     get_backend,
     parse_tool_calls,
@@ -58,6 +60,14 @@ class ParseToolCallsTC(unittest.TestCase):
 
     def test_no_json_yields_empty(self):
         self.assertEqual(parse_tool_calls("I cannot help.", _TOOLS), [])
+
+    def test_malformed_json_rejected(self):
+        # A JSON-looking but invalid payload must not become a successful
+        # empty batch; send() should record a parser error instead.
+        with self.assertRaises(ValueError):
+            parse_tool_calls('[{"op": "add_circle",}]', _TOOLS)
+        with self.assertRaises(ValueError):
+            parse_tool_calls('[{"op": "add_circle"', _TOOLS)
 
     def test_unknown_op_rejected(self):
         with self.assertRaises(ValueError):
@@ -151,6 +161,14 @@ class ClaudeCliSendTC(unittest.TestCase):
         self.assertIsNotNone(response.error)
         self.assertEqual(response.commands, [])
 
+    def test_send_malformed_json_is_error_not_empty_success(self):
+        # Invalid JSON must surface as an error, not a silent empty batch.
+        reply = self._envelope('[{"op": "add_circle",}]')
+        self.backend._communicate = lambda argv: (0, reply, "")
+        response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertIsNotNone(response.error)
+        self.assertEqual(response.commands, [])
+
     def test_send_unhashable_op_is_error_not_crash(self):
         # A malformed reply must come back as an error result, never an
         # unhandled exception out of send().
@@ -186,11 +204,169 @@ class RegistrationTC(unittest.TestCase):
         self.assertIsNotNone(backend)
         self.assertIsInstance(backend, ClaudeCliBackend)
 
+    def test_openai_http_registers_on_import(self):
+        backend = get_backend("openai (http)")
+        self.assertIsNotNone(backend)
+        self.assertIsInstance(backend, OpenAIHttpBackend)
+
+
+class OpenAIHttpBackendTC(unittest.TestCase):
+    def setUp(self):
+        self.backend = OpenAIHttpBackend(
+            base_url="http://127.0.0.1:11434/v1",
+            model="qwen2.5vl:7b",
+            api_key="")
+
+    def _chat_body(self, content):
+        message = {"role": "assistant", "content": content}
+        return json.dumps({
+            "choices": [{"message": message}],
+        }).encode("utf-8")
+
+    def test_available_needs_url_and_model(self):
+        self.assertTrue(self.backend.available())
+        self.assertFalse(OpenAIHttpBackend(
+            base_url="", model="m").available())
+        self.assertFalse(OpenAIHttpBackend(
+            base_url="http://127.0.0.1:11434/v1", model="").available())
+
+    def test_send_parses_commands(self):
+        raw = self._chat_body('[{"op": "add_circle", "r": 2.0}]')
+        self.backend._post_chat = lambda body: (200, raw)
+        response = self.backend.send("draw a circle", "empty world", _TOOLS)
+        self.assertIsInstance(response, BackendResponse)
+        self.assertIsNone(response.error)
+        self.assertEqual(response.commands, [{"op": "add_circle", "r": 2.0}])
+
+    def test_send_posts_openai_chat_shape(self):
+        seen = {}
+
+        def _capture(body):
+            seen["body"] = body
+            return 200, self._chat_body("[]")
+
+        self.backend._post_chat = _capture
+        self.backend.send("hello", "one shape", _TOOLS)
+        body = seen["body"]
+        self.assertEqual(body["model"], "qwen2.5vl:7b")
+        self.assertIs(body["stream"], False)
+        messages = body["messages"]
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0]["role"], "user")
+        self.assertIn("hello", messages[0]["content"])
+        self.assertIn("one shape", messages[0]["content"])
+        self.assertIn("add_circle", messages[0]["content"])
+
+    def test_send_http_error_status_is_error(self):
+        self.backend._post_chat = lambda body: (500, b"boom")
+        response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertIn("status 500", response.error)
+        self.assertEqual(response.commands, [])
+
+    def test_send_transport_failure_is_error(self):
+        def _fail(body):
+            raise OSError("connection refused")
+        self.backend._post_chat = _fail
+        response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertIn("failed", response.error)
+        self.assertEqual(response.commands, [])
+
+    def test_send_timeout_is_error(self):
+        def _timeout(body):
+            raise TimeoutError("timed out")
+        self.backend._post_chat = _timeout
+        response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertIn("timed out", response.error)
+
+    def test_send_unknown_op_reports_error_without_commands(self):
+        raw = self._chat_body('[{"op": "delete_universe"}]')
+        self.backend._post_chat = lambda body: (200, raw)
+        response = self.backend.send("wreck it", "scene", _TOOLS)
+        self.assertIsNotNone(response.error)
+        self.assertEqual(response.commands, [])
+
+    def test_send_malformed_json_is_error_not_empty_success(self):
+        raw = self._chat_body('[{"op": "add_circle",}]')
+        self.backend._post_chat = lambda body: (200, raw)
+        response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertIsNotNone(response.error)
+        self.assertEqual(response.commands, [])
+
+    def test_parse_chat_payload_joins_content_parts(self):
+        text = OpenAIHttpBackend._parse_chat_payload({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": '[{"op": '},
+                        {"type": "text", "text": '"add_line"}]'},
+                    ],
+                },
+            }],
+        })
+        self.assertEqual(text, '[{"op": "add_line"}]')
+
+    def test_env_defaults_when_ctor_omits(self):
+        env = {
+            "SOLVCON_OPENAI_BASE_URL": "http://example.test/v1",
+            "SOLVCON_OPENAI_MODEL": "demo-model",
+            "SOLVCON_OPENAI_API_KEY": "secret",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            backend = OpenAIHttpBackend()
+        self.assertEqual(backend.base_url, "http://example.test/v1")
+        self.assertEqual(backend.model, "demo-model")
+        self.assertEqual(backend._api_key, "secret")
+
+    def test_post_chat_uses_http_client(self):
+        # Stub http.client so send() still exercises URL, headers, and path
+        # assembly without a live server.
+        seen = {}
+        raw = self._chat_body('[{"op": "add_circle"}]')
+
+        class FakeResponse:
+            status = 200
+
+            def read(self):
+                return raw
+
+        class FakeConn:
+            def __init__(self, host, port, timeout=None):
+                seen["host"] = host
+                seen["port"] = port
+                seen["timeout"] = timeout
+
+            def request(self, method, path, body=None, headers=None):
+                seen["method"] = method
+                seen["path"] = path
+                seen["body"] = body
+                seen["headers"] = headers
+
+            def getresponse(self):
+                return FakeResponse()
+
+            def close(self):
+                seen["closed"] = True
+
+        self.backend._api_key = "tok"
+        with mock.patch(
+                "solvcon.agent._backends_impl.http.client.HTTPConnection",
+                FakeConn):
+            response = self.backend.send("draw", "scene", _TOOLS)
+        self.assertIsNone(response.error)
+        self.assertEqual(response.commands, [{"op": "add_circle"}])
+        self.assertEqual(seen["host"], "127.0.0.1")
+        self.assertEqual(seen["port"], 11434)
+        self.assertEqual(seen["method"], "POST")
+        self.assertEqual(seen["path"], "/v1/chat/completions")
+        self.assertEqual(seen["headers"]["Authorization"], "Bearer tok")
+        self.assertTrue(seen.get("closed"))
+
 
 _REAL = "SOLVCON_TEST_REAL_CLAUDE"
 
 
-@unittest.skipUnless(os.environ.get(_REAL),
+@unittest.skipUnless(os.environ.get(_REAL) == "1",
                      "set %s=1 to hit the installed claude CLI" % _REAL)
 class ClaudeCliRealTC(unittest.TestCase):
     """Opt-in end-to-end test against the installed claude CLI.
@@ -215,6 +391,39 @@ class ClaudeCliRealTC(unittest.TestCase):
         # broken flag, envelope, or parser would surface as an error or an
         # empty batch here.
         self.assertIsNone(response.error)
+        self.assertTrue(response.commands)
+        ops = {tool["name"] for tool in _TOOLS}
+        for command in response.commands:
+            self.assertIn(command.get("op"), ops)
+        self.assertIn("add_circle",
+                      [command["op"] for command in response.commands])
+
+
+_REAL_OPENAI = "SOLVCON_TEST_REAL_OPENAI_HTTP"
+
+
+@unittest.skipUnless(
+    os.environ.get(_REAL_OPENAI) == "1",
+    "set %s=1 to hit a live OpenAI-compatible server" % _REAL_OPENAI)
+class OpenAIHttpRealTC(unittest.TestCase):
+    """Opt-in end-to-end test against a live OpenAI-compatible server.
+
+    Skipped by default so CI stays hermetic.  A local run with
+    ``SOLVCON_TEST_REAL_OPENAI_HTTP=1`` posts to the configured base URL
+    (default: Ollama at ``http://127.0.0.1:11434/v1``) to confirm the request
+    shape, response parsing, and command extraction against a real model.
+    """
+
+    def setUp(self):
+        self.backend = OpenAIHttpBackend()
+        if not self.backend.available():
+            self.skipTest("openai http backend not configured")
+
+    def test_draws_a_circle_end_to_end(self):
+        response = self.backend.send(
+            "Add exactly one circle of radius 1 at the origin.",
+            "empty world with 0 shapes", _TOOLS)
+        self.assertIsNone(response.error, response.error)
         self.assertTrue(response.commands)
         ops = {tool["name"] for tool in _TOOLS}
         for command in response.commands:


### PR DESCRIPTION
Add an OpenAI-compatible HTTP backend for solvcon agent.

To try it manually against an OpenAI-compatible server (a local Ollama by default), build the extension and run a short snippet (a hand-written tool surface stands in for Agent Draw's, which is not yet on master):

    from solvcon.agent import OpenAIHttpBackend
    tools = [{"name": "add_circle", "description": "Add a circle."}]
    backend = OpenAIHttpBackend()
    print(backend.available())
    resp = backend.send("draw three circles in a row", "empty world", tools)
    print(resp.error, resp.commands)

The backend uses only the stdlib http.client, no vendor SDK, and defaults to a local Ollama at http://127.0.0.1:11434/v1 with model qwen2.5vl:7b. Point it elsewhere through the constructor or the SOLVCON_OPENAI_BASE_URL, SOLVCON_OPENAI_MODEL, and SOLVCON_OPENAI_API_KEY environment variables.

The unit tests stub the HTTP transport so CI stays hermetic and free. An opt-in end-to-end test hits a live server only when SOLVCON_TEST_REAL_OPENAI_HTTP is set, so you can verify the request shape, response parsing, and command extraction against a real model locally:

    SOLVCON_TEST_REAL_OPENAI_HTTP=1 make pytest PYTEST_OPTS="tests/test_agent_backends_impl.py::OpenAIHttpRealTC"

Next todo: Integrate the OpenAI HTTP backend into the agent session.

Related to #966.