### PR TITLE
Load sample meshes from the pilot console

### DIFF
--- a/solvcon/apputil.py
+++ b/solvcon/apputil.py
@@ -289,6 +289,17 @@ def build_pilot_namespace(mgr):
         """List the meshes currently loaded in the 3D viewers."""
         return [w.mesh for w in mgr.list3DWidgets() if w.mesh is not None]
 
+    def load_mesh(name):
+        """Build a built-in sample mesh, show it in a fresh 3D viewer, and
+        return the viewer.  Call sample_meshes() for the available names."""
+        from .pilot import _mesh
+        return show_mesh(_mesh.SampleMesh().make(name))
+
+    def sample_meshes():
+        """List the names of the built-in sample meshes."""
+        from .pilot import _mesh
+        return list(_mesh.SampleMesh.names())
+
     viewer = mgr.currentR3DWidget()
     handles = {
         'mgr': mgr,
@@ -297,6 +308,8 @@ def build_pilot_namespace(mgr):
         'show_mesh': show_mesh,
         'viewers': viewers,
         'meshes': meshes,
+        'load_mesh': load_mesh,
+        'sample_meshes': sample_meshes,
         'run_worker': run_worker,
     }
     entries = [
@@ -306,6 +319,8 @@ def build_pilot_namespace(mgr):
         ('show_mesh(m)', 'open a mesh in a fresh 3D viewer'),
         ('viewers()', 'list the open 3D viewers'),
         ('meshes()', 'list the loaded meshes'),
+        ('load_mesh(name)', 'show a built-in sample mesh by name'),
+        ('sample_meshes()', 'list the built-in sample-mesh names'),
         ('run_worker(f)', 'run f on a worker thread; returns a Future'),
         ('sc', 'the solvcon package'),
     ]

--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -102,7 +102,7 @@ class _Controller(metaclass=_Singleton):
 
         self.gmsh_dialog = _mesh.GmshFileDialog(mgr=self._rmgr)
         self.svg_dialog = _svg_gui.SVGFileDialog(mgr=self._rmgr)
-        self.sample_mesh = _mesh.SampleMesh(mgr=self._rmgr)
+        self.sample_mesh = _mesh.SampleMeshFeature(mgr=self._rmgr)
         self.mesh_style_status = _mesh.MeshStyleStatus(mgr=self._rmgr)
         self.mesh_info = _mesh_info.MeshInfo(
             mgr=self._rmgr, style_status=self.mesh_style_status)

--- a/solvcon/pilot/_mesh.py
+++ b/solvcon/pilot/_mesh.py
@@ -15,39 +15,30 @@ from . import _gui_common
 
 __all__ = [  # noqa: F822
     'SampleMesh',
+    'SampleMeshFeature',
     'MeshStyleStatus',
     'GmshFileDialog',
 ]
 
 
-class SampleMesh(_gui_common.PilotFeature):
+class SampleMesh:
     """
-    Create sample mesh windows.
+    The built-in sample meshes as data.
+
+    Each ``mesh_*`` method builds and returns a :class:`StaticMesh` with no
+    Qt, so the same example meshes serve the GUI feature and the console.
     """
 
-    def mesh_sample_dialog_entries(self):
-        """``(category, label, tip, func)`` for each sample this feature can
-        create; consumed by :class:`SampleMeshDialog`."""
-        return [
-            ("Basic shapes", "Triangle (2D)",
-             "Create a very simple sample mesh of a triangle",
-             self.mesh_triangle),
-            ("Basic shapes", "Tetrahedron (3D)",
-             "Create a very simple sample mesh of a tetrahedron",
-             self.mesh_tetrahedron),
-            ("Basic shapes", "\"solvcon\" text (2D)",
-             "Create a sample mesh drawing a text string of \"solvcon\"",
-             self.mesh_solvcon_2dtext),
-            ("Mixed elements", "Small (2D)",
-             "Create a small sample mesh of mixed elements in 2D",
-             self.mesh_2dmix_small),
-            ("Mixed elements", "Larger (2D)",
-             "Create a larger simple sample mesh of mixed elements in 2D",
-             self.mesh_2dmix_large),
-            ("Mixed elements", "3D",
-             "Create a very simple sample mesh of mixed elements in 3D",
-             self.mesh_3dmix),
-        ]
+    def make(self, name):
+        """Build and return the sample mesh named ``name``, e.g. 'tetrahedron'
+        for :meth:`mesh_tetrahedron`."""
+        return getattr(self, 'mesh_' + name)()
+
+    @classmethod
+    def names(cls):
+        """The sample-mesh names, in definition (menu) order."""
+        return tuple(name[len('mesh_'):] for name in vars(cls)
+                     if name.startswith('mesh_'))
 
     def mesh_triangle(self):
         mh = core.StaticMesh(ndim=2, nnode=4, nface=0, ncell=3)
@@ -57,10 +48,7 @@ class SampleMesh(_gui_common.PilotFeature):
         mh.build_interior()
         mh.build_boundary()
         mh.build_ghost()
-        w_tri = self._mgr.add3DWidget()
-        w_tri.updateMesh(mh)
-        w_tri.showAxis(True)
-        self._pycon.writeToHistory(f"tri nedge: {mh.nedge}\n")
+        return mh
 
     def mesh_tetrahedron(self):
         mh = core.StaticMesh(ndim=3, nnode=4, nface=4, ncell=1)
@@ -70,10 +58,7 @@ class SampleMesh(_gui_common.PilotFeature):
         mh.build_interior()
         mh.build_boundary()
         mh.build_ghost()
-        w_tet = self._mgr.add3DWidget()
-        w_tet.updateMesh(mh)
-        w_tet.showAxis(True)
-        self._pycon.writeToHistory(f"tet nedge: {mh.nedge}\n")
+        return mh
 
     def mesh_solvcon_2dtext(self):
         Q = core.StaticMesh.QUADRILATERAL
@@ -178,11 +163,7 @@ class SampleMesh(_gui_common.PilotFeature):
         mh.build_interior()
         mh.build_boundary()
         mh.build_ghost()
-        # Open a sub window for solvcon icon:
-        w_solvcon = self._mgr.add3DWidget()
-        w_solvcon.updateMesh(mh)
-        w_solvcon.showAxis(True)
-        self._pycon.writeToHistory(f"solvcon text nedge: {mh.nedge}\n")
+        return mh
 
     def mesh_2dmix_small(self):
         T = core.StaticMesh.TRIANGLE
@@ -201,12 +182,7 @@ class SampleMesh(_gui_common.PilotFeature):
         mh.build_interior()
         mh.build_boundary()
         mh.build_ghost()
-
-        # Open a sub window for small 2D mix mesh.
-        w_small2d = self._mgr.add3DWidget()
-        w_small2d.updateMesh(mh)
-        w_small2d.showAxis(True)
-        self._mgr.pycon.writeToHistory(f"2dmix large nedge: {mh.nedge}\n")
+        return mh
 
     def mesh_2dmix_large(self):
         T = core.StaticMesh.TRIANGLE
@@ -237,12 +213,7 @@ class SampleMesh(_gui_common.PilotFeature):
         mh.build_interior()
         mh.build_boundary()
         mh.build_ghost()
-
-        # Open a sub window for larger 2D mix mesh.
-        w_large2d = self._mgr.add3DWidget()
-        w_large2d.updateMesh(mh)
-        w_large2d.showAxis(True)
-        self._mgr.pycon.writeToHistory(f"2dmix large nedge: {mh.nedge}\n")
+        return mh
 
     def mesh_3dmix(self):
         HEX = core.StaticMesh.HEXAHEDRON
@@ -267,12 +238,68 @@ class SampleMesh(_gui_common.PilotFeature):
         mh.build_interior()
         mh.build_boundary()
         mh.build_ghost()
+        return mh
 
-        # Open a sub window for triangles and quadrilaterals:
-        w_3dmix = self._mgr.add3DWidget()
-        w_3dmix.updateMesh(mh)
-        w_3dmix.showAxis(True)
-        self._mgr.pycon.writeToHistory(f"3dmix nedge: {mh.nedge}\n")
+
+class SampleMeshFeature(_gui_common.PilotFeature):
+    """
+    Create sample mesh windows from the built-in example meshes.
+    """
+
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self._samples = SampleMesh()
+
+    def mesh_sample_dialog_entries(self):
+        """``(category, label, tip, func)`` for each sample this feature can
+        create; consumed by :class:`SampleMeshDialog`."""
+        return [
+            ("Basic shapes", "Triangle (2D)",
+             "Create a very simple sample mesh of a triangle",
+             self.mesh_triangle),
+            ("Basic shapes", "Tetrahedron (3D)",
+             "Create a very simple sample mesh of a tetrahedron",
+             self.mesh_tetrahedron),
+            ("Basic shapes", "\"solvcon\" text (2D)",
+             "Create a sample mesh drawing a text string of \"solvcon\"",
+             self.mesh_solvcon_2dtext),
+            ("Mixed elements", "Small (2D)",
+             "Create a small sample mesh of mixed elements in 2D",
+             self.mesh_2dmix_small),
+            ("Mixed elements", "Larger (2D)",
+             "Create a larger simple sample mesh of mixed elements in 2D",
+             self.mesh_2dmix_large),
+            ("Mixed elements", "3D",
+             "Create a very simple sample mesh of mixed elements in 3D",
+             self.mesh_3dmix),
+        ]
+
+    def _show(self, name):
+        """Build the sample mesh named ``name`` and open it in a fresh 3D
+        viewer, echoing its edge count to the console."""
+        mh = self._samples.make(name)
+        w = self._mgr.add3DWidget()
+        w.updateMesh(mh)
+        w.showAxis(True)
+        self._pycon.writeToHistory(f"{name} nedge: {mh.nedge}\n")
+
+    def mesh_triangle(self):
+        self._show('triangle')
+
+    def mesh_tetrahedron(self):
+        self._show('tetrahedron')
+
+    def mesh_solvcon_2dtext(self):
+        self._show('solvcon_2dtext')
+
+    def mesh_2dmix_small(self):
+        self._show('2dmix_small')
+
+    def mesh_2dmix_large(self):
+        self._show('2dmix_large')
+
+    def mesh_3dmix(self):
+        self._show('3dmix')
 
 
 class SampleMeshDialog(_gui_common.PilotFeature):

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -151,9 +151,12 @@ class PilotNamespaceTC(unittest.TestCase):
         self.assertIsNone(g['viewer'])
         self.assertIsNone(g['mesh'])
         self.assertTrue(callable(g['show_mesh']))
+        self.assertTrue(callable(g['load_mesh']))
+        self.assertTrue(callable(g['sample_meshes']))
         self.assertTrue(callable(g['run_worker']))
         self.assertIn('mgr', banner)
         self.assertIn('show_mesh(m)', banner)
+        self.assertIn('load_mesh(name)', banner)
 
     def test_show_mesh_opens_a_viewer(self):
         from solvcon import apputil
@@ -177,6 +180,31 @@ class PilotNamespaceTC(unittest.TestCase):
         self.mgr.add3DWidget().updateMesh(sentinel)
         self.env.run_code('pass')
         self.assertIs(self.env.globals['mesh'], sentinel)
+
+    @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+    def test_sample_meshes_lists_the_known_names(self):
+        from solvcon import apputil
+        apputil.install_pilot_namespace(self.mgr, self.env)
+        names = self.env.globals['sample_meshes']()
+        self.assertIn('tetrahedron', names)
+        self.assertIn('3dmix', names)
+
+    @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+    def test_load_mesh_shows_a_named_sample(self):
+        from solvcon import apputil
+        apputil.install_pilot_namespace(self.mgr, self.env)
+        viewer = self.env.globals['load_mesh']('tetrahedron')
+        # A real StaticMesh is built and opened in a fresh viewer.
+        self.assertEqual(viewer.mesh.ndim, 3)
+        self.assertTrue(viewer.axis)
+        self.assertEqual(self.env.globals['viewers'](), [viewer])
+
+    @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+    def test_load_mesh_rejects_an_unknown_name(self):
+        from solvcon import apputil
+        apputil.install_pilot_namespace(self.mgr, self.env)
+        with self.assertRaises(AttributeError):
+            self.env.globals['load_mesh']('no_such_mesh')
 
 
 class HousekeepingTC(unittest.TestCase):

--- a/tests/test_pilot_mesh.py
+++ b/tests/test_pilot_mesh.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import unittest
+
+import solvcon
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class SampleMeshTC(unittest.TestCase):
+    """The non-GUI sample-mesh data class and its name discovery."""
+
+    def setUp(self):
+        from solvcon.pilot import _mesh
+        self.samples = _mesh.SampleMesh()
+
+    def test_every_discovered_name_builds_a_mesh(self):
+        for name in self.samples.names():
+            mh = self.samples.make(name)
+            self.assertIn(mh.ndim, (2, 3))
+            self.assertGreater(mh.ncell, 0)
+
+    def test_dimensionality_of_named_samples(self):
+        self.assertEqual(self.samples.make('triangle').ndim, 2)
+        self.assertEqual(self.samples.make('tetrahedron').ndim, 3)
+        self.assertEqual(self.samples.make('3dmix').ndim, 3)
+
+    def test_names_derive_from_the_mesh_methods(self):
+        self.assertEqual(
+            self.samples.names(),
+            ('triangle', 'tetrahedron', 'solvcon_2dtext',
+             '2dmix_small', '2dmix_large', '3dmix'))
+
+    def test_unknown_name_is_rejected(self):
+        with self.assertRaises(AttributeError):
+            self.samples.make('bogus')
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
This PR separates the sample-mesh data from the GUI feature, then exposes it in the pilot console as two short handles. Users can use `load_mesh()` in the console to create a new sub-window and load the sample mesh in it:

```python
sample_meshes()
# ['triangle', 'tetrahedron', 'solvcon_2dtext', '2dmix_small', '2dmix_large', '3dmix']

load_mesh('tetrahedron')     # builds and opens the mesh in a new 3D viewer
load_mesh('3dmix')           # a 3D mixed-element mesh
```

You can also get the sub-window and its mesh object from the console:

```python
viewer = load_mesh('triangle')   # the viewer is returned for further work
show_mesh(viewer.mesh)           # the mesh is a plain StaticMesh you can reuse
```

For issue #1027.