### PR TITLE
Inspector Label 2: Add the 2D canvas overlay framework and basic shape labels

### DIFF
--- a/cpp/solvcon/pilot/R2DWidget.cpp
+++ b/cpp/solvcon/pilot/R2DWidget.cpp
@@ -5,12 +5,11 @@
 
 #include <solvcon/pilot/R2DWidget.hpp> // Must be the first include.
 
-#include <solvcon/pilot/RWorldRenderer2d.hpp>
-
 #include <array>
 #include <cmath>
 
 #include <QColor>
+#include <QImage>
 #include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
@@ -135,8 +134,10 @@ void R2DWidget::updateWorld(std::shared_ptr<WorldFp64> const & world)
     // Close any edit gesture on the outgoing world before swapping it out.
     finishEdit();
     m_world = world;
-    // A new world invalidates any shape id we held selected.
+    // A new world invalidates any shape id we held selected or highlighted;
+    // the display toggles persist so the overlay mode carries across worlds.
     m_selected = -1;
+    m_overlay.highlight_id = -1;
     m_drag = EditDrag::None;
     update();
 }
@@ -151,13 +152,28 @@ void R2DWidget::paintEvent(QPaintEvent * /*event*/)
 {
     QPainter painter(this);
     constexpr bool full_canvas = true;
-    RWorldRenderer2d(m_world.get(), m_view).paint_canvas(painter, width(), height(), full_canvas);
+    RWorldRenderer2d(m_world.get(), m_view, m_overlay).paint_canvas(painter, width(), height(), full_canvas);
 
     // Rubber-band preview of the shape currently being dragged, if any.
     paintDrawPreview(painter);
 
     // Selection box and rotate handle for the pan tool, if any.
     paintSelection(painter);
+}
+
+QImage R2DWidget::renderImage(Overlay2dOptions const & overlay) const
+{
+    // Match grab()'s device-pixel-ratio-aware output: back the image with
+    // device pixels and paint in logical coordinates, so a high-DPI export
+    // keeps the same resolution as the on-screen frame.
+    double const dpr = devicePixelRatioF();
+    QImage image(size() * dpr, QImage::Format_ARGB32_Premultiplied);
+    image.setDevicePixelRatio(dpr);
+    QPainter painter(&image);
+    constexpr bool full_canvas = true;
+    RWorldRenderer2d(m_world.get(), m_view, overlay)
+        .paint_canvas(painter, width(), height(), full_canvas);
+    return image;
 }
 
 void R2DWidget::paintDrawPreview(QPainter & painter) const

--- a/cpp/solvcon/pilot/R2DWidget.hpp
+++ b/cpp/solvcon/pilot/R2DWidget.hpp
@@ -16,6 +16,7 @@
 
 #include <solvcon/buffer/small_vector.hpp>
 #include <solvcon/pilot/DrawTool.hpp>
+#include <solvcon/pilot/RWorldRenderer2d.hpp>
 #include <solvcon/universe/ViewTransform2d.hpp>
 #include <solvcon/universe/World.hpp>
 
@@ -26,6 +27,7 @@
 #include <QPointF>
 #include <QWidget>
 
+class QImage;
 class QMouseEvent;
 class QPainter;
 class QPaintEvent;
@@ -91,6 +93,22 @@ public:
 
     /// Get the world currently being painted.
     std::shared_ptr<WorldFp64> const & world() const { return m_world; }
+
+    Overlay2dOptions const & overlayOptions() const { return m_overlay; }
+
+    void setOverlayOptions(Overlay2dOptions const & overlay)
+    {
+        m_overlay = overlay;
+        update();
+    }
+
+    /**
+     * Paint the world offscreen into an image at the widget's current size and
+     * view, using the given overlay instead of the on-screen one. Draws only
+     * the backdrop, chrome, and geometry overlay; the selection box and any
+     * in-progress rubber band stay out of the exported frame.
+     */
+    QImage renderImage(Overlay2dOptions const & overlay) const;
 
     /// Hook for subsequent stages; current implementation triggers a repaint.
     void requestRepaint() { update(); }
@@ -159,6 +177,7 @@ private:
 
     ViewTransform2dFp64 m_view;
     std::shared_ptr<WorldFp64> m_world;
+    Overlay2dOptions m_overlay;
     bool m_view_modified = false;
     QPointF m_last_mouse_pos;
 

--- a/cpp/solvcon/pilot/RWorldRenderer2d.cpp
+++ b/cpp/solvcon/pilot/RWorldRenderer2d.cpp
@@ -5,12 +5,22 @@
 
 #include <solvcon/pilot/RWorldRenderer2d.hpp> // Must be the first include.
 
+#include <algorithm>
 #include <cmath>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include <QColor>
+#include <QFontMetricsF>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPen>
+#include <QPointF>
+#include <QRectF>
+#include <QString>
+#include <QStringList>
 
 namespace solvcon
 {
@@ -23,6 +33,9 @@ QColor const MINOR_GRID(64, 64, 70);
 QColor const AXIS(200, 200, 80);
 QColor const ORIGIN(220, 80, 80);
 QColor const GEOMETRY(120, 180, 240);
+QColor const OVERLAY_TEXT(225, 225, 230);
+QColor const OVERLAY_BBOX(150, 200, 150);
+QColor const OVERLAY_HIGHLIGHT(240, 180, 60);
 
 constexpr double BASE_GRID_SPACING_PX = 64.0;
 constexpr double MIN_GRID_SPACING_PX = 16.0;
@@ -95,6 +108,186 @@ void paint_chrome(QPainter & painter, ViewTransform2dFp64 const & view, int widt
     }
 }
 
+/**
+ * Uniform-grid index of screen rectangles a label must not overlap: placed
+ * labels, each shape's padded bbox, and strips over the visible world axes.
+ * add() files a rectangle under the CELL-pixel cells it spans; hits() tests a
+ * trial only against rectangles in the cells it spans. Cells are clamped to
+ * the canvas, bounding the cost of a far-zoomed shape.
+ */
+struct LabelObstacles
+{
+    static constexpr double CELL = 128.0;
+
+    explicit LabelObstacles(double canvas_w, double canvas_h)
+        : max_cx(cell_of(canvas_w))
+        , max_cy(cell_of(canvas_h))
+    {
+    }
+
+    std::vector<QRectF> rects;
+    std::unordered_map<int64_t, std::vector<size_t>> cells;
+    int32_t max_cx;
+    int32_t max_cy;
+
+    static int64_t key(int32_t cx, int32_t cy)
+    {
+        return (static_cast<int64_t>(cy) << 32) ^ static_cast<uint32_t>(cx);
+    }
+
+    static int32_t cell_of(double v)
+    {
+        return static_cast<int32_t>(std::floor(v / CELL));
+    }
+
+    int32_t clamp_cx(int32_t cx) const { return std::clamp(cx, 0, max_cx); }
+    int32_t clamp_cy(int32_t cy) const { return std::clamp(cy, 0, max_cy); }
+
+    void add(QRectF const & r)
+    {
+        if (!(r.isValid() && r.width() > 0.0 && r.height() > 0.0))
+        {
+            return;
+        }
+
+        size_t const idx = rects.size();
+        rects.push_back(r);
+        int32_t const cy0 = clamp_cy(cell_of(r.top()));
+        int32_t const cy1 = clamp_cy(cell_of(r.bottom()));
+        int32_t const cx0 = clamp_cx(cell_of(r.left()));
+        int32_t const cx1 = clamp_cx(cell_of(r.right()));
+        for (int32_t cy = cy0; cy <= cy1; ++cy)
+        {
+            for (int32_t cx = cx0; cx <= cx1; ++cx)
+            {
+                cells[key(cx, cy)].push_back(idx);
+            }
+        }
+    }
+
+    bool hits(QRectF const & trial) const
+    {
+        int32_t const cy0 = clamp_cy(cell_of(trial.top()));
+        int32_t const cy1 = clamp_cy(cell_of(trial.bottom()));
+        int32_t const cx0 = clamp_cx(cell_of(trial.left()));
+        int32_t const cx1 = clamp_cx(cell_of(trial.right()));
+        for (int32_t cy = cy0; cy <= cy1; ++cy)
+        {
+            for (int32_t cx = cx0; cx <= cx1; ++cx)
+            {
+                auto const it = cells.find(key(cx, cy));
+                if (it == cells.end())
+                {
+                    continue;
+                }
+                for (size_t const idx : it->second)
+                {
+                    if (trial.intersects(rects[idx]))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+};
+
+/**
+ * Top-left for a block_w by block_h label placed outside `box`, on-canvas and
+ * clear of `obstacles`. Tries ten fixed seats flanking the box, then rings at
+ * growing radius, and keeps the clear seat nearest the box center. Falls back
+ * to the nearest blocked on-canvas seat, or the top-left corner if none fits.
+ */
+QPointF place_label_block(
+    QRectF const & box,
+    double block_w,
+    double block_h,
+    double canvas_w,
+    double canvas_h,
+    LabelObstacles const & obstacles)
+{
+    constexpr double MARGIN = 10.0;
+    constexpr double PI = 3.14159265358979323846;
+    constexpr int MAX_RINGS = 8;
+
+    auto on_canvas = [&](QPointF const & tl)
+    {
+        return tl.x() >= 2.0 && tl.y() >= 2.0 && tl.x() + block_w <= canvas_w - 2.0 && tl.y() + block_h <= canvas_h - 2.0;
+    };
+
+    bool found = false;
+    QPointF best(2.0, 2.0);
+    double best_dist2 = 1.0e300;
+    QPointF fallback(2.0, 2.0);
+    double fallback_dist2 = 1.0e300;
+    bool have_fallback = false;
+    QPointF const anchor = box.center();
+
+    auto consider = [&](QPointF const & tl)
+    {
+        if (!on_canvas(tl))
+        {
+            return;
+        }
+        QRectF const trial(tl.x(), tl.y(), block_w, block_h);
+        double const dx = trial.center().x() - anchor.x();
+        double const dy = trial.center().y() - anchor.y();
+        double const dist2 = dx * dx + dy * dy;
+        if (obstacles.hits(trial))
+        {
+            if (!have_fallback || dist2 < fallback_dist2)
+            {
+                have_fallback = true;
+                fallback_dist2 = dist2;
+                fallback = tl;
+            }
+            return;
+        }
+        if (!found || dist2 < best_dist2)
+        {
+            found = true;
+            best_dist2 = dist2;
+            best = tl;
+        }
+    };
+
+    consider(QPointF(box.left(), box.top() - block_h - MARGIN));
+    consider(QPointF(box.right() + MARGIN, box.top()));
+    consider(QPointF(box.right() + MARGIN, box.center().y() - block_h * 0.5));
+    consider(QPointF(box.right() + MARGIN, box.bottom() - block_h));
+    consider(QPointF(box.left(), box.bottom() + MARGIN));
+    consider(QPointF(box.left() - block_w - MARGIN, box.bottom() - block_h));
+    consider(QPointF(box.left() - block_w - MARGIN, box.center().y() - block_h * 0.5));
+    consider(QPointF(box.left() - block_w - MARGIN, box.top()));
+    consider(QPointF(box.center().x() - block_w * 0.5, box.top() - block_h - MARGIN));
+    consider(QPointF(box.center().x() - block_w * 0.5, box.bottom() + MARGIN));
+    if (found)
+    {
+        return best;
+    }
+
+    double const rx = 0.5 * box.width() + 0.5 * block_w;
+    double const ry = 0.5 * box.height() + 0.5 * block_h;
+    for (int ring = 0; ring < MAX_RINGS; ++ring)
+    {
+        double const clear = MARGIN + 8.0 * static_cast<double>(ring);
+        int const n_ang = 12 + ring * 4;
+        for (int a = 0; a < n_ang; ++a)
+        {
+            double const ang = (2.0 * PI * static_cast<double>(a)) / static_cast<double>(n_ang);
+            double const cx = anchor.x() + (rx + clear) * std::cos(ang);
+            double const cy = anchor.y() + (ry + clear) * std::sin(ang);
+            consider(QPointF(cx - 0.5 * block_w, cy - 0.5 * block_h));
+        }
+        if (found)
+        {
+            return best;
+        }
+    }
+    return have_fallback ? fallback : best;
+}
+
 } // anonymous namespace
 
 QPointF RWorldRenderer2d::map(double world_x, double world_y) const
@@ -157,6 +350,113 @@ void RWorldRenderer2d::paint(QPainter & painter) const
     }
 }
 
+void RWorldRenderer2d::paint_shape_annotations(QPainter & painter, int width, int height) const
+{
+    // Visible world rectangle from the two screen corners; world +Y is up, so
+    // screen-top maps to the larger world y.
+    double left = 0.0, top = 0.0, right = 0.0, bottom = 0.0;
+    m_view.world_from_screen(0.0, 0.0, left, top);
+    m_view.world_from_screen(static_cast<double>(width), static_cast<double>(height), right, bottom);
+
+    std::vector<int32_t> const ids = m_world->query_visible(
+        std::min(left, right), std::min(top, bottom), std::max(left, right), std::max(top, bottom));
+
+    QPen bbox_pen(OVERLAY_BBOX);
+    bbox_pen.setCosmetic(true);
+    bbox_pen.setWidthF(1.0);
+    bbox_pen.setStyle(Qt::DashLine);
+    QPen highlight_pen(OVERLAY_HIGHLIGHT);
+    highlight_pen.setCosmetic(true);
+    highlight_pen.setWidthF(2.0);
+    highlight_pen.setStyle(Qt::DashLine);
+
+    bool const place_labels = m_overlay.shape_ids;
+    constexpr double PAD = 4.0;
+    constexpr double AXIS_HALF = 5.0;
+    LabelObstacles obstacles(static_cast<double>(width), static_cast<double>(height));
+    std::vector<QRectF> boxes;
+    boxes.reserve(ids.size());
+    for (int32_t const id : ids)
+    {
+        auto const bb = m_world->shape_bbox(id);
+        QRectF box(map(bb[0], bb[3]), map(bb[2], bb[1]));
+        box = box.normalized().adjusted(-PAD, -PAD, PAD, PAD);
+        boxes.push_back(box);
+        if (place_labels)
+        {
+            obstacles.add(box);
+        }
+    }
+    if (place_labels && m_view.pan_y() >= 0.0 && m_view.pan_y() <= static_cast<double>(height))
+    {
+        obstacles.add(QRectF(
+            0.0, m_view.pan_y() - AXIS_HALF, static_cast<double>(width), 2.0 * AXIS_HALF));
+    }
+    if (place_labels && m_view.pan_x() >= 0.0 && m_view.pan_x() <= static_cast<double>(width))
+    {
+        obstacles.add(QRectF(
+            m_view.pan_x() - AXIS_HALF, 0.0, 2.0 * AXIS_HALF, static_cast<double>(height)));
+    }
+
+    // Cap how many shapes get a text label. Past this many visible shapes the
+    // labels overlap into an unreadable mass, and each placement searches the
+    // obstacle index, so an uncapped count degrades to quadratic work on a
+    // dense canvas. Bounding boxes and the highlight box stay drawn for all
+    // shapes (both are cheap), and the highlighted shape is always labeled.
+    constexpr size_t MAX_LABELED_SHAPES = 200;
+
+    QFontMetricsF const metrics(painter.font());
+    double const line_h = metrics.lineSpacing();
+    size_t labels_drawn = 0;
+    for (size_t i = 0; i < ids.size(); ++i)
+    {
+        int32_t const id = ids[i];
+        QRectF const & box = boxes[i];
+        bool const highlighted = (id == m_overlay.highlight_id);
+
+        if (m_overlay.bounding_boxes || highlighted)
+        {
+            painter.setPen(highlighted ? highlight_pen : bbox_pen);
+            painter.setBrush(Qt::NoBrush);
+            painter.drawRect(box.adjusted(PAD, PAD, -PAD, -PAD));
+        }
+        bool const label_this = place_labels && (highlighted || labels_drawn < MAX_LABELED_SHAPES);
+        if (!label_this)
+        {
+            continue;
+        }
+        ++labels_drawn;
+
+        QStringList rows;
+        rows << QStringLiteral("#%1 %2")
+                    .arg(id)
+                    .arg(QString::fromStdString(shape_type_name(m_world->shape_type_of(id))));
+        double widest = 0.0;
+        for (QString const & row : rows)
+        {
+            widest = std::max(widest, metrics.horizontalAdvance(row));
+        }
+        double const block_w = widest + 4.0;
+        double const block_h = line_h * static_cast<double>(rows.size()) + 2.0;
+
+        QPointF const tl = place_label_block(
+            box, block_w, block_h, static_cast<double>(width), static_cast<double>(height), obstacles);
+        QRectF const placed(tl.x(), tl.y(), block_w, block_h);
+        obstacles.add(placed);
+
+        painter.setPen(highlighted ? OVERLAY_HIGHLIGHT : OVERLAY_TEXT);
+        painter.drawText(placed, Qt::AlignLeft | Qt::AlignTop, rows.join(QChar('\n')));
+    }
+}
+
+void RWorldRenderer2d::paint_overlay(QPainter & painter, int width, int height) const
+{
+    if (m_world && m_overlay.shape_annotations())
+    {
+        paint_shape_annotations(painter, width, height);
+    }
+}
+
 void RWorldRenderer2d::paint_canvas(QPainter & painter, int width, int height, bool full_canvas) const
 {
     painter.setRenderHint(QPainter::Antialiasing, true);
@@ -178,6 +478,11 @@ void RWorldRenderer2d::paint_canvas(QPainter & painter, int width, int height, b
         origin_pen.setCapStyle(Qt::RoundCap);
         painter.setPen(origin_pen);
         painter.drawPoint(QPointF(m_view.pan_x(), m_view.pan_y()));
+    }
+
+    if (m_overlay.any())
+    {
+        paint_overlay(painter, width, height);
     }
 }
 

--- a/cpp/solvcon/pilot/RWorldRenderer2d.hpp
+++ b/cpp/solvcon/pilot/RWorldRenderer2d.hpp
@@ -17,6 +17,8 @@
 #include <solvcon/universe/ViewTransform2d.hpp>
 #include <solvcon/universe/World.hpp>
 
+#include <cstdint>
+
 #include <QPointF>
 
 class QPainter;
@@ -25,10 +27,31 @@ namespace solvcon
 {
 
 /**
+ * Toggleable, legibility-only annotations over the 2D canvas: shape ids,
+ * bounding boxes, and one highlighted shape id. Restates stored geometry only
+ * (no derived diagnostics).
+ *
+ * @ingroup group_domain
+ */
+struct Overlay2dOptions
+{
+    bool shape_ids = false;
+    bool bounding_boxes = false;
+    int32_t highlight_id = -1; ///< Emphasize this shape id; -1 draws none. Independent of selection.
+
+    bool shape_annotations() const
+    {
+        return shape_ids || bounding_boxes || highlight_id >= 0;
+    }
+
+    bool any() const { return shape_annotations(); }
+}; /* end struct Overlay2dOptions */
+
+/**
  * Renders a world's live points, segments, and curves into a QPainter in
  * screen space, mapping math-convention world coordinates through a 2D view
  * transform. paint() draws geometry only; paint_canvas() adds the backdrop
- * and optional grid/axes/origin chrome.
+ * and optional grid/axes/origin chrome, then the optional annotation overlay.
  * m_world is non-owning and may be null.
  *
  * @ingroup group_domain
@@ -36,13 +59,14 @@ namespace solvcon
 class RWorldRenderer2d
 {
 public:
-    RWorldRenderer2d(WorldFp64 const * world, ViewTransform2dFp64 const & view)
+    RWorldRenderer2d(WorldFp64 const * world, ViewTransform2dFp64 const & view, Overlay2dOptions const & overlay = {})
         : m_world(world)
         , m_view(view)
+        , m_overlay(overlay)
     {
     }
 
-    /// Paint backdrop, geometry, and optional chrome.
+    /// Paint backdrop, geometry, optional chrome, and the annotation overlay.
     /// @param painter Target painter in screen space.
     /// @param width Canvas width in pixels.
     /// @param height Canvas height in pixels.
@@ -52,11 +76,15 @@ public:
 private:
     void paint(QPainter & painter) const;
 
+    void paint_overlay(QPainter & painter, int width, int height) const;
+    void paint_shape_annotations(QPainter & painter, int width, int height) const;
+
     // Map math-convention world (x, y) to Qt screen pixels; z is dropped.
     QPointF map(double world_x, double world_y) const;
 
     WorldFp64 const * m_world;
     ViewTransform2dFp64 const & m_view;
+    Overlay2dOptions m_overlay;
 }; /* end class RWorldRenderer2d */
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -12,9 +12,12 @@
 #include <solvcon/pilot/RMenuModel.hpp>
 #include <solvcon/pilot/pilot.hpp>
 
+#include <optional>
+
 #include <QAction>
 #include <QActionGroup>
 #include <QClipboard>
+#include <QImage>
 #include <QMenu>
 #include <QPixmap>
 #include <QPointer>
@@ -608,6 +611,11 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapR2DWidget
             .def("updateWorld", &wrapped_type::updateWorld, py::arg("world"))
             .def_property_readonly("world", &wrapped_type::world)
             .def("requestRepaint", &wrapped_type::requestRepaint)
+            .def_property(
+                "overlay",
+                &wrapped_type::overlayOptions,
+                &wrapped_type::setOverlayOptions,
+                py::return_value_policy::copy)
             .def("setDrawTool", &wrapped_type::setDrawTool, py::arg("name"))
             .def_property_readonly("drawTool", &wrapped_type::drawTool)
             .def_property_readonly("selectedShape", &wrapped_type::selectedShape)
@@ -623,19 +631,31 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapR2DWidget
             ;
 
         (*this)
-            .def("clipImage", [](wrapped_type & self)
-                 {
-                     QClipboard * clipboard = QGuiApplication::clipboard();
-                     clipboard->setPixmap(self.grab()); })
+            .def(
+                "clipImage",
+                [](wrapped_type & self, std::optional<Overlay2dOptions> const & overlay)
+                {
+                    QClipboard * clipboard = QGuiApplication::clipboard();
+                    QPixmap const pixmap = overlay ? QPixmap::fromImage(self.renderImage(*overlay)) : self.grab();
+                    clipboard->setPixmap(pixmap);
+                },
+                py::arg("overlay") = py::none(),
+                "Copy the canvas to the clipboard. With no overlay, copies the "
+                "on-screen frame; with an Overlay2dOptions, renders that "
+                "annotation set offscreen instead.")
             .def(
                 "saveImage",
-                [](wrapped_type & self, std::string const & filename)
+                [](wrapped_type & self, std::string const & filename, std::optional<Overlay2dOptions> const & overlay)
                 {
-                    return self.grab().save(filename.c_str());
+                    QImage const image = overlay ? self.renderImage(*overlay) : self.grab().toImage();
+                    return image.save(filename.c_str());
                 },
                 py::arg("filename"),
-                "Grab the current on-screen frame and save it to filename; "
-                "returns whether the write succeeded.")
+                py::arg("overlay") = py::none(),
+                "Save the canvas to filename and return whether the write "
+                "succeeded. With no overlay, saves the on-screen frame; with "
+                "an Overlay2dOptions, renders that annotation set offscreen "
+                "instead, independent of what the widget currently shows.")
             //
             ;
     }
@@ -980,6 +1000,17 @@ void wrap_pilot(pybind11::module & mod)
         "panCamera / zoomCamera / pinchCamera, and fitCameraToScene; capture "
         "frames with "
         "saveImage / clipImage.");
+    py::class_<Overlay2dOptions> overlay_options(
+        mod,
+        "Overlay2dOptions",
+        "Toggleable, legibility-only annotations for the 2D canvas: per-shape "
+        "ids and bounding boxes, and one highlighted shape id. Carries no "
+        "derived facts.");
+    overlay_options.def(py::init<>());
+    overlay_options
+        .def_readwrite("shape_ids", &Overlay2dOptions::shape_ids)
+        .def_readwrite("bounding_boxes", &Overlay2dOptions::bounding_boxes)
+        .def_readwrite("highlight_id", &Overlay2dOptions::highlight_id);
     WrapR2DWidget::commit(mod, "R2DWidget", "R2DWidget");
     WrapRPythonConsoleDockWidget::commit(mod, "RPythonConsoleDockWidget", "RPythonConsoleDockWidget");
     WrapRMenuModel::commit(

--- a/solvcon/pilot/__init__.py
+++ b/solvcon/pilot/__init__.py
@@ -15,6 +15,7 @@ from ._pilot_core import (  # noqa: F401
     mgr,
     RDomainWidget,
     R2DWidget,
+    Overlay2dOptions,
     RPythonConsoleDockWidget,
     RManager,
 )

--- a/solvcon/pilot/_canvas_gui.py
+++ b/solvcon/pilot/_canvas_gui.py
@@ -49,8 +49,10 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
     """
     File-menu action that saves the focused 2D canvas via ``saveImage``.
 
-    The dialog allows the user to choose different file formats (PNG or JPEG)
-    and to include or exclude the label overlay.
+    The save dialog carries an "Include labels" switch and a normal/advanced
+    selector, so the exported image can bake in the annotation overlay
+    independent of what the canvas currently shows on screen. The controls
+    need custom widgets in the dialog, so it runs non-native.
     """
 
     def __init__(self, *args, **kw):
@@ -113,10 +115,14 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
         return True
 
     def _init_label_controls(self, widget):
-        """Reset the label controls to their defaults for each open."""
-        # TODO(labeling): preset the switch and mode from widget.overlay.
-        self._labels_check.setChecked(False)
-        self._normal_radio.setChecked(True)
+        """Preset the label controls from the canvas's current overlay.
+
+        The export defaults to matching what the canvas shows on screen.
+        """
+        on, advanced = _gui_common.label_switch_and_mode(widget.overlay)
+        self._labels_check.setChecked(on)
+        radio = self._advanced_radio if advanced else self._normal_radio
+        radio.setChecked(True)
         self._sync_label_radios()
 
     def _on_filter_selected(self, name_filter):
@@ -138,15 +144,23 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
             return
         self._save_current(path)
 
+    def _export_overlay(self, widget):
+        """Build the overlay to bake into the export from the dialog controls.
+
+        Starts from the canvas's current overlay so a highlight or bounding
+        box set elsewhere survives the export.
+        """
+        on = self._labels_check.isChecked()
+        advanced = on and self._advanced_radio.isChecked()
+        return _gui_common.apply_label_mode(widget.overlay, on, advanced)
+
     def _save_current(self, path):
         widget = self._mgr.currentR2DWidget()
         if widget is None:
             self._pycon.writeToHistory(
                 "Save 2D canvas: no focused 2D canvas\n")
             return False
-        # TODO(labeling): bake the dialog's chosen label overlay into the
-        # export (saveImage(path, overlay)) once the overlay backend lands.
-        ok = widget.saveImage(path)
+        ok = widget.saveImage(path, self._export_overlay(widget))
         if ok:
             self._pycon.writeToHistory(f"Save 2D canvas: wrote {path}\n")
         else:

--- a/solvcon/pilot/_gui_common.py
+++ b/solvcon/pilot/_gui_common.py
@@ -7,6 +7,15 @@ from ..core import Toggle
 from PySide6 import QtCore, QtGui
 
 
+def apply_label_mode(overlay, on, advanced):
+    overlay.shape_ids = on
+    return overlay
+
+
+def label_switch_and_mode(overlay):
+    return overlay.shape_ids, False
+
+
 class ToggleActionBridge(QtCore.QObject):
     """Two-way binding between a checkable QAction and a store toggle.
 

--- a/solvcon/pilot/_pilot_core.py
+++ b/solvcon/pilot/_pilot_core.py
@@ -28,6 +28,7 @@ list_of_rdomainwidget = [
 # R2DWidget.hpp/.cpp
 list_of_r2dwidget = [
     'R2DWidget',
+    'Overlay2dOptions',
 ]
 
 # RManager.hpp/.cpp

--- a/solvcon/pilot/_tree_panel.py
+++ b/solvcon/pilot/_tree_panel.py
@@ -445,8 +445,10 @@ class EntityTreeWidget(TreePanelBase):
     def _build_label_controls(self, layout):
         """Add the canvas label switch and its normal/advanced selector.
 
-        Signals connect only after the defaults are set, so building the row
-        emits no stray toggles.
+        The selector only makes sense while the switch is on, so it follows
+        the switch's enabled state. Both stay disabled until a canvas is
+        bound through :meth:`set_canvas`. Signals connect only after the
+        defaults are set, so building the row drives no overlay writes.
         """
         label_row = QHBoxLayout()
         label_row.setContentsMargins(0, 0, 0, 0)
@@ -475,28 +477,35 @@ class EntityTreeWidget(TreePanelBase):
             button.setEnabled(on)
 
     def _sync_label_controls(self):
-        """Reflect the bound canvas into the switch and selector."""
+        """Reflect the bound canvas's overlay into the controls."""
         self._syncing = True
         try:
             self._labels_check.setEnabled(self._canvas is not None)
             if self._canvas is None:
                 self._labels_check.setChecked(False)
-            # TODO(labeling): reflect the bound canvas's overlay (labels on,
-            # normal/advanced) into the switch and mode selector.
+            else:
+                on, advanced = _gui_common.label_switch_and_mode(
+                    self._canvas.overlay)
+                self._labels_check.setChecked(on)
+                mode = "advanced" if advanced else "normal"
+                self._label_modes[mode].setChecked(True)
             self._sync_label_controls_enabled()
         finally:
             self._syncing = False
 
     def _on_labels_changed(self, _checked=False):
-        """Keep the mode selector's enabled state in step with the switch."""
+        """Write the switch and mode to the bound canvas's overlay. """
         self._sync_label_controls_enabled()
         if self._syncing or self._canvas is None:
             return
-        # TODO(labeling): push (labels on, normal/advanced) into the bound
-        # canvas's overlay so toggling draws the annotations.
+        on = self._labels_check.isChecked()
+        advanced = on and self._label_modes["advanced"].isChecked()
+        overlay = self._canvas.overlay
+        _gui_common.apply_label_mode(overlay, on, advanced)
+        self._canvas.overlay = overlay
 
     def set_canvas(self, widget):
-        """Bind the active 2D canvas; ``None`` clears it."""
+        """Bind the active 2D canvas and show its world."""
         self._canvas = widget
         self.set_world(widget.world if widget is not None else None)
         self._sync_label_controls()

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -541,13 +541,106 @@ class Save2DCanvasDialogTC(unittest.TestCase):
         self.assertEqual(data[:8], _PNG_MAGIC)
 
 
+def _grab_foreground(widget, overlay=None):
+    """Render ``widget`` offscreen and count its non-background pixels.
+
+    With ``overlay`` given, that overlay is baked into the save (and the save
+    is asserted to succeed); otherwise the widget's current overlay is used.
+    Returns the foreground pixel count, which is 0 when the offscreen grab
+    reads back blank (some headless backends cannot capture a QWidget), so
+    callers can skip the pixel comparison rather than fail spuriously.
+    """
+    with tempfile.TemporaryDirectory() as folder:
+        path = os.path.join(folder, "grab.png")
+        if overlay is None:
+            widget.saveImage(path)
+        else:
+            assert widget.saveImage(path, overlay)
+        rgb = _load_rgba(path)[:, :, :3].astype('int16')
+    # The canvas backdrop is RGB(32, 32, 36); anything far from it is drawn.
+    background = np.array([32, 32, 36], dtype='int16')
+    return int((np.abs(rgb - background).max(axis=2) > 60).sum())
+
+
+def _all_on_overlay(highlight_id=-1):
+    """An Overlay2dOptions with every display toggle enabled, optionally
+    highlighting one shape id.
+    """
+    overlay = pilot.Overlay2dOptions()
+    overlay.shape_ids = True
+    overlay.bounding_boxes = True
+    overlay.highlight_id = highlight_id
+    return overlay
+
+
+def _save_and_check_png(testcase, widget):
+    """Save ``widget`` offscreen and assert it wrote a valid PNG."""
+    with tempfile.TemporaryDirectory() as folder:
+        path = os.path.join(folder, "widget.png")
+        widget.saveImage(path)
+        with open(path, 'rb') as stream:
+            data = stream.read()
+    testcase.assertEqual(data[:8], _PNG_MAGIC)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class R2DWidgetOverlayTC(unittest.TestCase):
+    """Annotation overlay: ids, bounding boxes, and highlight-by-id via
+    R2DWidget.overlay.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.widget = pilot.RManager.instance.setUp().add2DWidget()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.widget = None
+
+    def tearDown(self):
+        # The widget is shared across the class, so reset the overlay and view
+        # to leave a clean slate for the next test.
+        self.widget.overlay = pilot.Overlay2dOptions()
+        self.widget.resetView()
+
+    def test_overlay_render_is_crash_safe(self):
+        """Every annotation on, over a world with a removed shape, and with a
+        highlight id that names no live shape, still renders to a valid PNG.
+        """
+        self.widget.updateWorld(_build_world())
+        self.widget.resetView()
+        # highlight_id 9999 names no live shape: must not throw.
+        self.widget.overlay = _all_on_overlay(highlight_id=9999)
+        self.widget.requestRepaint()
+        _save_and_check_png(self, self.widget)
+
+    def test_overlay_adds_foreground_pixels(self):
+        """Enabling the annotations paints strictly more than the bare
+        geometry: the bounding boxes and id labels add pixels the plain
+        render does not have.
+        """
+        world = solvcon.WorldFp64()
+        sid = world.add_rectangle(-2, -1, 2, 1)
+        world.add_circle(-3, 2, 1.0)
+        self.widget.updateWorld(world)
+        self.widget.resetView()
+        self.widget.overlay = pilot.Overlay2dOptions()
+        self.widget.requestRepaint()
+        plain = _grab_foreground(self.widget)
+        if not plain:
+            self.skipTest("offscreen grab reads back blank on this backend")
+        self.widget.overlay = _all_on_overlay(highlight_id=sid)
+        self.widget.requestRepaint()
+        annotated = _grab_foreground(self.widget)
+        self.assertGreater(annotated, plain)
+
+
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class InspectorLabelControlsTC(unittest.TestCase):
-    """Cover the inspector label controls' UI behavior only.
+    """Cover the inspector label controls driving the canvas overlay.
 
-    The entity tree presents the label switch and normal/advanced selector
-    inside collapsible sections. Driving the canvas overlay from them is
-    deferred to the labeling backend, so nothing here exercises the overlay.
+    The inspector entity tree's label switch drives the bound canvas's
+    overlay, per canvas.
     """
 
     @classmethod
@@ -563,6 +656,7 @@ class InspectorLabelControlsTC(unittest.TestCase):
 
     def test_mode_radios_follow_switch(self):
         widget = self.mgr.add2DWidget()
+        widget.overlay = pilot.Overlay2dOptions()
         tree = self._tree(widget)
         self.assertFalse(tree._label_modes["normal"].isEnabled())
         tree._labels_check.setChecked(True)
@@ -586,6 +680,43 @@ class InspectorLabelControlsTC(unittest.TestCase):
         tree._label_section.set_expanded(False)
         self.assertFalse(tree._tree_section.body().isHidden())
         self.assertTrue(tree._label_section.body().isHidden())
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class R2DWidgetExportOverlayTC(unittest.TestCase):
+    """saveImage renders an explicit overlay offscreen, independent of the
+    on-screen overlay, so an image can be exported with or without labels.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.widget = pilot.RManager.instance.setUp().add2DWidget()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.widget = None
+
+    def test_export_overlay_independent_of_on_screen(self):
+        """Exporting with labels bakes them even when the widget shows none,
+        and exporting without labels omits them even when the widget shows
+        all: the file reflects the passed overlay, not the screen.
+        """
+        world = solvcon.WorldFp64()
+        world.add_rectangle(-2, -1, 2, 1)
+        world.add_circle(-3, 2, 1.0)
+        self.widget.updateWorld(world)
+        self.widget.resetView()
+        # Screen shows no labels; export with every label on.
+        self.widget.overlay = pilot.Overlay2dOptions()
+        self.widget.requestRepaint()
+        labeled = _grab_foreground(self.widget, _all_on_overlay())
+        # Screen shows every label; export with none.
+        self.widget.overlay = _all_on_overlay()
+        self.widget.requestRepaint()
+        plain = _grab_foreground(self.widget, pilot.Overlay2dOptions())
+        if not labeled and not plain:
+            self.skipTest("offscreen render reads back blank on this backend")
+        self.assertGreater(labeled, plain)
 
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,


### PR DESCRIPTION
Add the Overlay2dOptions framework with per-shape id, bounding-box, and highlight annotations, uniform-grid label placement, and a label-aware image export, and wire the inspector and save-dialog controls (advanced mode and grid labels follow up).

Related to https://github.com/solvcon/solvcon/issues/896

<img width="1271" height="663" alt="image" src="https://github.com/user-attachments/assets/6113121f-f212-49a4-bd2e-da8ad423e7d2" />
