### PR TITLE
Add the Qt-free pilot keymap core (step 1 of shortcut)

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RWindowsThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RLinuxThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/keymap.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxHighlighter.hpp
@@ -69,6 +70,7 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RWindowsThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RLinuxThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/keymap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxHighlighter.cpp

--- a/cpp/solvcon/pilot/keymap.cpp
+++ b/cpp/solvcon/pilot/keymap.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/keymap.hpp>
+
+#include <cstddef>
+#include <stdexcept>
+#include <variant>
+
+namespace solvcon
+{
+
+namespace
+{
+
+std::vector<ShortcutBinding> tableWith(std::vector<ShortcutBinding> extra)
+{
+    std::vector<ShortcutBinding> rows = {
+        {ShortcutCommand::Undo, StandardAction::Undo, ShortcutContext::Window},
+        {ShortcutCommand::Redo, StandardAction::Redo, ShortcutContext::Window},
+        {ShortcutCommand::CameraReset, KeyChord{KeyMod::None, Key::Escape}, ShortcutContext::Widget},
+    };
+    rows.insert(rows.end(), extra.begin(), extra.end());
+    return rows;
+}
+
+std::vector<ShortcutBinding> const & linuxTable()
+{
+    static std::vector<ShortcutBinding> const table = tableWith({});
+    return table;
+}
+
+std::vector<ShortcutBinding> const & windowsTable()
+{
+    static std::vector<ShortcutBinding> const table = tableWith({});
+    return table;
+}
+
+std::vector<ShortcutBinding> const & macTable()
+{
+    // macOS carries the Quit role from the start; the key sequence for Quit
+    // is added when file.exit begins routing through the manager.
+    static std::vector<ShortcutBinding> const table =
+        tableWith({{ShortcutCommand::Exit, Unbound{}, ShortcutContext::Application, MenuRole::Quit}});
+    return table;
+}
+
+} /* end namespace */
+
+std::string_view commandId(ShortcutCommand command)
+{
+    switch (command)
+    {
+    case ShortcutCommand::Undo:
+        return "edit.undo";
+    case ShortcutCommand::Redo:
+        return "edit.redo";
+    case ShortcutCommand::CameraReset:
+        return "camera.reset";
+    case ShortcutCommand::Exit:
+        return "file.exit";
+    case ShortcutCommand::Console:
+        return "window.console";
+    case ShortcutCommand::AgentPanel:
+        return "panel.agent_console";
+    }
+    throw std::logic_error("Unexpected command");
+}
+
+std::vector<ShortcutBinding> const & bindingTable(PlatformId platform)
+{
+    switch (platform)
+    {
+    case PlatformId::Mac:
+        return macTable();
+    case PlatformId::Windows:
+        return windowsTable();
+    case PlatformId::Linux:
+        return linuxTable();
+    }
+    throw std::logic_error("Unexpected platform");
+}
+
+ShortcutBinding const * bindingFor(PlatformId platform, ShortcutCommand command)
+{
+    for (auto const & binding : bindingTable(platform))
+    {
+        if (binding.command == command)
+        {
+            return &binding;
+        }
+    }
+    return nullptr;
+}
+
+ShortcutCapabilities capabilitiesFor(PlatformId platform)
+{
+    bool const appMenu = platform == PlatformId::Mac;
+    return {platform, appMenu, {}};
+}
+
+bool contextsOverlap(ShortcutContext lhs, ShortcutContext rhs)
+{
+    auto covers = [](ShortcutContext wide, ShortcutContext narrow)
+    {
+        switch (wide)
+        {
+        case ShortcutContext::Application:
+            return true;
+        case ShortcutContext::Window:
+            return narrow == ShortcutContext::Window || narrow == ShortcutContext::Widget;
+        case ShortcutContext::Widget:
+            return narrow == ShortcutContext::Widget;
+        }
+        return false;
+    };
+    return covers(lhs, rhs) || covers(rhs, lhs);
+}
+
+std::vector<ShortcutConflict> findDeclaredConflicts(PlatformId platform)
+{
+    std::vector<ShortcutConflict> conflicts;
+    auto const & table = bindingTable(platform);
+    for (std::size_t i = 0; i < table.size(); ++i)
+    {
+        auto const * chord_i = std::get_if<KeyChord>(&table[i].key);
+        if (chord_i == nullptr)
+        {
+            continue;
+        }
+        for (std::size_t j = i + 1; j < table.size(); ++j)
+        {
+            auto const * chord_j = std::get_if<KeyChord>(&table[j].key);
+            if (chord_j == nullptr)
+            {
+                continue;
+            }
+            if (*chord_i == *chord_j && contextsOverlap(table[i].context, table[j].context))
+            {
+                conflicts.push_back({table[i].command, table[j].command});
+            }
+        }
+    }
+    return conflicts;
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/keymap.hpp
+++ b/cpp/solvcon/pilot/keymap.hpp
@@ -1,0 +1,149 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Qt-free core of the pilot keyboard-shortcut system: the shared command
+ * vocabulary, the per-platform binding tables, the capability records, and
+ * the declared-conflict rule. Kept free of Qt so every CI runner can unit
+ * test all three platforms' tables without a display. The Qt adapter that
+ * resolves these into live QKeySequence values lives in RShortcutManager.
+ *
+ * @ingroup group_domain
+ */
+
+#include <string_view>
+#include <variant>
+#include <vector>
+
+namespace solvcon
+{
+
+enum class PlatformId
+{
+    Linux,
+    Mac,
+    Windows
+};
+
+enum class ShortcutContext
+{
+    Application,
+    Window,
+    Widget
+};
+
+enum class MenuRole
+{
+    None,
+    Quit,
+    Preferences,
+    About
+};
+
+enum class StandardAction
+{
+    Undo,
+    Redo
+};
+
+/// A modifier role, written against the command modifier rather than a
+/// physical key: Primary is Command on macOS and Control elsewhere. A flag
+/// set so a chord can name more than one modifier; the roof adds the bitwise
+/// combine and test helpers when it resolves a chord into Qt modifiers.
+enum class KeyMod : unsigned
+{
+    None = 0,
+    Primary = 1u << 0,
+    Shift = 1u << 1,
+    Alt = 1u << 2
+};
+
+/// A physical key a curated chord names. The vocabulary stays small: only the
+/// keys the pilot binds today, growing as later steps add curated chords.
+/// Arrow keys are deliberately absent; they belong to
+/// RDomainWidget::keyPressEvent, not the action system.
+enum class Key
+{
+    Escape
+};
+
+struct KeyChord
+{
+    KeyMod mods;
+    Key key;
+};
+
+constexpr bool operator==(KeyChord lhs, KeyChord rhs)
+{
+    return lhs.mods == rhs.mods && lhs.key == rhs.key;
+}
+
+struct Unbound
+{
+};
+
+/// A key spelling is either a standard action, a curated chord, or unbound.
+/// Unbound is a placeholder for a command that has no binding on a platform yet.
+/// StandardAction is a placeholder for a command that defers to Qt's standard sequence for that action.
+/// KeyChord is a curated chord that the pilot binds to a command.
+using KeySpelling = std::variant<Unbound, StandardAction, KeyChord>;
+
+/// A command named by the objectName the pilot already gives its action, so
+/// the vocabulary names existing commands across both the C++ and Python
+/// layers rather than inventing ids.
+enum class ShortcutCommand
+{
+    Undo,
+    Redo,
+    CameraReset,
+    Exit,
+    Console,
+    AgentPanel
+};
+
+struct ShortcutBinding
+{
+    ShortcutCommand command;
+    KeySpelling key;
+    ShortcutContext context;
+    MenuRole role = MenuRole::None;
+};
+
+struct ShortcutCapabilities
+{
+    PlatformId platform;
+    bool movesItemsToApplicationMenu;
+    std::vector<KeyChord> reservedSequences;
+};
+
+struct ShortcutConflict
+{
+    ShortcutCommand first;
+    ShortcutCommand second;
+};
+
+std::string_view commandId(ShortcutCommand command);
+
+std::vector<ShortcutBinding> const & bindingTable(PlatformId platform);
+
+/// The binding for @p command on @p platform, or nullptr when the command
+/// carries none on that platform yet.
+ShortcutBinding const * bindingFor(PlatformId platform, ShortcutCommand command);
+
+ShortcutCapabilities capabilitiesFor(PlatformId platform);
+
+/// Whether two contexts can be active together, under the conservative rule:
+/// Application overlaps every context, Window overlaps Window and Widget, and
+/// Widget overlaps Widget. Symmetric.
+bool contextsOverlap(ShortcutContext lhs, ShortcutContext rhs);
+
+std::vector<ShortcutConflict> findDeclaredConflicts(PlatformId platform);
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -39,9 +39,11 @@ add_executable(
     test_nopython_pilot_history.cpp
     test_nopython_pilot_syntax.cpp
     test_nopython_pilot_theme.cpp
+    test_nopython_pilot_keymap.cpp
     ${SOLVCON_INCLUDE_DIR}/solvcon/pilot/RPythonConsoleHistory.cpp
     ${SOLVCON_INCLUDE_DIR}/solvcon/pilot/RPythonSyntaxRules.cpp
     ${SOLVCON_INCLUDE_DIR}/solvcon/pilot/theme.cpp
+    ${SOLVCON_INCLUDE_DIR}/solvcon/pilot/keymap.cpp
     ${SOLVCON_TOGGLE_SOURCES}
     ${SOLVCON_PROFILING_SOURCES}
     ${SOLVCON_BUFFER_SOURCES}

--- a/gtests/test_nopython_pilot_keymap.cpp
+++ b/gtests/test_nopython_pilot_keymap.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/keymap.hpp>
+
+#include <array>
+#include <variant>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+constexpr std::array<solvcon::PlatformId, 3> PLATFORMS = {
+    solvcon::PlatformId::Linux, solvcon::PlatformId::Mac, solvcon::PlatformId::Windows};
+
+} /* end namespace */
+
+TEST(PilotKeymapTable, SeedsUndoRedoAndResetOnEveryPlatform)
+{
+    for (auto platform : PLATFORMS)
+    {
+        auto const * undo = solvcon::bindingFor(platform, solvcon::ShortcutCommand::Undo);
+        ASSERT_NE(undo, nullptr);
+        EXPECT_EQ(std::get<solvcon::StandardAction>(undo->key), solvcon::StandardAction::Undo);
+        EXPECT_EQ(undo->context, solvcon::ShortcutContext::Window);
+
+        auto const * redo = solvcon::bindingFor(platform, solvcon::ShortcutCommand::Redo);
+        ASSERT_NE(redo, nullptr);
+        EXPECT_EQ(std::get<solvcon::StandardAction>(redo->key), solvcon::StandardAction::Redo);
+
+        auto const * reset = solvcon::bindingFor(platform, solvcon::ShortcutCommand::CameraReset);
+        ASSERT_NE(reset, nullptr);
+        EXPECT_EQ(std::get<solvcon::KeyChord>(reset->key),
+                  (solvcon::KeyChord{solvcon::KeyMod::None, solvcon::Key::Escape}));
+        EXPECT_EQ(reset->context, solvcon::ShortcutContext::Widget);
+    }
+}
+
+TEST(PilotKeymapMac, AddsQuitRoleAndAppMenuOverTheSeed)
+{
+    EXPECT_TRUE(solvcon::capabilitiesFor(solvcon::PlatformId::Mac).movesItemsToApplicationMenu);
+    EXPECT_EQ(solvcon::bindingTable(solvcon::PlatformId::Mac).size(),
+              solvcon::bindingTable(solvcon::PlatformId::Linux).size() + 1);
+
+    auto const * exit = solvcon::bindingFor(solvcon::PlatformId::Mac, solvcon::ShortcutCommand::Exit);
+    ASSERT_NE(exit, nullptr);
+    EXPECT_TRUE(std::holds_alternative<solvcon::Unbound>(exit->key));
+    EXPECT_EQ(exit->role, solvcon::MenuRole::Quit);
+}
+
+TEST(PilotKeymapCapabilities, OnlyMacMovesItemsToApplicationMenu)
+{
+    EXPECT_TRUE(solvcon::capabilitiesFor(solvcon::PlatformId::Mac).movesItemsToApplicationMenu);
+    EXPECT_FALSE(solvcon::capabilitiesFor(solvcon::PlatformId::Linux).movesItemsToApplicationMenu);
+    EXPECT_FALSE(solvcon::capabilitiesFor(solvcon::PlatformId::Windows).movesItemsToApplicationMenu);
+}
+
+TEST(PilotKeymapContext, FollowsConservativeOverlapRule)
+{
+    EXPECT_TRUE(solvcon::contextsOverlap(solvcon::ShortcutContext::Application, solvcon::ShortcutContext::Widget));
+    EXPECT_TRUE(solvcon::contextsOverlap(solvcon::ShortcutContext::Window, solvcon::ShortcutContext::Widget));
+    EXPECT_TRUE(solvcon::contextsOverlap(solvcon::ShortcutContext::Widget, solvcon::ShortcutContext::Window));
+    // Two widget scopes stay conservatively overlapping until proven exclusive.
+    EXPECT_TRUE(solvcon::contextsOverlap(solvcon::ShortcutContext::Widget, solvcon::ShortcutContext::Widget));
+}
+
+TEST(PilotKeymapConflicts, DefaultTablesHaveNoDeclaredConflicts)
+{
+    for (auto platform : PLATFORMS)
+    {
+        EXPECT_TRUE(solvcon::findDeclaredConflicts(platform).empty());
+    }
+}
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Introduce the Qt-free keymap core, the foundation of the pilot keyboard-shortcut system: a shared command vocabulary, per-platform binding tables seeded from the pilot's current keys (each binding a KeySpelling sum type of a Qt StandardAction, a curated KeyChord, or Unbound), capability records, and the findDeclaredConflicts rule, compiled into test_nopython and covered by PilotKeymap* cases on every CI runner, with no pilot behavior change yet.

Related to #1070.