### PR TITLE
Agent Draw Command 3: World command vocabulary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ def main():
         packages=[
             'solvcon',
             'solvcon.agent',
+            'solvcon.agent.draw',
             'solvcon.multidim',
             'solvcon.multidim.euler',
             'solvcon.onedim',

--- a/solvcon/agent/draw/__init__.py
+++ b/solvcon/agent/draw/__init__.py
@@ -6,9 +6,9 @@
 Agent Draw front-end for the ``World`` API.
 
 The command vocabulary lives in ``command.py`` (one ``Command`` subclass per
-command, collected in ``DRAW``); the schema documents, validators, and tool
-definitions are derived from it. The harness and MCP adapters ride on the
-same commands.
+command); the schema documents, validators, and tool definitions are derived
+from one private command set. This module delegates its command-family API to
+that set, so the harness and MCP adapters ride on the same commands.
 """
 
 from .._command import (  # noqa: F401
@@ -17,18 +17,42 @@ from .._command import (  # noqa: F401
     CommandError,
     CommandResult,
 )
-from .command import (  # noqa: F401
-    DRAW,
-    COMMANDS,
-    COMMAND_SCHEMAS,
-    RESULT_SCHEMAS,
-    SCHEMA,
-    apply_defaults,
-    commands_by_category,
-    tool_definitions,
-    validate_command,
-    validate_result,
-    validate_script,
+from .command import _command_set
+
+_COMMAND_API = (
+    "apply_defaults",
+    "categories",
+    "command_from_tool_call",
+    "command_schemas",
+    "commands",
+    "commands_by_category",
+    "description",
+    "result_schemas",
+    "schema",
+    "title",
+    "tool_definitions",
+    "validate_command",
+    "validate_result",
+    "validate_script",
+)
+
+
+def __getattr__(name):
+    if name in _COMMAND_API:
+        return getattr(_command_set, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(_COMMAND_API))
+
+
+__all__ = (
+    "CRUD_CATEGORIES",
+    "Command",
+    "CommandError",
+    "CommandResult",
+    *_COMMAND_API,
 )
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/agent/draw/__init__.py
+++ b/solvcon/agent/draw/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Agent Draw front-end for the ``World`` API.
+
+The command vocabulary lives in ``command.py`` (one ``Command`` subclass per
+command, collected in ``DRAW``); the schema documents, validators, and tool
+definitions are derived from it. The harness and MCP adapters ride on the
+same commands.
+"""
+
+from .._command import (  # noqa: F401
+    CRUD_CATEGORIES,
+    Command,
+    CommandError,
+    CommandResult,
+)
+from .command import (  # noqa: F401
+    DRAW,
+    COMMANDS,
+    COMMAND_SCHEMAS,
+    RESULT_SCHEMAS,
+    SCHEMA,
+    apply_defaults,
+    commands_by_category,
+    tool_definitions,
+    validate_command,
+    validate_result,
+    validate_script,
+)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/agent/draw/command.py
+++ b/solvcon/agent/draw/command.py
@@ -1,0 +1,463 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+The command vocabulary for driving a ``World`` from an AI agent.
+
+Each command is one ``Command`` subclass registered in ``DRAW``; the JSON
+Schema documents and validators are derived from them (see
+:mod:`solvcon.agent._command`). Only the ``World``-specific fragments and
+behavior live here, so a mesh or pilot family declares commands the same way.
+``render_png`` returns a transport-ready image (base64 PNG), never raw bytes,
+so a result is JSON-serializable across any transport.
+
+Coordinates are world coordinates in the ``World``'s native units, math
+convention with +Y pointing up.
+"""
+
+import json
+import base64
+
+from .. import _command as _cmd
+
+
+# Shared JSON Schema fragments, used by reference; treat as immutable.
+NUMBER = {"type": "number"}
+POSITIVE = {"type": "number", "exclusiveMinimum": 0}
+INTEGER = {"type": "integer"}
+POSITIVE_INT = {"type": "integer", "exclusiveMinimum": 0}
+BOOLEAN = {"type": "boolean"}
+STRING = {"type": "string"}
+
+
+def _num(description):
+    return {**NUMBER, "description": description}
+
+
+def _pos(description):
+    return {**POSITIVE, "description": description}
+
+
+def _int(description):
+    return {**INTEGER, "description": description}
+
+
+def _point(description):
+    return {"type": "array", "items": {"type": "number"},
+            "minItems": 2, "maxItems": 3, "description": description}
+
+
+# Mirrors ViewTransform2dFp64, math convention +Y up.
+VIEW = {"type": "object",
+        "properties": {"pan_x": NUMBER, "pan_y": NUMBER, "zoom": POSITIVE},
+        "additionalProperties": False}
+
+_BBOX = {"type": "array", "items": NUMBER, "minItems": 4, "maxItems": 4,
+         "description": "Axis-aligned bounds [min_x, min_y, max_x, max_y]."}
+_SEG_LIST = {"type": "array",
+             "items": {"type": "array", "items": NUMBER,
+                       "minItems": 4, "maxItems": 4},
+             "description": "Line segments, each [x0, y0, x1, y1]."}
+_CURVE_LIST = {"type": "array",
+               "items": {"type": "array",
+                         "items": {"type": "array", "items": NUMBER,
+                                   "minItems": 2, "maxItems": 2},
+                         "minItems": 4, "maxItems": 4},
+               "description": "Cubic Beziers, each four [x, y] points."}
+_POINT_LIST = {"type": "array",
+               "items": {"type": "array", "items": NUMBER,
+                         "minItems": 2, "maxItems": 2},
+               "description": "Free points, each [x, y]."}
+
+# Mirrors WorldShapeState in cpp/solvcon/universe/World.hpp.
+SHAPE = {"type": "object",
+         "description": "One shape: id, type, bounds, and 2D geometry.",
+         "properties": {
+             "id": _int("Stable id assigned when the shape was created."),
+             "type": {**STRING,
+                      "description": "Lower-case shape type name."},
+             "bbox": _BBOX,
+             "segments": _SEG_LIST,
+             "curves": _CURVE_LIST},
+         "required": ["id", "type", "bbox", "segments", "curves"],
+         "additionalProperties": False}
+
+# Mirrors WorldState in cpp/solvcon/universe/World.hpp.
+STATE = {"type": "object",
+         "description": "The whole visible world: shapes plus bare geometry.",
+         "properties": {
+             "shapes": {"type": "array", "items": SHAPE,
+                        "description": "Every live shape."},
+             "segments": _SEG_LIST,
+             "curves": _CURVE_LIST,
+             "points": _POINT_LIST},
+         "required": ["shapes", "segments", "curves", "points"],
+         "additionalProperties": False}
+
+IMAGE = {"type": "object",
+         "description": "A rendered raster image, transport-ready.",
+         "properties": {
+             "data": {"type": "string", "contentEncoding": "base64",
+                      "contentMediaType": "image/png",
+                      "description": "Base64-encoded PNG bytes."},
+             "mime_type": {"const": "image/png",
+                           "description": "Media type of the encoded image."},
+             "width": _int("Image width in pixels."),
+             "height": _int("Image height in pixels.")},
+         "required": ["data", "mime_type", "width", "height"],
+         "additionalProperties": False}
+
+
+def _world_point(coords):
+    import solvcon
+    z = coords[2] if len(coords) > 2 else 0.0
+    return solvcon.Point3dFp64(coords[0], coords[1], z)
+
+
+def _require_live(world, shape_id):
+    # Preflight so every by-id command fails the one clean way ``get_shape``
+    # does, rather than leaking a C++-flavored IndexError/ValueError.
+    if not world.shape_is_live(shape_id):
+        raise _cmd.CommandError(f"no live shape with id {shape_id}")
+
+
+DRAW = _cmd.CommandSet("Agent Draw command",
+                       "Any single command in the Agent Draw schema.")
+
+
+@DRAW.register
+class AddPoint(_cmd.Command):
+    op = "add_point"
+    category = "create"
+    summary = "Add a free point at world (x, y, z); z is dropped in 2D."
+    arguments = {"x": _num("World x of the point."),
+                 "y": _num("World y of the point (+Y up)."),
+                 "z": {**NUMBER, "default": 0.0,
+                       "description": "World z; ignored in 2D."}}
+    optional = ("z",)
+    returns = {"npoint": _int("Total free points after the add.")}
+
+    def apply(self, world, args, ctx):
+        world.add_point(args["x"], args["y"], args["z"])
+        return {"npoint": world.npoint}
+
+
+@DRAW.register
+class AddSegment(_cmd.Command):
+    op = "add_segment"
+    category = "create"
+    summary = "Add a bare line segment between two world points."
+    arguments = {"p0": _point("Start point [x, y] or [x, y, z]."),
+                 "p1": _point("End point [x, y] or [x, y, z].")}
+    returns = {"nsegment": _int(
+        "Total segments in the world after the add, "
+        "including those owned by shapes.")}
+
+    def apply(self, world, args, ctx):
+        world.add_segment(_world_point(args["p0"]), _world_point(args["p1"]))
+        return {"nsegment": world.nsegment}
+
+
+@DRAW.register
+class AddLine(_cmd.Command):
+    op = "add_line"
+    category = "create"
+    summary = "Add a line shape from (x0, y0) to (x1, y1) in world coords."
+    arguments = {"x0": _num("World x of the start point."),
+                 "y0": _num("World y of the start point."),
+                 "x1": _num("World x of the end point."),
+                 "y1": _num("World y of the end point.")}
+    returns = {"shape_id": _int("Id of the new shape.")}
+
+    def apply(self, world, args, ctx):
+        return {"shape_id": world.add_line(
+            args["x0"], args["y0"], args["x1"], args["y1"])}
+
+
+@DRAW.register
+class AddTriangle(_cmd.Command):
+    op = "add_triangle"
+    category = "create"
+    summary = "Add a triangle shape through its three corners (+Y up)."
+    arguments = {"x0": _num("World x of corner 0."),
+                 "y0": _num("World y of corner 0."),
+                 "x1": _num("World x of corner 1."),
+                 "y1": _num("World y of corner 1."),
+                 "x2": _num("World x of corner 2."),
+                 "y2": _num("World y of corner 2.")}
+    returns = {"shape_id": _int("Id of the new shape.")}
+
+    def apply(self, world, args, ctx):
+        return {"shape_id": world.add_triangle(
+            args["x0"], args["y0"], args["x1"], args["y1"],
+            args["x2"], args["y2"])}
+
+
+@DRAW.register
+class AddRectangle(_cmd.Command):
+    op = "add_rectangle"
+    category = "create"
+    summary = "Add an axis-aligned rectangle from lower-left to upper-right."
+    arguments = {"x_min": _num("Lower-left corner x."),
+                 "y_min": _num("Lower-left corner y."),
+                 "x_max": _num("Upper-right corner x."),
+                 "y_max": _num("Upper-right corner y.")}
+    returns = {"shape_id": _int("Id of the new shape.")}
+
+    def apply(self, world, args, ctx):
+        return {"shape_id": world.add_rectangle(
+            args["x_min"], args["y_min"], args["x_max"], args["y_max"])}
+
+
+@DRAW.register
+class AddSquare(_cmd.Command):
+    op = "add_square"
+    category = "create"
+    summary = "Add an axis-aligned square from its lower-left corner."
+    arguments = {"x_min": _num("Lower-left corner x."),
+                 "y_min": _num("Lower-left corner y."),
+                 "size": _pos("Edge length; must be positive.")}
+    returns = {"shape_id": _int("Id of the new shape.")}
+
+    def apply(self, world, args, ctx):
+        return {"shape_id": world.add_square(
+            args["x_min"], args["y_min"], args["size"])}
+
+
+@DRAW.register
+class AddEllipse(_cmd.Command):
+    op = "add_ellipse"
+    category = "create"
+    summary = "Add an ellipse shape centered at (cx, cy)."
+    arguments = {"cx": _num("Center x."), "cy": _num("Center y."),
+                 "rx": _pos("Semi-axis along x; must be positive."),
+                 "ry": _pos("Semi-axis along y; must be positive.")}
+    returns = {"shape_id": _int("Id of the new shape.")}
+
+    def apply(self, world, args, ctx):
+        return {"shape_id": world.add_ellipse(
+            args["cx"], args["cy"], args["rx"], args["ry"])}
+
+
+@DRAW.register
+class AddCircle(_cmd.Command):
+    op = "add_circle"
+    category = "create"
+    summary = "Add a circle shape centered at (cx, cy)."
+    arguments = {"cx": _num("Center x."), "cy": _num("Center y."),
+                 "r": _pos("Radius; must be positive.")}
+    returns = {"shape_id": _int("Id of the new shape.")}
+
+    def apply(self, world, args, ctx):
+        return {"shape_id": world.add_circle(
+            args["cx"], args["cy"], args["r"])}
+
+
+@DRAW.register
+class AddBezier(_cmd.Command):
+    op = "add_bezier"
+    category = "create"
+    summary = "Add a bare cubic Bezier from four control points."
+    arguments = {"p0": _point("Start anchor [x, y] or [x, y, z]."),
+                 "p1": _point("First control point."),
+                 "p2": _point("Second control point."),
+                 "p3": _point("End anchor.")}
+    returns = {"nbezier": _int(
+        "Total Beziers in the world after the add, "
+        "including those owned by shapes.")}
+
+    def apply(self, world, args, ctx):
+        world.add_bezier(_world_point(args["p0"]), _world_point(args["p1"]),
+                         _world_point(args["p2"]), _world_point(args["p3"]))
+        return {"nbezier": world.nbezier}
+
+
+@DRAW.register
+class AddBezierShape(_cmd.Command):
+    op = "add_bezier_shape"
+    category = "create"
+    summary = "Add a cubic Bezier shape from four control points."
+    arguments = {"p0": _point("Start anchor [x, y] or [x, y, z]."),
+                 "p1": _point("First control point."),
+                 "p2": _point("Second control point."),
+                 "p3": _point("End anchor.")}
+    returns = {"shape_id": _int("Id of the new shape.")}
+
+    def apply(self, world, args, ctx):
+        return {"shape_id": world.add_bezier_shape(
+            _world_point(args["p0"]), _world_point(args["p1"]),
+            _world_point(args["p2"]), _world_point(args["p3"]))}
+
+
+@DRAW.register
+class GetShape(_cmd.Command):
+    op = "get_shape"
+    category = "read"
+    summary = "Read one shape's id, type, bbox, and geometry by its id."
+    arguments = {"shape_id": _int("Id of the shape to read.")}
+    returns = {"shape": SHAPE}
+
+    def apply(self, world, args, ctx):
+        # The World has no read-one accessor, so filter the rendered state.
+        shape_id = args["shape_id"]
+        state = json.loads(world.describe_state())
+        for shape in state["shapes"]:
+            if shape["id"] == shape_id:
+                return {"shape": shape}
+        raise _cmd.CommandError(f"no live shape with id {shape_id}")
+
+
+@DRAW.register
+class ShapeTypeOf(_cmd.Command):
+    op = "shape_type_of"
+    category = "read"
+    summary = "Name the type of the shape with the given id."
+    arguments = {"shape_id": _int("Id of the shape to inspect.")}
+    returns = {"type": {**STRING,
+                        "description": "Lower-case shape type."}}
+
+    def apply(self, world, args, ctx):
+        _require_live(world, args["shape_id"])
+        return {"type": world.shape_type_of(args["shape_id"])}
+
+
+@DRAW.register
+class NShape(_cmd.Command):
+    op = "nshape"
+    category = "read"
+    summary = "Count the live shapes in the world."
+    returns = {"nshape": _int("Number of live shapes.")}
+
+    def apply(self, world, args, ctx):
+        return {"nshape": world.nshape}
+
+
+@DRAW.register
+class QueryVisible(_cmd.Command):
+    op = "query_visible"
+    category = "read"
+    summary = "List the ids of shapes overlapping a query box."
+    arguments = {"min_x": _num("Query box lower-left x."),
+                 "min_y": _num("Query box lower-left y."),
+                 "max_x": _num("Query box upper-right x."),
+                 "max_y": _num("Query box upper-right y.")}
+    returns = {"shape_ids": {"type": "array", "items": INTEGER,
+                             "description": "Ids of shapes overlapping box."}}
+
+    def apply(self, world, args, ctx):
+        ids = world.query_visible(
+            args["min_x"], args["min_y"], args["max_x"], args["max_y"])
+        return {"shape_ids": list(ids)}
+
+
+@DRAW.register
+class DescribeState(_cmd.Command):
+    op = "describe_state"
+    category = "read"
+    summary = "Serialize the visible 2D geometry to a state object."
+    arguments = {"level": {"type": "string", "enum": ["basic"],
+                           "default": "basic",
+                           "description": "Level of detail; only 'basic'."}}
+    optional = ("level",)
+    returns = {"state": STATE}
+
+    def apply(self, world, args, ctx):
+        return {"state": json.loads(world.describe_state(level=args["level"]))}
+
+
+@DRAW.register
+class RenderPng(_cmd.Command):
+    op = "render_png"
+    category = "read"
+    summary = "Render the world to a PNG via the offscreen renderer."
+    arguments = {"width": {**POSITIVE_INT,
+                           "description": "Image width in pixels."},
+                 "height": {**POSITIVE_INT,
+                            "description": "Image height in pixels."},
+                 "view": {**VIEW,
+                          "default": {"pan_x": 0.0, "pan_y": 0.0, "zoom": 1.0},
+                          "description": "2D view transform (+Y up)."},
+                 "antialiasing": {**BOOLEAN, "default": False,
+                                  "description": "Enable antialiased edges."}}
+    optional = ("view", "antialiasing")
+    returns = {"image": IMAGE}
+
+    def apply(self, world, args, ctx):
+        renderer = getattr(ctx, "renderer", None)
+        if renderer is None:
+            raise _cmd.CommandError(
+                "render_png needs a renderer; none configured. The harness "
+                "and MCP front-ends inject the offscreen QImage renderer.")
+        png = renderer(world, args["view"], args["width"], args["height"],
+                       args["antialiasing"])
+        # Base64 so the result is plain JSON over any transport, not bytes.
+        return {"image": {"data": base64.b64encode(png).decode("ascii"),
+                          "mime_type": "image/png",
+                          "width": args["width"], "height": args["height"]}}
+
+
+@DRAW.register
+class TranslateShape(_cmd.Command):
+    op = "translate_shape"
+    category = "update"
+    summary = "Translate the shape with the given id by (dx, dy)."
+    arguments = {"shape_id": _int("Id of the shape to move."),
+                 "dx": _num("World displacement along x."),
+                 "dy": _num("World displacement along y.")}
+
+    def apply(self, world, args, ctx):
+        _require_live(world, args["shape_id"])
+        world.translate_shape(args["shape_id"], args["dx"], args["dy"])
+        return {}
+
+
+@DRAW.register
+class RemoveShape(_cmd.Command):
+    op = "remove_shape"
+    category = "delete"
+    summary = "Remove the shape with the given id."
+    arguments = {"shape_id": _int("Id of the shape to remove.")}
+
+    def apply(self, world, args, ctx):
+        _require_live(world, args["shape_id"])
+        world.remove_shape(args["shape_id"])
+        return {}
+
+
+@DRAW.register
+class Clear(_cmd.Command):
+    op = "clear"
+    category = "delete"
+    summary = "Remove every shape and bare primitive."
+
+    def apply(self, world, args, ctx):
+        world.clear()
+        return {}
+
+
+@DRAW.register
+class Log(_cmd.Command):
+    op = "log"
+    category = "log"
+    summary = "Record a free-text note in the command log."
+    arguments = {"message": {**STRING,
+                             "description": "Free-text note to record."}}
+
+    def apply(self, world, args, ctx):
+        ctx.append_log(args["message"])
+        return {}
+
+
+COMMANDS = DRAW.commands
+COMMAND_SCHEMAS = DRAW.command_schemas
+RESULT_SCHEMAS = DRAW.result_schemas
+SCHEMA = DRAW.schema
+validate_command = DRAW.validate_command
+validate_result = DRAW.validate_result
+validate_script = DRAW.validate_script
+apply_defaults = DRAW.apply_defaults
+tool_definitions = DRAW.tool_definitions
+commands_by_category = DRAW.commands_by_category
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/agent/draw/command.py
+++ b/solvcon/agent/draw/command.py
@@ -5,8 +5,8 @@
 """
 The command vocabulary for driving a ``World`` from an AI agent.
 
-Each command is one ``Command`` subclass registered in ``DRAW``; the JSON
-Schema documents and validators are derived from them (see
+Each command is one ``Command`` subclass registered in the command set; the
+JSON Schema documents and validators are derived from them (see
 :mod:`solvcon.agent._command`). Only the ``World``-specific fragments and
 behavior live here, so a mesh or pilot family declares commands the same way.
 ``render_png`` returns a transport-ready image (base64 PNG), never raw bytes,
@@ -122,11 +122,11 @@ def _require_live(world, shape_id):
         raise _cmd.CommandError(f"no live shape with id {shape_id}")
 
 
-DRAW = _cmd.CommandSet("Agent Draw command",
-                       "Any single command in the Agent Draw schema.")
+_command_set = _cmd.CommandSet(
+    "Agent Draw command", "Any single command in the Agent Draw schema.")
 
 
-@DRAW.register
+@_command_set.register
 class AddPoint(_cmd.Command):
     op = "add_point"
     category = "create"
@@ -143,7 +143,7 @@ class AddPoint(_cmd.Command):
         return {"npoint": world.npoint}
 
 
-@DRAW.register
+@_command_set.register
 class AddSegment(_cmd.Command):
     op = "add_segment"
     category = "create"
@@ -159,7 +159,7 @@ class AddSegment(_cmd.Command):
         return {"nsegment": world.nsegment}
 
 
-@DRAW.register
+@_command_set.register
 class AddLine(_cmd.Command):
     op = "add_line"
     category = "create"
@@ -175,7 +175,7 @@ class AddLine(_cmd.Command):
             args["x0"], args["y0"], args["x1"], args["y1"])}
 
 
-@DRAW.register
+@_command_set.register
 class AddTriangle(_cmd.Command):
     op = "add_triangle"
     category = "create"
@@ -194,7 +194,7 @@ class AddTriangle(_cmd.Command):
             args["x2"], args["y2"])}
 
 
-@DRAW.register
+@_command_set.register
 class AddRectangle(_cmd.Command):
     op = "add_rectangle"
     category = "create"
@@ -210,7 +210,7 @@ class AddRectangle(_cmd.Command):
             args["x_min"], args["y_min"], args["x_max"], args["y_max"])}
 
 
-@DRAW.register
+@_command_set.register
 class AddSquare(_cmd.Command):
     op = "add_square"
     category = "create"
@@ -225,7 +225,7 @@ class AddSquare(_cmd.Command):
             args["x_min"], args["y_min"], args["size"])}
 
 
-@DRAW.register
+@_command_set.register
 class AddEllipse(_cmd.Command):
     op = "add_ellipse"
     category = "create"
@@ -240,7 +240,7 @@ class AddEllipse(_cmd.Command):
             args["cx"], args["cy"], args["rx"], args["ry"])}
 
 
-@DRAW.register
+@_command_set.register
 class AddCircle(_cmd.Command):
     op = "add_circle"
     category = "create"
@@ -254,7 +254,7 @@ class AddCircle(_cmd.Command):
             args["cx"], args["cy"], args["r"])}
 
 
-@DRAW.register
+@_command_set.register
 class AddBezier(_cmd.Command):
     op = "add_bezier"
     category = "create"
@@ -273,7 +273,7 @@ class AddBezier(_cmd.Command):
         return {"nbezier": world.nbezier}
 
 
-@DRAW.register
+@_command_set.register
 class AddBezierShape(_cmd.Command):
     op = "add_bezier_shape"
     category = "create"
@@ -290,7 +290,7 @@ class AddBezierShape(_cmd.Command):
             _world_point(args["p2"]), _world_point(args["p3"]))}
 
 
-@DRAW.register
+@_command_set.register
 class GetShape(_cmd.Command):
     op = "get_shape"
     category = "read"
@@ -308,7 +308,7 @@ class GetShape(_cmd.Command):
         raise _cmd.CommandError(f"no live shape with id {shape_id}")
 
 
-@DRAW.register
+@_command_set.register
 class ShapeTypeOf(_cmd.Command):
     op = "shape_type_of"
     category = "read"
@@ -322,7 +322,7 @@ class ShapeTypeOf(_cmd.Command):
         return {"type": world.shape_type_of(args["shape_id"])}
 
 
-@DRAW.register
+@_command_set.register
 class NShape(_cmd.Command):
     op = "nshape"
     category = "read"
@@ -333,7 +333,7 @@ class NShape(_cmd.Command):
         return {"nshape": world.nshape}
 
 
-@DRAW.register
+@_command_set.register
 class QueryVisible(_cmd.Command):
     op = "query_visible"
     category = "read"
@@ -351,7 +351,7 @@ class QueryVisible(_cmd.Command):
         return {"shape_ids": list(ids)}
 
 
-@DRAW.register
+@_command_set.register
 class DescribeState(_cmd.Command):
     op = "describe_state"
     category = "read"
@@ -366,7 +366,7 @@ class DescribeState(_cmd.Command):
         return {"state": json.loads(world.describe_state(level=args["level"]))}
 
 
-@DRAW.register
+@_command_set.register
 class RenderPng(_cmd.Command):
     op = "render_png"
     category = "read"
@@ -397,7 +397,7 @@ class RenderPng(_cmd.Command):
                           "width": args["width"], "height": args["height"]}}
 
 
-@DRAW.register
+@_command_set.register
 class TranslateShape(_cmd.Command):
     op = "translate_shape"
     category = "update"
@@ -412,7 +412,7 @@ class TranslateShape(_cmd.Command):
         return {}
 
 
-@DRAW.register
+@_command_set.register
 class RemoveShape(_cmd.Command):
     op = "remove_shape"
     category = "delete"
@@ -425,7 +425,7 @@ class RemoveShape(_cmd.Command):
         return {}
 
 
-@DRAW.register
+@_command_set.register
 class Clear(_cmd.Command):
     op = "clear"
     category = "delete"
@@ -436,7 +436,7 @@ class Clear(_cmd.Command):
         return {}
 
 
-@DRAW.register
+@_command_set.register
 class Log(_cmd.Command):
     op = "log"
     category = "log"
@@ -448,16 +448,5 @@ class Log(_cmd.Command):
         ctx.append_log(args["message"])
         return {}
 
-
-COMMANDS = DRAW.commands
-COMMAND_SCHEMAS = DRAW.command_schemas
-RESULT_SCHEMAS = DRAW.result_schemas
-SCHEMA = DRAW.schema
-validate_command = DRAW.validate_command
-validate_result = DRAW.validate_result
-validate_script = DRAW.validate_script
-apply_defaults = DRAW.apply_defaults
-tool_definitions = DRAW.tool_definitions
-commands_by_category = DRAW.commands_by_category
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_draw_command.py
+++ b/tests/test_agent_draw_command.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""A basic go-through of the Agent Draw command vocabulary in
+solvcon.agent.draw, exercised end to end against a real WorldFp64 through the
+generic CommandProcessor. Only a representative slice is covered here; the
+comprehensive per-command suite lands in a later change."""
+
+import unittest
+
+import solvcon
+from solvcon.agent import CommandProcessor
+from solvcon.agent import draw
+
+
+class DrawVocabularyGoThroughTC(unittest.TestCase):
+    """Walk the draw family once: schema derivation, a CRUD flow, errors."""
+
+    def setUp(self):
+        self.world = solvcon.WorldFp64()
+        self.proc = CommandProcessor(self.world, draw)
+
+    def test_schema_is_derived_from_the_commands(self):
+        # The family speaks for itself; nothing enumerates ops by hand.
+        self.assertEqual(len(draw.schema["oneOf"]),
+                         len(draw.commands))
+        grouped = draw.commands_by_category()
+        self.assertIn("add_circle", grouped["create"])
+        self.assertIn("translate_shape", grouped["update"])
+        self.assertIn("clear", grouped["delete"])
+        tool = next(t for t in draw.tool_definitions()
+                    if t["name"] == "add_circle")
+        self.assertIn("r", tool["inputSchema"]["properties"])
+        self.assertIn("shape_id", tool["outputSchema"]["properties"])
+
+    def test_crud_flow_mutates_the_world(self):
+        created = self.proc.run(
+            {"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 2.0})
+        self.assertTrue(created.ok)
+        shape_id = created.value["shape_id"]
+        # A read reports the type the create just made, so the id is live.
+        self.assertEqual(
+            self.proc.run(
+                {"op": "shape_type_of", "shape_id": shape_id}).value,
+            {"type": "circle"})
+        self.assertEqual(self.proc.run({"op": "nshape"}).value["nshape"], 1)
+        self.assertTrue(self.proc.run(
+            {"op": "translate_shape",
+             "shape_id": shape_id, "dx": 1.0, "dy": 1.0}).ok)
+        # The delete is real: the shape count falls back to zero.
+        self.assertTrue(
+            self.proc.run({"op": "remove_shape", "shape_id": shape_id}).ok)
+        self.assertEqual(self.proc.run({"op": "nshape"}).value["nshape"], 0)
+
+    def test_bad_commands_fail_cleanly_without_touching_the_world(self):
+        # A schema violation is a failed result, not a raise or a mutation.
+        bad = self.proc.run(
+            {"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": -1.0})
+        self.assertFalse(bad.ok)
+        self.assertEqual(self.proc.run({"op": "nshape"}).value["nshape"], 0)
+        # A by-id op on a dead shape reports the one clean error, not a
+        # C++-flavored exception.
+        missing = self.proc.run(
+            {"op": "translate_shape", "shape_id": 999, "dx": 0.0, "dy": 0.0})
+        self.assertFalse(missing.ok)
+        self.assertIn("no live shape", missing.error)
+
+    def test_render_png_without_a_renderer_is_a_clean_failure(self):
+        # render_png never touches a GUI; with no injected renderer it fails
+        # rather than raising, so a batch is not aborted.
+        result = self.proc.run(
+            {"op": "render_png", "width": 8, "height": 8})
+        self.assertFalse(result.ok)
+        self.assertIn("renderer", result.error)
+
+    def test_log_records_a_note_in_the_processor_log(self):
+        self.assertTrue(self.proc.run(
+            {"op": "log", "message": "hello"}).ok)
+        self.assertEqual(self.proc.log, ["hello"])
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Add the Agent Draw command vocabulary for the World as the `solvcon.agent.draw` package: one `Command` subclass per World operation, collected in a single `CommandSet`. The schema documents, validators, and tool definitions are all derived from the registered commands by the generic framework merged in Agent Draw Command 1 and 2 (#1074, #1075), so this package declares only the World-specific fragments and apply behavior. A mesh or pilot family would declare its commands the same way.

The vocabulary spans the CRUD categories the framework understands:

- create: bare primitives (`add_point`, `add_segment`, `add_bezier`) and shapes (`add_line`, `add_triangle`, `add_rectangle`, `add_square`, `add_ellipse`, `add_circle`, `add_bezier_shape`).
- read: `get_shape`, `shape_type_of`, `nshape`, `query_visible`, `describe_state`, and `render_png`.
- update: `translate_shape`.
- delete: `remove_shape` and `clear`.
- log: `log`, a free-text note in the command log.

The result fragments mirror `WorldState` and `WorldShapeState` in `cpp/solvcon/universe/World.hpp`, so the published schema tracks the C++ side. Coordinates are world coordinates in the World's native units, math convention with +Y up. `render_png` renders through a renderer injected on the command context, and returns a base64 PNG rather than raw bytes so a result stays JSON-serializable over any transport; with no renderer configured it fails cleanly instead of raising, and never touches a GUI. By-id commands preflight the id so they fail the one clean way `get_shape` does, rather than leaking a C++-flavored exception. The JSON Schema property builders the fragments need live in the draw package, since the merged framework is domain-agnostic and carries none.

A basic go-through test walks the family once against a real `WorldFp64` through the generic `CommandProcessor`: schema derivation from the commands, a create-read-update-delete flow that mutates the world, clean failure paths for a schema violation and a dead-id operation, the renderer-less `render_png` failure, and the log note. It covers a representative slice only; the comprehensive per-command suite lands in Agent Draw Command 4 (#1077).

Related to #966.
