### PR TITLE
Fix SimpleArrayPlex typed roundtrip test

### DIFF
--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -4413,6 +4413,8 @@ class SimpleArrayPlexTC(unittest.TestCase):
         for dtype, (_, typed_name, _) in self._DTINFO.items():
             with self.subTest(dtype=dtype):
                 plex = solvcon.SimpleArray((2, 3, 4), dtype=dtype)
+                ndarr = np.array(plex, dtype=dtype, copy=False)
+                ndarr.flat[0] = 1
                 typed = plex.typed
                 plex2 = typed.plex
 
@@ -4423,11 +4425,10 @@ class SimpleArrayPlexTC(unittest.TestCase):
                 self.assertEqual(str(type(plex2)),
                                  "<class '_solvcon.SimpleArray'>")
 
-                # Verify data survives the roundtrip:
-                # write through typed, read back from plex2
-                ndarr = np.array(plex, copy=False)
-                ndarr.flat[0] = 1
-                self.assertEqual(plex2[0, 0, 0], typed[0, 0, 0])
+                self.assertEqual(
+                    1, np.array(typed, dtype=dtype, copy=False).flat[0])
+                self.assertEqual(
+                    1, np.array(plex2, dtype=dtype, copy=False).flat[0])
 
     def test_SimpleArrayPlex_typed_preserves_data(self):
         # Test non-complex dtypes using value= constructor


### PR DESCRIPTION
Related to #1067.

This changes tests/test_buffer.py so the roundtrip check no longer depends on copying uninitialized buffer contents through typed and plex conversions.

What changed:
- Initialize the source array through the NumPy view before taking the roundtrip copies.
- Assert the copied views preserve the initialized value.

Why:
- The previous test mutated the source buffer after the copies were already made. That exposed uninitialized bytes in the copies, which could surface as nan on Windows for float32.

Checks:
- python3 -m py_compile tests/test_buffer.py
- make flake8
- make checkascii
- make checktws
- git diff --check
- Windows verification on windev: targeted test, full SimpleArrayPlexTC, and full tests/test_buffer.py