### PR TITLE
Own `QApplication` only when the pilot creates it

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -33,13 +33,19 @@ RManager & RManager::instance()
 RManager::RManager()
     : QObject()
 {
-    m_core.reset(QApplication::instance());
-    static int argc = 1;
-    static char exename[] = "pilot";
-    static char * argv[] = {exename};
-    if (!m_core)
+    if (QCoreApplication * const existing = QApplication::instance())
     {
-        m_core.reset(new QApplication(argc, argv));
+        // Borrow an application another runtime owns, for example the one
+        // PySide6 creates when the pilot is embedded in Python.
+        m_core = existing;
+    }
+    else
+    {
+        static int argc = 1;
+        static char exename[] = "pilot";
+        static char * argv[] = {exename};
+        m_owned_core = std::make_unique<QApplication>(argc, argv);
+        m_core = m_owned_core.get();
     }
 
     m_mainWindow = new QMainWindow;
@@ -74,7 +80,8 @@ void RManager::reset()
     {
         m_menuModel->clear();
     }
-    m_core.reset();
+    m_owned_core.reset(); // Deletes the application only if the pilot made it.
+    m_core = nullptr;
     m_mainWindow = nullptr;
     m_menuModel = nullptr;
     m_pycon = nullptr;

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -57,7 +57,7 @@ public:
 
     static RManager & instance();
 
-    QCoreApplication * core() { return m_core.get(); }
+    QCoreApplication * core() { return m_core; }
 
     RDomainWidget * add3DWidget();
     R2DWidget * add2DWidget();
@@ -122,7 +122,11 @@ private:
 
     bool m_already_setup = false;
 
-    std::unique_ptr<QCoreApplication> m_core = nullptr;
+    /// Non-owning handle, possibly borrowed from another runtime (PySide6).
+    QCoreApplication * m_core = nullptr;
+
+    /// Owns the application only when the pilot created it, null otherwise.
+    std::unique_ptr<QApplication> m_owned_core = nullptr;
 
     QMainWindow * m_mainWindow = nullptr;
 


### PR DESCRIPTION
`RManager` held the application object in a single owning `std::unique_ptr<QCoreApplication>` that adopted whatever `QApplication::instance()` returned. When the pilot is embedded in Python, PySide6 has already created that application and owns it, so the owning handle made RManager a second owner. Not good.

For issue #990.