### PR TITLE
Support mermaid diagrams in the myst documentation

### DIFF
--- a/contrib/dependency/macos26/build-scdv-macos26.sh
+++ b/contrib/dependency/macos26/build-scdv-macos26.sh
@@ -948,7 +948,7 @@ scdv_time build_python python
 # Documentation toolchain (Sphinx-based; see doc/README.md). doxygen, the
 # system half of the C++ API path, is in scdv_brew_base_cmd above.
 "${PY}" -m pip install -U sphinx myst-parser pydata-sphinx-theme \
-  breathe sphinxcontrib-bibtex
+  breathe sphinxcontrib-bibtex sphinxcontrib-mermaid
 scdv_time build_pybind11 pybind11
 
 else

--- a/contrib/dependency/ubuntu2404/build-scdv-ubuntu24.sh
+++ b/contrib/dependency/ubuntu2404/build-scdv-ubuntu24.sh
@@ -890,7 +890,7 @@ scdv_time build_python python
 # Documentation toolchain (Sphinx-based; see doc/README.md). doxygen, the
 # system half of the C++ API path, is in scdv_apt_base_cmd above.
 "${PY}" -m pip install -U sphinx myst-parser pydata-sphinx-theme \
-  breathe sphinxcontrib-bibtex
+  breathe sphinxcontrib-bibtex sphinxcontrib-mermaid
 scdv_time build_pybind11 pybind11
 
 else

--- a/contrib/dependency/windows/build-scdv-windows.ps1
+++ b/contrib/dependency/windows/build-scdv-windows.ps1
@@ -1169,7 +1169,7 @@ try {
         & $Py -m pip install -U flake8 autopep8 black pytest jsonschema certifi
         Assert-LastExit 'pip install python-tools'
         & $Py -m pip install -U sphinx myst-parser pydata-sphinx-theme `
-            breathe sphinxcontrib-bibtex
+            breathe sphinxcontrib-bibtex sphinxcontrib-mermaid
         Assert-LastExit 'pip install doc-tools'
         Invoke-Timed { Build-Pybind11 } 'pybind11'
     } else {

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,5 +8,6 @@ myst-parser>=2.0
 furo>=2024.1
 breathe>=4.35
 sphinxcontrib-bibtex>=2.6
+sphinxcontrib-mermaid>=0.9
 
 # vim: set ft=requirements ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -44,6 +44,7 @@ extensions = [
     "sphinx.ext.mathjax",     # render LaTeX math
     "breathe",                # C++ via Doxygen XML
     "sphinxcontrib.bibtex",   # citations
+    "sphinxcontrib.mermaid",  # mermaid diagrams
     "pstake",                 # PSTricks .tex -> PNG at build time
 ]
 
@@ -55,6 +56,10 @@ myst_enable_extensions = [
     "colon_fence",
     "deflist",
 ]
+
+# Treat a ```mermaid fence as the mermaid directive, so the same fenced
+# block renders natively on GitHub and through sphinxcontrib.mermaid here.
+myst_fence_as_directive = ["mermaid"]
 
 autosummary_generate = True
 


### PR DESCRIPTION
Enable sphinxcontrib.mermaid and map a "```mermaid" fenced block to the mermaid directive through MyST. It renders on both GitHub and through Sphinx.

[skip-ci]