### PR TITLE
Remove unused Ubuntu dependency scripts

### DIFF
--- a/contrib/dependency/apt.ubuntu-1804-xenial.sh
+++ b/contrib/dependency/apt.ubuntu-1804-xenial.sh
@@ -1,4 +1,0 @@
-# Install compiler and tools.
-apt-get -qy install sudo build-essential make cmake libc6-dev gcc-7 g++-7 curl git
-# Install Python.
-apt-get -qy install python3 cython3 python3-numpy python3-nose python3-pytest

--- a/contrib/dependency/apt.ubuntu-2204.sh
+++ b/contrib/dependency/apt.ubuntu-2204.sh
@@ -1,7 +1,0 @@
-# Install system tools.
-apt-get -qy install sudo curl git
-# Install compiler and build tools.
-apt-get -qy install build-essential make cmake libc6-dev gcc g++ clang-tidy-18
-# Install Python.
-apt-get -qy install python3 python3-dev python3-env python3-setuptools python3.10-dev
-apt-get -qy install python3-numpy python3-pytest python3-flake8


### PR DESCRIPTION
The old Ubuntu 18.04 and 22.04 apt scripts are no longer referenced by the tree, CI workflows, or documentation. Current dependency documentation and Linux CI use the contrib/dependency/ubuntu2404/ scripts instead.

This removes only the two unused top-level scripts. A repository-wide search after the change finds no references to either filename.

Validation: git diff --check and repository-wide reference search pass. The Make-based lint targets were not run because GNU Make is unavailable on this Windows host; no source content is changed.

Related to #1061.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->