### PR TITLE
Inspector Label 3: Add advanced geometric labels to the 2D canvas overlay

### DIFF
--- a/cpp/solvcon/pilot/RWorldRenderer2d.cpp
+++ b/cpp/solvcon/pilot/RWorldRenderer2d.cpp
@@ -108,6 +108,104 @@ void paint_chrome(QPainter & painter, ViewTransform2dFp64 const & view, int widt
     }
 }
 
+/// Compact number for shape annotations: enough digits to read, no trailing noise.
+QString format_measure(double value)
+{
+    return QString::number(value, 'g', 4);
+}
+
+QString format_point(double x, double y)
+{
+    return QStringLiteral("(%1, %2)").arg(format_measure(x), format_measure(y));
+}
+
+double segment_length(double x0, double y0, double x1, double y1)
+{
+    double const dx = x1 - x0;
+    double const dy = y1 - y0;
+    return std::sqrt(dx * dx + dy * dy);
+}
+
+/// Return a list of lines describing the shape's geometry, including the id/type line.
+QStringList advanced_shape_label(WorldFp64 const & world, int32_t id)
+{
+    ShapeType const type = world.shape_type_of(id);
+    QStringList lines;
+    lines << QStringLiteral("#%1 %2").arg(id).arg(QString::fromStdString(shape_type_name(type)));
+
+    switch (type)
+    {
+    case ShapeType::LINE:
+    {
+        auto const s = world.shape_segment(id, 0);
+        lines << format_point(s.x0(), s.y0());
+        lines << format_point(s.x1(), s.y1());
+        lines << QStringLiteral("len=%1").arg(format_measure(segment_length(s.x0(), s.y0(), s.x1(), s.y1())));
+        break;
+    }
+    case ShapeType::TRIANGLE:
+    {
+        auto const s0 = world.shape_segment(id, 0);
+        auto const s1 = world.shape_segment(id, 1);
+        double const x0 = s0.x0(), y0 = s0.y0();
+        double const x1 = s0.x1(), y1 = s0.y1();
+        double const x2 = s1.x1(), y2 = s1.y1();
+        lines << format_point(x0, y0);
+        lines << format_point(x1, y1);
+        lines << format_point(x2, y2);
+        lines << QStringLiteral("sides=%1, %2, %3")
+                     .arg(format_measure(segment_length(x0, y0, x1, y1)),
+                          format_measure(segment_length(x1, y1, x2, y2)),
+                          format_measure(segment_length(x2, y2, x0, y0)));
+        break;
+    }
+    case ShapeType::RECTANGLE:
+    case ShapeType::SQUARE:
+    {
+        auto const obb = world.shape_obb(id); // TL, TR, BR, BL as xy pairs
+        double const x0 = obb[0], y0 = obb[1];
+        double const x1 = obb[2], y1 = obb[3];
+        double const x2 = obb[4], y2 = obb[5];
+        double const w = segment_length(x0, y0, x1, y1);
+        double const h = segment_length(x1, y1, x2, y2);
+        lines << format_point(x0, y0) + QStringLiteral(" .. ") + format_point(x2, y2);
+        lines << QStringLiteral("w=%1 h=%2").arg(format_measure(w), format_measure(h));
+        break;
+    }
+    case ShapeType::CIRCLE:
+    {
+        auto const bb = world.shape_bbox(id);
+        double const cx = 0.5 * (bb[0] + bb[2]);
+        double const cy = 0.5 * (bb[1] + bb[3]);
+        double const r = 0.5 * (bb[2] - bb[0]);
+        lines << QStringLiteral("c=%1").arg(format_point(cx, cy));
+        lines << QStringLiteral("r=%1").arg(format_measure(r));
+        break;
+    }
+    case ShapeType::ELLIPSE:
+    {
+        auto const obb = world.shape_obb(id);
+        double const cx = 0.25 * (obb[0] + obb[2] + obb[4] + obb[6]);
+        double const cy = 0.25 * (obb[1] + obb[3] + obb[5] + obb[7]);
+        double const rx = 0.5 * segment_length(obb[0], obb[1], obb[2], obb[3]);
+        double const ry = 0.5 * segment_length(obb[2], obb[3], obb[4], obb[5]);
+        lines << QStringLiteral("c=%1").arg(format_point(cx, cy));
+        lines << QStringLiteral("rx=%1 ry=%2").arg(format_measure(rx), format_measure(ry));
+        break;
+    }
+    case ShapeType::BEZIER:
+    {
+        auto const c = world.shape_curve(id, 0);
+        lines << format_point(c.x0(), c.y0());
+        lines << format_point(c.x3(), c.y3());
+        break;
+    }
+    default:
+        break;
+    }
+    return lines;
+}
+
 /**
  * Uniform-grid index of screen rectangles a label must not overlap: placed
  * labels, each shape's padded bbox, and strips over the visible world axes.
@@ -370,7 +468,7 @@ void RWorldRenderer2d::paint_shape_annotations(QPainter & painter, int width, in
     highlight_pen.setWidthF(2.0);
     highlight_pen.setStyle(Qt::DashLine);
 
-    bool const place_labels = m_overlay.shape_ids;
+    bool const place_labels = m_overlay.advanced_labels || m_overlay.shape_ids;
     constexpr double PAD = 4.0;
     constexpr double AXIS_HALF = 5.0;
     LabelObstacles obstacles(static_cast<double>(width), static_cast<double>(height));
@@ -428,9 +526,16 @@ void RWorldRenderer2d::paint_shape_annotations(QPainter & painter, int width, in
         ++labels_drawn;
 
         QStringList rows;
-        rows << QStringLiteral("#%1 %2")
-                    .arg(id)
-                    .arg(QString::fromStdString(shape_type_name(m_world->shape_type_of(id))));
+        if (m_overlay.advanced_labels)
+        {
+            rows = advanced_shape_label(*m_world, id);
+        }
+        else
+        {
+            rows << QStringLiteral("#%1 %2")
+                        .arg(id)
+                        .arg(QString::fromStdString(shape_type_name(m_world->shape_type_of(id))));
+        }
         double widest = 0.0;
         for (QString const & row : rows)
         {

--- a/cpp/solvcon/pilot/RWorldRenderer2d.hpp
+++ b/cpp/solvcon/pilot/RWorldRenderer2d.hpp
@@ -28,20 +28,21 @@ namespace solvcon
 
 /**
  * Toggleable, legibility-only annotations over the 2D canvas: shape ids,
- * bounding boxes, and one highlighted shape id. Restates stored geometry only
- * (no derived diagnostics).
+ * bounding boxes, advanced geometric labels, and one highlighted shape id.
+ * Restates stored geometry only (no derived diagnostics).
  *
  * @ingroup group_domain
  */
 struct Overlay2dOptions
 {
-    bool shape_ids = false;
-    bool bounding_boxes = false;
+    bool shape_ids = false; ///< Label each live shape with its id and type.
+    bool bounding_boxes = false; ///< Draw each live shape's axis-aligned box.
+    bool advanced_labels = false; ///< More details than just the id.
     int32_t highlight_id = -1; ///< Emphasize this shape id; -1 draws none. Independent of selection.
 
     bool shape_annotations() const
     {
-        return shape_ids || bounding_boxes || highlight_id >= 0;
+        return shape_ids || bounding_boxes || advanced_labels || highlight_id >= 0;
     }
 
     bool any() const { return shape_annotations(); }

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -1061,12 +1061,13 @@ void wrap_pilot(pybind11::module & mod)
         mod,
         "Overlay2dOptions",
         "Toggleable, legibility-only annotations for the 2D canvas: per-shape "
-        "ids and bounding boxes, and one highlighted shape id. Carries no "
-        "derived facts.");
+        "ids and bounding boxes, advanced geometric labels, and one "
+        "highlighted shape id. Carries no derived facts.");
     overlay_options.def(py::init<>());
     overlay_options
         .def_readwrite("shape_ids", &Overlay2dOptions::shape_ids)
         .def_readwrite("bounding_boxes", &Overlay2dOptions::bounding_boxes)
+        .def_readwrite("advanced_labels", &Overlay2dOptions::advanced_labels)
         .def_readwrite("highlight_id", &Overlay2dOptions::highlight_id);
     WrapR2DWidget::commit(mod, "R2DWidget", "R2DWidget");
     WrapRPythonConsoleDockWidget::commit(mod, "RPythonConsoleDockWidget", "RPythonConsoleDockWidget");

--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -435,6 +435,22 @@ public:
 
     ShapeType shape_type_of(int32_t shape_id) const { return find_shape_or_throw(shape_id).type; }
 
+    /// Segment ``i`` owned by a live shape (0-based within the shape).
+    segment_type shape_segment(int32_t shape_id, uint32_t i) const
+    {
+        ShapeRecord const & rec = find_shape_or_throw(shape_id);
+        check_size(i, rec.segment_count, "shape segment");
+        return m_segments->get(rec.segment_offset + i);
+    }
+
+    /// Curve ``i`` owned by a live shape (0-based within the shape).
+    bezier_type shape_curve(int32_t shape_id, uint32_t i) const
+    {
+        ShapeRecord const & rec = find_shape_or_throw(shape_id);
+        check_size(i, rec.curve_count, "shape curve");
+        return m_curves->get(rec.curve_offset + i);
+    }
+
     /**
      * Undo the most recent change. A change is any shape operation: creation,
      * deletion, move, rotate, or a future attribute edit. A no-op when nothing

--- a/solvcon/pilot/_gui_common.py
+++ b/solvcon/pilot/_gui_common.py
@@ -8,12 +8,22 @@ from PySide6 import QtCore, QtGui
 
 
 def apply_label_mode(overlay, on, advanced):
-    overlay.shape_ids = on
+    """Pack the label switch and mode into the overlay's flags.
+
+    ``on`` adds a shape label; ``advanced`` selects the geometric labels over
+    the plain id label. Returns the same overlay for chaining.
+    """
+    overlay.shape_ids = on and not advanced
+    overlay.advanced_labels = advanced
+    # TODO(grid): overlay.coordinate_labels = on once grid labels land.
     return overlay
 
 
 def label_switch_and_mode(overlay):
-    return overlay.shape_ids, False
+    """Return ``(on, advanced)`` for the overlay's current label state."""
+    # TODO(grid): OR in overlay.coordinate_labels.
+    on = overlay.shape_ids or overlay.advanced_labels
+    return on, overlay.advanced_labels
 
 
 class ToggleActionBridge(QtCore.QObject):

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -569,6 +569,7 @@ def _all_on_overlay(highlight_id=-1):
     overlay = pilot.Overlay2dOptions()
     overlay.shape_ids = True
     overlay.bounding_boxes = True
+    overlay.advanced_labels = True
     overlay.highlight_id = highlight_id
     return overlay
 
@@ -585,8 +586,8 @@ def _save_and_check_png(testcase, widget):
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class R2DWidgetOverlayTC(unittest.TestCase):
-    """Annotation overlay: ids, bounding boxes, and highlight-by-id via
-    R2DWidget.overlay.
+    """Annotation overlay: ids, advanced geometric labels, bounding boxes,
+    and highlight-by-id via R2DWidget.overlay.
     """
 
     @classmethod
@@ -602,6 +603,27 @@ class R2DWidgetOverlayTC(unittest.TestCase):
         # to leave a clean slate for the next test.
         self.widget.overlay = pilot.Overlay2dOptions()
         self.widget.resetView()
+
+    def test_overlay_defaults_off(self):
+        """A fresh widget draws no annotations: every toggle is off and no
+        shape is highlighted.
+        """
+        overlay = self.widget.overlay
+        self.assertFalse(overlay.shape_ids)
+        self.assertFalse(overlay.bounding_boxes)
+        self.assertFalse(overlay.advanced_labels)
+        self.assertEqual(overlay.highlight_id, -1)
+
+    def test_overlay_options_round_trip(self):
+        """Assigning an Overlay2dOptions reads back field for field, so the
+        experiment can flip individual arms on the same widget.
+        """
+        self.widget.overlay = _all_on_overlay(highlight_id=2)
+        got = self.widget.overlay
+        self.assertTrue(got.shape_ids)
+        self.assertTrue(got.bounding_boxes)
+        self.assertTrue(got.advanced_labels)
+        self.assertEqual(got.highlight_id, 2)
 
     def test_overlay_render_is_crash_safe(self):
         """Every annotation on, over a world with a removed shape, and with a
@@ -634,13 +656,37 @@ class R2DWidgetOverlayTC(unittest.TestCase):
         annotated = _grab_foreground(self.widget)
         self.assertGreater(annotated, plain)
 
+    def test_advanced_labels_add_more_pixels_than_ids(self):
+        """Advanced labels paint geometric detail beyond the bare id/type
+        tag, so the annotated frame has strictly more foreground pixels.
+        """
+        world = solvcon.WorldFp64()
+        world.add_rectangle(-2, -1, 2, 1)
+        world.add_circle(-3, 2, 1.0)
+        world.add_triangle(0, 0, 1, 0, 0, 1)
+        self.widget.updateWorld(world)
+        self.widget.resetView()
+        basic = pilot.Overlay2dOptions()
+        basic.shape_ids = True
+        self.widget.overlay = basic
+        self.widget.requestRepaint()
+        plain = _grab_foreground(self.widget)
+        if not plain:
+            self.skipTest("offscreen grab reads back blank on this backend")
+        rich = pilot.Overlay2dOptions()
+        rich.advanced_labels = True
+        self.widget.overlay = rich
+        self.widget.requestRepaint()
+        annotated = _grab_foreground(self.widget)
+        self.assertGreater(annotated, plain)
+
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class InspectorLabelControlsTC(unittest.TestCase):
     """Cover the inspector label controls driving the canvas overlay.
 
-    The inspector entity tree's label switch drives the bound canvas's
-    overlay, per canvas.
+    The inspector entity tree's label switch and normal/advanced selector
+    drive the bound canvas's overlay, per canvas.
     """
 
     @classmethod
@@ -661,6 +707,44 @@ class InspectorLabelControlsTC(unittest.TestCase):
         self.assertFalse(tree._label_modes["normal"].isEnabled())
         tree._labels_check.setChecked(True)
         self.assertTrue(tree._label_modes["normal"].isEnabled())
+
+    def test_switch_drives_normal_labels(self):
+        """The switch turns on the id label (normal mode) and clears it
+        again, so the inspector governs the canvas overlay.
+        """
+        widget = self.mgr.add2DWidget()
+        widget.overlay = pilot.Overlay2dOptions()
+        tree = self._tree(widget)
+        tree._labels_check.setChecked(True)
+        self.assertTrue(widget.overlay.shape_ids)
+        self.assertFalse(widget.overlay.advanced_labels)
+        tree._labels_check.setChecked(False)
+        self.assertFalse(widget.overlay.shape_ids)
+
+    def test_advanced_mode_swaps_id_for_geometry(self):
+        """Advanced mode drops the plain id label for the geometric labels
+        (which already carry the id/type line).
+        """
+        widget = self.mgr.add2DWidget()
+        widget.overlay = pilot.Overlay2dOptions()
+        tree = self._tree(widget)
+        tree._labels_check.setChecked(True)
+        tree._label_modes["advanced"].setChecked(True)
+        self.assertFalse(widget.overlay.shape_ids)
+        self.assertTrue(widget.overlay.advanced_labels)
+
+    def test_controls_reflect_bound_canvas(self):
+        """Binding a canvas whose overlay is already on advanced presets the
+        switch and selector, so the inspector shows that canvas's state
+        instead of resetting it.
+        """
+        widget = self.mgr.add2DWidget()
+        overlay = pilot.Overlay2dOptions()
+        overlay.advanced_labels = True
+        widget.overlay = overlay
+        tree = self._tree(widget)
+        self.assertTrue(tree._labels_check.isChecked())
+        self.assertTrue(tree._label_modes["advanced"].isChecked())
 
     def test_world_tree_lives_in_entity_section(self):
         widget = self.mgr.add2DWidget()


### PR DESCRIPTION
Add an advanced label mode that restates each shape's stored geometry (line endpoints and length, triangle vertices and sides, rectangle span and width/height, circle center and radius, ellipse center and semi-axes, Bezier endpoints), backed by new World shape_segment and shape_curve accessors, and wire the inspector and save-dialog mode selector to it. Stacked on #1073.

Related to https://github.com/solvcon/solvcon/issues/896
