### PR TITLE
Relate to issue-685 - baseline calculation

### DIFF
--- a/solvcon/track/dataset.py
+++ b/solvcon/track/dataset.py
@@ -155,7 +155,14 @@ class NasaDataset:
             print(f"{file_path} exists,skip download.")
             return
 
-        response = urllib.request.urlopen(self.url)
+        # The TechPort API rejects requests carrying Python's default
+        # ``Python-urllib`` User-Agent (HTTP 403 Forbidden), so wrap the
+        # call in a Request that advertises a project-identifying agent.
+        req = urllib.request.Request(
+            self.url,
+            headers={"User-Agent": "solvcon-track/1.0"},
+        )
+        response = urllib.request.urlopen(req)
         presigned_url = json.loads(response.read())["presignedUrl"]
         self.download_dir.mkdir(parents=True, exist_ok=True)
         urllib.request.urlretrieve(

--- a/solvcon/track/kalmanfilter.py
+++ b/solvcon/track/kalmanfilter.py
@@ -29,7 +29,7 @@ Kalman filter for strapdown inertial navigation in the Earth-centered
 Earth-fixed (ECEF) frame.
 
 This module is tailored to the Blue Origin Deorbit, Descent, and Landing
-Tipping Point (BODDL-TP) NASA dataset:
+Tipping Point (BODDL-TP) NASA dataset.
 
 The propagated state vector is
 
@@ -73,10 +73,12 @@ DLC_IMU_DCM_CON_IMU = np.array([
     [-0.2477, -0.1673,  0.9543],
     [-0.0478,  0.9859,  0.1604],
     [-0.9677, -0.0059, -0.2522],
-])
+], dtype='float64')
 """DCM that rotates a vector in the DLC IMU frame into the CON frame."""
 
-DLC_IMU_LEVER_ARM_CON = np.array([-0.08035, 0.28390, -1.42333])
+DLC_IMU_LEVER_ARM_CON = np.array(
+    [-0.08035, 0.28390, -1.42333], dtype='float64',
+)
 """Position of the DLC IMU in the CON frame, relative to CON (m)."""
 
 STATE_DIM = 10
@@ -96,7 +98,7 @@ def _skew(v):
         [0.0, -v[2], v[1]],
         [v[2], 0.0, -v[0]],
         [-v[1], v[0], 0.0],
-    ])
+    ], dtype='float64')
 
 
 def quat_identity():
@@ -106,7 +108,7 @@ def quat_identity():
     :return: Array ``[0, 0, 0, 1]``.
     :rtype: numpy.ndarray
     """
-    return np.array([0.0, 0.0, 0.0, 1.0])
+    return np.array([0.0, 0.0, 0.0, 1.0], dtype='float64')
 
 
 def quat_multiply(q1, q2):
@@ -123,14 +125,14 @@ def quat_multiply(q1, q2):
     :return: Composed quaternion ``[v0, v1, v2, s]``.
     :rtype: numpy.ndarray
     """
-    v1 = np.asarray(q1[0:3], dtype=float)
+    v1 = np.asarray(q1[0:3], dtype='float64')
     s1 = float(q1[3])
-    v2 = np.asarray(q2[0:3], dtype=float)
+    v2 = np.asarray(q2[0:3], dtype='float64')
     s2 = float(q2[3])
 
     s = s1 * s2 - float(np.dot(v1, v2))
     v = s1 * v2 + s2 * v1 - np.cross(v1, v2)
-    return np.array([v[0], v[1], v[2], s])
+    return np.array([v[0], v[1], v[2], s], dtype='float64')
 
 
 def quat_to_dcm(q):
@@ -143,10 +145,11 @@ def quat_to_dcm(q):
     :return: 3x3 body-to-reference rotation matrix.
     :rtype: numpy.ndarray
     """
-    v = np.asarray(q[0:3], dtype=float)
+    v = np.asarray(q[0:3], dtype='float64')
     s = float(q[3])
     vv = float(np.dot(v, v))
-    return (s * s - vv) * np.eye(3) + 2.0 * np.outer(v, v) - 2.0 * s * _skew(v)
+    eye3 = np.eye(3, dtype='float64')
+    return (s * s - vv) * eye3 + 2.0 * np.outer(v, v) - 2.0 * s * _skew(v)
 
 
 def rotvec_to_quat(theta):
@@ -159,12 +162,14 @@ def rotvec_to_quat(theta):
     :return: Unit quaternion ``[v0, v1, v2, s]``.
     :rtype: numpy.ndarray
     """
-    theta = np.asarray(theta, dtype=float)
+    theta = np.asarray(theta, dtype='float64')
     angle = float(np.linalg.norm(theta))
     if angle < 1.0e-12:
         half = 0.5 * theta
         scalar = 1.0 - 0.125 * float(np.dot(theta, theta))
-        return np.array([half[0], half[1], half[2], scalar])
+        return np.array(
+            [half[0], half[1], half[2], scalar], dtype='float64',
+        )
     half = 0.5 * angle
     axis = theta / angle
     sin_half = np.sin(half)
@@ -173,7 +178,7 @@ def rotvec_to_quat(theta):
         axis[1] * sin_half,
         axis[2] * sin_half,
         np.cos(half),
-    ])
+    ], dtype='float64')
 
 
 class InertialKalmanFilter:
@@ -248,7 +253,7 @@ class InertialKalmanFilter:
             correction (default).
         :type lever_arm: numpy.ndarray or None
         """
-        state = np.asarray(initial_state, dtype=float).copy()
+        state = np.asarray(initial_state, dtype='float64').copy()
         if state.shape != (STATE_DIM,):
             raise ValueError(
                 f"initial_state must have shape ({STATE_DIM},), "
@@ -267,29 +272,30 @@ class InertialKalmanFilter:
         self.use_j2 = bool(use_j2)
         self.include_centrifugal = bool(include_centrifugal)
         if lever_arm is None:
-            self.lever_arm = np.zeros(3)
+            self.lever_arm = np.zeros(3, dtype='float64')
         else:
             self.lever_arm = np.asarray(
-                lever_arm, dtype=float,
+                lever_arm, dtype='float64',
             ).reshape(3).copy()
 
         self._prev_omega_body = None
 
         # Bake the dt-dependent linear pieces of the strapdown dynamics
         # into F now that dt is fixed
-        f_matrix = np.eye(STATE_DIM)
-        f_matrix[0:3, 3:6] = dt * np.eye(3)
+        f_matrix = np.eye(STATE_DIM, dtype='float64')
+        f_matrix[0:3, 3:6] = dt * np.eye(3, dtype='float64')
         omega_ie_skew = np.array([
             [0.0, -self.earth_rate, 0.0],
             [self.earth_rate, 0.0, 0.0],
             [0.0, 0.0, 0.0],
-        ])
+        ], dtype='float64')
         f_matrix[3:6, 3:6] += -2.0 * omega_ie_skew * dt
         if self.include_centrifugal:
             omega_sq = self.earth_rate * self.earth_rate
-            f_matrix[3:6, 0:3] += np.diag([omega_sq, omega_sq, 0.0]) * dt
+            cf = np.array([omega_sq, omega_sq, 0.0], dtype='float64')
+            f_matrix[3:6, 0:3] += np.diag(cf) * dt
         self._f_matrix = f_matrix
-        self._b_matrix = np.eye(STATE_DIM, CONTROL_DIM)
+        self._b_matrix = np.eye(STATE_DIM, CONTROL_DIM, dtype='float64')
 
         h_sa = SimpleArrayFloat64([1, STATE_DIM])
 
@@ -351,10 +357,10 @@ class InertialKalmanFilter:
         :return: Gravitational acceleration in ECEF (m/s^2).
         :rtype: numpy.ndarray
         """
-        position = np.asarray(position, dtype=float)
+        position = np.asarray(position, dtype='float64')
         r = float(np.linalg.norm(position))
         if r <= 0.0:
-            return np.zeros(3)
+            return np.zeros(3, dtype='float64')
 
         x, y, z = position
         base = -WGS84_GM / (r ** 3)
@@ -368,7 +374,7 @@ class InertialKalmanFilter:
             base * x * (1.0 - c * (5.0 * zr2 - 1.0)),
             base * y * (1.0 - c * (5.0 * zr2 - 1.0)),
             base * z * (1.0 - c * (5.0 * zr2 - 3.0)),
-        ])
+        ], dtype='float64')
 
     def predict(self, delta_vel_body, delta_angle_body):
         """
@@ -384,14 +390,18 @@ class InertialKalmanFilter:
         :rtype: numpy.ndarray
         """
         dt = self.dt
-        delta_vel_body = np.asarray(delta_vel_body, dtype=float).reshape(3)
-        delta_angle_body = np.asarray(delta_angle_body, dtype=float).reshape(3)
+        delta_vel_body = np.asarray(
+            delta_vel_body, dtype='float64',
+        ).reshape(3)
+        delta_angle_body = np.asarray(
+            delta_angle_body, dtype='float64',
+        ).reshape(3)
 
         # Lever-arm correction
         omega = delta_angle_body / dt
         if np.any(self.lever_arm):
             if self._prev_omega_body is None:
-                delta_omega = np.zeros(3)
+                delta_omega = np.zeros(3, dtype='float64')
             else:
                 delta_omega = omega - self._prev_omega_body
             centripetal = (
@@ -407,7 +417,7 @@ class InertialKalmanFilter:
 
         dcm_be = quat_to_dcm(q_k)
         dcm_eb = dcm_be.T
-        omega_ie = np.array([0.0, 0.0, self.earth_rate])
+        omega_ie = np.array([0.0, 0.0, self.earth_rate], dtype='float64')
 
         dv_ecef = dcm_be @ delta_vel_body
         g = self.gravity(p_k)
@@ -422,7 +432,7 @@ class InertialKalmanFilter:
         # ``v*dt``, Coriolis, and the linear centrifugal coupling are
         # already applied by ``F x_k``; ``u`` only carries the residual
         # state-dependent pieces.
-        u = np.zeros(CONTROL_DIM)
+        u = np.zeros(CONTROL_DIM, dtype='float64')
         u[0:3] = 0.5 * dt * dv_grav
         u[3:6] = dv_grav
         u[6:10] = q_new - q_k
@@ -452,7 +462,7 @@ def _initial_state_from_event(gt_event):
         data["truth_quat_CON2ECEF[2]"],
         data["truth_quat_CON2ECEF[3]"],
         data["truth_quat_CON2ECEF[4]"],
-    ], dtype=float)
+    ], dtype='float64')
 
 
 def _imu_increments(imu_event):
@@ -470,12 +480,12 @@ def _imu_increments(imu_event):
         data["DATA_DELTA_VEL[1]"],
         data["DATA_DELTA_VEL[2]"],
         data["DATA_DELTA_VEL[3]"],
-    ], dtype=float)
+    ], dtype='float64')
     da_imu = np.array([
         data["DATA_DELTA_ANGLE[1]"],
         data["DATA_DELTA_ANGLE[2]"],
         data["DATA_DELTA_ANGLE[3]"],
-    ], dtype=float)
+    ], dtype='float64')
     dv = DLC_IMU_DCM_CON_IMU @ dv_imu
     da = DLC_IMU_DCM_CON_IMU @ da_imu
     return dv, da
@@ -495,19 +505,19 @@ def _gt_pos_vel(gt_event):
         data["truth_pos_CON_ECEF_ECEF_M[1]"],
         data["truth_pos_CON_ECEF_ECEF_M[2]"],
         data["truth_pos_CON_ECEF_ECEF_M[3]"],
-    ], dtype=float)
+    ], dtype='float64')
     v = np.array([
         data["truth_vel_CON_ECEF_ECEF_MpS[1]"],
         data["truth_vel_CON_ECEF_ECEF_MpS[2]"],
         data["truth_vel_CON_ECEF_ECEF_MpS[3]"],
-    ], dtype=float)
+    ], dtype='float64')
     return p, v
 
 
 def _figure_path(prefix):
     """
-    Build the PNG output path by appending the fixed figure file name
-    ``kf_predict.png`` to the user-supplied path-and-file-name prefix.
+    Build the PNG output path by appending the fixed suffix
+    ``_kf_predict.png`` to the user-supplied path-and-file-name prefix.
 
     :param prefix: Output directory path plus file-name prefix.
     :type prefix: str
@@ -591,12 +601,12 @@ def _predict_flight():
             gt_p.append(p)
             gt_v.append(v)
 
-    pred_t = np.asarray(pred_t)
-    pred_p = np.asarray(pred_p)
-    pred_v = np.asarray(pred_v)
-    gt_t = np.asarray(gt_t)
-    gt_p = np.asarray(gt_p)
-    gt_v = np.asarray(gt_v)
+    pred_t = np.asarray(pred_t, dtype='float64')
+    pred_p = np.asarray(pred_p, dtype='float64')
+    pred_v = np.asarray(pred_v, dtype='float64')
+    gt_t = np.asarray(gt_t, dtype='float64')
+    gt_p = np.asarray(gt_p, dtype='float64')
+    gt_v = np.asarray(gt_v, dtype='float64')
 
     # Interpolation so the error is evaluated at the same
     # instants as the ground-truth samples.
@@ -626,10 +636,9 @@ def main(argv=None):
         "--save-fig-prefix",
         default=None,
         help="path plus file-name prefix for saving the results figure; "
-             "the fixed name 'kf_predict.png' is appended verbatim, so "
-             "'/tmp/run1_' gives /tmp/run1_kf_predict.png and '/tmp/out/' "
-             "gives /tmp/out/kf_predict.png; when omitted the figure is "
-             "shown in a window instead",
+             "the fixed suffix '_kf_predict.png' is appended, so "
+             "'/tmp/run1' gives /tmp/run1_kf_predict.png; when omitted "
+             "the figure is shown in a window instead",
     )
     args = parser.parse_args(argv)
 

--- a/solvcon/track/kalmanfilter.py
+++ b/solvcon/track/kalmanfilter.py
@@ -1,0 +1,702 @@
+# Copyright (c) 2026, Stephen Xie <zonghanxie@proton.me>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Kalman filter for strapdown inertial navigation in the Earth-centered
+Earth-fixed (ECEF) frame.
+
+This module is tailored to the Blue Origin Deorbit, Descent, and Landing
+Tipping Point (BODDL-TP) NASA dataset:
+
+The propagated state vector is
+
+    x = [p_x, p_y, p_z, v_x, v_y, v_z, q_v0, q_v1, q_v2, q_s]   (shape 10,)
+
+and the covariance is the 10x10 covariance of this same state.
+"""
+
+import pathlib
+
+import numpy as np
+
+from .. import SimpleArrayFloat64
+from .. import KalmanFilterFp64
+
+
+__all__ = [
+    "EARTH_RATE",
+    "WGS84_GM",
+    "WGS84_SEMI_MAJOR",
+    "WGS84_J2",
+    "DLC_IMU_DCM_CON_IMU",
+    "DLC_IMU_LEVER_ARM_CON",
+    "InertialKalmanFilter",
+]
+
+
+EARTH_RATE = 7.2921150e-5
+"""Earth sidereal rotation rate (rad/s)."""
+
+WGS84_GM = 3.986004418e14
+"""WGS-84 Earth gravitational constant (m^3/s^2)."""
+
+WGS84_SEMI_MAJOR = 6378137.0
+"""WGS-84 equatorial radius (m)."""
+
+WGS84_J2 = 1.0826267e-3
+"""WGS-84 second zonal harmonic (dimensionless)."""
+
+DLC_IMU_DCM_CON_IMU = np.array([
+    [-0.2477, -0.1673,  0.9543],
+    [-0.0478,  0.9859,  0.1604],
+    [-0.9677, -0.0059, -0.2522],
+])
+"""DCM that rotates a vector in the DLC IMU frame into the CON frame."""
+
+DLC_IMU_LEVER_ARM_CON = np.array([-0.08035, 0.28390, -1.42333])
+"""Position of the DLC IMU in the CON frame, relative to CON (m)."""
+
+STATE_DIM = 10
+CONTROL_DIM = 10
+
+
+def _skew(v):
+    """
+    Build the 3x3 skew-symmetric cross-product matrix of a 3-vector.
+
+    :param v: Three-element vector.
+    :type v: numpy.ndarray
+    :return: Matrix ``[v]x`` such that ``[v]x @ u == numpy.cross(v, u)``.
+    :rtype: numpy.ndarray
+    """
+    return np.array([
+        [0.0, -v[2], v[1]],
+        [v[2], 0.0, -v[0]],
+        [-v[1], v[0], 0.0],
+    ])
+
+
+def quat_identity():
+    """
+    Return the Breckenridge identity quaternion (scalar stored last).
+
+    :return: Array ``[0, 0, 0, 1]``.
+    :rtype: numpy.ndarray
+    """
+    return np.array([0.0, 0.0, 0.0, 1.0])
+
+
+def quat_multiply(q1, q2):
+    """
+    Multiply two Breckenridge quaternions ``q1 (x) q2`` with scalar last.
+
+    Because Breckenridge sets ``ijk = +1``, the cross-product term of the
+    vector component carries the opposite sign to the Hamilton form.
+
+    :param q1: Left quaternion ``[v0, v1, v2, s]``.
+    :type q1: numpy.ndarray
+    :param q2: Right quaternion ``[v0, v1, v2, s]``.
+    :type q2: numpy.ndarray
+    :return: Composed quaternion ``[v0, v1, v2, s]``.
+    :rtype: numpy.ndarray
+    """
+    v1 = np.asarray(q1[0:3], dtype=float)
+    s1 = float(q1[3])
+    v2 = np.asarray(q2[0:3], dtype=float)
+    s2 = float(q2[3])
+
+    s = s1 * s2 - float(np.dot(v1, v2))
+    v = s1 * v2 + s2 * v1 - np.cross(v1, v2)
+    return np.array([v[0], v[1], v[2], s])
+
+
+def quat_to_dcm(q):
+    """
+    Convert a Breckenridge quaternion into the DCM rotating a vector from
+    the body frame to the reference (ECEF) frame.
+
+    :param q: Unit quaternion ``[v0, v1, v2, s]``.
+    :type q: numpy.ndarray
+    :return: 3x3 body-to-reference rotation matrix.
+    :rtype: numpy.ndarray
+    """
+    v = np.asarray(q[0:3], dtype=float)
+    s = float(q[3])
+    vv = float(np.dot(v, v))
+    return (s * s - vv) * np.eye(3) + 2.0 * np.outer(v, v) - 2.0 * s * _skew(v)
+
+
+def rotvec_to_quat(theta):
+    """
+    Convert a rotation vector (axis times angle) into a Breckenridge
+    quaternion with scalar last.
+
+    :param theta: Rotation vector in radians, shape ``(3,)``.
+    :type theta: numpy.ndarray
+    :return: Unit quaternion ``[v0, v1, v2, s]``.
+    :rtype: numpy.ndarray
+    """
+    theta = np.asarray(theta, dtype=float)
+    angle = float(np.linalg.norm(theta))
+    if angle < 1.0e-12:
+        half = 0.5 * theta
+        scalar = 1.0 - 0.125 * float(np.dot(theta, theta))
+        return np.array([half[0], half[1], half[2], scalar])
+    half = 0.5 * angle
+    axis = theta / angle
+    sin_half = np.sin(half)
+    return np.array([
+        axis[0] * sin_half,
+        axis[1] * sin_half,
+        axis[2] * sin_half,
+        np.cos(half),
+    ])
+
+
+class InertialKalmanFilter:
+    """
+    Strapdown Kalman-filter predictor in ECEF, wrapping ``KalmanFilterFp64``.
+
+    Each call to :meth:`predict` consumes one IMU sample (delta-velocity and
+    delta-angle in the body frame), composes the corresponding control input
+    ``u``, and delegates the linear propagation to the C++
+    :class:`modmesh.KalmanFilterFp64` instance.  ``dt`` is fixed at
+    construction time -- the BODDL-TP DLC IMU has a constant sampling
+    interval -- so the C++ filter and the ``F``/``B`` matrices are built
+    exactly once.
+
+    :ivar dt: IMU sampling interval (s) baked into ``F``.
+    :vartype dt: float
+    :ivar earth_rate: Earth rotation rate (rad/s).
+    :vartype earth_rate: float
+    :ivar use_j2: Whether to include the J2 term in the gravity model.
+    :vartype use_j2: bool
+    :ivar include_centrifugal: Whether to include the centrifugal term.
+    :vartype include_centrifugal: bool
+    :ivar filter: Underlying C++ Kalman filter.
+    :vartype filter: modmesh.KalmanFilterFp64
+    """
+
+    def __init__(
+        self,
+        initial_state,
+        dt,
+        earth_rate=EARTH_RATE,
+        process_noise=1.0e-3,
+        measurement_noise=1.0,
+        jitter=1.0e-9,
+        use_j2=True,
+        include_centrifugal=True,
+        lever_arm=None,
+    ):
+        """
+        Build the filter from an initial state.
+
+        :param initial_state: Initial 10-element state ``[p, v, q]`` where
+            ``q`` is the Breckenridge body-to-ECEF quaternion with scalar
+            last.  Must be non-zero in its quaternion slice.
+        :type initial_state: numpy.ndarray
+        :param dt: IMU sampling interval (s).  Must be strictly positive.
+            Baked into ``F`` so the C++ filter only needs to be
+            constructed once.
+        :type dt: float
+        :param earth_rate: Scalar Earth rotation rate (rad/s).
+        :type earth_rate: float
+        :param process_noise: Process noise standard deviation forwarded to
+            ``KalmanFilterFp64`` (``Q = process_noise**2 * I``).
+        :type process_noise: float
+        :param measurement_noise: Measurement noise standard deviation; the
+            predict-only workflow does not use it but the C++ constructor
+            requires a value.
+        :type measurement_noise: float
+        :param jitter: Numerical jitter added to the innovation covariance
+            by the C++ filter during updates.
+        :type jitter: float
+        :param use_j2: Include the J2 zonal term in the gravity model.
+        :type use_j2: bool
+        :param include_centrifugal: Include centrifugal acceleration.
+        :type include_centrifugal: bool
+        :param lever_arm: Position of the IMU sensor in the body/CON frame
+            relative to the CON reference point (m).  When non-zero, the
+            ``predict`` step subtracts the tangential (``alpha x l``) and
+            centripetal (``omega x (omega x l)``) lever-arm accelerations
+            from the supplied IMU delta-velocity, recovering the
+            equivalent specific force at CON.  ``None`` disables the
+            correction (default).
+        :type lever_arm: numpy.ndarray or None
+        """
+        state = np.asarray(initial_state, dtype=float).copy()
+        if state.shape != (STATE_DIM,):
+            raise ValueError(
+                f"initial_state must have shape ({STATE_DIM},), "
+                f"got {state.shape}"
+            )
+        qnorm = float(np.linalg.norm(state[6:10]))
+        if qnorm == 0.0:
+            raise ValueError("initial quaternion has zero norm")
+        state[6:10] /= qnorm
+
+        dt = float(dt)
+        if dt <= 0.0:
+            raise ValueError("dt must be strictly positive")
+        self.dt = dt
+        self.earth_rate = float(earth_rate)
+        self.use_j2 = bool(use_j2)
+        self.include_centrifugal = bool(include_centrifugal)
+        if lever_arm is None:
+            self.lever_arm = np.zeros(3)
+        else:
+            self.lever_arm = np.asarray(
+                lever_arm, dtype=float,
+            ).reshape(3).copy()
+
+        self._prev_omega_body = None
+
+        # Bake the dt-dependent linear pieces of the strapdown dynamics
+        # into F now that dt is fixed
+        f_matrix = np.eye(STATE_DIM)
+        f_matrix[0:3, 3:6] = dt * np.eye(3)
+        omega_ie_skew = np.array([
+            [0.0, -self.earth_rate, 0.0],
+            [self.earth_rate, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+        ])
+        f_matrix[3:6, 3:6] += -2.0 * omega_ie_skew * dt
+        if self.include_centrifugal:
+            omega_sq = self.earth_rate * self.earth_rate
+            f_matrix[3:6, 0:3] += np.diag([omega_sq, omega_sq, 0.0]) * dt
+        self._f_matrix = f_matrix
+        self._b_matrix = np.eye(STATE_DIM, CONTROL_DIM)
+
+        h_sa = SimpleArrayFloat64([1, STATE_DIM])
+
+        self.filter = KalmanFilterFp64(
+            x=SimpleArrayFloat64(array=state),
+            f=SimpleArrayFloat64(array=self._f_matrix),
+            b=SimpleArrayFloat64(array=self._b_matrix),
+            h=h_sa,
+            process_noise=float(process_noise),
+            measurement_noise=float(measurement_noise),
+            jitter=float(jitter),
+        )
+
+    @property
+    def state(self):
+        """
+        Return a copy of the current 10-element mean state vector.
+
+        :return: Array ``[p (3), v (3), q (4)]``.
+        :rtype: numpy.ndarray
+        """
+        return self.filter.state.ndarray.copy()
+
+    @property
+    def covariance(self):
+        """
+        Return a copy of the current 10x10 state covariance matrix.
+
+        :return: Covariance matrix.
+        :rtype: numpy.ndarray
+        """
+        return self.filter.covariance.ndarray.copy()
+
+    @property
+    def position(self):
+        """Position vector in ECEF (m)."""
+        return self.state[0:3]
+
+    @property
+    def velocity(self):
+        """Velocity vector in ECEF (m/s)."""
+        return self.state[3:6]
+
+    @property
+    def quaternion(self):
+        """Body-to-ECEF quaternion ``[v0, v1, v2, s]``."""
+        return self.state[6:10]
+
+    def gravity(self, position):
+        """
+        Evaluate ECEF gravitational acceleration at ``position``.
+
+        The model is two-body gravity plus an optional J2 zonal-harmonic
+        term.  The centrifugal acceleration is not included here because
+        that term is handled by the linear part of ``F``.
+
+        :param position: ECEF position vector (m).
+        :type position: numpy.ndarray
+        :return: Gravitational acceleration in ECEF (m/s^2).
+        :rtype: numpy.ndarray
+        """
+        position = np.asarray(position, dtype=float)
+        r = float(np.linalg.norm(position))
+        if r <= 0.0:
+            return np.zeros(3)
+
+        x, y, z = position
+        base = -WGS84_GM / (r ** 3)
+        if not self.use_j2:
+            return base * position
+
+        zr2 = (z / r) ** 2
+        ar2 = (WGS84_SEMI_MAJOR / r) ** 2
+        c = 1.5 * WGS84_J2 * ar2
+        return np.array([
+            base * x * (1.0 - c * (5.0 * zr2 - 1.0)),
+            base * y * (1.0 - c * (5.0 * zr2 - 1.0)),
+            base * z * (1.0 - c * (5.0 * zr2 - 3.0)),
+        ])
+
+    def predict(self, delta_vel_body, delta_angle_body):
+        """
+        Run one predict step using IMU delta-velocity and delta-angle.
+
+        :param delta_vel_body: Integrated specific force over ``dt`` in the
+            body frame (m/s), shape ``(3,)``.
+        :type delta_vel_body: numpy.ndarray
+        :param delta_angle_body: Integrated angular rate over ``dt`` in the
+            body frame (rad), shape ``(3,)``.
+        :type delta_angle_body: numpy.ndarray
+        :return: Updated 10-element state vector (copy).
+        :rtype: numpy.ndarray
+        """
+        dt = self.dt
+        delta_vel_body = np.asarray(delta_vel_body, dtype=float).reshape(3)
+        delta_angle_body = np.asarray(delta_angle_body, dtype=float).reshape(3)
+
+        # Lever-arm correction
+        omega = delta_angle_body / dt
+        if np.any(self.lever_arm):
+            if self._prev_omega_body is None:
+                delta_omega = np.zeros(3)
+            else:
+                delta_omega = omega - self._prev_omega_body
+            centripetal = (
+                np.cross(omega, np.cross(omega, self.lever_arm)) * dt
+            )
+            tangential = np.cross(delta_omega, self.lever_arm)
+            delta_vel_body = delta_vel_body - centripetal - tangential
+        self._prev_omega_body = omega
+
+        x_k = self.state
+        p_k = x_k[0:3]
+        q_k = x_k[6:10]
+
+        dcm_be = quat_to_dcm(q_k)
+        dcm_eb = dcm_be.T
+        omega_ie = np.array([0.0, 0.0, self.earth_rate])
+
+        dv_ecef = dcm_be @ delta_vel_body
+        g = self.gravity(p_k)
+        dv_grav = dv_ecef + g * dt
+
+        delta_theta_eb_body = delta_angle_body - dcm_eb @ omega_ie * dt
+
+        dq = rotvec_to_quat(-delta_theta_eb_body)
+        q_new = quat_multiply(q_k, dq)
+        q_new /= np.linalg.norm(q_new)
+
+        # ``v*dt``, Coriolis, and the linear centrifugal coupling are
+        # already applied by ``F x_k``; ``u`` only carries the residual
+        # state-dependent pieces.
+        u = np.zeros(CONTROL_DIM)
+        u[0:3] = 0.5 * dt * dv_grav
+        u[3:6] = dv_grav
+        u[6:10] = q_new - q_k
+
+        self.filter.predict(SimpleArrayFloat64(array=u))
+        return self.state
+
+
+def _initial_state_from_event(gt_event):
+    """
+    Build a 10-element state vector from a ground-truth event.
+
+    :param gt_event: Ground-truth event reference.
+    :type gt_event: modmesh.track.dataset.EventReference
+    :return: Initial state ``[p (3), v (3), q (4)]``.
+    :rtype: numpy.ndarray
+    """
+    data = gt_event.data
+    return np.array([
+        data["truth_pos_CON_ECEF_ECEF_M[1]"],
+        data["truth_pos_CON_ECEF_ECEF_M[2]"],
+        data["truth_pos_CON_ECEF_ECEF_M[3]"],
+        data["truth_vel_CON_ECEF_ECEF_MpS[1]"],
+        data["truth_vel_CON_ECEF_ECEF_MpS[2]"],
+        data["truth_vel_CON_ECEF_ECEF_MpS[3]"],
+        data["truth_quat_CON2ECEF[1]"],
+        data["truth_quat_CON2ECEF[2]"],
+        data["truth_quat_CON2ECEF[3]"],
+        data["truth_quat_CON2ECEF[4]"],
+    ], dtype=float)
+
+
+def _imu_increments(imu_event):
+    """
+    Extract delta-velocity and delta-angle vectors from an IMU event and
+    rotate them from the DLC IMU sensor frame into the vehicle CON frame.
+
+    :param imu_event: IMU event reference.
+    :type imu_event: modmesh.track.dataset.EventReference
+    :return: Tuple ``(delta_vel_con, delta_angle_con)`` expressed in CON.
+    :rtype: tuple[numpy.ndarray, numpy.ndarray]
+    """
+    data = imu_event.data
+    dv_imu = np.array([
+        data["DATA_DELTA_VEL[1]"],
+        data["DATA_DELTA_VEL[2]"],
+        data["DATA_DELTA_VEL[3]"],
+    ], dtype=float)
+    da_imu = np.array([
+        data["DATA_DELTA_ANGLE[1]"],
+        data["DATA_DELTA_ANGLE[2]"],
+        data["DATA_DELTA_ANGLE[3]"],
+    ], dtype=float)
+    dv = DLC_IMU_DCM_CON_IMU @ dv_imu
+    da = DLC_IMU_DCM_CON_IMU @ da_imu
+    return dv, da
+
+
+def _gt_pos_vel(gt_event):
+    """
+    Extract ground-truth position and velocity vectors from an event.
+
+    :param gt_event: Ground-truth event reference.
+    :type gt_event: modmesh.track.dataset.EventReference
+    :return: Tuple ``(position, velocity)`` in ECEF.
+    :rtype: tuple[numpy.ndarray, numpy.ndarray]
+    """
+    data = gt_event.data
+    p = np.array([
+        data["truth_pos_CON_ECEF_ECEF_M[1]"],
+        data["truth_pos_CON_ECEF_ECEF_M[2]"],
+        data["truth_pos_CON_ECEF_ECEF_M[3]"],
+    ], dtype=float)
+    v = np.array([
+        data["truth_vel_CON_ECEF_ECEF_MpS[1]"],
+        data["truth_vel_CON_ECEF_ECEF_MpS[2]"],
+        data["truth_vel_CON_ECEF_ECEF_MpS[3]"],
+    ], dtype=float)
+    return p, v
+
+
+def _figure_path(prefix):
+    """
+    Build the PNG output path by appending the fixed figure file name
+    ``kf_predict.png`` to the user-supplied path-and-file-name prefix.
+
+    :param prefix: Output directory path plus file-name prefix.
+    :type prefix: str
+    :return: Path of the PNG file to write.
+    :rtype: pathlib.Path
+    """
+    return pathlib.Path(f"{prefix}_kf_predict.png")
+
+
+def _predict_flight():
+    """
+    Load the BODDL-TP dataset, run KF predict, and evaluate errors.
+
+    :return: Tuple ``(pred_t, pred_p, pred_v, gt_t, gt_p, gt_v,
+        err_p)``.  Times are seconds since the first ground-truth
+        event; positions and velocities are ECEF arrays with one row
+        per sample; ``err_p`` holds the per-axis position error on the
+        ground-truth timestamps.
+    :rtype: tuple[numpy.ndarray, ...]
+    """
+    import ssl
+
+    from solvcon.track import dataset as dataset_mod
+
+    ssl._create_default_https_context = ssl._create_stdlib_context
+    dataset_obj = dataset_mod.NasaDataset(
+        "https://techport.nasa.gov/api/file/presignedUrl/380503",
+        "DDL-F1_Dataset-20201013.zip",
+    )
+    dataset_obj.download()
+    dataset_obj.extract()
+    dataset_obj.load()
+
+    gt_start = next(
+        (ev for ev in dataset_obj.events if ev.source == "ground_truth"),
+        None,
+    )
+    if gt_start is None:
+        raise RuntimeError("dataset contains no ground-truth events")
+
+    # assuming ``dt`` is fixed across the run
+    imu_ts_after_start = [
+        ev.timestamp for ev in dataset_obj.events
+        if ev.source == "imu" and ev.timestamp >= gt_start.timestamp
+    ]
+    if len(imu_ts_after_start) < 2:
+        raise RuntimeError(
+            "need at least two IMU events after gt_start to fix dt"
+        )
+    dt = (imu_ts_after_start[1] - imu_ts_after_start[0]) * 1.0e-9
+    if dt <= 0.0:
+        raise RuntimeError("non-positive dt from the first two IMU samples")
+
+    kf = InertialKalmanFilter(
+        initial_state=_initial_state_from_event(gt_start),
+        dt=dt,
+        lever_arm=DLC_IMU_LEVER_ARM_CON,
+    )
+
+    t0 = gt_start.timestamp * 1.0e-9
+    pred_t = [0.0]
+    pred_p = [kf.position.copy()]
+    pred_v = [kf.velocity.copy()]
+    gt_t = [0.0]
+    gt_p0, gt_v0 = _gt_pos_vel(gt_start)
+    gt_p = [gt_p0]
+    gt_v = [gt_v0]
+
+    for ev in dataset_obj.events:
+        if ev.timestamp < gt_start.timestamp:
+            continue
+        if ev.source == "imu":
+            dv, da = _imu_increments(ev)
+            kf.predict(dv, da)
+            pred_t.append(ev.timestamp * 1.0e-9 - t0)
+            pred_p.append(kf.position.copy())
+            pred_v.append(kf.velocity.copy())
+        elif ev.source == "ground_truth" and ev is not gt_start:
+            p, v = _gt_pos_vel(ev)
+            gt_t.append(ev.timestamp * 1.0e-9 - t0)
+            gt_p.append(p)
+            gt_v.append(v)
+
+    pred_t = np.asarray(pred_t)
+    pred_p = np.asarray(pred_p)
+    pred_v = np.asarray(pred_v)
+    gt_t = np.asarray(gt_t)
+    gt_p = np.asarray(gt_p)
+    gt_v = np.asarray(gt_v)
+
+    # Interpolation so the error is evaluated at the same
+    # instants as the ground-truth samples.
+    pred_p_on_gt = np.column_stack([
+        np.interp(gt_t, pred_t, pred_p[:, i]) for i in range(3)
+    ])
+    err_p = pred_p_on_gt - gt_p
+
+    return pred_t, pred_p, pred_v, gt_t, gt_p, gt_v, err_p
+
+
+def main(argv=None):
+    """
+    Parse command-line arguments, run the KF predict through
+    :func:`_predict_flight`, and plot the results.
+
+    :param argv: Command-line arguments; ``None`` uses ``sys.argv``.
+    :type argv: list[str] or None
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Kalman-filter predict baseline on the BODDL-TP "
+                    "Flight 1 dataset",
+    )
+    parser.add_argument(
+        "--save-fig-prefix",
+        default=None,
+        help="path plus file-name prefix for saving the results figure; "
+             "the fixed name 'kf_predict.png' is appended verbatim, so "
+             "'/tmp/run1_' gives /tmp/run1_kf_predict.png and '/tmp/out/' "
+             "gives /tmp/out/kf_predict.png; when omitted the figure is "
+             "shown in a window instead",
+    )
+    args = parser.parse_args(argv)
+
+    import matplotlib
+    if args.save_fig_prefix is not None:
+        # Agg renders without a display, so saving works headlessly.
+        matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    (pred_t, pred_p, pred_v, gt_t, gt_p, gt_v,
+     err_p) = _predict_flight()
+
+    fig, axes = plt.subplots(3, 3, figsize=(16, 9), sharex=True)
+    axis_names = ("X", "Y", "Z")
+    for i, name in enumerate(axis_names):
+        axes[i, 0].plot(
+            gt_t, gt_p[:, i],
+            "k.", markersize=2, label="ground truth",
+        )
+        axes[i, 0].plot(
+            pred_t, pred_p[:, i],
+            "b-", linewidth=0.7, label="KF predict",
+        )
+        axes[i, 0].set_ylabel(f"p_{name} (m)")
+        axes[i, 0].grid(True)
+        axes[i, 0].legend(loc="best", fontsize=8)
+
+        axes[i, 1].plot(
+            gt_t, gt_v[:, i],
+            "k.", markersize=2, label="ground truth",
+        )
+        axes[i, 1].plot(
+            pred_t, pred_v[:, i],
+            "r-", linewidth=0.7, label="KF predict",
+        )
+        axes[i, 1].set_ylabel(f"v_{name} (m/s)")
+        axes[i, 1].grid(True)
+        axes[i, 1].legend(loc="best", fontsize=8)
+
+        axes[i, 2].plot(
+            gt_t, err_p[:, i],
+            "g-", linewidth=0.7, label=f"err p_{name}",
+        )
+        axes[i, 2].axhline(0.0, color="k", linewidth=0.5)
+        axes[i, 2].set_ylabel(f"err p_{name} (m)")
+        axes[i, 2].grid(True)
+        axes[i, 2].legend(loc="best", fontsize=8)
+
+    axes[0, 0].set_title("ECEF position")
+    axes[0, 1].set_title("ECEF velocity")
+    axes[0, 2].set_title("Position error (predict - truth)")
+    axes[2, 0].set_xlabel("time since first ground-truth (s)")
+    axes[2, 1].set_xlabel("time since first ground-truth (s)")
+    axes[2, 2].set_xlabel("time since first ground-truth (s)")
+    fig.suptitle("KF predict vs. NASA ground truth")
+    fig.tight_layout()
+
+    if args.save_fig_prefix is None:
+        plt.show()
+    else:
+        out = _figure_path(args.save_fig_prefix)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(out, dpi=150)
+        print(f"saved figure to {out}")
+
+
+if __name__ == "__main__":
+    main()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_track_kalmanfilter.py
+++ b/tests/test_track_kalmanfilter.py
@@ -1,0 +1,495 @@
+
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import pathlib
+import unittest
+
+import numpy as np
+
+from solvcon.track import kalmanfilter
+from solvcon.track.kalmanfilter import (
+    EARTH_RATE,
+    WGS84_GM,
+    WGS84_J2,
+    WGS84_SEMI_MAJOR,
+    DLC_IMU_DCM_CON_IMU,
+    InertialKalmanFilter,
+    quat_identity,
+    quat_multiply,
+    quat_to_dcm,
+    rotvec_to_quat,
+)
+
+
+DT = 0.02
+
+
+def _rest_state():
+    state = np.zeros(10)
+    state[0] = WGS84_SEMI_MAJOR
+    state[9] = 1.0
+    return state
+
+
+def _two_body_gravity(position):
+    position = np.asarray(position, dtype=float)
+    r = float(np.linalg.norm(position))
+    return -WGS84_GM * position / r ** 3
+
+
+class _StubEvent:
+
+    def __init__(self, data):
+        self.data = data
+
+
+class QuaternionMathTC(unittest.TestCase):
+
+    def test_skew_matches_cross_product(self):
+        v = np.array([0.3, -1.2, 2.5])
+        u = np.array([-0.7, 0.4, 1.1])
+        np.testing.assert_allclose(
+            kalmanfilter._skew(v) @ u, np.cross(v, u), atol=1e-15,
+        )
+
+    def test_skew_antisymmetric(self):
+        m = kalmanfilter._skew(np.array([1.0, 2.0, 3.0]))
+        np.testing.assert_array_equal(m.T, -m)
+
+    def test_identity_value(self):
+        np.testing.assert_array_equal(
+            quat_identity(), [0.0, 0.0, 0.0, 1.0],
+        )
+
+    def test_multiply_identity_is_neutral(self):
+        q = rotvec_to_quat([0.3, -0.5, 0.8])
+        np.testing.assert_allclose(
+            quat_multiply(q, quat_identity()), q, atol=1e-15,
+        )
+        np.testing.assert_allclose(
+            quat_multiply(quat_identity(), q), q, atol=1e-15,
+        )
+
+    def test_multiply_breckenridge_basis_products(self):
+        i = [1.0, 0.0, 0.0, 0.0]
+        j = [0.0, 1.0, 0.0, 0.0]
+        np.testing.assert_allclose(
+            quat_multiply(i, j), [0.0, 0.0, -1.0, 0.0], atol=1e-15,
+        )
+        np.testing.assert_allclose(
+            quat_multiply(j, i), [0.0, 0.0, 1.0, 0.0], atol=1e-15,
+        )
+
+    def test_multiply_preserves_unit_norm(self):
+        q1 = rotvec_to_quat([0.2, 0.1, -0.4])
+        q2 = rotvec_to_quat([-0.3, 0.7, 0.5])
+        norm = float(np.linalg.norm(quat_multiply(q1, q2)))
+        self.assertAlmostEqual(norm, 1.0, places=12)
+
+    def test_multiply_dcm_homomorphism(self):
+        q1 = rotvec_to_quat([0.2, 0.1, -0.4])
+        q2 = rotvec_to_quat([-0.3, 0.7, 0.5])
+        np.testing.assert_allclose(
+            quat_to_dcm(quat_multiply(q1, q2)),
+            quat_to_dcm(q1) @ quat_to_dcm(q2),
+            atol=1e-12,
+        )
+
+    def test_dcm_of_identity(self):
+        np.testing.assert_array_equal(
+            quat_to_dcm(quat_identity()), np.eye(3),
+        )
+
+    def test_dcm_orthonormal_proper(self):
+        r = quat_to_dcm(rotvec_to_quat([0.4, -0.9, 1.3]))
+        np.testing.assert_allclose(r @ r.T, np.eye(3), atol=1e-12)
+        self.assertAlmostEqual(float(np.linalg.det(r)), 1.0, places=12)
+
+    def test_dcm_quarter_turn_convention(self):
+        q = rotvec_to_quat([0.0, 0.0, np.pi / 2.0])
+        np.testing.assert_allclose(
+            quat_to_dcm(q) @ [1.0, 0.0, 0.0], [0.0, -1.0, 0.0], atol=1e-15,
+        )
+
+    def test_rotvec_zero_gives_identity(self):
+        np.testing.assert_array_equal(
+            rotvec_to_quat(np.zeros(3)), quat_identity(),
+        )
+
+    def test_rotvec_small_angle_series(self):
+        theta = np.array([1.0e-13, 0.0, 0.0])
+        q = rotvec_to_quat(theta)
+        np.testing.assert_allclose(
+            q, [5.0e-14, 0.0, 0.0, 1.0], rtol=1e-6, atol=0.0,
+        )
+
+    def test_rotvec_half_turn_about_z(self):
+        q = rotvec_to_quat([0.0, 0.0, np.pi])
+        np.testing.assert_allclose(
+            q, [0.0, 0.0, 1.0, 0.0], atol=1e-15,
+        )
+
+    def test_rotvec_dcm_matches_rodrigues(self):
+        for theta in ([0.5, 0.0, 0.0], [0.1, -0.7, 0.4], [-1.2, 0.3, 2.1]):
+            theta = np.asarray(theta)
+            angle = float(np.linalg.norm(theta))
+            axis = theta / angle
+            expected = (
+                np.cos(angle) * np.eye(3)
+                + (1.0 - np.cos(angle)) * np.outer(axis, axis)
+                - np.sin(angle) * kalmanfilter._skew(axis)
+            )
+            np.testing.assert_allclose(
+                quat_to_dcm(rotvec_to_quat(theta)), expected, atol=1e-12,
+            )
+
+
+class DlcImuConstantTC(unittest.TestCase):
+
+    def test_dcm_con_imu_orthonormal(self):
+        r = DLC_IMU_DCM_CON_IMU
+        np.testing.assert_allclose(r @ r.T, np.eye(3), atol=5e-4)
+
+    def test_dcm_con_imu_proper_rotation(self):
+        det = float(np.linalg.det(DLC_IMU_DCM_CON_IMU))
+        self.assertAlmostEqual(det, 1.0, delta=1e-3)
+
+
+class GravityModelTC(unittest.TestCase):
+
+    def test_two_body_equator_value(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT, use_j2=False)
+        g = kf.gravity([WGS84_SEMI_MAJOR, 0.0, 0.0])
+        expected = -WGS84_GM / WGS84_SEMI_MAJOR ** 2
+        np.testing.assert_allclose(g, [expected, 0.0, 0.0], rtol=1e-14)
+
+    def test_two_body_general_position(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT, use_j2=False)
+        p = np.array([3.0e6, -4.0e6, 2.5e6])
+        np.testing.assert_allclose(
+            kf.gravity(p), _two_body_gravity(p), rtol=1e-14,
+        )
+
+    def test_j2_equator_scale(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT, use_j2=True)
+        g = kf.gravity([WGS84_SEMI_MAJOR, 0.0, 0.0])
+        expected_x = (
+            -WGS84_GM / WGS84_SEMI_MAJOR ** 2 * (1.0 + 1.5 * WGS84_J2)
+        )
+        np.testing.assert_allclose(
+            g, [expected_x, 0.0, 0.0], rtol=1e-12, atol=1e-15,
+        )
+
+    def test_j2_pole_scale(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT, use_j2=True)
+        g = kf.gravity([0.0, 0.0, WGS84_SEMI_MAJOR])
+        expected_z = (
+            -WGS84_GM / WGS84_SEMI_MAJOR ** 2 * (1.0 - 3.0 * WGS84_J2)
+        )
+        np.testing.assert_allclose(
+            g, [0.0, 0.0, expected_z], rtol=1e-12, atol=1e-15,
+        )
+
+    def test_zero_position_returns_zero(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT)
+        np.testing.assert_array_equal(kf.gravity(np.zeros(3)), np.zeros(3))
+
+
+class FilterConstructionTC(unittest.TestCase):
+
+    def test_rejects_wrong_state_shape(self):
+        with self.assertRaisesRegex(
+            ValueError, "initial_state must have shape",
+        ):
+            InertialKalmanFilter(np.zeros(9), dt=DT)
+
+    def test_rejects_zero_quaternion(self):
+        with self.assertRaisesRegex(ValueError, "zero norm"):
+            InertialKalmanFilter(np.zeros(10), dt=DT)
+
+    def test_rejects_zero_dt(self):
+        with self.assertRaisesRegex(ValueError, "strictly positive"):
+            InertialKalmanFilter(_rest_state(), dt=0.0)
+
+    def test_rejects_negative_dt(self):
+        with self.assertRaisesRegex(ValueError, "strictly positive"):
+            InertialKalmanFilter(_rest_state(), dt=-DT)
+
+    def test_normalizes_initial_quaternion(self):
+        state = _rest_state()
+        state[6:10] = [0.0, 3.0, 0.0, 4.0]
+        kf = InertialKalmanFilter(state, dt=DT)
+        np.testing.assert_allclose(
+            kf.quaternion, [0.0, 0.6, 0.0, 0.8], rtol=1e-15,
+        )
+
+    def test_does_not_mutate_input_state(self):
+        state = _rest_state()
+        state[6:10] = [0.0, 3.0, 0.0, 4.0]
+        before = state.copy()
+        InertialKalmanFilter(state, dt=DT)
+        np.testing.assert_array_equal(state, before)
+
+    def test_state_roundtrip(self):
+        state = np.array(
+            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 0.0, 0.0, 0.0, 1.0],
+        )
+        kf = InertialKalmanFilter(state, dt=DT)
+        np.testing.assert_array_equal(kf.position, [1.0, 2.0, 3.0])
+        np.testing.assert_array_equal(kf.velocity, [4.0, 5.0, 6.0])
+        np.testing.assert_array_equal(kf.quaternion, [0.0, 0.0, 0.0, 1.0])
+
+    def test_lever_arm_defaults_to_zero(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT)
+        np.testing.assert_array_equal(kf.lever_arm, np.zeros(3))
+
+    def test_lever_arm_stored_as_copy(self):
+        arm = np.array([0.1, 0.2, 0.3])
+        kf = InertialKalmanFilter(_rest_state(), dt=DT, lever_arm=arm)
+        arm[0] = 99.0
+        np.testing.assert_array_equal(kf.lever_arm, [0.1, 0.2, 0.3])
+
+    def test_covariance_shape(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT)
+        self.assertEqual(kf.covariance.shape, (10, 10))
+
+
+class FilterPredictTC(unittest.TestCase):
+
+    def test_stationary_body_stays_put(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT, earth_rate=0.0)
+        p0 = kf.position
+        dv = -kf.gravity(p0) * DT
+        for _ in range(50):
+            kf.predict(dv, np.zeros(3))
+        np.testing.assert_allclose(kf.position, p0, rtol=0.0, atol=1e-6)
+        np.testing.assert_allclose(kf.velocity, np.zeros(3), atol=1e-9)
+        np.testing.assert_allclose(
+            kf.quaternion, quat_identity(), atol=1e-15,
+        )
+
+    def test_free_fall_single_step(self):
+        kf = InertialKalmanFilter(
+            _rest_state(), dt=DT, earth_rate=0.0, use_j2=False,
+        )
+        p0 = kf.position
+        g0 = _two_body_gravity(p0)
+        kf.predict(np.zeros(3), np.zeros(3))
+        np.testing.assert_allclose(kf.velocity, g0 * DT, rtol=1e-12)
+        np.testing.assert_allclose(
+            kf.position - p0, 0.5 * g0 * DT ** 2, rtol=1e-5, atol=1e-12,
+        )
+
+    def test_free_fall_two_steps(self):
+        kf = InertialKalmanFilter(
+            _rest_state(), dt=DT, earth_rate=0.0, use_j2=False,
+        )
+        p0 = kf.position
+        g0 = _two_body_gravity(p0)
+        v1 = g0 * DT
+        p1 = p0 + 0.5 * g0 * DT ** 2
+        g1 = _two_body_gravity(p1)
+        v2 = v1 + g1 * DT
+        p2 = p1 + v1 * DT + 0.5 * g1 * DT ** 2
+        kf.predict(np.zeros(3), np.zeros(3))
+        kf.predict(np.zeros(3), np.zeros(3))
+        np.testing.assert_allclose(kf.velocity, v2, rtol=1e-10)
+        np.testing.assert_allclose(
+            kf.position - p0, p2 - p0, rtol=1e-5, atol=1e-12,
+        )
+
+    def test_commanded_acceleration_single_step(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT, earth_rate=0.0)
+        p0 = kf.position
+        a_cmd = np.array([0.0, 2.5, 0.0])
+        dv = (a_cmd - kf.gravity(p0)) * DT
+        kf.predict(dv, np.zeros(3))
+        np.testing.assert_allclose(
+            kf.velocity, a_cmd * DT, rtol=1e-9, atol=1e-15,
+        )
+        np.testing.assert_allclose(
+            kf.position - p0, 0.5 * a_cmd * DT ** 2, rtol=1e-9, atol=1e-9,
+        )
+
+    def test_pure_spin_integrates_attitude(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT, earth_rate=0.0)
+        dtheta = np.array([0.0, 0.0, 0.008])
+        nstep = 25
+        for _ in range(nstep):
+            kf.predict(np.zeros(3), dtheta)
+        total = dtheta * nstep
+        angle = float(np.linalg.norm(total))
+        axis = total / angle
+        expected_dcm = (
+            np.cos(angle) * np.eye(3)
+            + (1.0 - np.cos(angle)) * np.outer(axis, axis)
+            + np.sin(angle) * kalmanfilter._skew(axis)
+        )
+        np.testing.assert_allclose(
+            quat_to_dcm(kf.quaternion), expected_dcm, atol=1e-12,
+        )
+
+    def test_quaternion_norm_preserved(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT, earth_rate=0.0)
+        dtheta = np.array([0.01, -0.02, 0.015])
+        for _ in range(200):
+            kf.predict(np.zeros(3), dtheta)
+        norm = float(np.linalg.norm(kf.quaternion))
+        self.assertAlmostEqual(norm, 1.0, places=12)
+
+    def test_earth_rest_equilibrium(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT)
+        p0 = kf.position
+        g0 = kf.gravity(p0)
+        centrifugal = np.array([
+            EARTH_RATE ** 2 * p0[0], EARTH_RATE ** 2 * p0[1], 0.0,
+        ])
+        dv = (-g0 - centrifugal) * DT
+        dtheta = np.array([0.0, 0.0, EARTH_RATE * DT])
+        for _ in range(20):
+            kf.predict(dv, dtheta)
+        np.testing.assert_allclose(kf.velocity, np.zeros(3), atol=1e-7)
+        np.testing.assert_allclose(
+            kf.quaternion, quat_identity(), atol=1e-12,
+        )
+        np.testing.assert_allclose(kf.position, p0, rtol=0.0, atol=1e-2)
+
+    def test_coriolis_deflects_moving_body(self):
+        state = _rest_state()
+        vel = 100.0
+        state[3:6] = [0.0, vel, 0.0]
+        kf = InertialKalmanFilter(state, dt=DT, include_centrifugal=False)
+        dv = -kf.gravity(kf.position) * DT
+        kf.predict(dv, np.zeros(3))
+        expected_vx = 2.0 * EARTH_RATE * vel * DT
+        np.testing.assert_allclose(
+            kf.velocity, [expected_vx, vel, 0.0], rtol=1e-12, atol=1e-15,
+        )
+
+    def test_centrifugal_toggle_changes_velocity(self):
+        kf_on = InertialKalmanFilter(_rest_state(), dt=DT)
+        kf_off = InertialKalmanFilter(
+            _rest_state(), dt=DT, include_centrifugal=False,
+        )
+        dv = -kf_on.gravity(kf_on.position) * DT
+        kf_on.predict(dv, np.zeros(3))
+        kf_off.predict(dv, np.zeros(3))
+        diff = kf_on.velocity - kf_off.velocity
+        expected = [EARTH_RATE ** 2 * WGS84_SEMI_MAJOR * DT, 0.0, 0.0]
+        np.testing.assert_allclose(diff, expected, rtol=1e-12, atol=1e-15)
+
+    def test_lever_arm_zero_equals_disabled(self):
+        kf_zero = InertialKalmanFilter(
+            _rest_state(), dt=DT, earth_rate=0.0, lever_arm=np.zeros(3),
+        )
+        kf_none = InertialKalmanFilter(
+            _rest_state(), dt=DT, earth_rate=0.0, lever_arm=None,
+        )
+        dv = np.array([0.1, -0.2, 0.3])
+        dtheta = np.array([0.01, 0.02, -0.03])
+        for _ in range(3):
+            kf_zero.predict(dv, dtheta)
+            kf_none.predict(dv, dtheta)
+        np.testing.assert_array_equal(kf_zero.state, kf_none.state)
+
+    def test_lever_arm_correction(self):
+        arm = np.array([0.1, -0.2, 0.5])
+        kf_arm = InertialKalmanFilter(
+            _rest_state(), dt=DT, earth_rate=0.0, lever_arm=arm,
+        )
+        kf_ref = InertialKalmanFilter(
+            _rest_state(), dt=DT, earth_rate=0.0, lever_arm=None,
+        )
+
+        kf_arm.predict(np.zeros(3), np.zeros(3))
+        kf_ref.predict(np.zeros(3), np.zeros(3))
+        np.testing.assert_array_equal(kf_arm.state, kf_ref.state)
+
+        dtheta = np.array([0.02, 0.04, -0.06])
+        kf_arm.predict(np.zeros(3), dtheta)
+        kf_ref.predict(np.zeros(3), dtheta)
+        omega = dtheta / DT
+        correction = (
+            np.cross(omega, np.cross(omega, arm)) * DT
+            + np.cross(omega, arm)
+        )
+        np.testing.assert_allclose(
+            kf_arm.velocity - kf_ref.velocity, -correction,
+            rtol=1e-12, atol=1e-15,
+        )
+        np.testing.assert_array_equal(kf_arm.quaternion, kf_ref.quaternion)
+
+    def test_predict_returns_current_state(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT, earth_rate=0.0)
+        ret = kf.predict(np.zeros(3), np.zeros(3))
+        np.testing.assert_array_equal(ret, kf.state)
+
+    def test_covariance_trace_increases(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT, earth_rate=0.0)
+        trace0 = float(np.trace(kf.covariance))
+        kf.predict(np.zeros(3), np.zeros(3))
+        self.assertGreater(float(np.trace(kf.covariance)), trace0)
+
+    def test_accepts_python_lists(self):
+        kf = InertialKalmanFilter(_rest_state(), dt=DT, earth_rate=0.0)
+        ret = kf.predict([0.0, 0.0, 0.0], [0.0, 0.0, 0.0])
+        self.assertEqual(ret.shape, (10,))
+
+
+class FigurePathTC(unittest.TestCase):
+
+    def test_file_name_prefix(self):
+        self.assertEqual(
+            kalmanfilter._figure_path("/tmp/run1"),
+            pathlib.Path("/tmp/run1_kf_predict.png"),
+        )
+
+    def test_directory_prefix(self):
+        self.assertEqual(
+            kalmanfilter._figure_path("/tmp/out/"),
+            pathlib.Path("/tmp/out/_kf_predict.png"),
+        )
+
+    def test_relative_prefix(self):
+        self.assertEqual(
+            kalmanfilter._figure_path("results"),
+            pathlib.Path("results_kf_predict.png"),
+        )
+
+
+class EventHelperTC(unittest.TestCase):
+
+    def test_initial_state_from_event(self):
+        data = {}
+        for i in (1, 2, 3):
+            data[f"truth_pos_CON_ECEF_ECEF_M[{i}]"] = float(i)
+            data[f"truth_vel_CON_ECEF_ECEF_MpS[{i}]"] = float(3 + i)
+        for i in (1, 2, 3, 4):
+            data[f"truth_quat_CON2ECEF[{i}]"] = float(6 + i)
+        state = kalmanfilter._initial_state_from_event(_StubEvent(data))
+        np.testing.assert_array_equal(state, np.arange(1.0, 11.0))
+
+    def test_imu_increments_rotate_into_con(self):
+        dv_imu = np.array([1.0, 2.0, 3.0])
+        da_imu = np.array([0.1, 0.2, 0.3])
+        data = {}
+        for i in (1, 2, 3):
+            data[f"DATA_DELTA_VEL[{i}]"] = dv_imu[i - 1]
+            data[f"DATA_DELTA_ANGLE[{i}]"] = da_imu[i - 1]
+        dv, da = kalmanfilter._imu_increments(_StubEvent(data))
+        np.testing.assert_array_equal(dv, DLC_IMU_DCM_CON_IMU @ dv_imu)
+        np.testing.assert_array_equal(da, DLC_IMU_DCM_CON_IMU @ da_imu)
+
+    def test_gt_pos_vel(self):
+        data = {}
+        for i in (1, 2, 3):
+            data[f"truth_pos_CON_ECEF_ECEF_M[{i}]"] = float(i)
+            data[f"truth_vel_CON_ECEF_ECEF_MpS[{i}]"] = float(3 + i)
+        p, v = kalmanfilter._gt_pos_vel(_StubEvent(data))
+        np.testing.assert_array_equal(p, [1.0, 2.0, 3.0])
+        np.testing.assert_array_equal(v, [4.0, 5.0, 6.0])
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_track_kalmanfilter.py
+++ b/tests/test_track_kalmanfilter.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2026, solvcon team <contact@solvcon.net>
 # BSD 3-Clause License, see COPYING
 
@@ -24,17 +23,19 @@ from solvcon.track.kalmanfilter import (
 
 
 DT = 0.02
+ZERO3 = np.zeros(3, dtype='float64')
+EYE3 = np.eye(3, dtype='float64')
 
 
 def _rest_state():
-    state = np.zeros(10)
+    state = np.zeros(10, dtype='float64')
     state[0] = WGS84_SEMI_MAJOR
     state[9] = 1.0
     return state
 
 
 def _two_body_gravity(position):
-    position = np.asarray(position, dtype=float)
+    position = np.asarray(position, dtype='float64')
     r = float(np.linalg.norm(position))
     return -WGS84_GM * position / r ** 3
 
@@ -48,14 +49,14 @@ class _StubEvent:
 class QuaternionMathTC(unittest.TestCase):
 
     def test_skew_matches_cross_product(self):
-        v = np.array([0.3, -1.2, 2.5])
-        u = np.array([-0.7, 0.4, 1.1])
+        v = np.array([0.3, -1.2, 2.5], dtype='float64')
+        u = np.array([-0.7, 0.4, 1.1], dtype='float64')
         np.testing.assert_allclose(
             kalmanfilter._skew(v) @ u, np.cross(v, u), atol=1e-15,
         )
 
     def test_skew_antisymmetric(self):
-        m = kalmanfilter._skew(np.array([1.0, 2.0, 3.0]))
+        m = kalmanfilter._skew(np.array([1.0, 2.0, 3.0], dtype='float64'))
         np.testing.assert_array_equal(m.T, -m)
 
     def test_identity_value(self):
@@ -99,12 +100,12 @@ class QuaternionMathTC(unittest.TestCase):
 
     def test_dcm_of_identity(self):
         np.testing.assert_array_equal(
-            quat_to_dcm(quat_identity()), np.eye(3),
+            quat_to_dcm(quat_identity()), EYE3,
         )
 
     def test_dcm_orthonormal_proper(self):
         r = quat_to_dcm(rotvec_to_quat([0.4, -0.9, 1.3]))
-        np.testing.assert_allclose(r @ r.T, np.eye(3), atol=1e-12)
+        np.testing.assert_allclose(r @ r.T, EYE3, atol=1e-12)
         self.assertAlmostEqual(float(np.linalg.det(r)), 1.0, places=12)
 
     def test_dcm_quarter_turn_convention(self):
@@ -115,11 +116,11 @@ class QuaternionMathTC(unittest.TestCase):
 
     def test_rotvec_zero_gives_identity(self):
         np.testing.assert_array_equal(
-            rotvec_to_quat(np.zeros(3)), quat_identity(),
+            rotvec_to_quat(ZERO3), quat_identity(),
         )
 
     def test_rotvec_small_angle_series(self):
-        theta = np.array([1.0e-13, 0.0, 0.0])
+        theta = np.array([1.0e-13, 0.0, 0.0], dtype='float64')
         q = rotvec_to_quat(theta)
         np.testing.assert_allclose(
             q, [5.0e-14, 0.0, 0.0, 1.0], rtol=1e-6, atol=0.0,
@@ -133,11 +134,11 @@ class QuaternionMathTC(unittest.TestCase):
 
     def test_rotvec_dcm_matches_rodrigues(self):
         for theta in ([0.5, 0.0, 0.0], [0.1, -0.7, 0.4], [-1.2, 0.3, 2.1]):
-            theta = np.asarray(theta)
+            theta = np.asarray(theta, dtype='float64')
             angle = float(np.linalg.norm(theta))
             axis = theta / angle
             expected = (
-                np.cos(angle) * np.eye(3)
+                np.cos(angle) * EYE3
                 + (1.0 - np.cos(angle)) * np.outer(axis, axis)
                 - np.sin(angle) * kalmanfilter._skew(axis)
             )
@@ -150,7 +151,7 @@ class DlcImuConstantTC(unittest.TestCase):
 
     def test_dcm_con_imu_orthonormal(self):
         r = DLC_IMU_DCM_CON_IMU
-        np.testing.assert_allclose(r @ r.T, np.eye(3), atol=5e-4)
+        np.testing.assert_allclose(r @ r.T, EYE3, atol=5e-4)
 
     def test_dcm_con_imu_proper_rotation(self):
         det = float(np.linalg.det(DLC_IMU_DCM_CON_IMU))
@@ -167,7 +168,7 @@ class GravityModelTC(unittest.TestCase):
 
     def test_two_body_general_position(self):
         kf = InertialKalmanFilter(_rest_state(), dt=DT, use_j2=False)
-        p = np.array([3.0e6, -4.0e6, 2.5e6])
+        p = np.array([3.0e6, -4.0e6, 2.5e6], dtype='float64')
         np.testing.assert_allclose(
             kf.gravity(p), _two_body_gravity(p), rtol=1e-14,
         )
@@ -194,7 +195,7 @@ class GravityModelTC(unittest.TestCase):
 
     def test_zero_position_returns_zero(self):
         kf = InertialKalmanFilter(_rest_state(), dt=DT)
-        np.testing.assert_array_equal(kf.gravity(np.zeros(3)), np.zeros(3))
+        np.testing.assert_array_equal(kf.gravity(ZERO3), ZERO3)
 
 
 class FilterConstructionTC(unittest.TestCase):
@@ -203,11 +204,11 @@ class FilterConstructionTC(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, "initial_state must have shape",
         ):
-            InertialKalmanFilter(np.zeros(9), dt=DT)
+            InertialKalmanFilter(np.zeros(9, dtype='float64'), dt=DT)
 
     def test_rejects_zero_quaternion(self):
         with self.assertRaisesRegex(ValueError, "zero norm"):
-            InertialKalmanFilter(np.zeros(10), dt=DT)
+            InertialKalmanFilter(np.zeros(10, dtype='float64'), dt=DT)
 
     def test_rejects_zero_dt(self):
         with self.assertRaisesRegex(ValueError, "strictly positive"):
@@ -235,6 +236,7 @@ class FilterConstructionTC(unittest.TestCase):
     def test_state_roundtrip(self):
         state = np.array(
             [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 0.0, 0.0, 0.0, 1.0],
+            dtype='float64',
         )
         kf = InertialKalmanFilter(state, dt=DT)
         np.testing.assert_array_equal(kf.position, [1.0, 2.0, 3.0])
@@ -243,10 +245,10 @@ class FilterConstructionTC(unittest.TestCase):
 
     def test_lever_arm_defaults_to_zero(self):
         kf = InertialKalmanFilter(_rest_state(), dt=DT)
-        np.testing.assert_array_equal(kf.lever_arm, np.zeros(3))
+        np.testing.assert_array_equal(kf.lever_arm, ZERO3)
 
     def test_lever_arm_stored_as_copy(self):
-        arm = np.array([0.1, 0.2, 0.3])
+        arm = np.array([0.1, 0.2, 0.3], dtype='float64')
         kf = InertialKalmanFilter(_rest_state(), dt=DT, lever_arm=arm)
         arm[0] = 99.0
         np.testing.assert_array_equal(kf.lever_arm, [0.1, 0.2, 0.3])
@@ -263,9 +265,9 @@ class FilterPredictTC(unittest.TestCase):
         p0 = kf.position
         dv = -kf.gravity(p0) * DT
         for _ in range(50):
-            kf.predict(dv, np.zeros(3))
+            kf.predict(dv, ZERO3)
         np.testing.assert_allclose(kf.position, p0, rtol=0.0, atol=1e-6)
-        np.testing.assert_allclose(kf.velocity, np.zeros(3), atol=1e-9)
+        np.testing.assert_allclose(kf.velocity, ZERO3, atol=1e-9)
         np.testing.assert_allclose(
             kf.quaternion, quat_identity(), atol=1e-15,
         )
@@ -276,7 +278,7 @@ class FilterPredictTC(unittest.TestCase):
         )
         p0 = kf.position
         g0 = _two_body_gravity(p0)
-        kf.predict(np.zeros(3), np.zeros(3))
+        kf.predict(ZERO3, ZERO3)
         np.testing.assert_allclose(kf.velocity, g0 * DT, rtol=1e-12)
         np.testing.assert_allclose(
             kf.position - p0, 0.5 * g0 * DT ** 2, rtol=1e-5, atol=1e-12,
@@ -293,8 +295,8 @@ class FilterPredictTC(unittest.TestCase):
         g1 = _two_body_gravity(p1)
         v2 = v1 + g1 * DT
         p2 = p1 + v1 * DT + 0.5 * g1 * DT ** 2
-        kf.predict(np.zeros(3), np.zeros(3))
-        kf.predict(np.zeros(3), np.zeros(3))
+        kf.predict(ZERO3, ZERO3)
+        kf.predict(ZERO3, ZERO3)
         np.testing.assert_allclose(kf.velocity, v2, rtol=1e-10)
         np.testing.assert_allclose(
             kf.position - p0, p2 - p0, rtol=1e-5, atol=1e-12,
@@ -303,9 +305,9 @@ class FilterPredictTC(unittest.TestCase):
     def test_commanded_acceleration_single_step(self):
         kf = InertialKalmanFilter(_rest_state(), dt=DT, earth_rate=0.0)
         p0 = kf.position
-        a_cmd = np.array([0.0, 2.5, 0.0])
+        a_cmd = np.array([0.0, 2.5, 0.0], dtype='float64')
         dv = (a_cmd - kf.gravity(p0)) * DT
-        kf.predict(dv, np.zeros(3))
+        kf.predict(dv, ZERO3)
         np.testing.assert_allclose(
             kf.velocity, a_cmd * DT, rtol=1e-9, atol=1e-15,
         )
@@ -315,15 +317,15 @@ class FilterPredictTC(unittest.TestCase):
 
     def test_pure_spin_integrates_attitude(self):
         kf = InertialKalmanFilter(_rest_state(), dt=DT, earth_rate=0.0)
-        dtheta = np.array([0.0, 0.0, 0.008])
+        dtheta = np.array([0.0, 0.0, 0.008], dtype='float64')
         nstep = 25
         for _ in range(nstep):
-            kf.predict(np.zeros(3), dtheta)
+            kf.predict(ZERO3, dtheta)
         total = dtheta * nstep
         angle = float(np.linalg.norm(total))
         axis = total / angle
         expected_dcm = (
-            np.cos(angle) * np.eye(3)
+            np.cos(angle) * EYE3
             + (1.0 - np.cos(angle)) * np.outer(axis, axis)
             + np.sin(angle) * kalmanfilter._skew(axis)
         )
@@ -333,9 +335,9 @@ class FilterPredictTC(unittest.TestCase):
 
     def test_quaternion_norm_preserved(self):
         kf = InertialKalmanFilter(_rest_state(), dt=DT, earth_rate=0.0)
-        dtheta = np.array([0.01, -0.02, 0.015])
+        dtheta = np.array([0.01, -0.02, 0.015], dtype='float64')
         for _ in range(200):
-            kf.predict(np.zeros(3), dtheta)
+            kf.predict(ZERO3, dtheta)
         norm = float(np.linalg.norm(kf.quaternion))
         self.assertAlmostEqual(norm, 1.0, places=12)
 
@@ -345,12 +347,12 @@ class FilterPredictTC(unittest.TestCase):
         g0 = kf.gravity(p0)
         centrifugal = np.array([
             EARTH_RATE ** 2 * p0[0], EARTH_RATE ** 2 * p0[1], 0.0,
-        ])
+        ], dtype='float64')
         dv = (-g0 - centrifugal) * DT
-        dtheta = np.array([0.0, 0.0, EARTH_RATE * DT])
+        dtheta = np.array([0.0, 0.0, EARTH_RATE * DT], dtype='float64')
         for _ in range(20):
             kf.predict(dv, dtheta)
-        np.testing.assert_allclose(kf.velocity, np.zeros(3), atol=1e-7)
+        np.testing.assert_allclose(kf.velocity, ZERO3, atol=1e-7)
         np.testing.assert_allclose(
             kf.quaternion, quat_identity(), atol=1e-12,
         )
@@ -362,7 +364,7 @@ class FilterPredictTC(unittest.TestCase):
         state[3:6] = [0.0, vel, 0.0]
         kf = InertialKalmanFilter(state, dt=DT, include_centrifugal=False)
         dv = -kf.gravity(kf.position) * DT
-        kf.predict(dv, np.zeros(3))
+        kf.predict(dv, ZERO3)
         expected_vx = 2.0 * EARTH_RATE * vel * DT
         np.testing.assert_allclose(
             kf.velocity, [expected_vx, vel, 0.0], rtol=1e-12, atol=1e-15,
@@ -374,28 +376,28 @@ class FilterPredictTC(unittest.TestCase):
             _rest_state(), dt=DT, include_centrifugal=False,
         )
         dv = -kf_on.gravity(kf_on.position) * DT
-        kf_on.predict(dv, np.zeros(3))
-        kf_off.predict(dv, np.zeros(3))
+        kf_on.predict(dv, ZERO3)
+        kf_off.predict(dv, ZERO3)
         diff = kf_on.velocity - kf_off.velocity
         expected = [EARTH_RATE ** 2 * WGS84_SEMI_MAJOR * DT, 0.0, 0.0]
         np.testing.assert_allclose(diff, expected, rtol=1e-12, atol=1e-15)
 
     def test_lever_arm_zero_equals_disabled(self):
         kf_zero = InertialKalmanFilter(
-            _rest_state(), dt=DT, earth_rate=0.0, lever_arm=np.zeros(3),
+            _rest_state(), dt=DT, earth_rate=0.0, lever_arm=ZERO3,
         )
         kf_none = InertialKalmanFilter(
             _rest_state(), dt=DT, earth_rate=0.0, lever_arm=None,
         )
-        dv = np.array([0.1, -0.2, 0.3])
-        dtheta = np.array([0.01, 0.02, -0.03])
+        dv = np.array([0.1, -0.2, 0.3], dtype='float64')
+        dtheta = np.array([0.01, 0.02, -0.03], dtype='float64')
         for _ in range(3):
             kf_zero.predict(dv, dtheta)
             kf_none.predict(dv, dtheta)
         np.testing.assert_array_equal(kf_zero.state, kf_none.state)
 
     def test_lever_arm_correction(self):
-        arm = np.array([0.1, -0.2, 0.5])
+        arm = np.array([0.1, -0.2, 0.5], dtype='float64')
         kf_arm = InertialKalmanFilter(
             _rest_state(), dt=DT, earth_rate=0.0, lever_arm=arm,
         )
@@ -403,13 +405,13 @@ class FilterPredictTC(unittest.TestCase):
             _rest_state(), dt=DT, earth_rate=0.0, lever_arm=None,
         )
 
-        kf_arm.predict(np.zeros(3), np.zeros(3))
-        kf_ref.predict(np.zeros(3), np.zeros(3))
+        kf_arm.predict(ZERO3, ZERO3)
+        kf_ref.predict(ZERO3, ZERO3)
         np.testing.assert_array_equal(kf_arm.state, kf_ref.state)
 
-        dtheta = np.array([0.02, 0.04, -0.06])
-        kf_arm.predict(np.zeros(3), dtheta)
-        kf_ref.predict(np.zeros(3), dtheta)
+        dtheta = np.array([0.02, 0.04, -0.06], dtype='float64')
+        kf_arm.predict(ZERO3, dtheta)
+        kf_ref.predict(ZERO3, dtheta)
         omega = dtheta / DT
         correction = (
             np.cross(omega, np.cross(omega, arm)) * DT
@@ -423,13 +425,13 @@ class FilterPredictTC(unittest.TestCase):
 
     def test_predict_returns_current_state(self):
         kf = InertialKalmanFilter(_rest_state(), dt=DT, earth_rate=0.0)
-        ret = kf.predict(np.zeros(3), np.zeros(3))
+        ret = kf.predict(ZERO3, ZERO3)
         np.testing.assert_array_equal(ret, kf.state)
 
     def test_covariance_trace_increases(self):
         kf = InertialKalmanFilter(_rest_state(), dt=DT, earth_rate=0.0)
         trace0 = float(np.trace(kf.covariance))
-        kf.predict(np.zeros(3), np.zeros(3))
+        kf.predict(ZERO3, ZERO3)
         self.assertGreater(float(np.trace(kf.covariance)), trace0)
 
     def test_accepts_python_lists(self):
@@ -469,11 +471,12 @@ class EventHelperTC(unittest.TestCase):
         for i in (1, 2, 3, 4):
             data[f"truth_quat_CON2ECEF[{i}]"] = float(6 + i)
         state = kalmanfilter._initial_state_from_event(_StubEvent(data))
-        np.testing.assert_array_equal(state, np.arange(1.0, 11.0))
+        expected = np.arange(1.0, 11.0, dtype='float64')
+        np.testing.assert_array_equal(state, expected)
 
     def test_imu_increments_rotate_into_con(self):
-        dv_imu = np.array([1.0, 2.0, 3.0])
-        da_imu = np.array([0.1, 0.2, 0.3])
+        dv_imu = np.array([1.0, 2.0, 3.0], dtype='float64')
+        da_imu = np.array([0.1, 0.2, 0.3], dtype='float64')
         data = {}
         for i in (1, 2, 3):
             data[f"DATA_DELTA_VEL[{i}]"] = dv_imu[i - 1]


### PR DESCRIPTION
This PR is to add predict calculation of Kalman filter to serve as 
the baseline results of BODDL-TP Flight 1 data.

The predict calculation is to utilize IMU data only and use the first 
record of ground truth as initial condition to predict positions in the ECEF 
frame and then compare with the ground truth to check errors.

This calculation is to predict a 10-element state vector including 3 
positions, 3 velocity and 4 quaterion in the ECEF frame. Coriolis, 
centrifugal force and earth gravity are considered to minimize the error.

Detailed calculation formula is at [this gist](https://gist.github.com/xingularity/f7cde43bf034d3b452c9f0d893306cde#file-predict-md). Please refer to the `Modeling Assumptions and Limitations` section to understand current limitations

Related to #685 .

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
