### PR TITLE
Inspector Label 4: Add grid coordinate labels to the 2D canvas overlay

### DIFF
--- a/.claude/skills/cpp-style-review/SKILL.md
+++ b/.claude/skills/cpp-style-review/SKILL.md
@@ -61,6 +61,12 @@ it briefly but don't re-implement the check here.
 
 **Comments**
 - **Comments are very important.** Check all comments in the diff for clarity, accuracy, and relevance. Flag any comment that is unclear, misleading, trivial, or outdated.
+- **Doxygen markers (check every changed comment, not just its content).**
+  Per STYLE.md, use `/** ... */` for any block of two or more lines, `///`
+  for a one-line brief on a declaration, and `///<` for a trailing member or
+  enumerator brief. Flag a multi-line `///` block (two or more consecutive
+  `///` lines forming one brief) and tell the author to convert it to
+  `/** */`. Judging a comment's wording is not enough; verify the marker too.
 - Refer to "C++ Comment" in STYLE.md for what counts as a comment and how to judge it.
 
 **pybind11**

--- a/cpp/solvcon/pilot/RWorldRenderer2d.cpp
+++ b/cpp/solvcon/pilot/RWorldRenderer2d.cpp
@@ -40,17 +40,15 @@ QColor const OVERLAY_HIGHLIGHT(240, 180, 60);
 constexpr double BASE_GRID_SPACING_PX = 64.0;
 constexpr double MIN_GRID_SPACING_PX = 16.0;
 constexpr double MAX_GRID_SPACING_PX = 256.0;
+constexpr double COORD_TICK_PX = 6.0;
 
 // Cosmetic (zoom-independent) screen widths for world geometry.
 constexpr double GEOMETRY_LINE_WIDTH_PX = 1.5;
 constexpr int GEOMETRY_POINT_WIDTH_PX = 5;
 
-void paint_chrome(QPainter & painter, ViewTransform2dFp64 const & view, int width, int height)
+/// Return a grid spacing in world units that maps to a screen spacing in pixels.
+double grid_spacing_world(ViewTransform2dFp64 const & view)
 {
-    double const widget_w = static_cast<double>(width);
-    double const widget_h = static_cast<double>(height);
-
-    // Snap grid spacing to a power of ten times {1, 2, 5} for a readable band.
     double const target_world = BASE_GRID_SPACING_PX / view.zoom();
     double const exponent = std::floor(std::log10(target_world));
     double const base = std::pow(10.0, exponent);
@@ -61,12 +59,76 @@ void paint_chrome(QPainter & painter, ViewTransform2dFp64 const & view, int widt
         double const candidate_px = view.zoom() * candidate;
         if (candidate_px >= MIN_GRID_SPACING_PX && candidate_px <= MAX_GRID_SPACING_PX)
         {
-            spacing_world = candidate;
-            break;
+            return candidate;
         }
         spacing_world = candidate;
     }
-    double const spacing_px = view.zoom() * spacing_world;
+    return spacing_world;
+}
+
+/**
+ * Ascending screen coordinates of the visible grid lines on one axis, as a
+ * range so callers iterate with a for-loop instead of a visitor lambda. The
+ * grid chrome and the coordinate labels share it, so lines and labels never
+ * drift.
+ */
+class GridLineRange
+{
+public:
+    GridLineRange(double pan, double spacing_px, double extent)
+        : m_spacing(spacing_px)
+        , m_extent(extent)
+        , m_first(spacing_px > 0.0 ? first_line(pan, spacing_px) : extent)
+    {
+    }
+
+    class Iterator
+    {
+    public:
+        Iterator(double pos, double spacing)
+            : m_pos(pos)
+            , m_spacing(spacing)
+        {
+        }
+
+        double operator*() const { return m_pos; }
+        Iterator & operator++()
+        {
+            m_pos += m_spacing;
+            return *this;
+        }
+        bool operator!=(double extent) const { return m_pos < extent; }
+
+    private:
+        double m_pos;
+        double m_spacing;
+    };
+
+    Iterator begin() const { return Iterator(m_first, m_spacing); }
+    double end() const { return m_extent; }
+
+private:
+    static double first_line(double pan, double spacing_px)
+    {
+        double first = std::fmod(pan, spacing_px);
+        if (first < 0.0)
+        {
+            first += spacing_px;
+        }
+        return first;
+    }
+
+    double m_spacing;
+    double m_extent;
+    double m_first;
+};
+
+void paint_chrome(QPainter & painter, ViewTransform2dFp64 const & view, int width, int height)
+{
+    double const widget_w = static_cast<double>(width);
+    double const widget_h = static_cast<double>(height);
+
+    double const spacing_px = view.zoom() * grid_spacing_world(view);
 
     // Draw minor grid lines in screen space directly.
     QPen minor_pen(MINOR_GRID);
@@ -74,21 +136,11 @@ void paint_chrome(QPainter & painter, ViewTransform2dFp64 const & view, int widt
     minor_pen.setWidth(1);
     painter.setPen(minor_pen);
 
-    double const first_x = std::fmod(view.pan_x(), spacing_px);
-    for (double sx = first_x; sx < widget_w; sx += spacing_px)
+    for (double sx : GridLineRange(view.pan_x(), spacing_px, widget_w))
     {
         painter.drawLine(QPointF(sx, 0.0), QPointF(sx, widget_h));
     }
-    for (double sx = first_x - spacing_px; sx > 0.0; sx -= spacing_px)
-    {
-        painter.drawLine(QPointF(sx, 0.0), QPointF(sx, widget_h));
-    }
-    double const first_y = std::fmod(view.pan_y(), spacing_px);
-    for (double sy = first_y; sy < widget_h; sy += spacing_px)
-    {
-        painter.drawLine(QPointF(0.0, sy), QPointF(widget_w, sy));
-    }
-    for (double sy = first_y - spacing_px; sy > 0.0; sy -= spacing_px)
+    for (double sy : GridLineRange(view.pan_y(), spacing_px, widget_h))
     {
         painter.drawLine(QPointF(0.0, sy), QPointF(widget_w, sy));
     }
@@ -107,6 +159,178 @@ void paint_chrome(QPainter & painter, ViewTransform2dFp64 const & view, int widt
         painter.drawLine(QPointF(view.pan_x(), 0.0), QPointF(view.pan_x(), widget_h));
     }
 }
+
+/// Return the decimal places that keep adjacent grid labels distinct.
+int coordinate_decimals(double spacing_world)
+{
+    if (!std::isfinite(spacing_world) || spacing_world <= 0.0)
+    {
+        return 0;
+    }
+    double const places = std::ceil(-std::log10(spacing_world));
+    return std::clamp(static_cast<int>(places), 0, 12);
+}
+
+/// Format a grid coordinate at the grid's own precision, snapping away floating-point noise.
+QString format_coordinate(double value, double spacing_world, int decimals)
+{
+    double const snapped = std::round(value / spacing_world) * spacing_world;
+    return QString::number(snapped, 'f', decimals);
+}
+
+/**
+ * Labels the visible grid lines with their world coordinates and names the two
+ * axes. Numerals land on the same lines as paint_chrome's grid; each label,
+ * the numerals and the two axis letters alike, is drawn only where it stays on
+ * the canvas and clear of the labels already placed, so the set stays readable
+ * at any zoom. The per-frame state the placement steps share (metrics, the
+ * placed rectangles) lives in members rather than a web of captured lambdas.
+ */
+class CoordinateLabelPainter
+{
+public:
+    CoordinateLabelPainter(QPainter & painter, ViewTransform2dFp64 const & view, int width, int height)
+        : m_painter(painter)
+        , m_view(view)
+        , m_widget_w(static_cast<double>(width))
+        , m_widget_h(static_cast<double>(height))
+        , m_spacing_world(grid_spacing_world(view))
+        , m_spacing_px(view.zoom() * m_spacing_world)
+        , m_metrics(painter.font())
+        , m_decimals(coordinate_decimals(m_spacing_world))
+        , m_ascent(m_metrics.ascent())
+        , m_text_h(m_metrics.height())
+    {
+    }
+
+    void paint()
+    {
+        if (!(m_spacing_px > 0.0) || !std::isfinite(m_spacing_world))
+        {
+            return;
+        }
+        m_painter.setPen(OVERLAY_TEXT);
+        paint_x_row();
+        paint_y_column();
+        paint_axis_letters();
+    }
+
+    /// Screen rectangles of the labels drawn, for other overlays to avoid.
+    std::vector<QRectF> const & placed() const { return m_placed; }
+
+private:
+    /// On the canvas and clear of every label already placed.
+    bool fits(QRectF const & r) const
+    {
+        if (r.left() < 0.0 || r.top() < 0.0 || r.right() > m_widget_w || r.bottom() > m_widget_h)
+        {
+            return false;
+        }
+        for (QRectF const & other : m_placed)
+        {
+            if (r.intersects(other))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void paint_x_row()
+    {
+        constexpr double PAD = 8.0;
+        double const x_baseline = m_widget_h - COORD_TICK_PX - 3.0;
+        double last_right = -1.0e300;
+        for (double sx : GridLineRange(m_view.pan_x(), m_spacing_px, m_widget_w))
+        {
+            if (sx <= last_right + PAD) // cheap necessary condition; the rect test refines it
+            {
+                continue;
+            }
+            double wx = 0.0, wy = 0.0;
+            m_view.world_from_screen(sx, 0.0, wx, wy);
+            QString const text = format_coordinate(wx, m_spacing_world, m_decimals);
+            double const half = 0.5 * m_metrics.horizontalAdvance(text);
+            QRectF const rect(sx - half, x_baseline - m_ascent, 2.0 * half, m_text_h);
+            if (!fits(rect))
+            {
+                continue;
+            }
+            m_painter.drawLine(QPointF(sx, m_widget_h), QPointF(sx, m_widget_h - COORD_TICK_PX));
+            m_painter.drawText(QPointF(sx - half, x_baseline), text);
+            m_placed.push_back(rect);
+            last_right = sx + half;
+        }
+    }
+
+    void paint_y_column()
+    {
+        double const y_shift = 0.5 * (m_ascent - m_metrics.descent());
+        double const min_dy = m_text_h + 4.0;
+        double const label_x = COORD_TICK_PX + 3.0;
+        double last_sy = -1.0e300;
+        for (double sy : GridLineRange(m_view.pan_y(), m_spacing_px, m_widget_h))
+        {
+            if (sy - last_sy < min_dy)
+            {
+                continue;
+            }
+            double wx = 0.0, wy = 0.0;
+            m_view.world_from_screen(0.0, sy, wx, wy);
+            // The x row already carries a 0 at the visible x=0 column, so drop
+            // the duplicate here only when that column is actually on screen.
+            if (std::round(wy / m_spacing_world) == 0.0 && m_view.pan_x() >= 0.0 && m_view.pan_x() <= m_widget_w)
+            {
+                continue;
+            }
+            QString const text = format_coordinate(wy, m_spacing_world, m_decimals);
+            QRectF const rect(label_x, sy + y_shift - m_ascent, m_metrics.horizontalAdvance(text), m_text_h);
+            if (!fits(rect))
+            {
+                continue;
+            }
+            m_painter.drawLine(QPointF(0.0, sy), QPointF(COORD_TICK_PX, sy));
+            m_painter.drawText(QPointF(label_x, sy + y_shift), text);
+            m_placed.push_back(rect);
+            last_sy = sy;
+        }
+    }
+
+    void paint_axis_letters()
+    {
+        if (m_view.pan_y() >= 0.0 && m_view.pan_y() <= m_widget_h)
+        {
+            place_letter(m_widget_w - 12.0, m_view.pan_y() - 4.0, QStringLiteral("x"));
+        }
+        if (m_view.pan_x() >= 0.0 && m_view.pan_x() <= m_widget_w)
+        {
+            // A full ascent below the top, so the box clears the top edge.
+            place_letter(m_view.pan_x() + 4.0, m_ascent + 2.0, QStringLiteral("y"));
+        }
+    }
+
+    void place_letter(double base_x, double base_y, QString const & text)
+    {
+        QRectF const rect(base_x, base_y - m_ascent, m_metrics.horizontalAdvance(text), m_text_h);
+        if (fits(rect))
+        {
+            m_painter.drawText(QPointF(base_x, base_y), text);
+            m_placed.push_back(rect);
+        }
+    }
+
+    QPainter & m_painter;
+    ViewTransform2dFp64 const & m_view;
+    double m_widget_w;
+    double m_widget_h;
+    double m_spacing_world;
+    double m_spacing_px;
+    QFontMetricsF m_metrics;
+    int m_decimals;
+    double m_ascent;
+    double m_text_h;
+    std::vector<QRectF> m_placed;
+};
 
 /// Compact number for shape annotations: enough digits to read, no trailing noise.
 QString format_measure(double value)
@@ -448,7 +672,8 @@ void RWorldRenderer2d::paint(QPainter & painter) const
     }
 }
 
-void RWorldRenderer2d::paint_shape_annotations(QPainter & painter, int width, int height) const
+void RWorldRenderer2d::paint_shape_annotations(
+    QPainter & painter, int width, int height, std::vector<QRectF> const & reserved) const
 {
     // Visible world rectangle from the two screen corners; world +Y is up, so
     // screen-top maps to the larger world y.
@@ -494,6 +719,13 @@ void RWorldRenderer2d::paint_shape_annotations(QPainter & painter, int width, in
     {
         obstacles.add(QRectF(
             m_view.pan_x() - AXIS_HALF, 0.0, 2.0 * AXIS_HALF, static_cast<double>(height)));
+    }
+    if (place_labels)
+    {
+        for (QRectF const & r : reserved)
+        {
+            obstacles.add(r);
+        }
     }
 
     // Cap how many shapes get a text label. Past this many visible shapes the
@@ -556,9 +788,19 @@ void RWorldRenderer2d::paint_shape_annotations(QPainter & painter, int width, in
 
 void RWorldRenderer2d::paint_overlay(QPainter & painter, int width, int height) const
 {
+    // Coordinate labels paint first, so shape labels (drawn last, on top) must
+    // treat their rectangles as obstacles or a gutter shape label lands over
+    // the coordinate text.
+    std::vector<QRectF> coord_labels;
+    if (m_overlay.coordinate_labels)
+    {
+        CoordinateLabelPainter labels(painter, m_view, width, height);
+        labels.paint();
+        coord_labels = labels.placed();
+    }
     if (m_world && m_overlay.shape_annotations())
     {
-        paint_shape_annotations(painter, width, height);
+        paint_shape_annotations(painter, width, height, coord_labels);
     }
 }
 

--- a/cpp/solvcon/pilot/RWorldRenderer2d.hpp
+++ b/cpp/solvcon/pilot/RWorldRenderer2d.hpp
@@ -18,8 +18,10 @@
 #include <solvcon/universe/World.hpp>
 
 #include <cstdint>
+#include <vector>
 
 #include <QPointF>
+#include <QRectF>
 
 class QPainter;
 
@@ -28,8 +30,9 @@ namespace solvcon
 
 /**
  * Toggleable, legibility-only annotations over the 2D canvas: shape ids,
- * bounding boxes, advanced geometric labels, and one highlighted shape id.
- * Restates stored geometry only (no derived diagnostics).
+ * bounding boxes, grid coordinate labels, advanced geometric labels, and one
+ * highlighted shape id. Draws only stored geometry and the view's own grid,
+ * never derived diagnostics.
  *
  * @ingroup group_domain
  */
@@ -37,6 +40,7 @@ struct Overlay2dOptions
 {
     bool shape_ids = false; ///< Label each live shape with its id and type.
     bool bounding_boxes = false; ///< Draw each live shape's axis-aligned box.
+    bool coordinate_labels = false; ///< Label grid lines with world coordinates.
     bool advanced_labels = false; ///< More details than just the id.
     int32_t highlight_id = -1; ///< Emphasize this shape id; -1 draws none. Independent of selection.
 
@@ -45,7 +49,7 @@ struct Overlay2dOptions
         return shape_ids || bounding_boxes || advanced_labels || highlight_id >= 0;
     }
 
-    bool any() const { return shape_annotations(); }
+    bool any() const { return coordinate_labels || shape_annotations(); }
 }; /* end struct Overlay2dOptions */
 
 /**
@@ -78,7 +82,7 @@ private:
     void paint(QPainter & painter) const;
 
     void paint_overlay(QPainter & painter, int width, int height) const;
-    void paint_shape_annotations(QPainter & painter, int width, int height) const;
+    void paint_shape_annotations(QPainter & painter, int width, int height, std::vector<QRectF> const & reserved) const;
 
     // Map math-convention world (x, y) to Qt screen pixels; z is dropped.
     QPointF map(double world_x, double world_y) const;

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -1061,12 +1061,13 @@ void wrap_pilot(pybind11::module & mod)
         mod,
         "Overlay2dOptions",
         "Toggleable, legibility-only annotations for the 2D canvas: per-shape "
-        "ids and bounding boxes, advanced geometric labels, and one "
-        "highlighted shape id. Carries no derived facts.");
+        "ids and bounding boxes, world-coordinate labels, advanced geometric "
+        "labels, and one highlighted shape id. Carries no derived facts.");
     overlay_options.def(py::init<>());
     overlay_options
         .def_readwrite("shape_ids", &Overlay2dOptions::shape_ids)
         .def_readwrite("bounding_boxes", &Overlay2dOptions::bounding_boxes)
+        .def_readwrite("coordinate_labels", &Overlay2dOptions::coordinate_labels)
         .def_readwrite("advanced_labels", &Overlay2dOptions::advanced_labels)
         .def_readwrite("highlight_id", &Overlay2dOptions::highlight_id);
     WrapR2DWidget::commit(mod, "R2DWidget", "R2DWidget");

--- a/solvcon/pilot/_canvas_gui.py
+++ b/solvcon/pilot/_canvas_gui.py
@@ -49,10 +49,11 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
     """
     File-menu action that saves the focused 2D canvas via ``saveImage``.
 
-    The save dialog carries an "Include labels" switch and a normal/advanced
-    selector, so the exported image can bake in the annotation overlay
-    independent of what the canvas currently shows on screen. The controls
-    need custom widgets in the dialog, so it runs non-native.
+    The save dialog carries an "Include labels" switch with a normal/advanced
+    selector and an independent "Include coordinates" switch, so the exported
+    image can bake in the annotation overlay independent of what the canvas
+    currently shows on screen. The controls need custom widgets in the dialog,
+    so it runs non-native.
     """
 
     def __init__(self, *args, **kw):
@@ -68,7 +69,8 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
         self._build_label_controls()
 
     def _build_label_controls(self):
-        """Add the label switch and normal/advanced selector to the dialog."""
+        """Add the label switch, normal/advanced selector, and the independent
+        coordinate switch to the dialog."""
         self._labels_check = QtWidgets.QCheckBox("Include labels")
         self._normal_radio = QtWidgets.QRadioButton("normal")
         self._advanced_radio = QtWidgets.QRadioButton("advanced")
@@ -77,10 +79,12 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
         group.addButton(self._normal_radio)
         group.addButton(self._advanced_radio)
         self._label_group = group
+        self._coords_check = QtWidgets.QCheckBox("Include coordinates")
         row = QtWidgets.QHBoxLayout()
         row.addWidget(self._labels_check)
         row.addWidget(self._normal_radio)
         row.addWidget(self._advanced_radio)
+        row.addWidget(self._coords_check)
         row.addStretch(1)
         grid = self._diag.layout()
         grid.addLayout(row, grid.rowCount(), 0, 1, grid.columnCount())
@@ -119,8 +123,10 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
 
         The export defaults to matching what the canvas shows on screen.
         """
-        on, advanced = _gui_common.label_switch_and_mode(widget.overlay)
+        on, advanced, coords = _gui_common.label_switch_and_mode(
+            widget.overlay)
         self._labels_check.setChecked(on)
+        self._coords_check.setChecked(coords)
         radio = self._advanced_radio if advanced else self._normal_radio
         radio.setChecked(True)
         self._sync_label_radios()
@@ -152,7 +158,9 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
         """
         on = self._labels_check.isChecked()
         advanced = on and self._advanced_radio.isChecked()
-        return _gui_common.apply_label_mode(widget.overlay, on, advanced)
+        coords = self._coords_check.isChecked()
+        return _gui_common.apply_label_mode(
+            widget.overlay, on, advanced, coords)
 
     def _save_current(self, path):
         widget = self._mgr.currentR2DWidget()

--- a/solvcon/pilot/_gui_common.py
+++ b/solvcon/pilot/_gui_common.py
@@ -7,23 +7,20 @@ from ..core import Toggle
 from PySide6 import QtCore, QtGui
 
 
-def apply_label_mode(overlay, on, advanced):
-    """Pack the label switch and mode into the overlay's flags.
-
-    ``on`` adds a shape label; ``advanced`` selects the geometric labels over
-    the plain id label. Returns the same overlay for chaining.
-    """
+def apply_label_mode(overlay, on, advanced, coordinates):
+    """Pack the shape-label switch, its mode, and the coordinate switch into
+    an overlay's flags. The shape labels and the grid coordinate labels are
+    independent, so each switch owns its own flags."""
     overlay.shape_ids = on and not advanced
-    overlay.advanced_labels = advanced
-    # TODO(grid): overlay.coordinate_labels = on once grid labels land.
+    overlay.advanced_labels = on and advanced
+    overlay.coordinate_labels = coordinates
     return overlay
 
 
 def label_switch_and_mode(overlay):
-    """Return ``(on, advanced)`` for the overlay's current label state."""
-    # TODO(grid): OR in overlay.coordinate_labels.
+    """Return ``(on, advanced, coordinates)`` for an overlay's label state."""
     on = overlay.shape_ids or overlay.advanced_labels
-    return on, overlay.advanced_labels
+    return on, overlay.advanced_labels, overlay.coordinate_labels
 
 
 class ToggleActionBridge(QtCore.QObject):

--- a/solvcon/pilot/_tree_panel.py
+++ b/solvcon/pilot/_tree_panel.py
@@ -9,12 +9,13 @@ import json
 
 import numpy as np
 
-from PySide6.QtCore import Qt, QTimer, Signal
+from PySide6.QtCore import Qt, QTimer, Signal, QSize, QRectF
+from PySide6.QtGui import QColor, QPainter
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QTreeWidget,
                                QTreeWidgetItem, QFrame, QDockWidget,
                                QStackedWidget, QHBoxLayout, QButtonGroup,
                                QRadioButton, QCheckBox, QPushButton,
-                               QSizePolicy)
+                               QSizePolicy, QAbstractButton)
 
 from .. import core
 from . import _gui_common
@@ -334,6 +335,61 @@ class _CollapsibleSection(QWidget):
         self._toggle.setChecked(expanded)
 
 
+class _ToggleSwitch(QAbstractButton):
+    """A sliding on/off switch with a trailing text label."""
+
+    _TRACK_W = 34
+    _TRACK_H = 18
+    _MARGIN = 3
+
+    def __init__(self, text="", parent=None):
+        super().__init__(parent)
+        self.setText(text)
+        self.setCheckable(True)
+        self.setCursor(Qt.PointingHandCursor)
+
+    def sizeHint(self):
+        metrics = self.fontMetrics()
+        gap = 6 if self.text() else 0
+        text_w = metrics.horizontalAdvance(self.text())
+        return QSize(self._TRACK_W + gap + text_w,
+                     max(self._TRACK_H, metrics.height()))
+
+    def paintEvent(self, _event):
+        on = self.isChecked()
+        enabled = self.isEnabled()
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing, True)
+
+        top = 0.5 * (self.height() - self._TRACK_H)
+        track = QRectF(0, top, self._TRACK_W, self._TRACK_H)
+        if on:
+            fill = QColor(90, 160, 90) if enabled else QColor(70, 100, 70)
+        else:
+            fill = QColor(110, 110, 118) if enabled else QColor(70, 70, 74)
+        radius = self._TRACK_H / 2
+        painter.setPen(Qt.NoPen)
+        painter.setBrush(fill)
+        painter.drawRoundedRect(track, radius, radius)
+
+        knob_d = self._TRACK_H - 2 * self._MARGIN
+        knob_x = (track.right() - self._MARGIN - knob_d if on
+                  else track.left() + self._MARGIN)
+        painter.setBrush(QColor(240, 240, 240) if enabled
+                         else QColor(180, 180, 180))
+        painter.drawEllipse(QRectF(knob_x, top + self._MARGIN,
+                                   knob_d, knob_d))
+
+        if self.text():
+            color = (self.palette().text().color() if enabled
+                     else QColor(140, 140, 140))
+            painter.setPen(color)
+            text_left = self._TRACK_W + 6
+            painter.drawText(
+                QRectF(text_left, 0, self.width() - text_left, self.height()),
+                Qt.AlignLeft | Qt.AlignVCenter, self.text())
+
+
 class EntityTreeWidget(TreePanelBase):
     """Widget that presents the entity tree inside the dock."""
 
@@ -443,32 +499,44 @@ class EntityTreeWidget(TreePanelBase):
         layout.addLayout(level_row)
 
     def _build_label_controls(self, layout):
-        """Add the canvas label switch and its normal/advanced selector.
+        """Add the shape-label switch with its normal/advanced selector on the
+        first row and the independent grid-coordinate switch on the second.
 
-        The selector only makes sense while the switch is on, so it follows
-        the switch's enabled state. Both stay disabled until a canvas is
-        bound through :meth:`set_canvas`. Signals connect only after the
-        defaults are set, so building the row drives no overlay writes.
+        The mode selector only makes sense while the shape-label switch is on,
+        so it follows the switch's enabled state. Every control stays disabled
+        until a canvas is bound through :meth:`set_canvas`. Signals connect
+        only after the defaults are set, so building the rows drives no overlay
+        writes.
         """
-        label_row = QHBoxLayout()
-        label_row.setContentsMargins(0, 0, 0, 0)
-        label_row.setSpacing(8)
+        shape_row = QHBoxLayout()
+        shape_row.setContentsMargins(0, 0, 0, 0)
+        shape_row.setSpacing(8)
         self._labels_check = QCheckBox("show")
-        label_row.addWidget(self._labels_check)
+        shape_row.addWidget(self._labels_check)
         mode_group = QButtonGroup(self)
         for mode in self.LABEL_MODES:
             button = QRadioButton(mode)
             mode_group.addButton(button)
-            label_row.addWidget(button)
+            shape_row.addWidget(button)
             self._label_modes[mode] = button
-        label_row.addStretch(1)
+        shape_row.addStretch(1)
+
+        coord_row = QHBoxLayout()
+        coord_row.setContentsMargins(0, 0, 0, 0)
+        self._coords_check = _ToggleSwitch("coordinates")
+        coord_row.addWidget(self._coords_check)
+        coord_row.addStretch(1)
+
         self._label_modes["normal"].setChecked(True)
         self._labels_check.setEnabled(False)
+        self._coords_check.setEnabled(False)
         self._sync_label_controls_enabled()
         self._labels_check.toggled.connect(self._on_labels_changed)
+        self._coords_check.toggled.connect(self._on_labels_changed)
         for button in self._label_modes.values():
             button.toggled.connect(self._on_labels_changed)
-        layout.addLayout(label_row)
+        layout.addLayout(shape_row)
+        layout.addLayout(coord_row)
 
     def _sync_label_controls_enabled(self):
         """Enable the mode radios only when a canvas is bound and on."""
@@ -480,13 +548,17 @@ class EntityTreeWidget(TreePanelBase):
         """Reflect the bound canvas's overlay into the controls."""
         self._syncing = True
         try:
-            self._labels_check.setEnabled(self._canvas is not None)
-            if self._canvas is None:
+            bound = self._canvas is not None
+            self._labels_check.setEnabled(bound)
+            self._coords_check.setEnabled(bound)
+            if not bound:
                 self._labels_check.setChecked(False)
+                self._coords_check.setChecked(False)
             else:
-                on, advanced = _gui_common.label_switch_and_mode(
+                on, advanced, coords = _gui_common.label_switch_and_mode(
                     self._canvas.overlay)
                 self._labels_check.setChecked(on)
+                self._coords_check.setChecked(coords)
                 mode = "advanced" if advanced else "normal"
                 self._label_modes[mode].setChecked(True)
             self._sync_label_controls_enabled()
@@ -494,14 +566,16 @@ class EntityTreeWidget(TreePanelBase):
             self._syncing = False
 
     def _on_labels_changed(self, _checked=False):
-        """Write the switch and mode to the bound canvas's overlay. """
+        """Write the switch, mode, and coordinate flag to the bound canvas's
+        overlay."""
         self._sync_label_controls_enabled()
         if self._syncing or self._canvas is None:
             return
         on = self._labels_check.isChecked()
         advanced = on and self._label_modes["advanced"].isChecked()
+        coords = self._coords_check.isChecked()
         overlay = self._canvas.overlay
-        _gui_common.apply_label_mode(overlay, on, advanced)
+        _gui_common.apply_label_mode(overlay, on, advanced, coords)
         self._canvas.overlay = overlay
 
     def set_canvas(self, widget):

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -569,6 +569,7 @@ def _all_on_overlay(highlight_id=-1):
     overlay = pilot.Overlay2dOptions()
     overlay.shape_ids = True
     overlay.bounding_boxes = True
+    overlay.coordinate_labels = True
     overlay.advanced_labels = True
     overlay.highlight_id = highlight_id
     return overlay
@@ -587,7 +588,7 @@ def _save_and_check_png(testcase, widget):
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class R2DWidgetOverlayTC(unittest.TestCase):
     """Annotation overlay: ids, advanced geometric labels, bounding boxes,
-    and highlight-by-id via R2DWidget.overlay.
+    coordinate labels, and highlight-by-id via R2DWidget.overlay.
     """
 
     @classmethod
@@ -611,6 +612,7 @@ class R2DWidgetOverlayTC(unittest.TestCase):
         overlay = self.widget.overlay
         self.assertFalse(overlay.shape_ids)
         self.assertFalse(overlay.bounding_boxes)
+        self.assertFalse(overlay.coordinate_labels)
         self.assertFalse(overlay.advanced_labels)
         self.assertEqual(overlay.highlight_id, -1)
 
@@ -622,6 +624,7 @@ class R2DWidgetOverlayTC(unittest.TestCase):
         got = self.widget.overlay
         self.assertTrue(got.shape_ids)
         self.assertTrue(got.bounding_boxes)
+        self.assertTrue(got.coordinate_labels)
         self.assertTrue(got.advanced_labels)
         self.assertEqual(got.highlight_id, 2)
 
@@ -636,10 +639,50 @@ class R2DWidgetOverlayTC(unittest.TestCase):
         self.widget.requestRepaint()
         _save_and_check_png(self, self.widget)
 
+    def test_overlay_extreme_zoom_labels_are_safe(self):
+        """Coordinate labels at a large zoom and offset render to a valid PNG.
+
+        Iterating grid lines in screen space bounds the label count to the
+        visible grid, so an extreme view cannot overflow a grid index.
+        """
+        world = solvcon.WorldFp64()
+        world.add_circle(1000.0, 1000.0, 1.0)
+        self.widget.updateWorld(world)
+        v = solvcon.ViewTransform2dFp64()
+        v.zoom = 1.0e6
+        v.pan(-1000.0e6, 1000.0e6)
+        self.widget.setViewTransform(v)
+        overlay = pilot.Overlay2dOptions()
+        overlay.coordinate_labels = True
+        self.widget.overlay = overlay
+        self.widget.requestRepaint()
+        _save_and_check_png(self, self.widget)
+
+    def test_coordinate_labels_add_foreground(self):
+        """Coordinate labels alone paint tick marks and numerals over the grid,
+        so the frame gains foreground with no shape annotation on. Isolating
+        them keeps the assertion from passing on bounding boxes alone.
+        """
+        world = solvcon.WorldFp64()
+        world.add_circle(0.0, 0.0, 1.0)
+        self.widget.updateWorld(world)
+        self.widget.resetView()
+        self.widget.overlay = pilot.Overlay2dOptions()
+        self.widget.requestRepaint()
+        plain = _grab_foreground(self.widget)
+        if not plain:
+            self.skipTest("offscreen grab reads back blank on this backend")
+        labeled = pilot.Overlay2dOptions()
+        labeled.coordinate_labels = True
+        self.widget.overlay = labeled
+        self.widget.requestRepaint()
+        annotated = _grab_foreground(self.widget)
+        self.assertGreater(annotated, plain)
+
     def test_overlay_adds_foreground_pixels(self):
         """Enabling the annotations paints strictly more than the bare
-        geometry: the bounding boxes and id labels add pixels the plain
-        render does not have.
+        geometry: the bounding boxes, id labels, and coordinate labels all add
+        pixels the plain render does not have.
         """
         world = solvcon.WorldFp64()
         sid = world.add_rectangle(-2, -1, 2, 1)
@@ -709,8 +752,8 @@ class InspectorLabelControlsTC(unittest.TestCase):
         self.assertTrue(tree._label_modes["normal"].isEnabled())
 
     def test_switch_drives_normal_labels(self):
-        """The switch turns on the id label (normal mode) and clears it
-        again, so the inspector governs the canvas overlay.
+        """The switch turns the id labels (normal mode) on and off, driving
+        the shape annotations without touching the coordinate grid labels.
         """
         widget = self.mgr.add2DWidget()
         widget.overlay = pilot.Overlay2dOptions()
@@ -718,8 +761,23 @@ class InspectorLabelControlsTC(unittest.TestCase):
         tree._labels_check.setChecked(True)
         self.assertTrue(widget.overlay.shape_ids)
         self.assertFalse(widget.overlay.advanced_labels)
+        self.assertFalse(widget.overlay.coordinate_labels)
         tree._labels_check.setChecked(False)
         self.assertFalse(widget.overlay.shape_ids)
+
+    def test_coordinates_switch_is_independent(self):
+        """The coordinates checkbox drives coordinate_labels on its own, with
+        the shape-label switch off, so the two are independent controls.
+        """
+        widget = self.mgr.add2DWidget()
+        widget.overlay = pilot.Overlay2dOptions()
+        tree = self._tree(widget)
+        tree._coords_check.setChecked(True)
+        self.assertTrue(widget.overlay.coordinate_labels)
+        self.assertFalse(widget.overlay.shape_ids)
+        self.assertFalse(widget.overlay.advanced_labels)
+        tree._coords_check.setChecked(False)
+        self.assertFalse(widget.overlay.coordinate_labels)
 
     def test_advanced_mode_swaps_id_for_geometry(self):
         """Advanced mode drops the plain id label for the geometric labels
@@ -741,10 +799,12 @@ class InspectorLabelControlsTC(unittest.TestCase):
         widget = self.mgr.add2DWidget()
         overlay = pilot.Overlay2dOptions()
         overlay.advanced_labels = True
+        overlay.coordinate_labels = True
         widget.overlay = overlay
         tree = self._tree(widget)
         self.assertTrue(tree._labels_check.isChecked())
         self.assertTrue(tree._label_modes["advanced"].isChecked())
+        self.assertTrue(tree._coords_check.isChecked())
 
     def test_world_tree_lives_in_entity_section(self):
         widget = self.mgr.add2DWidget()
@@ -765,6 +825,24 @@ class InspectorLabelControlsTC(unittest.TestCase):
         self.assertFalse(tree._tree_section.body().isHidden())
         self.assertTrue(tree._label_section.body().isHidden())
 
+    def test_labels_are_per_canvas(self):
+        """The inspector follows the active canvas: toggling labels drives
+        only the bound canvas, and rebinding reflects the other's own state,
+        so the two canvases stay independent.
+        """
+        first = self.mgr.add2DWidget()
+        second = self.mgr.add2DWidget()
+        first.overlay = pilot.Overlay2dOptions()
+        second.overlay = pilot.Overlay2dOptions()
+        tree = self._tree(first)
+        tree._coords_check.setChecked(True)
+        self.assertTrue(first.overlay.coordinate_labels)
+        self.assertFalse(second.overlay.coordinate_labels)
+        tree.set_canvas(second)
+        self.assertFalse(tree._coords_check.isChecked())
+        self.assertFalse(second.overlay.coordinate_labels)
+        self.assertTrue(first.overlay.coordinate_labels)
+
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class R2DWidgetExportOverlayTC(unittest.TestCase):
@@ -783,8 +861,7 @@ class R2DWidgetExportOverlayTC(unittest.TestCase):
     def test_export_overlay_independent_of_on_screen(self):
         """Exporting with labels bakes them even when the widget shows none,
         and exporting without labels omits them even when the widget shows
-        all: the file reflects the passed overlay, not the screen.
-        """
+        all: the file reflects the passed overlay, not the screen."""
         world = solvcon.WorldFp64()
         world.add_rectangle(-2, -1, 2, 1)
         world.add_circle(-3, 2, 1.0)


### PR DESCRIPTION
Add the final overlay member, world-coordinate labels along the grid, factoring the grid-spacing math out of paint_chrome into shared helpers (grid_spacing_world and for_each_grid_line) so the labels land on the same grid lines and never drift. Labels format at the grid's own precision and name the two axes.

Placement keeps the set readable at any zoom: every label, the grid numerals and the two axis letters alike, is drawn only where it stays within the canvas and clear of the labels already placed, so none is clipped at an edge or painted over another. This also fixes the "y" axis letter, which previously sat too close to the top edge and clipped out of view entirely.

Coordinate labels are their own switch, in the inspector's Labels section and in the save dialog, independent of the shape-label switch and its normal/advanced mode, so either set can be shown alone or together.

Stacked on #1080.

Related to https://github.com/solvcon/solvcon/issues/896

<img width="1921" height="969" alt="image" src="https://github.com/user-attachments/assets/478ad749-b597-44fb-bcdf-78bc342c127d" />

