### PR TITLE
Add `SimpleArray::where`

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -1381,6 +1381,9 @@ public:
 
     SimpleArray<uint64_t> argwhere() const;
 
+    template <typename U>
+    SimpleArray<U> where(SimpleArray<U> const & x, SimpleArray<U> const & y) const;
+
 }; /* end class SimpleArrayMixinSearch */
 
 template <typename A, typename T>
@@ -2788,6 +2791,32 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argwhere() const
             offset %= stride;
         }
         ++idx;
+    }
+
+    return result;
+}
+
+template <typename A, typename T>
+template <typename U>
+SimpleArray<U> detail::SimpleArrayMixinSearch<A, T>::where(SimpleArray<U> const & x, SimpleArray<U> const & y) const
+{
+    auto athis = static_cast<A const *>(this);
+
+    static_assert(std::is_same_v<T, bool>, "SimpleArray::where() requires a boolean array");
+
+    if (athis->shape() != x.shape() || athis->shape() != y.shape())
+    {
+        throw std::invalid_argument(std::format(
+            "SimpleArray::where(): shape mismatch: condition={} x={} y={}",
+            format_shape(athis->shape()),
+            format_shape(x.shape()),
+            format_shape(y.shape())));
+    }
+
+    SimpleArray<U> result(athis->shape());
+    for (size_t i = 0; i < athis->size(); ++i)
+    {
+        result.data(i) = athis->data(i) ? x.data(i) : y.data(i);
     }
 
     return result;

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -2813,11 +2813,30 @@ SimpleArray<U> detail::SimpleArrayMixinSearch<A, T>::where(SimpleArray<U> const 
             format_shape(y.shape())));
     }
 
-    SimpleArray<U> result(athis->shape());
-    for (size_t i = 0; i < athis->size(); ++i)
+    if (athis->nghost() != x.nghost() || athis->nghost() != y.nghost())
     {
-        result.data(i) = athis->data(i) ? x.data(i) : y.data(i);
+        throw std::invalid_argument(std::format(
+            "SimpleArray::where(): nghost mismatch: condition={} x={} y={}",
+            athis->nghost(),
+            x.nghost(),
+            y.nghost()));
     }
+
+    SimpleArray<U> result(athis->shape());
+    result.set_nghost(athis->nghost());
+
+    if (athis->shape().empty() || athis->size() == 0)
+    {
+        return result;
+    }
+
+    auto const range = IndexRange(*athis);
+    sshape_type idx = range.first();
+
+    do
+    {
+        result.at(idx) = athis->at(idx) ? x.at(idx) : y.at(idx);
+    } while (range.next(idx));
 
     return result;
 }

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -698,7 +698,70 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             //
             ;
 
+        if constexpr (std::is_same_v<T, bool>)
+        {
+            (*this).def(
+                "where",
+                &where,
+                py::arg("x"),
+                py::arg("y"));
+        }
+
         return *this;
+    }
+
+    static pybind11::object where(wrapped_type const & self, pybind11::object const & x, pybind11::object const & y)
+    {
+
+        std::string py_typename_x(pybind11::detail::obj_class_name(x.ptr()));
+        std::string py_typename_y(pybind11::detail::obj_class_name(y.ptr()));
+        const std::size_t found_x = py_typename_x.find("_solvcon.SimpleArray");
+        const std::size_t found_y = py_typename_y.find("_solvcon.SimpleArray");
+
+        if (found_x == std::string::npos || found_y == std::string::npos)
+        {
+            throw std::invalid_argument(
+                "SimpleArray::where(): x and y must be SimpleArray");
+        }
+
+        py_typename_x.replace(0, strlen("_solvcon.SimpleArray"), "");
+        py_typename_y.replace(0, strlen("_solvcon.SimpleArray"), "");
+        py_typename_x[0] = tolower(py_typename_x[0]);
+        py_typename_y[0] = tolower(py_typename_y[0]);
+
+        const DataType dt_x(py_typename_x);
+        const DataType dt_y(py_typename_y);
+
+        if (dt_x != dt_y)
+        {
+            throw std::invalid_argument(
+                "SimpleArray::where(): x and y must have the same dtype");
+        }
+
+#define DECL_MM_WHERE_TYPED(DataTypeName) \
+    case DataType::DataTypeName:          \
+        return pybind11::cast(self.where(x.cast<SimpleArray##DataTypeName>(), y.cast<SimpleArray##DataTypeName>()));
+
+        switch (dt_x)
+        {
+            DECL_MM_WHERE_TYPED(Int8)
+            DECL_MM_WHERE_TYPED(Int16)
+            DECL_MM_WHERE_TYPED(Int32)
+            DECL_MM_WHERE_TYPED(Int64)
+            DECL_MM_WHERE_TYPED(Uint8)
+            DECL_MM_WHERE_TYPED(Uint16)
+            DECL_MM_WHERE_TYPED(Uint32)
+            DECL_MM_WHERE_TYPED(Uint64)
+            DECL_MM_WHERE_TYPED(Float32)
+            DECL_MM_WHERE_TYPED(Float64)
+        default:
+            break;
+        }
+
+#undef DECL_MM_WHERE_TYPED
+
+        throw std::invalid_argument(
+            "SimpleArray::where(): unsupported dtype");
     }
 }; /* end class WrapSimpleArray */
 

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -760,8 +760,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
 
 #undef DECL_MM_WHERE_TYPED
 
-        throw std::invalid_argument(
-            "SimpleArray::where(): unsupported dtype");
+        throw std::invalid_argument("SimpleArray::where(): unsupported dtype");
     }
 }; /* end class WrapSimpleArray */
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -4183,28 +4183,92 @@ class SimpleArraySearchTC(unittest.TestCase):
         np.testing.assert_array_equal(ret.ndarray, np.argwhere(narr == 10))
 
     def test_where(self):
-        # test 1-D data
-        data = [1, 3, 5, 7, 9]
-        narr = np.array(data, dtype='uint64')
+        # test 1-D contiguous array
+        narr = np.arange(10, dtype='uint64')
         sarr = solvcon.SimpleArrayUint64(array=narr)
-
         np.testing.assert_array_equal(
             ((sarr < 5).where(sarr.add(1), sarr.mul(10))).ndarray,
             np.where(narr < 5, narr + 1, narr * 10)
         )
 
-        # test N-D data
-        data = [
-            [1, 3, 5, 7, 9],
-            [2, 4, 6, 8, 10],
-            [1, 10, 1, 10, 1]
-        ]
-        narr = np.array(data, dtype='float64')
+        # test 2-D contiguous array
+        narr = np.arange(12, dtype='float64').reshape(3, 4)
         sarr = solvcon.SimpleArrayFloat64(array=narr)
+        np.testing.assert_array_equal(
+            ((sarr < 6).where(sarr.add(1), sarr.mul(10))).ndarray,
+            np.where(narr < 6, narr + 1, narr * 10)
+        )
+
+        # test 3-D contiguous array
+        narr = np.arange(24, dtype='int32').reshape(2, 3, 4)
+        sarr = solvcon.SimpleArrayInt32(array=narr)
+        np.testing.assert_array_equal(
+            ((sarr < 12).where(sarr.add(1), sarr.mul(10))).ndarray,
+            np.where(narr < 12, narr + 1, narr * 10)
+        )
+
+        # test 4-D contiguous array
+        narr = np.arange(120, dtype='float32').reshape(2, 3, 4, 5)
+        sarr = solvcon.SimpleArrayFloat32(array=narr)
+        np.testing.assert_array_equal(
+            ((sarr < 60).where(sarr.add(1), sarr.mul(10))).ndarray,
+            np.where(narr < 60, narr + 1, narr * 10)
+        )
+
+        # test non-contiguous array
+        narr = np.arange(24, dtype='float64').reshape(4, 6)
+
+        cond_view = (narr < 12)[::2, ::2]
+        x_view = (narr + 1)[::2, ::2]
+        y_view = (narr * 10)[::2, ::2]
+
+        cond_sarr = solvcon.SimpleArrayBool(array=cond_view)
+        x_sarr = solvcon.SimpleArrayFloat64(array=x_view)
+        y_sarr = solvcon.SimpleArrayFloat64(array=y_view)
 
         np.testing.assert_array_equal(
-            ((sarr == 10).where(sarr.add(1), sarr.mul(10))).ndarray,
-            np.where(narr == 10, narr + 1, narr * 10)
+            ((cond_sarr).where(x_sarr, y_sarr)).ndarray,
+            np.where(cond_view, x_view, y_view)
+        )
+
+        # test c-contiguous and f-contiguous arrays
+        narr = np.arange(24, dtype='float32').reshape(4, 3, 2)
+        cond_narr = (narr < 12).copy(order='C')
+        x_narr = (narr + 1).copy(order='C')
+        y_narr = (narr * 10).copy(order='F')
+
+        cond_sarr = solvcon.SimpleArrayBool(array=cond_narr)
+        x_sarr = solvcon.SimpleArrayFloat32(array=x_narr)
+        y_sarr = solvcon.SimpleArrayFloat32(array=y_narr)
+
+        self.assertTrue(cond_sarr.is_c_contiguous)
+        self.assertTrue(x_sarr.is_c_contiguous)
+        self.assertTrue(y_sarr.is_f_contiguous)
+        self.assertFalse(x_sarr.is_f_contiguous)
+        self.assertFalse(y_sarr.is_c_contiguous)
+
+        np.testing.assert_array_equal(
+            ((cond_sarr).where(x_sarr, y_sarr)).ndarray,
+            np.where(cond_narr, x_narr, y_narr)
+        )
+
+        # test ghost array
+        narr = np.arange(24, dtype='float32').reshape(4, 3, 2)
+        cond_narr = (narr < 12)
+        x_narr = (narr + 1)
+        y_narr = (narr * 10)
+
+        cond_sarr = solvcon.SimpleArrayBool(array=cond_narr)
+        x_sarr = solvcon.SimpleArrayFloat32(array=x_narr)
+        y_sarr = solvcon.SimpleArrayFloat32(array=y_narr)
+
+        cond_sarr.nghost = 1
+        x_sarr.nghost = 1
+        y_sarr.nghost = 1
+
+        np.testing.assert_array_equal(
+            ((cond_sarr).where(x_sarr, y_sarr)).ndarray,
+            np.where(cond_narr, x_narr, y_narr)
         )
 
         # test condition dtype is not bool

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -4182,6 +4182,49 @@ class SimpleArraySearchTC(unittest.TestCase):
         ret = sarr.eq(10).argwhere()
         np.testing.assert_array_equal(ret.ndarray, np.argwhere(narr == 10))
 
+    def test_where(self):
+        # test 1-D data
+        data = [1, 3, 5, 7, 9]
+        narr = np.array(data, dtype='uint64')
+        sarr = solvcon.SimpleArrayUint64(array=narr)
+
+        np.testing.assert_array_equal(
+            ((sarr < 5).where(sarr.add(1), sarr.mul(10))).ndarray,
+            np.where(narr < 5, narr + 1, narr * 10)
+        )
+
+        # test N-D data
+        data = [
+            [1, 3, 5, 7, 9],
+            [2, 4, 6, 8, 10],
+            [1, 10, 1, 10, 1]
+        ]
+        narr = np.array(data, dtype='float64')
+        sarr = solvcon.SimpleArrayFloat64(array=narr)
+
+        np.testing.assert_array_equal(
+            ((sarr == 10).where(sarr.add(1), sarr.mul(10))).ndarray,
+            np.where(narr == 10, narr + 1, narr * 10)
+        )
+
+        # test condition dtype is not bool
+        sarr1 = solvcon.SimpleArrayInt32((2, 3), value=1)
+        with self.assertRaisesRegex(
+            AttributeError, r"has no attribute 'where'"
+        ):
+            sarr1.where(sarr1, sarr1.add(1))
+
+        # test shape mismatch
+        cond = solvcon.SimpleArrayBool((1, 3), value=True)
+        sarr2 = solvcon.SimpleArrayInt32((1, 2), value=2)
+        sarr3 = solvcon.SimpleArrayInt32((1, 2), value=3)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"SimpleArray::where\(\): shape mismatch: "
+            r"condition=\(1, 3\) x=\(1, 2\) y=\(1, 2\)"
+        ):
+            cond.where(sarr2, sarr3)
+
 
 class SimpleArrayPlexTC(unittest.TestCase):
 


### PR DESCRIPTION
<!---->
This PR adds `SimpleArray::where()` with NumPy-style three-argument semantics.

The Python API uses `condition.where(x, y)`, where the condition is a `SimpleArrayBool`.

The implementation dispatches `x` and `y` by their `SimpleArray` dtype in the Python wrapper, and returns a result array with the same dtype as `x` and `y`.

The first implementation supports existing numeric `SimpleArray` dtypes and requires `condition`, `x`, and `y` to have the same shape.

Broadcasting and scalar `x` or `y` inputs are left for follow-up work.

Tests compare the result against `numpy.where()` for 1-D and N-D arrays, and cover shape mismatch handling.

Related to #519.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->