### PR TITLE
Add the Agent Console panel and single-turn agent orchestration for the pilot

### DIFF
--- a/solvcon/agent/_core.py
+++ b/solvcon/agent/_core.py
@@ -37,22 +37,36 @@ class _OutcomeStub:
     error: str = None
 
 
+_draw_module = None
+
+
+def _resolve_draw():
+    """The module supplying the command surface and runner: Agent Draw when it
+    is importable, else the built-in :mod:`_draw` bridge (#965).  Both expose
+    the same handles (``Executor``, ``tool_definitions``), so callers need not
+    know which won.  Resolved once per process."""
+    # TODO: when the agentdraw package ships in-tree, import it at module level
+    # and drop the _draw fallback and this selector.
+    global _draw_module
+    if _draw_module is None:
+        try:
+            from solvcon.pilot import agentdraw
+            _draw_module = agentdraw
+        except ImportError:
+            from . import _draw
+            _draw_module = _draw
+    return _draw_module
+
+
 def _make_executor(world, renderer=None):
-    """Build an Agent Draw ``Executor`` for ``world``."""
-    # TODO: when the agentdraw package ships in-tree, import it at module
-    # level (here and in tool_surface) and drop the empty-list fallback.
-    from solvcon.pilot import agentdraw
-    return agentdraw.Executor(world, renderer)
+    """Build the command runner for ``world`` from the resolved draw module."""
+    return _resolve_draw().Executor(world, renderer)
 
 
 def tool_surface():
-    """The Agent Draw tool definitions for a backend, or ``[]`` if the
-    ``agentdraw`` package is unavailable."""
-    try:
-        from solvcon.pilot import agentdraw
-    except ImportError:
-        return []
-    return agentdraw.tool_definitions()
+    """The tool definitions a backend proposes against, from the resolved draw
+    module."""
+    return _resolve_draw().tool_definitions()
 
 
 class AgentSession:
@@ -68,6 +82,7 @@ class AgentSession:
         self.backend = backend
         self._renderer = renderer
         self._runner = runner
+        self._runner_injected = runner is not None
         self._transcript = []
 
     @property
@@ -81,6 +96,14 @@ class AgentSession:
         if self._runner is None:
             self._runner = _make_executor(self.world, self._renderer)
         return self._runner
+
+    def bind_world(self, world):
+        """Point the session at ``world`` for later turns, dropping a lazily
+        built runner so the next command batch targets the new world.  A runner
+        passed to the constructor is kept."""
+        self.world = world
+        if not self._runner_injected:
+            self._runner = None
 
     def tool_surface(self):
         """The Agent Draw tool definitions to hand the backend."""
@@ -102,25 +125,80 @@ class AgentSession:
         kinds = ", ".join(types) if types else "none"
         return "world with %d shapes (types: %s)" % (len(shapes), kinds)
 
-    def apply_commands(self, commands):
-        """Run each command, recording one transcript turn.  An empty batch is
-        a no-op that builds no runner; a runner that raises is captured into a
-        failed :class:`_OutcomeStub`, so one bad command never aborts a batch.
+    @staticmethod
+    def _op_of(command):
+        """The command's declared ``op``, or ``"?"`` when it names none."""
+        return command.get("op", "?") if isinstance(command, dict) else "?"
+
+    def _execute(self, commands):
+        """Run each command in order and return one result per command.
+
+        An empty batch builds no runner.  A runner that fails to build, or that
+        raises on a command, becomes a failed :class:`_OutcomeStub` (one per
+        command), so a bad runner or command never aborts the batch and the
+        results always line up with the commands.  This does not touch the
+        transcript.
         """
         if not commands:
             return []
-        runner = self.runner
+        try:
+            runner = self.runner
+        except Exception as exc:
+            error = "%s: %s" % (type(exc).__name__, exc)
+            return [_OutcomeStub(self._op_of(c), error=error)
+                    for c in commands]
         results = []
         for command in commands:
             try:
                 results.append(runner.run(command))
             except Exception as exc:
-                op = command.get("op", "?") if isinstance(command, dict) \
-                    else "?"
                 results.append(_OutcomeStub(
-                    op, error="%s: %s" % (type(exc).__name__, exc)))
-        self._transcript.append(TranscriptTurn(
-            role="agent", commands=list(commands), results=results))
+                    self._op_of(command),
+                    error="%s: %s" % (type(exc).__name__, exc)))
         return results
+
+    def _record_agent(self, text, commands=(), results=()):
+        """Append and return one agent turn."""
+        turn = TranscriptTurn(
+            role="agent", text=text,
+            commands=list(commands), results=list(results))
+        self._transcript.append(turn)
+        return turn
+
+    def apply_commands(self, commands):
+        """Run each command, recording one agent turn.  An empty batch is a
+        no-op that builds no runner and records nothing."""
+        if not commands:
+            return []
+        results = self._execute(commands)
+        self._record_agent("", commands, results)
+        return results
+
+    def run_turn(self, prompt):
+        """Drive one request end to end for a single-turn chat.
+
+        Record the user's ``prompt``, ask the backend for commands against the
+        current scene and tool surface, run them, and record one agent turn
+        carrying the reply text, the commands, and their results.  With no
+        backend, record only the user turn and return ``None``.  A backend that
+        raises is recorded as a failed agent turn rather than propagated, so a
+        headless caller always gets a turn back.  No prior turns are replayed:
+        multi-turn chat history is a later addition.
+        """
+        self._transcript.append(TranscriptTurn(role="user", text=prompt))
+        if self.backend is None:
+            return None
+        try:
+            response = self.backend.send(
+                prompt, self.scene_context(), self.tool_surface())
+        except Exception as exc:
+            return self._record_agent(
+                "[error] %s: %s" % (type(exc).__name__, exc))
+        parts = [response.text] if response.text else []
+        if response.error:
+            parts.append("[error] %s" % response.error)
+        return self._record_agent(
+            "\n".join(parts), response.commands,
+            self._execute(response.commands))
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/agent/_draw.py
+++ b/solvcon/agent/_draw.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Minimal fallback surface for the Agent.
+
+Agent Draw (#965) owns the real ``World`` command schema and Executor.  Until
+that package ships in-tree, this module is a thin, Qt-free stand-in so the
+session and the tests have a working tool surface and runner: it carries only a
+dummy no-op op.  :mod:`_core` prefers the agentdraw package whenever it is
+importable, so this bridge is unused once #965 lands.
+"""
+
+import dataclasses
+
+
+# TODO: remove this whole module once Agent Draw (#965) provides the real tool
+# surface and Executor. The dummy op exists only so a backend and the tests
+# have a trivial command to exercise the dispatch path headless.
+_DUMMY_OP = "ping"
+_DUMMY_TOOL = {
+    "name": _DUMMY_OP,
+    "description": "Test-only no-op that acknowledges without drawing.",
+    "parameters": {},
+}
+
+
+@dataclasses.dataclass
+class DrawResult:
+    """Outcome of one command: the ``op``, whether it applied, and the reason
+    when it did not."""
+
+    op: str
+    ok: bool = True
+    error: str = None
+
+
+def tool_definitions():
+    """The fallback tool surface: only the dummy ``ping`` op."""
+    return [dict(_DUMMY_TOOL)]
+
+
+class Executor:
+    """Apply fallback command dicts.
+
+    Only the dummy ``ping`` op is known; any real drawing op is reported as a
+    failed :class:`DrawResult` pointing at Agent Draw (#965) rather than
+    raised, so one command never aborts a batch.  ``world`` and ``renderer``
+    match the agentdraw Executor signature so :mod:`_core` builds either the
+    same way; both are unused until the real ops land.
+    """
+
+    def __init__(self, world, renderer=None):
+        self._world = world
+
+    def run(self, command):
+        op = command.get("op") if isinstance(command, dict) else None
+        if op == _DUMMY_OP:
+            return DrawResult(op, ok=True)
+        return DrawResult(op or "?", ok=False,
+                          error="op %r needs Agent Draw (#965)" % (op,))
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/_agent_gui.py
+++ b/solvcon/pilot/_agent_gui.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Agent Console: a dock that drives the 2D world from natural language.
+
+The console sits at the bottom-right, beside the Python console, and runs the
+selected AI backend on the active canvas world for one request at a time.  It
+reuses the headless :class:`~solvcon.agent.AgentSession`, so the drawing logic
+stays Qt-free and testable.  Multi-turn chat history is a later addition: each
+prompt is an independent single turn.
+"""
+
+from itertools import zip_longest
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QDockWidget,
+                               QLabel, QComboBox, QTextEdit, QLineEdit,
+                               QPushButton)
+
+from ..agent import AgentSession, available_backends
+from . import _gui_common
+
+__all__ = [  # noqa: F822
+    'AgentConsoleWidget',
+    'AgentPanel',
+]
+
+
+class AgentConsoleWidget(QWidget):
+    """The console body: a backend selector, a transcript, and a prompt box.
+
+    Display-only.  It emits :attr:`submitted` with the typed prompt and exposes
+    the chosen backend; the owning feature runs the turn and calls back to
+    append the reply.
+    """
+
+    submitted = Signal(str)
+
+    def __init__(self, backends=(), parent=None):
+        super().__init__(parent)
+        self._backend_combo = QComboBox()
+        for backend in backends:
+            self._backend_combo.addItem(backend.name, backend)
+
+        self._transcript = QTextEdit()
+        self._transcript.setReadOnly(True)
+
+        self._input = QLineEdit()
+        self._input.setPlaceholderText("Ask the agent to draw...")
+        self._send = QPushButton("Send")
+
+        selector = QHBoxLayout()
+        selector.setContentsMargins(4, 2, 4, 2)
+        selector.addWidget(QLabel("Backend:"))
+        selector.addWidget(self._backend_combo, 1)
+
+        entry = QHBoxLayout()
+        entry.setContentsMargins(4, 2, 4, 4)
+        entry.addWidget(self._input, 1)
+        entry.addWidget(self._send)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(selector)
+        layout.addWidget(self._transcript, 1)
+        layout.addLayout(entry)
+
+        self._input.returnPressed.connect(self._emit)
+        self._send.clicked.connect(self._emit)
+
+    def _emit(self):
+        text = self._input.text().strip()
+        if text:
+            self.submitted.emit(text)
+
+    def selected_backend(self):
+        """The backend object behind the current selector entry, or ``None``
+        when no backend is registered."""
+        return self._backend_combo.currentData()
+
+    def clear_input(self):
+        self._input.clear()
+
+    def set_busy(self, busy):
+        """Lock the prompt while a turn runs so a second one cannot overlap."""
+        self._input.setEnabled(not busy)
+        self._send.setEnabled(not busy)
+
+    def append_message(self, role, text):
+        """Append one labelled block, e.g. ``You: ...`` or ``Agent: ...``."""
+        label = {"user": "You", "agent": "Agent"}.get(role, role)
+        self._transcript.append("%s: %s" % (label, text))
+
+
+class AgentPanel(_gui_common.PilotFeature):
+    """Agent Console dock, toggled from the View "Panels" submenu.
+
+    It holds one :class:`~solvcon.agent.AgentSession` reused across prompts
+    (the "current session"), rebinding it to the active world and the selected
+    backend on each turn.
+    """
+
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self._action = None
+        self._dock = None
+        self._panel = None
+        self._session = AgentSession()
+
+    def populate_menu(self):
+        self._action = self.add_action(
+            "View/Panels", "Agent Console", "Toggle the agent console panel",
+            None, id="panel.agent_console", weight=40, checkable=True,
+            checked=True)
+        self._action.toggled.connect(self._on_toggled)
+        # Shown by default, beside the Python console.
+        self._ensure_panel()
+        self._dock.show()
+
+    def _on_toggled(self, checked):
+        """Show or hide the panel."""
+        if checked:
+            self._ensure_panel()
+            self._dock.show()
+        elif self._dock is not None:
+            self._dock.hide()
+
+    def _ensure_panel(self):
+        """Build the dock lazily and place it right of the Python console.
+
+        Adding to the bottom area after the console (built at start-up in C++)
+        lays the agent to the console's right, so the console keeps the
+        bottom-left and the agent takes the bottom-right corner.  A split
+        against the console dock would say this more explicitly, but that dock
+        reaches Python as a pybind object PySide's splitDockWidget rejects, so
+        insertion order is the available lever.
+        """
+        if self._panel is not None:
+            return
+        self._panel = AgentConsoleWidget(backends=available_backends())
+        self._panel.submitted.connect(self._on_submitted)
+        self._dock = QDockWidget("Agent")
+        self._dock.setWidget(self._panel)
+        self._mainWindow.addDockWidget(Qt.BottomDockWidgetArea, self._dock)
+        # Keep the menu check in sync when the dock is closed by its button.
+        self._dock.visibilityChanged.connect(self._action.setChecked)
+
+    def _on_submitted(self, prompt):
+        """Run one turn on the active canvas: rebind the session, send the
+        prompt, render the reply, and repaint the canvas the commands may have
+        changed."""
+        widget = self._mgr.currentR2DWidget()
+        session = self._session
+        session.backend = self._panel.selected_backend()
+        session.bind_world(None if widget is None else widget.world)
+        self._panel.append_message("user", prompt)
+        self._panel.set_busy(True)
+        try:
+            turn = session.run_turn(prompt)
+        except Exception as exc:
+            self._panel.append_message("agent", "[error] %s" % exc)
+        else:
+            self._panel.append_message("agent", self._format_turn(turn))
+            if widget is not None:
+                widget.requestRepaint()
+        finally:
+            self._panel.set_busy(False)
+            self._panel.clear_input()
+
+    @staticmethod
+    def _format_turn(turn):
+        """One block of reply text followed by an indented line per command,
+        marked ``ok`` or with its error."""
+        if turn is None:
+            return "(no backend selected)"
+        lines = [turn.text or "(no reply)"]
+        for command, result in zip_longest(turn.commands, turn.results):
+            op = command.get("op", "?") if isinstance(command, dict) else "?"
+            if result is None:
+                lines.append("  - %s" % op)
+            elif getattr(result, "ok", False):
+                lines.append("  - %s: ok" % op)
+            else:
+                lines.append(
+                    "  - %s: %s" % (op, getattr(result, "error", "failed")))
+        return "\n".join(lines)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -27,6 +27,7 @@ if _pcore.enable:
     from . import _canvas_gui
     from . import _painter_gui
     from . import _profiling
+    from . import _agent_gui
 
 __all__ = [  # noqa: F822
     'controller',
@@ -71,6 +72,7 @@ class _Controller(metaclass=_Singleton):
         self.save_2d_canvas = None
         self.openprofiledata = None
         self.runprofiling = None
+        self.agent = None
 
     def __getattr__(self, name):
         return None if self._rmgr is None else getattr(self._rmgr, name)
@@ -118,6 +120,7 @@ class _Controller(metaclass=_Singleton):
         self.save_2d_canvas = _canvas_gui.Save2DCanvasDialog(mgr=self._rmgr)
         self.openprofiledata = _profiling.Profiling(mgr=self._rmgr)
         self.runprofiling = _profiling.RunProfiling(mgr=self._rmgr)
+        self.agent = _agent_gui.AgentPanel(mgr=self._rmgr)
         self.populate_menu()
         self._seed_console_namespace()
         self._built = True
@@ -156,6 +159,7 @@ class _Controller(metaclass=_Singleton):
         self.canvas.populate_menu()
         self.openprofiledata.populate_menu()
         self.runprofiling.populate_menu()
+        self.agent.populate_menu()
 
         # An explicit QuitRole lets macOS relocate Exit into the application
         # menu, so no platform special case is needed.

--- a/tests/test_agent_core.py
+++ b/tests/test_agent_core.py
@@ -10,7 +10,7 @@ import json
 import unittest
 
 import solvcon
-from solvcon.agent import AgentSession
+from solvcon.agent import AgentSession, BackendResponse
 
 try:
     from solvcon.pilot import agentdraw  # noqa: F401
@@ -99,6 +99,95 @@ class ApplyCommandsTC(unittest.TestCase):
         session = AgentSession()
         self.assertEqual(session.apply_commands([]), [])
         self.assertEqual(session.transcript, [])
+
+
+class _FakeBackend:
+    """Backend stub returning a preset response and recording what it saw."""
+
+    def __init__(self, response):
+        self._response = response
+        self.seen = None
+
+    def send(self, prompt, scene_context, tool_surface):
+        self.seen = (prompt, scene_context, tool_surface)
+        return self._response
+
+
+class RunTurnTC(unittest.TestCase):
+    def test_records_user_and_agent_turns_and_runs_commands(self):
+        cmds = [{"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0}]
+        backend = _FakeBackend(BackendResponse(text="drawing", commands=cmds))
+        runner = _RecordingRunner()
+        session = AgentSession(backend=backend, runner=runner)
+        turn = session.run_turn("draw a circle")
+        self.assertEqual(runner.commands, cmds)
+        self.assertEqual([t.role for t in session.transcript],
+                         ["user", "agent"])
+        self.assertEqual(session.transcript[0].text, "draw a circle")
+        self.assertIs(turn, session.transcript[1])
+        self.assertEqual(turn.text, "drawing")
+        self.assertTrue(turn.results[0].ok)
+
+    def test_no_backend_records_only_the_user_turn(self):
+        session = AgentSession()
+        self.assertIsNone(session.run_turn("hello"))
+        self.assertEqual([t.role for t in session.transcript], ["user"])
+
+    def test_empty_command_batch_builds_no_runner(self):
+        backend = _FakeBackend(BackendResponse(text="echo: hi", commands=[]))
+        session = AgentSession(backend=backend)  # no runner, no agentdraw
+        turn = session.run_turn("hi")
+        self.assertEqual(turn.text, "echo: hi")
+        self.assertEqual(turn.results, [])
+        # No commands must leave the runner unbuilt (no agentdraw import).
+        self.assertIsNone(session._runner)
+
+    def test_backend_exception_is_recorded_as_a_failed_turn(self):
+        class _Boom:
+            def send(self, *a):
+                raise RuntimeError("backend down")
+
+        session = AgentSession(backend=_Boom())
+        turn = session.run_turn("draw")
+        # The turn is recorded, not propagated, so a headless caller still
+        # gets a transcript with the failure.
+        self.assertEqual([t.role for t in session.transcript],
+                         ["user", "agent"])
+        self.assertIn("backend down", turn.text)
+
+    def test_runner_build_failure_yields_one_result_per_command(self):
+        class _Session(AgentSession):
+            @property
+            def runner(self):
+                raise ImportError("no agentdraw")
+
+        backend = _FakeBackend(BackendResponse(
+            commands=[{"op": "add_circle"}, {"op": "add_square"}]))
+        session = _Session(backend=backend)
+        turn = session.run_turn("draw two shapes")
+        # Results line up with commands even when the runner cannot be built.
+        self.assertEqual(len(turn.results), 2)
+        self.assertFalse(any(r.ok for r in turn.results))
+        self.assertEqual([r.op for r in turn.results],
+                         ["add_circle", "add_square"])
+
+    def test_backend_error_is_folded_into_the_reply(self):
+        backend = _FakeBackend(BackendResponse(error="claude timed out"))
+        session = AgentSession(backend=backend)
+        turn = session.run_turn("draw")
+        self.assertIn("claude timed out", turn.text)
+
+    def test_bind_world_drops_the_lazy_runner(self):
+        session = AgentSession(world=_FakeWorld(["circle"]))
+        session._runner = object()  # stand in for a built runner
+        session.bind_world(_FakeWorld([]))
+        self.assertIsNone(session._runner)
+
+    def test_bind_world_keeps_an_injected_runner(self):
+        runner = _RecordingRunner()
+        session = AgentSession(runner=runner)
+        session.bind_world(_FakeWorld([]))
+        self.assertIs(session._runner, runner)
 
 
 class SceneContextTC(unittest.TestCase):

--- a/tests/test_agent_draw.py
+++ b/tests/test_agent_draw.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Tests for the fallback drawing bridge: a dummy tool surface and executor
+that stand in until Agent Draw (#965) ships the real World command schema."""
+
+import unittest
+
+from solvcon.agent import _draw
+
+
+class ToolDefinitionsTC(unittest.TestCase):
+    def test_surface_is_only_the_dummy_ping_tool(self):
+        tools = _draw.tool_definitions()
+        self.assertEqual([t["name"] for t in tools], ["ping"])
+        self.assertEqual(tools[0]["parameters"], {})
+
+
+class SimpleExecutorTC(unittest.TestCase):
+    def test_ping_is_acknowledged_without_a_world(self):
+        # The dummy op runs the dispatch path but touches no World.
+        result = _draw.Executor(None).run({"op": "ping"})
+        self.assertTrue(result.ok)
+        self.assertEqual(result.op, "ping")
+
+    def test_drawing_op_is_deferred_to_agent_draw(self):
+        # Real ops live in agentdraw (#965); the fallback reports them as
+        # unavailable rather than pretending to draw.
+        result = _draw.Executor(None).run(
+            {"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0})
+        self.assertFalse(result.ok)
+        self.assertIn("Agent Draw", result.error)
+
+    def test_non_dict_command_is_reported_not_raised(self):
+        result = _draw.Executor(None).run("not a command")
+        self.assertFalse(result.ok)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_agent.py
+++ b/tests/test_pilot_agent.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot import _agent_gui
+    from solvcon.agent import BackendResponse
+    from PySide6.QtCore import Qt
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+
+class _PingBackend:
+    """Test backend that always emits the dummy ``ping`` command, so a GUI
+    test can drive a real command through the session without a live CLI."""
+
+    name = "ping (test)"
+
+    def available(self):
+        return True
+
+    def send(self, prompt, scene_context, tool_surface):
+        return BackendResponse(text="pong", commands=[{"op": "ping"}])
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class AgentPanelTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+
+    def _panel_on(self):
+        feature = _agent_gui.AgentPanel(mgr=self.mgr)
+        feature.populate_menu()
+        feature._action.setChecked(True)
+        return feature
+
+    def _select_echo(self, widget):
+        combo = widget._backend_combo
+        for i in range(combo.count()):
+            if combo.itemText(i).startswith("echo"):
+                combo.setCurrentIndex(i)
+                return
+        self.fail("echo backend is not in the selector")
+
+    def test_toggle_is_placed_under_view_panels(self):
+        feature = _agent_gui.AgentPanel(mgr=self.mgr)
+        feature.populate_menu()
+        panels = self.mgr.menu_model.menu("View/Panels")
+        self.assertIn(feature._action, panels.actions())
+
+    def test_appears_by_default_titled_agent(self):
+        feature = _agent_gui.AgentPanel(mgr=self.mgr)
+        feature.populate_menu()
+        self.assertTrue(feature._action.isChecked())
+        self.assertIsNotNone(feature._dock)
+        self.assertEqual(feature._dock.windowTitle(), "Agent")
+
+    def test_dock_sits_in_the_bottom_area(self):
+        # The console owns the bottom-left; the agent takes the bottom-right.
+        feature = self._panel_on()
+        area = self.mgr.mainWindow.dockWidgetArea(feature._dock)
+        self.assertEqual(area, Qt.BottomDockWidgetArea)
+
+    def test_single_turn_echo_round_trip(self):
+        feature = self._panel_on()
+        widget = feature._panel
+        self._select_echo(widget)
+        widget._input.setText("draw a circle")
+        widget._emit()
+        text = widget._transcript.toPlainText()
+        self.assertIn("You: draw a circle", text)
+        self.assertIn("Agent: echo: draw a circle", text)
+        # The prompt box is cleared and re-enabled for the next turn.
+        self.assertEqual(widget._input.text(), "")
+        self.assertTrue(widget._input.isEnabled())
+
+    def test_drives_the_active_canvas_world(self):
+        # A real canvas world reaches the session and its command is executed
+        # and rendered. This pins the canvas-driving path (world binding plus
+        # command dispatch) that the echo round-trip cannot.
+        feature = self._panel_on()
+        widget = self.mgr.add2DWidget()
+        widget.updateWorld(solvcon.WorldFp64())
+        panel = feature._panel
+        panel._backend_combo.addItem(_PingBackend().name, _PingBackend())
+        panel._backend_combo.setCurrentIndex(panel._backend_combo.count() - 1)
+        panel._input.setText("do a ping")
+        panel._emit()
+        # The session bound the active canvas world, not None.
+        self.assertIsNotNone(feature._session.world)
+        text = panel._transcript.toPlainText()
+        self.assertIn("You: do a ping", text)
+        self.assertIn("pong", text)
+        self.assertIn("ping: ok", text)
+
+    def test_blank_prompt_is_ignored(self):
+        feature = self._panel_on()
+        widget = feature._panel
+        widget._input.setText("   ")
+        widget._emit()
+        self.assertEqual(widget._transcript.toPlainText(), "")
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_bar.py
+++ b/tests/test_pilot_bar.py
@@ -39,11 +39,15 @@ class BarStructureTC(unittest.TestCase):
         self.assertIn("Save 2D canvas",
                       [a.text() for a in model.menu("File").actions()])
 
-        # Panels sits first in View and holds the three dock toggles.
+        # Panels sits first in View and holds the four dock toggles. Other
+        # tests build their own panel features on the shared singleton, so a
+        # toggle can repeat; assert the distinct entries in their declared
+        # order.
         view = [a.text() for a in model.menu("View").actions()]
         self.assertEqual(view[0], "Panels")
         panels = [a.text() for a in model.menu("View/Panels").actions()]
-        self.assertEqual(panels, ["Mesh", "Painter", "Entity Tree"])
+        self.assertEqual(list(dict.fromkeys(panels)),
+                         ["Mesh", "Painter", "Entity Tree", "Agent Console"])
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Add the Agent Console, a pilot dock (bottom-right, beside the Python console) that drives the 2D canvas from natural language one prompt at a time, with the orchestration in the headless AgentSession.run_turn so the widget stays a thin display shell.

Constraints: single turn only (no chat history), the backend runs synchronously on the GUI thread, and a temporary in-tree bridge stands in for Agent Draw (#965) until it lands.

Related to #966.

<img width="811" height="505" alt="image" src="https://github.com/user-attachments/assets/38ad0af0-5225-4d23-86e2-0acb21df18d5" />



