### PR TITLE
Agent Draw Command 1: generic command framework

### DIFF
--- a/solvcon/agent/__init__.py
+++ b/solvcon/agent/__init__.py
@@ -6,14 +6,27 @@
 Agent: drive the 2D ``World`` with an AI backend, with or without a GUI.
 
 This package lives outside :mod:`solvcon.pilot` so it can also drive pure
-computation that needs no graphics.  The headless core (:mod:`_core`) and the
-backend abstraction (:mod:`_backend`) load without Qt, so they run in CI and a
-headless build.
+computation that needs no graphics.  The headless core (:mod:`_core`), the
+backend abstraction (:mod:`_backend`), and the command framework
+(:mod:`_command`) load without Qt, so they run in CI and a headless build.  A
+command family such as :mod:`solvcon.agent.draw` builds on the framework here.
 """
 
+from . import _command  # noqa: F401
 from . import _core  # noqa: F401
 from . import _backend  # noqa: F401
 from . import _backends_impl  # noqa: F401
+
+# _command.py
+list_of_command = [
+    'Command',
+    'CommandSet',
+    'CommandError',
+    'CommandResult',
+    'CommandProcessor',
+    'CommandDispatcher',
+    'CRUD_CATEGORIES',
+]
 
 # _core.py
 list_of_core = [
@@ -45,7 +58,8 @@ list_of_backends_impl = [
 Agent = None
 
 __all__ = (  # noqa: F822
-    list_of_core + list_of_backend + list_of_backends_impl + ['Agent']
+    list_of_command + list_of_core + list_of_backend
+    + list_of_backends_impl + ['Agent']
 )
 
 
@@ -54,6 +68,7 @@ def _load(module, symbol_list):
         globals()[name] = getattr(module, name)
 
 
+_load(_command, list_of_command)
 _load(_core, list_of_core)
 _load(_backend, list_of_backend)
 _load(_backends_impl, list_of_backends_impl)

--- a/solvcon/agent/_command.py
+++ b/solvcon/agent/_command.py
@@ -1,0 +1,361 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Generic command framework for the Agent.
+
+``Command`` subclasses are collected in a ``CommandSet`` that derives the
+JSON Schema, validators, and tool definitions; a ``CommandProcessor`` runs
+them against a target, and a ``CommandDispatcher`` routes ops across
+families. Imports no Qt; concrete commands live in domain packages such as
+:mod:`solvcon.agent.draw`.
+"""
+
+import copy
+import dataclasses
+
+
+class CommandError(ValueError):
+    """A command failed schema validation or could not be applied."""
+
+
+CRUD_CATEGORIES = ("create", "read", "update", "delete", "log")
+
+
+class Command:
+    """One command: op name, JSON Schema, and behavior."""
+
+    op = ""
+    category = ""
+    summary = ""
+    arguments = {}
+    optional = ()
+    returns = {}
+
+    def apply(self, target, args, ctx):
+        """Apply the command to ``target`` and return its result mapping."""
+        raise NotImplementedError
+
+
+def _command_schema(cmd):
+    # ``op`` is a required const; ``category`` is an annotation
+    # validators ignore.
+    required = [name for name in cmd.arguments if name not in cmd.optional]
+    return {
+        "title": cmd.op,
+        "description": cmd.summary,
+        "category": cmd.category,
+        "type": "object",
+        "properties": {"op": {"const": cmd.op}, **cmd.arguments},
+        "required": ["op"] + required,
+        "additionalProperties": False,
+    }
+
+
+def _result_schema(cmd):
+    return {
+        "title": f"{cmd.op}_result",
+        "type": "object",
+        "properties": dict(cmd.returns),
+        "required": list(cmd.returns),
+        "additionalProperties": False,
+    }
+
+
+def _merge_default(default, value):
+    """Recursively overlay ``value`` onto ``default``."""
+    if not (isinstance(default, dict) and isinstance(value, dict)):
+        return value
+    out = {}
+    for name, prop in default.items():
+        out[name] = (_merge_default(prop, value[name]) if name in value
+                     else copy.deepcopy(prop))
+    for name, val in value.items():
+        if name not in default:
+            out[name] = val
+    return out
+
+
+class CommandSet:
+    """A named family of commands with its derived schema and validators."""
+
+    def __init__(self, title, description, categories=CRUD_CATEGORIES):
+        self.title = title  # family name, used as the schema title
+        self.description = description  # human summary of the family
+        self.categories = tuple(categories)  # allowed op categories
+        self.commands = {}
+        self._built = None
+
+    def register(self, command):
+        """Add a command to the set; usable as a class decorator."""
+        cls = command if isinstance(command, type) else type(command)
+        if not command.op:
+            raise ValueError(f"{cls.__name__} has no op name")
+        if command.op in self.commands:
+            raise ValueError(f"duplicate command op '{command.op}'")
+        if command.category not in self.categories:
+            raise ValueError(
+                f"{command.op} has unknown category '{command.category}'")
+        for name in command.optional:
+            if name not in command.arguments:
+                raise ValueError(
+                    f"{command.op} optional '{name}' is not an argument")
+        for name, prop in command.arguments.items():
+            if (isinstance(prop, dict) and "default" in prop
+                    and name not in command.optional):
+                raise ValueError(
+                    f"{command.op}.{name} is defaulted but required")
+        self.commands[command.op] = cls() if command is cls else command
+        self._built = None
+        return command
+
+    def _build(self):
+        import jsonschema
+        command_schemas = {op: _command_schema(cmd)
+                           for op, cmd in self.commands.items()}
+        result_schemas = {op: _result_schema(cmd)
+                          for op, cmd in self.commands.items()}
+        return {
+            "command_schemas": command_schemas,
+            "result_schemas": result_schemas,
+            "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "title": self.title,
+                "description": self.description,
+                "oneOf": list(command_schemas.values()),
+            },
+            "validators": {op: jsonschema.Draft202012Validator(schema)
+                           for op, schema in command_schemas.items()},
+            "result_validators": {op: jsonschema.Draft202012Validator(schema)
+                                  for op, schema in result_schemas.items()},
+        }
+
+    @property
+    def _cache(self):
+        # TODO: cold-cache build races benignly (identical state); lock if
+        # that changes.
+        if self._built is None:
+            self._built = self._build()
+        return self._built
+
+    @property
+    def command_schemas(self):
+        return self._cache["command_schemas"]
+
+    @property
+    def result_schemas(self):
+        return self._cache["result_schemas"]
+
+    @property
+    def schema(self):
+        return self._cache["schema"]
+
+    def _validate(self, kind, op, value, prefix):
+        import jsonschema
+        validator = self._cache[kind].get(op)
+        if validator is None:
+            raise CommandError(
+                f"unknown op '{op}'; valid ops: {sorted(self.commands)}")
+        try:
+            validator.validate(value)
+        except jsonschema.ValidationError as exc:
+            raise CommandError(f"{prefix}{exc.message}") from exc
+        return value
+
+    def validate_command(self, command):
+        """Validate ``command`` against its op's JSON Schema."""
+        if not isinstance(command, dict):
+            raise CommandError(
+                f"command must be an object, got {type(command).__name__}")
+        op = command.get("op")
+        if not isinstance(op, str):
+            raise CommandError("command is missing a string 'op' field")
+        self._validate("validators", op, command, f"{op}: ")
+        return command
+
+    def validate_result(self, op, value):
+        """Validate a command's result against its declared output schema."""
+        return self._validate(
+            "result_validators", op, value, f"{op} result: ")
+
+    def validate_script(self, commands):
+        """Validate a list of commands."""
+        if not isinstance(commands, list):
+            raise CommandError("a script must be a list of commands")
+        for command in commands:
+            self.validate_command(command)
+        return commands
+
+    def apply_defaults(self, command):
+        """Return a copy of ``command`` with optional args defaulted."""
+        schema = self.command_schemas[command["op"]]
+        out = dict(command)
+        for name, prop in schema["properties"].items():
+            if not isinstance(prop, dict) or "default" not in prop:
+                continue
+            default = prop["default"]
+            if name not in out:
+                out[name] = copy.deepcopy(default)
+            else:
+                out[name] = _merge_default(default, out[name])
+        return out
+
+    def tool_definitions(self):
+        """Describe every command as an MCP-style tool definition."""
+        tools = []
+        for op, schema in self.command_schemas.items():
+            properties = {name: prop
+                          for name, prop in schema["properties"].items()
+                          if name != "op"}
+            required = [name for name in schema["required"] if name != "op"]
+            tools.append({
+                "name": op,
+                "category": schema["category"],
+                "description": schema["description"],
+                "inputSchema": {
+                    "type": "object",
+                    "properties": properties,
+                    "required": required,
+                    "additionalProperties": False,
+                },
+                "outputSchema": self.result_schemas[op],
+            })
+        return tools
+
+    def command_from_tool_call(self, name, arguments=None):
+        """Rebuild a command dict from an MCP-style tool call."""
+        return {**(arguments or {}), "op": name}
+
+    def commands_by_category(self):
+        """Group op names by category, in the set's category order."""
+        grouped = {category: [] for category in self.categories}
+        for op, cmd in self.commands.items():
+            grouped[cmd.category].append(op)
+        return grouped
+
+
+@dataclasses.dataclass
+class CommandResult:
+    """The outcome of applying one command."""
+    op: str
+    ok: bool
+    value: object = None
+    error: str = None
+
+
+class CommandProcessor:
+    """Run a ``CommandSet``'s commands against a ``target``, keeping a log."""
+
+    def __init__(self, target, command_set, validate_results=False,
+                 reraise=False):
+        self.target = target  # object the commands mutate
+        self.command_set = command_set  # family whose commands run here
+        self.validate_results = validate_results  # check each result schema
+        self.reraise = reraise  # let unexpected errors propagate, not capture
+        self._log = []
+
+    def append_log(self, message):
+        self._log.append(message)
+
+    @property
+    def log(self):
+        return list(self._log)
+
+    def run(self, command):
+        """Validate and apply one command, returning its ``CommandResult``."""
+        op = command.get("op", "?") if isinstance(command, dict) else "?"
+        try:
+            self.command_set.validate_command(command)
+        except CommandError as exc:
+            return CommandResult(op, False, error=str(exc))
+        return self._apply(op, command)
+
+    def run_script(self, commands, stop_on_error=False):
+        """Validate the whole script, then apply each command in order."""
+        self.command_set.validate_script(commands)
+        results = []
+        for command in commands:
+            result = self._apply(command["op"], command)
+            results.append(result)
+            if stop_on_error and not result.ok:
+                break
+        return results
+
+    def _apply(self, op, command):
+        """Apply the command to the target, returning a ``CommandResult``."""
+        args = self.command_set.apply_defaults(command)
+        try:
+            value = self.command_set.commands[op].apply(
+                self.target, args, self)
+            if self.validate_results:
+                self.command_set.validate_result(op, value)
+        except CommandError as exc:
+            return CommandResult(op, False, error=str(exc))
+        except Exception as exc:
+            if self.reraise:
+                raise
+            return CommandResult(
+                op, False, error=f"{type(exc).__name__}: {exc}")
+        return CommandResult(op, True, value=value)
+
+
+class CommandDispatcher:
+    """Route each command to the processor of the family owning its op."""
+
+    def __init__(self, executors):
+        self.executors = list(executors)  # per-family processors to route to
+        self._routes = {}
+        for executor in self.executors:
+            for op in executor.command_set.commands:
+                if op in self._routes:
+                    raise ValueError(
+                        f"duplicate command op '{op}' across families")
+                self._routes[op] = executor
+
+    def tool_definitions(self):
+        """Concatenate every member family's tool definitions."""
+        tools = []
+        for executor in self.executors:
+            tools.extend(executor.command_set.tool_definitions())
+        return tools
+
+    def _route(self, command):
+        if not isinstance(command, dict):
+            raise CommandError(
+                f"command must be an object, got {type(command).__name__}")
+        op = command.get("op")
+        executor = self._routes.get(op)
+        if executor is None:
+            raise CommandError(
+                f"unknown op '{op}'; valid ops: {sorted(self._routes)}")
+        return executor
+
+    def run(self, command):
+        """Route and run one command, capturing routing failures."""
+        try:
+            executor = self._route(command)
+        except CommandError as exc:
+            op = command.get("op") if isinstance(command, dict) else None
+            return CommandResult(op if isinstance(op, str) else "?",
+                                 False, error=str(exc))
+        return executor.run(command)
+
+    def run_script(self, commands, stop_on_error=False):
+        """Validate the whole script across families, then apply in order."""
+        if not isinstance(commands, list):
+            raise CommandError("a script must be a list of commands")
+        routed = []
+        for command in commands:
+            executor = self._route(command)
+            executor.command_set.validate_command(command)
+            routed.append((executor, command))
+        results = []
+        for executor, command in routed:
+            result = executor.run(command)
+            results.append(result)
+            if stop_on_error and not result.ok:
+                break
+        return results
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_command_framework.py
+++ b/tests/test_command_framework.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""A basic go-through of the generic command framework in
+solvcon.agent._command, exercised through a small demo family over a plain
+target so the base Command, CommandSet, and CommandProcessor are covered
+independently of the drawing family and the C++ World. The comprehensive
+suite lands in a later change."""
+
+import unittest
+
+from solvcon import agent
+
+
+class _Bag:
+    """A plain mutable target the demo commands operate on."""
+
+    def __init__(self):
+        self.items = []
+        self.style = None
+
+
+class AddItem(agent.Command):
+    op = "add_item"
+    category = "create"
+    summary = "Add a named item, with an optional tag."
+    arguments = {"name": {"type": "string", "description": "Item name."},
+                 "tag": {"type": "string", "default": "none",
+                         "description": "Optional tag."}}
+    optional = ("tag",)
+    returns = {"count": {"type": "integer",
+                         "description": "Items after the add."}}
+
+    def apply(self, target, args, ctx):
+        target.items.append((args["name"], args["tag"]))
+        return {"count": len(target.items)}
+
+
+class Count(agent.Command):
+    op = "count"
+    category = "read"
+    summary = "Count the items."
+    returns = {"n": {"type": "integer", "description": "Item count."}}
+
+    def apply(self, target, args, ctx):
+        return {"n": len(target.items)}
+
+
+class ClearBag(agent.Command):
+    op = "clear"
+    category = "delete"
+    summary = "Remove every item."
+
+    def apply(self, target, args, ctx):
+        target.items.clear()
+        return {}
+
+
+class SetStyle(agent.Command):
+    op = "style"
+    category = "update"
+    summary = "Set nested style options."
+    arguments = {"style": {
+        "type": "object", "description": "Nested style options.",
+        "default": {"stroke": {"color": "black", "width": 1}}}}
+    optional = ("style",)
+
+    def apply(self, target, args, ctx):
+        target.style = args["style"]
+        return {}
+
+
+class Boom(agent.Command):
+    op = "boom"
+    category = "update"
+    summary = "Raise to exercise error capture."
+
+    def apply(self, target, args, ctx):
+        raise RuntimeError("boom")
+
+
+def _family():
+    family = agent.CommandSet("demo command",
+                              "Any single command in the demo set.")
+    for cls in (AddItem, Count, ClearBag, SetStyle, Boom):
+        family.register(cls)
+    return family
+
+
+class CommandFrameworkGoThroughTC(unittest.TestCase):
+    """Walk the framework once end to end on the demo family."""
+
+    def setUp(self):
+        self.family = _family()
+
+    def test_schema_is_derived_from_registered_commands(self):
+        ops = {"add_item", "count", "clear", "style", "boom"}
+        self.assertEqual(set(self.family.commands), ops)
+        self.assertEqual(set(self.family.command_schemas), ops)
+        self.assertEqual(len(self.family.schema["oneOf"]), len(ops))
+        grouped = self.family.commands_by_category()
+        self.assertEqual(list(grouped), list(agent.CRUD_CATEGORIES))
+        self.assertIn("add_item", grouped["create"])
+
+    def test_validation_accepts_good_and_rejects_bad(self):
+        command = {"op": "add_item", "name": "x"}
+        self.assertIs(self.family.validate_command(command), command)
+        with self.assertRaises(agent.CommandError):
+            self.family.validate_command({"op": "add_item"})
+        with self.assertRaises(agent.CommandError):
+            self.family.validate_command({"op": "nope"})
+
+    def test_apply_defaults_fills_omitted_optional(self):
+        filled = self.family.apply_defaults({"op": "add_item", "name": "x"})
+        self.assertEqual(filled["tag"], "none")
+
+    def test_executor_dispatches_and_applies_defaults(self):
+        ex = agent.CommandProcessor(_Bag(), self.family)
+        res = ex.run({"op": "add_item", "name": "x"})
+        self.assertIsInstance(res, agent.CommandResult)
+        self.assertTrue(res.ok)
+        self.assertEqual(res.value, {"count": 1})
+
+    def test_executor_captures_a_validation_failure(self):
+        ex = agent.CommandProcessor(_Bag(), self.family)
+        res = ex.run({"op": "add_item"})
+        self.assertFalse(res.ok)
+        self.assertEqual(res.op, "add_item")
+
+    def test_run_script_applies_in_order(self):
+        ex = agent.CommandProcessor(_Bag(), self.family)
+        results = ex.run_script([
+            {"op": "clear"},
+            {"op": "add_item", "name": "a"},
+            {"op": "add_item", "name": "b"},
+            {"op": "count"},
+        ])
+        self.assertTrue(all(r.ok for r in results))
+        self.assertEqual(results[-1].value["n"], 2)
+
+    def test_apply_defaults_merges_nested_dict_default(self):
+        filled = self.family.apply_defaults(
+            {"op": "style", "style": {"stroke": {"width": 2}}})
+        self.assertEqual(filled["style"],
+                         {"stroke": {"color": "black", "width": 2}})
+
+    def test_register_accepts_an_instance(self):
+        family = agent.CommandSet("demo", "Demo.")
+        family.register(AddItem())
+        self.assertIn("add_item", family.commands)
+
+    def test_family_specific_categories(self):
+        family = agent.CommandSet("pilot", "Pilot ops.",
+                                  categories=("action", "view"))
+
+        class Screenshot(agent.Command):
+            op = "screenshot"
+            category = "view"
+            summary = "Grab the viewport."
+
+            def apply(self, target, args, ctx):
+                return {}
+
+        family.register(Screenshot)
+        self.assertEqual(list(family.commands_by_category()),
+                         ["action", "view"])
+        with self.assertRaises(ValueError):
+            family.register(AddItem)
+
+    def test_command_from_tool_call_rebuilds_the_command(self):
+        command = self.family.command_from_tool_call(
+            "add_item", {"name": "x"})
+        self.assertEqual(command, {"op": "add_item", "name": "x"})
+        self.assertIs(self.family.validate_command(command), command)
+
+    def test_run_script_stop_on_error_halts(self):
+        bag = _Bag()
+        ex = agent.CommandProcessor(bag, self.family)
+        results = ex.run_script([
+            {"op": "add_item", "name": "a"},
+            {"op": "boom"},
+            {"op": "add_item", "name": "b"},
+        ], stop_on_error=True)
+        self.assertEqual([r.ok for r in results], [True, False])
+        self.assertEqual(len(bag.items), 1)
+
+    def test_reraise_propagates_unexpected_exceptions(self):
+        ex = agent.CommandProcessor(_Bag(), self.family, reraise=True)
+        with self.assertRaises(RuntimeError):
+            ex.run({"op": "boom"})
+        res = ex.run({"op": "add_item"})
+        self.assertFalse(res.ok)
+
+
+class CommandDispatcherTC(unittest.TestCase):
+    """Route ops across two families with distinct targets."""
+
+    def setUp(self):
+        self.bag = _Bag()
+        pilot = agent.CommandSet("pilot", "Pilot ops.", categories=("action",))
+
+        class Ping(agent.Command):
+            op = "ping"
+            category = "action"
+            summary = "Acknowledge."
+            returns = {"pong": {"type": "boolean",
+                                "description": "Always true."}}
+
+            def apply(self, target, args, ctx):
+                return {"pong": True}
+
+        pilot.register(Ping)
+        self.dispatcher = agent.CommandDispatcher([
+            agent.CommandProcessor(self.bag, _family()),
+            agent.CommandProcessor(object(), pilot),
+        ])
+
+    def test_routes_each_op_to_its_family(self):
+        self.assertTrue(self.dispatcher.run(
+            {"op": "add_item", "name": "x"}).ok)
+        self.assertEqual(len(self.bag.items), 1)
+        self.assertEqual(self.dispatcher.run({"op": "ping"}).value,
+                         {"pong": True})
+
+    def test_unknown_op_is_a_failed_result(self):
+        res = self.dispatcher.run({"op": "nope"})
+        self.assertFalse(res.ok)
+        self.assertIn("ping", res.error)
+
+    def test_tool_surface_is_the_concatenation(self):
+        names = [t["name"] for t in self.dispatcher.tool_definitions()]
+        self.assertEqual(sorted(names),
+                         ["add_item", "boom", "clear", "count", "ping",
+                          "style"])
+
+    def test_duplicate_op_across_families_is_rejected(self):
+        with self.assertRaises(ValueError):
+            agent.CommandDispatcher([
+                agent.CommandProcessor(_Bag(), _family()),
+                agent.CommandProcessor(_Bag(), _family())])
+
+    def test_run_script_across_families(self):
+        results = self.dispatcher.run_script([
+            {"op": "add_item", "name": "a"},
+            {"op": "ping"},
+            {"op": "count"},
+        ])
+        self.assertTrue(all(r.ok for r in results))
+        self.assertEqual(results[-1].value["n"], 1)
+        with self.assertRaises(agent.CommandError):
+            self.dispatcher.run_script([{"op": "nope"}])
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Add the Qt-free Agent command framework that domain families (drawing, mesh, pilot control) build on. A `Command` declares its op, category, and JSON Schema for its arguments and returns; a `CommandSet` collects commands and derives the schema, validators, and MCP-style tool definitions from them; a `CommandProcessor` runs validated commands against a target and captures failures as results; and a `CommandDispatcher` routes ops across several families so one session can expose them together. The framework mirrors the existing backend registry and imports no Qt, so it stays headless and unit-testable.

## How a command flows

A command is a plain dict such as `{"op": "add_item", "name": "x"}`, usually proposed by an AI backend against the tool definitions the `CommandSet` derives. The `CommandProcessor` is the single entry point that turns that untrusted dict into a real, recorded change to the target. It validates the dict against the op's JSON Schema, fills omitted optional arguments from their defaults, calls the command's `apply`, and wraps the outcome in a `CommandResult`. It never raises, so one bad command cannot abort a batch.

Responsibilities are split so families stay reusable: validation and the schema live on the stateless `CommandSet`, while the target, the log, and the run policy live on the `CommandProcessor` that is bound to one target. Many targets can therefore share one family definition.

```mermaid
flowchart TD
    A["Command dict (op + arguments)"] --> B["CommandProcessor.run"]
    B --> C{"validate against JSON Schema"}
    C -- invalid --> F["CommandResult: ok=False, error"]
    C -- valid --> D["apply_defaults: fill optional args"]
    D --> E["Command.apply(target, args, ctx)"]
    E -- "returns mapping" --> G["CommandResult: ok=True, value"]
    E -- "raises" --> F
    G --> H["appended to log"]
    F --> H
```

When one session exposes several families at once, a `CommandDispatcher` sits in front and routes each op to the `CommandProcessor` that owns it. Ops stay unprefixed but must be unique across the group, and the tool surface is the concatenation of the members'.

```mermaid
flowchart LR
    I["Command dict"] --> J["CommandDispatcher"]
    J -- "draw op" --> K["CommandProcessor (draw World)"]
    J -- "pilot op" --> L["CommandProcessor (pilot app)"]
    J -- "unknown op" --> M["CommandResult: ok=False"]
```

Continues the closed PR #965. Related to #966.
