### PR TITLE
Add worktree skill for isolated task worktrees

### DIFF
--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: worktree
+description: Enter an isolated git worktree and do the task there. Use when the user wants to avoid polluting the main working tree.
+---
+
+# Worktree
+
+Use an automatically provided worktree. Otherwise create one, then do the task. No extra ceremony.
+
+## 1. Enter or create
+
+If the agent or session already provides a worktree, enter it. Otherwise derive a short kebab-case `name` from `<description>`, or omit it and let the tool pick one.
+
+Based on the agent type, do one of the following:
+
+- **Claude Code:** use Claude's builtin `EnterWorktree` with that `name`. If the worktree does not exist, it will be created automatically.
+- **Cursor:**  use Cursors's builtin `/worktree` command instead. If the built-in command is unavailable, fall back like Codex below.
+- **Codex, otherwise:** run `git worktree add -b worktree-<name> .claude/worktrees/<name> origin/master`, then run all commands from it.
+
+## 2. Do the task
+
+Implement `<description>` in the worktree. Follow normal project rules. Stop when done; do not auto-commit, open a PR, or remove the worktree unless asked.
+
+<!-- vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: -->


### PR DESCRIPTION
Add a worktree skill that enters or creates an isolated git worktree for the task and stops there, with agent-specific entry (Claude EnterWorktree, Cursor /worktree, otherwise git worktree add).

[skip-ci]
