### PR TITLE
Add a basic window manager to the Window menu

### DIFF
--- a/solvcon/pilot/_base_app.py
+++ b/solvcon/pilot/_base_app.py
@@ -372,6 +372,9 @@ class OneDimBaseApp(_gui_common.PilotFeature):
     use_grid_layout: bool = False
     adjust_region: bool = False
 
+    #: Title of the plot sub-window; the Window menu lists windows by it.
+    TITLE = "Base Window"
+
     def populate_menu(self):
         """
         Set menu item for GUI.
@@ -394,6 +397,7 @@ class OneDimBaseApp(_gui_common.PilotFeature):
 
         # A new sub-window (`QMdiSubWindow`) for the plot area
         self._subwin = self._mgr.addSubWindow(QWidget())
+        self._subwin.setWindowTitle(self.TITLE)
         self._subwin.setWidget(PlotArea(self))
         self._subwin.showMaximized()
         self._subwin.show()

--- a/solvcon/pilot/_burgers1d.py
+++ b/solvcon/pilot/_burgers1d.py
@@ -70,6 +70,7 @@ class Burgers1DApp(_base_app.OneDimBaseApp):
     """
     Main application for Burgers' equation 1D solver.
     """
+    TITLE = "Burgers equation"
     num_region: int = 3
     region_x: list = [-10.0, 0.0, 2.0, 5.0]
     region_velocity: list = [-0.5, 1.0, 0.5]

--- a/solvcon/pilot/_euler1d.py
+++ b/solvcon/pilot/_euler1d.py
@@ -12,6 +12,8 @@ class Euler1DApp(_base_app.OneDimBaseApp):
     Main application for Euler 1D solver.
     """
 
+    TITLE = "Euler solver"
+
     def populate_menu(self):
         """
         Set menu item for GUI.

--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -28,6 +28,7 @@ if _pcore.enable:
     from . import _profiling
     from . import _agent_gui
     from . import _theme
+    from . import _window_manager
 
 __all__ = [  # noqa: F822
     'controller',
@@ -73,6 +74,7 @@ class _Controller(metaclass=_Singleton):
         self.runprofiling = None
         self.agent = None
         self.theme_menu = None
+        self.window_manager = None
 
     def __getattr__(self, name):
         return None if self._rmgr is None else getattr(self._rmgr, name)
@@ -121,6 +123,7 @@ class _Controller(metaclass=_Singleton):
         self.runprofiling = _profiling.RunProfiling(mgr=self._rmgr)
         self.agent = _agent_gui.AgentPanel(mgr=self._rmgr)
         self.theme_menu = _theme.ThemeMenu(mgr=self._rmgr)
+        self.window_manager = _window_manager.WindowManager(mgr=self._rmgr)
         self.populate_menu()
         self._seed_console_namespace()
         self._built = True
@@ -160,6 +163,7 @@ class _Controller(metaclass=_Singleton):
         self.runprofiling.populate_menu()
         self.agent.populate_menu()
         self.theme_menu.populate_menu()
+        self.window_manager.populate_menu()
 
         # An explicit QuitRole lets macOS relocate Exit into the application
         # menu, so no platform special case is needed.
@@ -171,12 +175,12 @@ class _Controller(metaclass=_Singleton):
                 menu_role=QAction.MenuRole.QuitRole),
             100)
         wm.menu_model.place(
-            "Window",
+            "View/Panels",
             _gui_common.build_action(
                 wm.mainWindow, "Console", "Open / Close Console",
-                wm.toggleConsole, id="window.console",
+                wm.toggleConsole, id="panel.console",
                 checkable=True, checked=True),
-            50)
+            30)
 
 
 controller = _Controller()

--- a/solvcon/pilot/_linear_wave.py
+++ b/solvcon/pilot/_linear_wave.py
@@ -30,6 +30,8 @@ class LinearWave:
 
 class LinearWave1DApp(_base_app.OneDimBaseApp):
 
+    TITLE = "Linear Wave"
+
     def populate_menu(self):
         """
         Set menu item for GUI.

--- a/solvcon/pilot/_profiling.py
+++ b/solvcon/pilot/_profiling.py
@@ -72,6 +72,7 @@ class Profiling(_gui_common.PilotFeature):
 
     def _add_result_window(self, result: list[dict[str, typing.Any]]):
         self._table = self._mgr.addSubWindow(QWidget())
+        self._table.setWindowTitle("Profiling result")
         self._tree_view = QTreeView(self._table)
 
         self._model = QStandardItemModel(self._tree_view)
@@ -264,6 +265,7 @@ class RunProfiling(_gui_common.PilotFeature):
 
     def _add_result_window(self, result):
         self._table = self._mgr.addSubWindow(QWidget())
+        self._table.setWindowTitle("Profiling result")
         self._tree_view = QTreeView(self._table)
 
         self._model = QStandardItemModel(self._tree_view)

--- a/solvcon/pilot/_window_manager.py
+++ b/solvcon/pilot/_window_manager.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Window manager feature for pilot.
+
+List every open MDI sub-window under the "Window" menu and bring one to
+the foreground when its entry is chosen.
+"""
+
+from PySide6 import QtGui
+
+from . import _gui_common
+
+__all__ = [
+    'WindowManager',
+]
+
+
+class WindowManager(_gui_common.PilotFeature):
+    """List open MDI sub-windows under the "Window" menu.
+
+    One checkable action per open sub-window, labelled by its title.
+    Triggering an action activates that sub-window; the active one is
+    checked. The list is rebuilt each time the menu is about to show.
+    """
+
+    #: objectName tagging every dynamic per-sub-window action.
+    ITEM_ID = "window.subwindow"
+
+    def __init__(self, *args, **kw):
+        super(WindowManager, self).__init__(*args, **kw)
+        self._menu = None
+        self._items = []
+
+    def populate_menu(self):
+        """Anchor the dynamic list on the "Window" menu.
+
+        The menu holds nothing static (panel toggles live under
+        View/Panels), so the list is seeded right away: a native menu
+        bar hides an empty menu, and a hidden menu can never fire
+        aboutToShow to fill itself.
+        """
+        self._menu = self._mgr.menu_model.menu("Window")
+        self._menu.aboutToShow.connect(self._rebuild)
+        self._rebuild()
+
+    def _rebuild(self):
+        """Refresh the sub-window list to match the MDI area.
+
+        Drop the actions from the previous show, then append one checkable
+        action per visible sub-window in area order, checking the active
+        one. A disabled placeholder is shown when none are open.
+        """
+        for act in self._items:
+            self._menu.removeAction(act)
+            act.deleteLater()
+        self._items = []
+
+        mdi = self._mgr.mdiArea
+        active = mdi.activeSubWindow()
+        subwins = [s for s in mdi.subWindowList() if s.isVisible()]
+
+        if not subwins:
+            self._append_placeholder()
+            return
+
+        for subwin in enumerate(subwins):
+            self._append_item(subwin, subwin is active)
+
+    def _append_item(self, index, subwin, is_active):
+        """Append one checkable action that activates ``subwin``."""
+        title = subwin.windowTitle() or "window"
+        act = QtGui.QAction("%s" % (title), self._menu)
+        act.setObjectName(self.ITEM_ID)
+        act.setStatusTip("Bring '%s' to the foreground" % title)
+        act.setCheckable(True)
+        act.setChecked(is_active)
+        act.triggered.connect(
+            lambda checked=False, s=subwin: self._activate(s))
+        self._menu.addAction(act)
+        self._items.append(act)
+
+    def _append_placeholder(self):
+        """Append a disabled hint when no sub-window is open."""
+        act = QtGui.QAction("(No open windows)", self._menu)
+        act.setEnabled(False)
+        self._menu.addAction(act)
+        self._items.append(act)
+
+    def _activate(self, subwin):
+        """Bring ``subwin`` to the foreground, restoring if minimized."""
+        if subwin.isMinimized():
+            subwin.showNormal()
+        self._mgr.mdiArea.setActiveSubWindow(subwin)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_bar.py
+++ b/tests/test_pilot_bar.py
@@ -47,6 +47,12 @@ class BarStructureTC(unittest.TestCase):
         self.assertEqual(view[0], "Panels")
         panels = [a.text() for a in model.menu("View/Panels").actions()]
         self.assertEqual(list(dict.fromkeys(panels)),
-                         ["Inspector", "Painter", "Agent Console"])
+                         ["Inspector", "Painter", "Console", "Agent Console"])
+
+        # The Console toggle lives with the other panel toggles; the Window
+        # menu holds only the dynamic sub-window list.
+        self.assertIsNotNone(model.action("panel.console"))
+        self.assertNotIn("Console",
+                         [a.text() for a in model.menu("Window").actions()])
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_window_menu.py
+++ b/tests/test_pilot_window_menu.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Tests for the "Window" menu window manager.
+
+Exercise the dynamic sub-window list the WindowManager feature anchors
+under the "Window" menu: what it lists, which entry is checked, and what
+activating an entry does.
+"""
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot import _euler1d, _gui
+    from solvcon.pilot._window_manager import WindowManager
+    from PySide6 import QtWidgets
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class WindowMenuTC(unittest.TestCase):
+    """Drive the WindowManager list through the live "Window" menu."""
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.model = self.mgr.menu_model
+        self.area = self.mgr.mdiArea
+        # Show the manager so a freshly added sub-window reports visible; the
+        # list filters on isVisible() to tell open windows from closed ones.
+        self.mgr.show()
+        # The viewers do not delete on close, so an earlier test's windows
+        # linger hidden in the list; drop them before each case.
+        self.area.closeAllSubWindows()
+        QtWidgets.QApplication.processEvents()
+
+    def tearDown(self):
+        self.area.closeAllSubWindows()
+        QtWidgets.QApplication.processEvents()
+
+    def _show(self):
+        """Fire the real freshness hook that refreshes the list."""
+        self.model.menu("Window").aboutToShow.emit()
+
+    def _items(self):
+        """The dynamic per-sub-window actions, isolated by objectName."""
+        return [a for a in self.model.menu("Window").actions()
+                if a.objectName() == WindowManager.ITEM_ID]
+
+    def test_empty_lists_no_windows(self):
+        self._show()
+        self.assertEqual(self._items(), [])
+
+    def test_menu_is_never_empty(self):
+        # A native menu bar hides an empty menu, and a hidden menu can
+        # never fire aboutToShow to fill itself, so the list must be
+        # seeded without waiting for the first show.
+        self.assertFalse(self.model.menu("Window").isEmpty())
+
+    def test_single_window_is_listed(self):
+        self.mgr.add2DWidget()
+        self._show()
+        items = self._items()
+        self.assertEqual(len(items), 1)
+        self.assertTrue(items[0].text().endswith("2D canvas"))
+
+    def test_multiple_windows_are_listed(self):
+        self.mgr.add2DWidget()
+        self.mgr.add3DWidget()
+        self._show()
+        items = self._items()
+        self.assertEqual(len(items), 2)
+        self.assertTrue(items[0].text().endswith("2D canvas"))
+        self.assertTrue(items[1].text().endswith("Domain viewer"))
+
+    def test_active_window_is_checked(self):
+        self.mgr.add2DWidget()
+        self.mgr.add3DWidget()
+        self._show()
+        items = self._items()
+        checked = [a for a in items if a.isChecked()]
+        self.assertEqual(len(checked), 1)
+        active = self.area.activeSubWindow()
+        self.assertTrue(checked[0].text().endswith(active.windowTitle()))
+
+    def test_selecting_item_activates_that_window(self):
+        self.mgr.add2DWidget()
+        first = self.area.subWindowList()[-1]
+        self.mgr.add3DWidget()
+        self._show()
+        items = self._items()
+        items[0].trigger()
+        self.assertIs(self.area.activeSubWindow(), first)
+        self.assertIsNotNone(self.mgr.currentR2DWidget())
+
+    def test_list_updates_when_window_added(self):
+        self.mgr.add2DWidget()
+        self._show()
+        self.assertEqual(len(self._items()), 1)
+        self.mgr.add3DWidget()
+        self._show()
+        self.assertEqual(len(self._items()), 2)
+
+    def test_closing_window_removes_its_entry(self):
+        self.mgr.add2DWidget()
+        self.mgr.add3DWidget()
+        self._show()
+        self.assertEqual(len(self._items()), 2)
+        self.area.subWindowList()[-1].close()
+        self._show()
+        self.assertEqual(len(self._items()), 1)
+
+    def test_solver_window_carries_its_title(self):
+        # A 1D solver window used to carry no title at all, so the list
+        # could only show it as a bare numbered "window" entry.
+        app = _euler1d.Euler1DApp(mgr=self.mgr)
+        app.run()
+        self._show()
+        items = self._items()
+        self.assertTrue(items[-1].text().endswith("Euler solver"))
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Canvas and mesh viewers open MDI sub-windows, but the Window menu had no way to see them or bring one to the foreground. A WindowManager feature now rebuilds, each time the Window menu is about to show, a checkable action per visible sub-window; triggering one activates it and the active sub-window is shown checked. Closed viewers fall out of the list and an empty list shows a disabled placeholder. The feature is wired into the controller beside the existing Console toggle.

Related to #1030 

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
