### PR TITLE
Add Breckenridge quaternion math for the issue-685 KF baseline

### DIFF
--- a/solvcon/track/kalmanfilter.py
+++ b/solvcon/track/kalmanfilter.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026, Stephen Xie <zonghanxie@proton.me>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Quaternion utilities for strapdown inertial navigation, using the
+Breckenridge convention (``i^2 = j^2 = k^2 = -1``, ``ijk = +1``) with
+the scalar component stored last: ``q = [q_v0, q_v1, q_v2, q_s]``.
+"""
+
+import numpy as np
+
+
+def _skew(v):
+    """
+    Build the 3x3 skew-symmetric cross-product matrix of a 3-vector.
+
+    :param v: Three-element vector.
+    :type v: numpy.ndarray
+    :return: Matrix ``[v]x`` such that ``[v]x @ u == numpy.cross(v, u)``.
+    :rtype: numpy.ndarray
+    """
+    return np.array([
+        [0.0, -v[2], v[1]],
+        [v[2], 0.0, -v[0]],
+        [-v[1], v[0], 0.0],
+    ], dtype='float64')
+
+
+def quat_identity():
+    """
+    Return the Breckenridge identity quaternion (scalar stored last).
+
+    :return: Array ``[0, 0, 0, 1]``.
+    :rtype: numpy.ndarray
+    """
+    return np.array([0.0, 0.0, 0.0, 1.0], dtype='float64')
+
+
+def quat_multiply(q1, q2):
+    """
+    Multiply two Breckenridge quaternions ``q1 (x) q2`` with scalar last.
+
+    Because Breckenridge sets ``ijk = +1``, the cross-product term of the
+    vector component carries the opposite sign to the Hamilton form.
+
+    :param q1: Left quaternion ``[v0, v1, v2, s]``.
+    :type q1: numpy.ndarray
+    :param q2: Right quaternion ``[v0, v1, v2, s]``.
+    :type q2: numpy.ndarray
+    :return: Composed quaternion ``[v0, v1, v2, s]``.
+    :rtype: numpy.ndarray
+    """
+    v1 = np.asarray(q1[0:3], dtype='float64')
+    s1 = float(q1[3])
+    v2 = np.asarray(q2[0:3], dtype='float64')
+    s2 = float(q2[3])
+
+    s = s1 * s2 - float(np.dot(v1, v2))
+    v = s1 * v2 + s2 * v1 - np.cross(v1, v2)
+    return np.array([v[0], v[1], v[2], s], dtype='float64')
+
+
+def quat_to_dcm(q):
+    """
+    Convert a Breckenridge quaternion into the DCM rotating a vector from
+    the body frame to the reference (ECEF) frame.
+
+    :param q: Unit quaternion ``[v0, v1, v2, s]``.
+    :type q: numpy.ndarray
+    :return: 3x3 body-to-reference rotation matrix.
+    :rtype: numpy.ndarray
+    """
+    v = np.asarray(q[0:3], dtype='float64')
+    s = float(q[3])
+    vv = float(np.dot(v, v))
+    eye3 = np.eye(3, dtype='float64')
+    return (s * s - vv) * eye3 + 2.0 * np.outer(v, v) - 2.0 * s * _skew(v)
+
+
+def rotvec_to_quat(theta):
+    """
+    Convert a rotation vector (axis times angle) into a Breckenridge
+    quaternion with scalar last.
+
+    :param theta: Rotation vector in radians, shape ``(3,)``.
+    :type theta: numpy.ndarray
+    :return: Unit quaternion ``[v0, v1, v2, s]``.
+    :rtype: numpy.ndarray
+    """
+    theta = np.asarray(theta, dtype='float64')
+    angle = float(np.linalg.norm(theta))
+    if angle < 1.0e-12:
+        half = 0.5 * theta
+        scalar = 1.0 - 0.125 * float(np.dot(theta, theta))
+        return np.array(
+            [half[0], half[1], half[2], scalar], dtype='float64',
+        )
+    half = 0.5 * angle
+    axis = theta / angle
+    sin_half = np.sin(half)
+    return np.array([
+        axis[0] * sin_half,
+        axis[1] * sin_half,
+        axis[2] * sin_half,
+        np.cos(half),
+    ], dtype='float64')
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_track_kalmanfilter.py
+++ b/tests/test_track_kalmanfilter.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import unittest
+
+import numpy as np
+
+from solvcon.track import kalmanfilter
+from solvcon.track.kalmanfilter import (
+    quat_identity,
+    quat_multiply,
+    quat_to_dcm,
+    rotvec_to_quat,
+)
+
+
+ZERO3 = np.zeros(3, dtype='float64')
+EYE3 = np.eye(3, dtype='float64')
+
+
+class QuaternionMathTC(unittest.TestCase):
+
+    def test_skew_matches_cross_product(self):
+        v = np.array([0.3, -1.2, 2.5], dtype='float64')
+        u = np.array([-0.7, 0.4, 1.1], dtype='float64')
+        np.testing.assert_allclose(
+            kalmanfilter._skew(v) @ u, np.cross(v, u), atol=1e-15,
+        )
+
+    def test_skew_antisymmetric(self):
+        m = kalmanfilter._skew(np.array([1.0, 2.0, 3.0], dtype='float64'))
+        np.testing.assert_array_equal(m.T, -m)
+
+    def test_identity_value(self):
+        np.testing.assert_array_equal(
+            quat_identity(), [0.0, 0.0, 0.0, 1.0],
+        )
+
+    def test_multiply_identity_is_neutral(self):
+        q = rotvec_to_quat([0.3, -0.5, 0.8])
+        np.testing.assert_allclose(
+            quat_multiply(q, quat_identity()), q, atol=1e-15,
+        )
+        np.testing.assert_allclose(
+            quat_multiply(quat_identity(), q), q, atol=1e-15,
+        )
+
+    def test_multiply_breckenridge_basis_products(self):
+        i = [1.0, 0.0, 0.0, 0.0]
+        j = [0.0, 1.0, 0.0, 0.0]
+        np.testing.assert_allclose(
+            quat_multiply(i, j), [0.0, 0.0, -1.0, 0.0], atol=1e-15,
+        )
+        np.testing.assert_allclose(
+            quat_multiply(j, i), [0.0, 0.0, 1.0, 0.0], atol=1e-15,
+        )
+
+    def test_multiply_preserves_unit_norm(self):
+        q1 = rotvec_to_quat([0.2, 0.1, -0.4])
+        q2 = rotvec_to_quat([-0.3, 0.7, 0.5])
+        norm = float(np.linalg.norm(quat_multiply(q1, q2)))
+        self.assertAlmostEqual(norm, 1.0, places=12)
+
+    def test_multiply_dcm_homomorphism(self):
+        q1 = rotvec_to_quat([0.2, 0.1, -0.4])
+        q2 = rotvec_to_quat([-0.3, 0.7, 0.5])
+        np.testing.assert_allclose(
+            quat_to_dcm(quat_multiply(q1, q2)),
+            quat_to_dcm(q1) @ quat_to_dcm(q2),
+            atol=1e-12,
+        )
+
+    def test_dcm_of_identity(self):
+        np.testing.assert_array_equal(
+            quat_to_dcm(quat_identity()), EYE3,
+        )
+
+    def test_dcm_orthonormal_proper(self):
+        r = quat_to_dcm(rotvec_to_quat([0.4, -0.9, 1.3]))
+        np.testing.assert_allclose(r @ r.T, EYE3, atol=1e-12)
+        self.assertAlmostEqual(float(np.linalg.det(r)), 1.0, places=12)
+
+    def test_dcm_quarter_turn_convention(self):
+        q = rotvec_to_quat([0.0, 0.0, np.pi / 2.0])
+        np.testing.assert_allclose(
+            quat_to_dcm(q) @ [1.0, 0.0, 0.0], [0.0, -1.0, 0.0], atol=1e-15,
+        )
+
+    def test_rotvec_zero_gives_identity(self):
+        np.testing.assert_array_equal(
+            rotvec_to_quat(ZERO3), quat_identity(),
+        )
+
+    def test_rotvec_small_angle_series(self):
+        theta = np.array([1.0e-13, 0.0, 0.0], dtype='float64')
+        q = rotvec_to_quat(theta)
+        np.testing.assert_allclose(
+            q, [5.0e-14, 0.0, 0.0, 1.0], rtol=1e-6, atol=0.0,
+        )
+
+    def test_rotvec_half_turn_about_z(self):
+        q = rotvec_to_quat([0.0, 0.0, np.pi])
+        np.testing.assert_allclose(
+            q, [0.0, 0.0, 1.0, 0.0], atol=1e-15,
+        )
+
+    def test_rotvec_dcm_matches_rodrigues(self):
+        for theta in ([0.5, 0.0, 0.0], [0.1, -0.7, 0.4], [-1.2, 0.3, 2.1]):
+            theta = np.asarray(theta, dtype='float64')
+            angle = float(np.linalg.norm(theta))
+            axis = theta / angle
+            expected = (
+                np.cos(angle) * EYE3
+                + (1.0 - np.cos(angle)) * np.outer(axis, axis)
+                - np.sin(angle) * kalmanfilter._skew(axis)
+            )
+            np.testing.assert_allclose(
+                quat_to_dcm(rotvec_to_quat(theta)), expected, atol=1e-12,
+            )
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
This PR is the first of a series of PR to add prediction calculation of Kalman filter for serving as the baseline results of BODDL-TP Flight 1 dataset. This PR is mainly to deliver basic DCM and quaternion math facilities for baseline calculation.

First slice of the IMU-only baseline for issue #685 (estimate the position and attitude of the NASA BODDL-TP flight with a Kalman filter). The dataset's truth_quat_CON2ECEF field uses the Breckenridge quaternion convention (i^2 = j^2 = k^2 = -1, ijk = +1, scalar stored last). This PR delivers only the attitude math the filter will build on: the skew matrix, quaternion identity and product, quaternion-to-DCM conversion, and the rotation-vector exponential with a small-angle branch. Unit tests lock the convention with basis products (i*j = -k), the DCM homomorphism, orthonormality, and a Rodrigues-formula cross-check.

Related to #685.

Detailed formula for issue-685 baseline calculation is at [this gist](https://gist.github.com/xingularity/f7cde43bf034d3b452c9f0d893306cde).

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
