### PR TITLE
Inspector Label 1: Add 2D canvas label controls and collapsible inspector sections

### DIFF
--- a/solvcon/pilot/_canvas_gui.py
+++ b/solvcon/pilot/_canvas_gui.py
@@ -48,17 +48,48 @@ def resolve_save_path(path, name_filter):
 class Save2DCanvasDialog(_gui_common.PilotFeature):
     """
     File-menu action that saves the focused 2D canvas via ``saveImage``.
+
+    The dialog allows the user to choose different file formats (PNG or JPEG)
+    and to include or exclude the label overlay.
     """
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
         self._diag = QtWidgets.QFileDialog(self._mainWindow)
+        self._diag.setOption(QtWidgets.QFileDialog.DontUseNativeDialog, True)
         self._diag.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
         self._diag.setFileMode(QtWidgets.QFileDialog.AnyFile)
         self._diag.setNameFilters([_PNG_FILTER, _JPG_FILTER])
         self._diag.setDefaultSuffix("png")
         self._diag.setWindowTitle("Save 2D canvas")
         self._diag.filterSelected.connect(self._on_filter_selected)
+        self._build_label_controls()
+
+    def _build_label_controls(self):
+        """Add the label switch and normal/advanced selector to the dialog."""
+        self._labels_check = QtWidgets.QCheckBox("Include labels")
+        self._normal_radio = QtWidgets.QRadioButton("normal")
+        self._advanced_radio = QtWidgets.QRadioButton("advanced")
+        self._normal_radio.setChecked(True)
+        group = QtWidgets.QButtonGroup(self._diag)
+        group.addButton(self._normal_radio)
+        group.addButton(self._advanced_radio)
+        self._label_group = group
+        row = QtWidgets.QHBoxLayout()
+        row.addWidget(self._labels_check)
+        row.addWidget(self._normal_radio)
+        row.addWidget(self._advanced_radio)
+        row.addStretch(1)
+        grid = self._diag.layout()
+        grid.addLayout(row, grid.rowCount(), 0, 1, grid.columnCount())
+        self._labels_check.toggled.connect(self._sync_label_radios)
+        self._sync_label_radios()
+
+    def _sync_label_radios(self, _checked=False):
+        """Enable the mode radios only while labels are included."""
+        on = self._labels_check.isChecked()
+        self._normal_radio.setEnabled(on)
+        self._advanced_radio.setEnabled(on)
 
     def populate_menu(self):
         self.add_action(
@@ -71,13 +102,22 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
         )
 
     def run(self):
-        if self._mgr.currentR2DWidget() is None:
+        widget = self._mgr.currentR2DWidget()
+        if widget is None:
             self._pycon.writeToHistory(
                 "Save 2D canvas: no focused 2D canvas\n")
             return False
+        self._init_label_controls(widget)
         self._on_filter_selected(self._diag.selectedNameFilter())
         self._diag.open(self, QtCore.SLOT("on_finished()"))
         return True
+
+    def _init_label_controls(self, widget):
+        """Reset the label controls to their defaults for each open."""
+        # TODO(labeling): preset the switch and mode from widget.overlay.
+        self._labels_check.setChecked(False)
+        self._normal_radio.setChecked(True)
+        self._sync_label_radios()
 
     def _on_filter_selected(self, name_filter):
         filt = (name_filter or "").lower()
@@ -104,6 +144,8 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
             self._pycon.writeToHistory(
                 "Save 2D canvas: no focused 2D canvas\n")
             return False
+        # TODO(labeling): bake the dialog's chosen label overlay into the
+        # export (saveImage(path, overlay)) once the overlay backend lands.
         ok = widget.saveImage(path)
         if ok:
             self._pycon.writeToHistory(f"Save 2D canvas: wrote {path}\n")

--- a/solvcon/pilot/_tree_panel.py
+++ b/solvcon/pilot/_tree_panel.py
@@ -9,11 +9,12 @@ import json
 
 import numpy as np
 
-from PySide6.QtCore import Qt, QTimer
+from PySide6.QtCore import Qt, QTimer, Signal
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QTreeWidget,
                                QTreeWidgetItem, QFrame, QDockWidget,
                                QStackedWidget, QHBoxLayout, QButtonGroup,
-                               QRadioButton)
+                               QRadioButton, QCheckBox, QPushButton,
+                               QSizePolicy)
 
 from .. import core
 from . import _gui_common
@@ -43,14 +44,20 @@ class TreePanelBase(QWidget):
         self._tree.setHeaderHidden(True)
         # Drop the tree frame so its scroll bar sits flush in the panel.
         self._tree.setFrameShape(QFrame.NoFrame)
+        # Keep the tree's content width from driving the dock width.
+        self._tree.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Expanding)
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         self._build_header(layout)
-        layout.addWidget(self._tree)
+        self._build_body(layout)
         self.setLayout(layout)
 
     def _build_header(self, layout):
         """Add controls above the tree; the base panel adds none."""
+
+    def _build_body(self, layout):
+        """Place the tree below the header (EntityTreeWidget overrides it)."""
+        layout.addWidget(self._tree)
 
     def _show_placeholder(self, text):
         """Clear the tree and show a single ``text`` row."""
@@ -263,10 +270,76 @@ class MeshInfoTree(TreePanelBase):
             self.normals_toggled(checked)
 
 
+class _CollapsibleSection(QWidget):
+    """A titled block that folds to just its header when the header is clicked.
+
+    Toggling the header shows or hides the body and emits :attr:`toggled`. A
+    ``fill`` section gives its body the internal stretch, so height granted by
+    the owning panel grows the body rather than the header (see
+    :meth:`EntityTreeWidget._apply_tree_fill`).
+    """
+
+    toggled = Signal(bool)
+
+    _ARROW_OPEN = chr(0x25be)
+    _ARROW_SHUT = chr(0x25b8)
+
+    def __init__(self, title, body, fill=False, parent=None):
+        super().__init__(parent)
+        self._body = body
+        self._title = title
+        self._toggle = QPushButton()
+        self._toggle.setCheckable(True)
+        self._toggle.setChecked(True)
+        self._toggle.setFlat(True)
+        self._toggle.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
+        self._toggle.setStyleSheet(
+            """
+            QPushButton {
+                border: none;
+                font-weight: bold;
+                font-size: 14px;
+                padding: 4px 6px;
+                text-align: left;
+            }
+            QPushButton:hover {
+                background: rgba(127, 127, 127, 40);
+            }
+            """)
+        self._sync_toggle_text(True)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self._toggle)
+        layout.addWidget(self._body, 1 if fill else 0)
+        self._toggle.toggled.connect(self._on_toggled)
+
+    def _sync_toggle_text(self, expanded):
+        arrow = self._ARROW_OPEN if expanded else self._ARROW_SHUT
+        self._toggle.setText(f"{arrow}   {self._title}")
+
+    def _on_toggled(self, expanded):
+        self._body.setVisible(expanded)
+        self._sync_toggle_text(expanded)
+        self.toggled.emit(expanded)
+
+    def body(self):
+        """The section's body widget, hidden while the section is folded."""
+        return self._body
+
+    def is_expanded(self):
+        return self._toggle.isChecked()
+
+    def set_expanded(self, expanded):
+        self._toggle.setChecked(expanded)
+
+
 class EntityTreeWidget(TreePanelBase):
     """Widget that presents the entity tree inside the dock."""
 
     LEVELS = ("basic", "diagnostics")
+
+    LABEL_MODES = ("normal", "advanced")
 
     # Poll period in milliseconds while the tree is on screen. The 2D canvas
     # mutates its world in C++ without a change signal, so the tree re-reads
@@ -280,6 +353,14 @@ class EntityTreeWidget(TreePanelBase):
 
     def __init__(self, world=None, parent=None):
         self._levels = {}
+        self._label_modes = {}
+        self._tree_section = None
+        self._label_section = None
+        self._panel_layout = None
+        self._tree_index = 0
+        self._tail_index = 0
+        self._canvas = None
+        self._syncing = False
         super().__init__(parent)
         self._world = None
         self._fingerprint = self._UNSET
@@ -301,9 +382,54 @@ class EntityTreeWidget(TreePanelBase):
         self._timer.stop()
 
     def _build_header(self, layout):
-        """Add the basic/diagnostics level selector above the tree."""
+        """Stack the labels section over the entity-tree section."""
+        self._panel_layout = layout
+        label_body = self._section_body()
+        self._build_label_controls(label_body.layout())
+        self._label_section = _CollapsibleSection("Labels", label_body)
+        layout.addWidget(self._label_section)
+        layout.addWidget(self._separator())
+        tree_body = self._section_body()
+        self._build_level_selector(tree_body.layout())
+        tree_body.layout().addWidget(self._tree, 1)
+        self._tree_section = _CollapsibleSection("Entity Tree", tree_body,
+                                                 fill=True)
+        layout.addWidget(self._tree_section)
+        self._tree_index = layout.count() - 1
+        layout.addStretch(0)
+        self._tail_index = layout.count() - 1
+        self._tree_section.toggled.connect(self._apply_tree_fill)
+        self._apply_tree_fill(self._tree_section.is_expanded())
+
+    def _apply_tree_fill(self, expanded):
+        """Give the spare height to the open tree, else to the tail stretch."""
+        self._panel_layout.setStretch(self._tree_index, 1 if expanded else 0)
+        self._panel_layout.setStretch(self._tail_index, 0 if expanded else 1)
+
+    def _build_body(self, layout):
+        """The tree is nested in the entity-tree section, not added here."""
+
+    @staticmethod
+    def _section_body():
+        """An empty container whose contents sit indented under the title."""
+        body = QWidget()
+        body_layout = QVBoxLayout(body)
+        body_layout.setContentsMargins(12, 2, 4, 6)
+        body_layout.setSpacing(2)
+        return body
+
+    @staticmethod
+    def _separator():
+        """A horizontal rule between two sections."""
+        line = QFrame()
+        line.setFrameShape(QFrame.HLine)
+        line.setFrameShadow(QFrame.Sunken)
+        return line
+
+    def _build_level_selector(self, layout):
+        """Add the basic/diagnostics level radios (the entity-tree block)."""
         level_row = QHBoxLayout()
-        level_row.setContentsMargins(4, 2, 4, 2)
+        level_row.setContentsMargins(0, 0, 0, 0)
         group = QButtonGroup(self)
         for level in self.LEVELS:
             button = QRadioButton(level)
@@ -315,6 +441,65 @@ class EntityTreeWidget(TreePanelBase):
         for button in self._levels.values():
             button.toggled.connect(self._on_level_toggled)
         layout.addLayout(level_row)
+
+    def _build_label_controls(self, layout):
+        """Add the canvas label switch and its normal/advanced selector.
+
+        Signals connect only after the defaults are set, so building the row
+        emits no stray toggles.
+        """
+        label_row = QHBoxLayout()
+        label_row.setContentsMargins(0, 0, 0, 0)
+        label_row.setSpacing(8)
+        self._labels_check = QCheckBox("show")
+        label_row.addWidget(self._labels_check)
+        mode_group = QButtonGroup(self)
+        for mode in self.LABEL_MODES:
+            button = QRadioButton(mode)
+            mode_group.addButton(button)
+            label_row.addWidget(button)
+            self._label_modes[mode] = button
+        label_row.addStretch(1)
+        self._label_modes["normal"].setChecked(True)
+        self._labels_check.setEnabled(False)
+        self._sync_label_controls_enabled()
+        self._labels_check.toggled.connect(self._on_labels_changed)
+        for button in self._label_modes.values():
+            button.toggled.connect(self._on_labels_changed)
+        layout.addLayout(label_row)
+
+    def _sync_label_controls_enabled(self):
+        """Enable the mode radios only when a canvas is bound and on."""
+        on = self._canvas is not None and self._labels_check.isChecked()
+        for button in self._label_modes.values():
+            button.setEnabled(on)
+
+    def _sync_label_controls(self):
+        """Reflect the bound canvas into the switch and selector."""
+        self._syncing = True
+        try:
+            self._labels_check.setEnabled(self._canvas is not None)
+            if self._canvas is None:
+                self._labels_check.setChecked(False)
+            # TODO(labeling): reflect the bound canvas's overlay (labels on,
+            # normal/advanced) into the switch and mode selector.
+            self._sync_label_controls_enabled()
+        finally:
+            self._syncing = False
+
+    def _on_labels_changed(self, _checked=False):
+        """Keep the mode selector's enabled state in step with the switch."""
+        self._sync_label_controls_enabled()
+        if self._syncing or self._canvas is None:
+            return
+        # TODO(labeling): push (labels on, normal/advanced) into the bound
+        # canvas's overlay so toggling draws the annotations.
+
+    def set_canvas(self, widget):
+        """Bind the active 2D canvas; ``None`` clears it."""
+        self._canvas = widget
+        self.set_world(widget.world if widget is not None else None)
+        self._sync_label_controls()
 
     @classmethod
     def make_world_info(cls, state):
@@ -523,9 +708,8 @@ class TreePanel(_gui_common.PilotFeature):
             self._mesh_tree.set_mesh(widget3d.mesh)
             return
         widget2d = self._mgr.currentR2DWidget()
-        if widget2d is not None:
-            self._stack.setCurrentWidget(self._entity_tree)
-            self._entity_tree.set_world(widget2d.world)
+        self._stack.setCurrentWidget(self._entity_tree)
+        self._entity_tree.set_canvas(widget2d)
 
     def _on_boundary_toggled(self, ibc, checked):
         widget = self._mgr.currentR3DWidget()

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -541,6 +541,53 @@ class Save2DCanvasDialogTC(unittest.TestCase):
         self.assertEqual(data[:8], _PNG_MAGIC)
 
 
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class InspectorLabelControlsTC(unittest.TestCase):
+    """Cover the inspector label controls' UI behavior only.
+
+    The entity tree presents the label switch and normal/advanced selector
+    inside collapsible sections. Driving the canvas overlay from them is
+    deferred to the labeling backend, so nothing here exercises the overlay.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mgr = pilot.RManager.instance.setUp()
+
+    @staticmethod
+    def _tree(widget):
+        from solvcon.pilot._tree_panel import EntityTreeWidget
+        tree = EntityTreeWidget()
+        tree.set_canvas(widget)
+        return tree
+
+    def test_mode_radios_follow_switch(self):
+        widget = self.mgr.add2DWidget()
+        tree = self._tree(widget)
+        self.assertFalse(tree._label_modes["normal"].isEnabled())
+        tree._labels_check.setChecked(True)
+        self.assertTrue(tree._label_modes["normal"].isEnabled())
+
+    def test_world_tree_lives_in_entity_section(self):
+        widget = self.mgr.add2DWidget()
+        tree = self._tree(widget)
+        self.assertIs(tree._tree.parentWidget().parentWidget(),
+                      tree._tree_section)
+
+    def test_sections_collapse_independently(self):
+        widget = self.mgr.add2DWidget()
+        tree = self._tree(widget)
+        self.assertFalse(tree._tree_section.body().isHidden())
+        self.assertFalse(tree._label_section.body().isHidden())
+        tree._tree_section.set_expanded(False)
+        self.assertTrue(tree._tree_section.body().isHidden())
+        self.assertFalse(tree._label_section.body().isHidden())
+        tree._tree_section.set_expanded(True)
+        tree._label_section.set_expanded(False)
+        self.assertFalse(tree._tree_section.body().isHidden())
+        self.assertTrue(tree._label_section.body().isHidden())
+
+
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
                  "live-GUI interaction is unstable under GitHub Actions")
 class PainterToolboxTC(unittest.TestCase):


### PR DESCRIPTION
Adds the inspector label switch and normal/advanced selector plus collapsible inspector sections and the save-dialog controls as UI-only scaffolding, with TODO(labeling) markers where they will drive the canvas overlay.

Related to https://github.com/solvcon/solvcon/issues/896

## Screenshot

Note that labeling is not working in this PR.
<img width="1000" height="623" alt="image" src="https://github.com/user-attachments/assets/a002146d-3803-4943-9135-c28b9e40e847" />
