### PR TITLE
Add periodic contributor update workflow

### DIFF
--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -1,0 +1,64 @@
+name: Update Contributors
+
+on:
+  schedule:
+    - cron: '17 8 1 * *'
+  workflow_dispatch:
+
+concurrency:
+  group: update-contributors
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Update contributor list
+        run: |
+          python3 contrib/lint/analyze-contributors.py \
+            --update-file CONTRIBUTORS.md
+
+      - name: Create contributor update pull request
+        id: contributor_pr
+        uses: peter-evans/create-pull-request@v8
+        with:
+          add-paths: CONTRIBUTORS.md
+          base: master
+          branch: automation/update-contributors
+          delete-branch: true
+          commit-message: Update contributor list
+          title: Update contributor list
+          body: |
+            This pull request updates the contributor list from the commit
+            history and source-file copyright headers. Please review the
+            generated changes before merging.
+
+            Related to #912.
+
+      - name: Send contributor update notification
+        if: >-
+          steps.contributor_pr.outputs.pull-request-operation == 'created' ||
+          steps.contributor_pr.outputs.pull-request-operation == 'updated'
+        uses: dawidd6/action-send-mail@v6
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: Contributor list update in ${{ github.repository }}
+          body: |
+            The contributor list has changed and is ready for human review.
+
+            ${{ steps.contributor_pr.outputs.pull-request-url }}
+          to: solvcon@googlegroups.com
+          from: solvcon_notification

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -2,12 +2,13 @@ name: Update Contributors
 
 on:
   schedule:
+    # Run monthly on the first day at 08:17 UTC.
     - cron: '17 8 1 * *'
   workflow_dispatch:
 
 concurrency:
   group: update-contributors
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -30,25 +31,51 @@ jobs:
 
       - name: Create contributor update pull request
         id: contributor_pr
-        uses: peter-evans/create-pull-request@v8
-        with:
-          add-paths: CONTRIBUTORS.md
-          base: master
-          branch: automation/update-contributors
-          delete-branch: true
-          commit-message: Update contributor list
-          title: Update contributor list
-          body: |
-            This pull request updates the contributor list from the commit
-            history and source-file copyright headers. Please review the
-            generated changes before merging.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet -- CONTRIBUTORS.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-            Related to #912.
+          branch=automation/update-contributors
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            git fetch origin "+$branch:refs/remotes/origin/$branch"
+          fi
+          if git rev-parse --verify "origin/$branch" >/dev/null 2>&1 && \
+              git diff --quiet "origin/$branch" -- CONTRIBUTORS.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git switch -C "$branch"
+          git add CONTRIBUTORS.md
+          git commit -m "Update contributor list"
+          git push --force-with-lease origin "HEAD:$branch"
+
+          pr_url=$(gh pr list \
+            --base master \
+            --head "$branch" \
+            --state open \
+            --json url \
+            --jq '.[0].url')
+
+          if [ -z "$pr_url" ]; then
+            pr_url=$(gh pr create \
+              --base master \
+              --head "$branch" \
+              --title "Update contributor list" \
+              --body $'This pull request updates the contributor list from the commit history and source-file copyright headers. Please review the generated changes before merging.\n\nRelated to #912.')
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "pull-request-url=$pr_url" >> "$GITHUB_OUTPUT"
 
       - name: Send contributor update notification
-        if: >-
-          steps.contributor_pr.outputs.pull-request-operation == 'created' ||
-          steps.contributor_pr.outputs.pull-request-operation == 'updated'
+        if: steps.contributor_pr.outputs.changed == 'true'
         uses: dawidd6/action-send-mail@v6
         with:
           server_address: smtp.gmail.com

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -68,14 +68,16 @@ jobs:
               --base master \
               --head "$branch" \
               --title "Update contributor list" \
-              --body $'This pull request updates the contributor list from the commit history and source-file copyright headers. Please review the generated changes before merging.\n\nRelated to #912.')
+              --body 'This pull request updates the contributor list from the commit history and source-file copyright headers. Please review the generated changes before merging.')
           fi
 
           echo "changed=true" >> "$GITHUB_OUTPUT"
           echo "pull-request-url=$pr_url" >> "$GITHUB_OUTPUT"
 
       - name: Send contributor update notification
-        if: steps.contributor_pr.outputs.changed == 'true'
+        if: >-
+          steps.contributor_pr.outputs.changed == 'true' &&
+          github.repository == 'solvcon/solvcon'
         uses: dawidd6/action-send-mail@v6
         with:
           server_address: smtp.gmail.com

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -40,11 +40,19 @@ jobs:
           fi
 
           branch=automation/update-contributors
+          pr_url=$(gh pr list \
+            --base master \
+            --head "$branch" \
+            --state open \
+            --json url \
+            --jq '.[0].url')
+
           if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
             git fetch origin "+$branch:refs/remotes/origin/$branch"
           fi
           if git rev-parse --verify "origin/$branch" >/dev/null 2>&1 && \
-              git diff --quiet "origin/$branch" -- CONTRIBUTORS.md; then
+              git diff --quiet "origin/$branch" -- CONTRIBUTORS.md && \
+              [ -n "$pr_url" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -55,13 +63,6 @@ jobs:
           git add CONTRIBUTORS.md
           git commit -m "Update contributor list"
           git push --force-with-lease origin "HEAD:$branch"
-
-          pr_url=$(gh pr list \
-            --base master \
-            --head "$branch" \
-            --state open \
-            --json url \
-            --jq '.[0].url')
 
           if [ -z "$pr_url" ]; then
             pr_url=$(gh pr create \

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -11,84 +11,31 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  issues: write
 
 jobs:
-  update:
+  remind:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: master
-          fetch-depth: 0
-
-      - name: Update contributor list
-        run: |
-          python3 contrib/lint/analyze-contributors.py \
-            --update-file CONTRIBUTORS.md
-
-      - name: Create contributor update pull request
-        id: contributor_pr
+      - name: Create contributor update reminder
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if git diff --quiet -- CONTRIBUTORS.md; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          branch=automation/update-contributors
-          pr_url=$(gh pr list \
-            --base master \
-            --head "$branch" \
+          title='Update contributor list'
+          open_reminders=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
             --state open \
-            --json url \
-            --jq '.[0].url')
+            --limit 100 \
+            --json title \
+            --jq "map(select(.title == \"$title\")) | length")
 
-          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-            git fetch origin "+$branch:refs/remotes/origin/$branch"
-          fi
-          if git rev-parse --verify "origin/$branch" >/dev/null 2>&1 && \
-              git diff --quiet "origin/$branch" -- CONTRIBUTORS.md && \
-              [ -n "$pr_url" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+          if [ "$open_reminders" -gt 0 ]; then
+            echo 'An open contributor update reminder already exists.'
             exit 0
           fi
 
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git switch -C "$branch"
-          git add CONTRIBUTORS.md
-          git commit -m "Update contributor list"
-          git push --force-with-lease origin "HEAD:$branch"
-
-          if [ -z "$pr_url" ]; then
-            pr_url=$(gh pr create \
-              --base master \
-              --head "$branch" \
-              --title "Update contributor list" \
-              --body 'This pull request updates the contributor list from the commit history and source-file copyright headers. Please review the generated changes before merging.')
-          fi
-
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-          echo "pull-request-url=$pr_url" >> "$GITHUB_OUTPUT"
-
-      - name: Send contributor update notification
-        if: >-
-          steps.contributor_pr.outputs.changed == 'true' &&
-          github.repository == 'solvcon/solvcon'
-        uses: dawidd6/action-send-mail@v6
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{ secrets.EMAIL_USERNAME }}
-          password: ${{ secrets.EMAIL_PASSWORD }}
-          subject: Contributor list update in ${{ github.repository }}
-          body: |
-            The contributor list has changed and is ready for human review.
-
-            ${{ steps.contributor_pr.outputs.pull-request-url }}
-          to: solvcon@googlegroups.com
-          from: solvcon_notification
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$title" \
+            --body $'Please update `CONTRIBUTORS.md` and review the generated changes before committing them.\n\nRun:\n```console\npython3 contrib/lint/analyze-contributors.py --update-file CONTRIBUTORS.md\n```'

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,14 +2,6 @@
 
 solvcon is made possible by the following contributors.
 
-To update this list, check out `master` with full Git history and run:
-
-```console
-python3 contrib/lint/analyze-contributors.py --update-file CONTRIBUTORS.md
-```
-
-Review the generated changes before submitting them for merge.
-
 - Buganini Chiu <buganini@b612.tw>
 - Chun-Hsu Lai <as2266317@gmail.com>
 - Chun-Shih Chang <austin20463@gmail.com> <sankagetsu.cs08@nycu.edu.tw>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,14 @@
 
 solvcon is made possible by the following contributors.
 
+To update this list, check out `master` with full Git history and run:
+
+```console
+python3 contrib/lint/analyze-contributors.py --update-file CONTRIBUTORS.md
+```
+
+Review the generated changes before submitting them for merge.
+
 - Buganini Chiu <buganini@b612.tw>
 - Chun-Hsu Lai <as2266317@gmail.com>
 - Chun-Shih Chang <austin20463@gmail.com> <sankagetsu.cs08@nycu.edu.tw>


### PR DESCRIPTION
## Summary

- schedule a monthly contributor-list maintenance reminder
- create one open GitHub issue instead of committing generated changes as a bot
- keep the actual update and commit attributable to the maintainer who performs it
- avoid duplicate reminders while an existing `Update contributor list` issue remains open
- use only `issues: write`; do not create branches, pull requests, or email notifications

## Reminder workflow

The issue includes the existing maintenance command:

```console
python3 contrib/lint/analyze-contributors.py --update-file CONTRIBUTORS.md
```

A maintainer can run it, review the generated diff, and commit it under their own identity. Manual workflow dispatch follows the same duplicate-safe path as the monthly schedule.

## Validation

- `actionlint` v1.7.7 passes
- the live read-only `gh issue list` query returns the expected numeric count
- permissions assertion confirms `issues: write` with no contents or pull-request access
- `git diff --check` passes

Related to #912.