### PR TITLE
Furnish the per-platform theme rooms for macOS, Windows, and Linux (steps 5, 6, 7 of theme)

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMacThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RWindowsThemeBackend.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RLinuxThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp
@@ -66,6 +67,7 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMacThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RWindowsThemeBackend.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RLinuxThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.cpp

--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/theme.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeBackend.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RMacThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp
@@ -62,6 +63,7 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/theme.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeBackend.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RMacThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.cpp

--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/theme.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMacThemeBackend.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RWindowsThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp
@@ -64,6 +65,7 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/theme.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMacThemeBackend.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RWindowsThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.cpp

--- a/cpp/solvcon/pilot/RLinuxThemeBackend.cpp
+++ b/cpp/solvcon/pilot/RLinuxThemeBackend.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RLinuxThemeBackend.hpp>
+
+#include <cstdint>
+
+#include <QApplication>
+#include <QByteArray>
+#include <QColor>
+#include <QPalette>
+#include <QStyle>
+#include <QtGlobal>
+
+namespace solvcon
+{
+
+namespace
+{
+
+// Whether the running desktop names a Qt platform theme the room honors, read
+// from the environment through the Qt-free recognizer.
+bool desktopHasNativeTheme()
+{
+    QByteArray const desktop = qgetenv("XDG_CURRENT_DESKTOP");
+    return linuxDesktopHasNativeTheme(desktop.isEmpty() ? nullptr : desktop.constData());
+}
+
+} /* end namespace */
+
+PlatformId RLinuxThemeBackend::platform() const
+{
+    return PlatformId::Linux;
+}
+
+std::string RLinuxThemeBackend::styleName() const
+{
+    // Keep the desktop's own Qt style so the pilot looks native; an empty name
+    // tells the manager to leave the installed style alone.
+    return {};
+}
+
+std::optional<ThemeColor> RLinuxThemeBackend::accentColor(ThemeVariant /*variant*/) const
+{
+    // Only a recognized desktop is trusted to expose an accent worth honoring;
+    // elsewhere the curated highlight stays.
+    if (!desktopHasNativeTheme())
+    {
+        return std::nullopt;
+    }
+
+    QStyle * style = QApplication::style();
+    if (style == nullptr)
+    {
+        return std::nullopt;
+    }
+
+    QPalette const platform = style->standardPalette();
+    QColor accent;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    accent = platform.color(QPalette::Accent);
+#endif
+    if (!accent.isValid())
+    {
+        accent = platform.color(QPalette::Highlight);
+    }
+    if (!accent.isValid())
+    {
+        return std::nullopt;
+    }
+    return ThemeColor{static_cast<std::uint8_t>(accent.red()),
+                      static_cast<std::uint8_t>(accent.green()),
+                      static_cast<std::uint8_t>(accent.blue())};
+}
+
+void RLinuxThemeBackend::applyNativeChrome(QWidget * /*window*/, ThemeVariant /*variant*/)
+{
+    // Linux window managers own the title bar, so there is no chrome to apply.
+}
+
+ThemeCapabilities RLinuxThemeBackend::capabilities() const
+{
+    ThemeCapabilities caps = themeCapabilitiesFor(PlatformId::Linux);
+    // The accent is only genuinely native on a recognized desktop; elsewhere
+    // the highlight is the curated one, so report that plainly.
+    caps.has_native_accent = desktopHasNativeTheme();
+    return caps;
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RLinuxThemeBackend.hpp
+++ b/cpp/solvcon/pilot/RLinuxThemeBackend.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * The Linux room: the native theme backend for Linux and other desktops.
+ *
+ * Keeps the desktop's own Qt style, honors the desktop accent when a
+ * recognized platform theme exposes one, and otherwise leans on the curated
+ * palettes. It is the room with the most variety across desktops, so it leans
+ * hardest on the shared fallback. This is also the factory's default, selected
+ * for any platform without a room of its own.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/RThemeBackend.hpp>
+
+#include <optional>
+#include <string>
+
+namespace solvcon
+{
+
+/**
+ * @brief The Linux native theme backend.
+ *
+ * @ingroup group_domain
+ */
+class RLinuxThemeBackend
+    : public RThemeBackend
+{
+
+public:
+
+    PlatformId platform() const override;
+    std::string styleName() const override;
+    std::optional<ThemeColor> accentColor(ThemeVariant variant) const override;
+    void applyNativeChrome(QWidget * window, ThemeVariant variant) override;
+    ThemeCapabilities capabilities() const override;
+
+}; /* end class RLinuxThemeBackend */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RMacThemeBackend.cpp
+++ b/cpp/solvcon/pilot/RMacThemeBackend.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RMacThemeBackend.hpp>
+
+#include <QtGlobal>
+
+// The whole room is native to macOS, so the body compiles only there. On other
+// platforms this is an empty translation unit and the factory never names the
+// class.
+#if defined(Q_OS_MACOS)
+
+#include <cstdint>
+
+#include <QApplication>
+#include <QColor>
+#include <QPalette>
+#include <QStyle>
+
+namespace solvcon
+{
+
+PlatformId RMacThemeBackend::platform() const
+{
+    return PlatformId::Mac;
+}
+
+std::string RMacThemeBackend::styleName() const
+{
+    return "macos";
+}
+
+std::optional<ThemeColor> RMacThemeBackend::accentColor(ThemeVariant /*variant*/) const
+{
+    // The macos style's standard palette carries the user's system accent in
+    // the Accent role (Qt 6.6+), falling back to Highlight. Reading it from the
+    // style rather than the application palette keeps it independent of the
+    // curated palette the manager later applies over the top.
+    QStyle * style = QApplication::style();
+    if (style == nullptr)
+    {
+        return std::nullopt;
+    }
+
+    QPalette const platform = style->standardPalette();
+    QColor accent;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    accent = platform.color(QPalette::Accent);
+#endif
+    if (!accent.isValid())
+    {
+        accent = platform.color(QPalette::Highlight);
+    }
+    if (!accent.isValid())
+    {
+        return std::nullopt;
+    }
+    return ThemeColor{static_cast<std::uint8_t>(accent.red()),
+                      static_cast<std::uint8_t>(accent.green()),
+                      static_cast<std::uint8_t>(accent.blue())};
+}
+
+void RMacThemeBackend::applyNativeChrome(QWidget * /*window*/, ThemeVariant /*variant*/)
+{
+    // The color-scheme hint the manager sets flips the whole native appearance
+    // on Qt 6.8 and newer, title bar included, so there is no extra chrome to
+    // apply here.
+}
+
+ThemeCapabilities RMacThemeBackend::capabilities() const
+{
+    ThemeCapabilities caps = themeCapabilitiesFor(PlatformId::Mac);
+#if QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
+    // Without the color-scheme hint the native appearance cannot be pinned, so
+    // a forced variant is carried only by the curated palette and the title bar
+    // stays on the operating system setting.
+    caps.controls_titlebar = false;
+#endif
+    return caps;
+}
+
+} /* end namespace solvcon */
+
+#endif /* defined(Q_OS_MACOS) */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RMacThemeBackend.hpp
+++ b/cpp/solvcon/pilot/RMacThemeBackend.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * The macOS room: the native theme backend for macOS.
+ *
+ * Installs the native macos style, reads the user's system accent, and leans
+ * on the color-scheme hint the manager sets to pin a variant, title bar
+ * included, on Qt 6.8 and newer. Only linked into the macOS build; the factory
+ * in RThemeBackend.cpp is the sole site that selects it.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/RThemeBackend.hpp>
+
+#include <optional>
+#include <string>
+
+namespace solvcon
+{
+
+/**
+ * @brief The macOS native theme backend.
+ *
+ * @ingroup group_domain
+ */
+class RMacThemeBackend
+    : public RThemeBackend
+{
+
+public:
+
+    PlatformId platform() const override;
+    std::string styleName() const override;
+    std::optional<ThemeColor> accentColor(ThemeVariant variant) const override;
+    void applyNativeChrome(QWidget * window, ThemeVariant variant) override;
+    ThemeCapabilities capabilities() const override;
+
+}; /* end class RMacThemeBackend */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RThemeBackend.cpp
+++ b/cpp/solvcon/pilot/RThemeBackend.cpp
@@ -5,6 +5,8 @@
 
 #include <solvcon/pilot/RThemeBackend.hpp>
 
+#include <solvcon/pilot/RLinuxThemeBackend.hpp>
+
 #include <QtGlobal>
 
 #if defined(Q_OS_MACOS)
@@ -16,53 +18,6 @@
 namespace solvcon
 {
 
-namespace
-{
-
-/**
- * @brief The fallback backend: it keeps the platform's own default style and
- * pulls no native levers.
- *
- * Every platform starts here and is replaced by its furnished room in a later
- * step. Keeping the default style already gives each platform its native
- * widgets; the room adds the accent, the title bar, and an explicit style
- * choice on top.
- */
-class DefaultThemeBackend
-    : public RThemeBackend
-{
-
-public:
-
-    explicit DefaultThemeBackend(PlatformId platform)
-        : m_platform(platform)
-    {
-    }
-
-    PlatformId platform() const override { return m_platform; }
-
-    std::string styleName() const override { return {}; }
-
-    std::optional<ThemeColor> accentColor(ThemeVariant /*variant*/) const override
-    {
-        return std::nullopt;
-    }
-
-    void applyNativeChrome(QWidget * /*window*/, ThemeVariant /*variant*/) override {}
-
-    ThemeCapabilities capabilities() const override
-    {
-        return themeCapabilitiesFor(m_platform);
-    }
-
-private:
-
-    PlatformId m_platform;
-
-}; /* end class DefaultThemeBackend */
-
-} /* end namespace */
-
 std::unique_ptr<RThemeBackend> makeThemeBackend()
 {
 #if defined(Q_OS_MACOS)
@@ -70,7 +25,8 @@ std::unique_ptr<RThemeBackend> makeThemeBackend()
 #elif defined(Q_OS_WIN)
     return std::make_unique<RWindowsThemeBackend>();
 #else
-    return std::make_unique<DefaultThemeBackend>(PlatformId::Linux);
+    // Linux, and every other desktop without a room of its own, land here.
+    return std::make_unique<RLinuxThemeBackend>();
 #endif
 }
 

--- a/cpp/solvcon/pilot/RThemeBackend.cpp
+++ b/cpp/solvcon/pilot/RThemeBackend.cpp
@@ -7,6 +7,10 @@
 
 #include <QtGlobal>
 
+#if defined(Q_OS_MACOS)
+#include <solvcon/pilot/RMacThemeBackend.hpp>
+#endif
+
 namespace solvcon
 {
 
@@ -60,7 +64,7 @@ private:
 std::unique_ptr<RThemeBackend> makeThemeBackend()
 {
 #if defined(Q_OS_MACOS)
-    return std::make_unique<DefaultThemeBackend>(PlatformId::Mac);
+    return std::make_unique<RMacThemeBackend>();
 #elif defined(Q_OS_WIN)
     return std::make_unique<DefaultThemeBackend>(PlatformId::Windows);
 #else

--- a/cpp/solvcon/pilot/RThemeBackend.cpp
+++ b/cpp/solvcon/pilot/RThemeBackend.cpp
@@ -9,6 +9,8 @@
 
 #if defined(Q_OS_MACOS)
 #include <solvcon/pilot/RMacThemeBackend.hpp>
+#elif defined(Q_OS_WIN)
+#include <solvcon/pilot/RWindowsThemeBackend.hpp>
 #endif
 
 namespace solvcon
@@ -66,7 +68,7 @@ std::unique_ptr<RThemeBackend> makeThemeBackend()
 #if defined(Q_OS_MACOS)
     return std::make_unique<RMacThemeBackend>();
 #elif defined(Q_OS_WIN)
-    return std::make_unique<DefaultThemeBackend>(PlatformId::Windows);
+    return std::make_unique<RWindowsThemeBackend>();
 #else
     return std::make_unique<DefaultThemeBackend>(PlatformId::Linux);
 #endif

--- a/cpp/solvcon/pilot/RWindowsThemeBackend.cpp
+++ b/cpp/solvcon/pilot/RWindowsThemeBackend.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RWindowsThemeBackend.hpp>
+
+#include <QtGlobal>
+
+// The whole room is native to Windows, so the body compiles only there. On
+// other platforms this is an empty translation unit and the factory never names
+// the class.
+#if defined(Q_OS_WIN)
+
+#include <cstdint>
+
+#include <QApplication>
+#include <QColor>
+#include <QGuiApplication>
+#include <QPalette>
+#include <QString>
+#include <QStyle>
+#include <QStyleFactory>
+#include <QWidget>
+
+#include <windows.h>
+
+namespace solvcon
+{
+
+namespace
+{
+
+// The desktop window manager attribute that switches the title bar to its dark
+// variant. Defined here so the room needs no extra SDK header.
+constexpr DWORD kUseImmersiveDarkMode = 20;
+
+} /* end namespace */
+
+PlatformId RWindowsThemeBackend::platform() const
+{
+    return PlatformId::Windows;
+}
+
+std::string RWindowsThemeBackend::styleName() const
+{
+    // Prefer the Fluent windows11 style; fall back to windowsvista on the Qt
+    // builds that do not ship it.
+    if (QStyleFactory::keys().contains(QStringLiteral("windows11")))
+    {
+        return "windows11";
+    }
+    return "windowsvista";
+}
+
+std::optional<ThemeColor> RWindowsThemeBackend::accentColor(ThemeVariant /*variant*/) const
+{
+    // The Windows style's standard palette carries the operating system accent
+    // in the Accent role (Qt 6.6+), falling back to Highlight. Reading it from
+    // the style keeps it independent of the curated palette applied over the
+    // top.
+    QStyle * style = QApplication::style();
+    if (style == nullptr)
+    {
+        return std::nullopt;
+    }
+
+    QPalette const platform = style->standardPalette();
+    QColor accent;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    accent = platform.color(QPalette::Accent);
+#endif
+    if (!accent.isValid())
+    {
+        accent = platform.color(QPalette::Highlight);
+    }
+    if (!accent.isValid())
+    {
+        return std::nullopt;
+    }
+    return ThemeColor{static_cast<std::uint8_t>(accent.red()),
+                      static_cast<std::uint8_t>(accent.green()),
+                      static_cast<std::uint8_t>(accent.blue())};
+}
+
+void RWindowsThemeBackend::applyNativeChrome(QWidget * window, ThemeVariant variant)
+{
+    if (window == nullptr)
+    {
+        return;
+    }
+
+    // Under the offscreen or minimal platform there is no native window to
+    // theme, so skip the call rather than reach for a handle that is not there.
+    QString const qpa = QGuiApplication::platformName();
+    if (qpa == QStringLiteral("offscreen") || qpa == QStringLiteral("minimal"))
+    {
+        return;
+    }
+
+    auto * const hwnd = reinterpret_cast<HWND>(window->winId());
+    if (hwnd == nullptr)
+    {
+        return;
+    }
+
+    // dwmapi is loaded at runtime so the room needs no extra link dependency.
+    HMODULE const dwm = LoadLibraryW(L"dwmapi.dll");
+    if (dwm == nullptr)
+    {
+        return;
+    }
+
+    using DwmSetWindowAttributeFn = HRESULT(WINAPI *)(HWND, DWORD, LPCVOID, DWORD);
+    auto * const set_attribute = reinterpret_cast<DwmSetWindowAttributeFn>(
+        GetProcAddress(dwm, "DwmSetWindowAttribute"));
+    if (set_attribute != nullptr)
+    {
+        BOOL const dark = (variant == ThemeVariant::Dark) ? TRUE : FALSE;
+        set_attribute(hwnd, kUseImmersiveDarkMode, &dark, sizeof(dark));
+    }
+    FreeLibrary(dwm);
+}
+
+ThemeCapabilities RWindowsThemeBackend::capabilities() const
+{
+    // The title bar switches through the desktop window manager on every Qt
+    // version, and the curated palette carries a forced variant where the
+    // color-scheme hint is a no-op, so the seeded record already holds.
+    return themeCapabilitiesFor(PlatformId::Windows);
+}
+
+} /* end namespace solvcon */
+
+#endif /* defined(Q_OS_WIN) */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RWindowsThemeBackend.hpp
+++ b/cpp/solvcon/pilot/RWindowsThemeBackend.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * The Windows room: the native theme backend for Windows.
+ *
+ * Installs the windows11 style (falling back to windowsvista), reads the
+ * operating system accent, and switches the title bar to its dark variant
+ * through the desktop window manager. Only linked into the Windows build; the
+ * factory in RThemeBackend.cpp is the sole site that selects it.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/RThemeBackend.hpp>
+
+#include <optional>
+#include <string>
+
+namespace solvcon
+{
+
+/**
+ * @brief The Windows native theme backend.
+ *
+ * @ingroup group_domain
+ */
+class RWindowsThemeBackend
+    : public RThemeBackend
+{
+
+public:
+
+    PlatformId platform() const override;
+    std::string styleName() const override;
+    std::optional<ThemeColor> accentColor(ThemeVariant variant) const override;
+    void applyNativeChrome(QWidget * window, ThemeVariant variant) override;
+    ThemeCapabilities capabilities() const override;
+
+}; /* end class RWindowsThemeBackend */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/theme.cpp
+++ b/cpp/solvcon/pilot/theme.cpp
@@ -122,6 +122,61 @@ static ThemePalette makeMacDarkPalette()
     return p;
 }
 
+// The Windows tables follow the Fluent conventions of Windows 11: a light
+// neutral window and a near-black dark window, with the default system blue as
+// the fallback accent. A running Windows backend replaces the highlight with
+// the operating system accent when it reads one.
+
+static ThemePalette makeWindowsLightPalette()
+{
+    ThemePalette p;
+    p.window = {0xf3, 0xf3, 0xf3};
+    p.window_text = {0x1a, 0x1a, 0x1a};
+    p.base = {0xff, 0xff, 0xff};
+    p.alternate_base = {0xf5, 0xf5, 0xf5};
+    p.text = {0x1a, 0x1a, 0x1a};
+    p.button = {0xfb, 0xfb, 0xfb};
+    p.button_text = {0x1a, 0x1a, 0x1a};
+    p.bright_text = {0xc4, 0x2b, 0x1c};
+    p.highlight = {0x00, 0x67, 0xc0};
+    p.highlighted_text = {0xff, 0xff, 0xff};
+    p.tool_tip_base = {0xf9, 0xf9, 0xf9};
+    p.tool_tip_text = {0x1a, 0x1a, 0x1a};
+    p.placeholder_text = {0x8a, 0x8a, 0x8a};
+    p.link = {0x00, 0x5a, 0x9e};
+    p.link_visited = {0x74, 0x4d, 0xa9};
+    p.disabled_text = {0xa8, 0xa8, 0xa8};
+    p.disabled_button_text = {0xa8, 0xa8, 0xa8};
+    p.disabled_window_text = {0xa8, 0xa8, 0xa8};
+    p.disabled_highlight = {0xcc, 0xcc, 0xcc};
+    return p;
+}
+
+static ThemePalette makeWindowsDarkPalette()
+{
+    ThemePalette p;
+    p.window = {0x20, 0x20, 0x20};
+    p.window_text = {0xf0, 0xf0, 0xf0};
+    p.base = {0x2b, 0x2b, 0x2b};
+    p.alternate_base = {0x30, 0x30, 0x30};
+    p.text = {0xf0, 0xf0, 0xf0};
+    p.button = {0x33, 0x33, 0x33};
+    p.button_text = {0xf0, 0xf0, 0xf0};
+    p.bright_text = {0xff, 0x99, 0x8a};
+    p.highlight = {0x4c, 0xc2, 0xff};
+    p.highlighted_text = {0x00, 0x00, 0x00};
+    p.tool_tip_base = {0x2b, 0x2b, 0x2b};
+    p.tool_tip_text = {0xf0, 0xf0, 0xf0};
+    p.placeholder_text = {0x9a, 0x9a, 0x9a};
+    p.link = {0x60, 0xcd, 0xff};
+    p.link_visited = {0xc5, 0x9a, 0xf0};
+    p.disabled_text = {0x6e, 0x6e, 0x6e};
+    p.disabled_button_text = {0x6e, 0x6e, 0x6e};
+    p.disabled_window_text = {0x6e, 0x6e, 0x6e};
+    p.disabled_highlight = {0x3a, 0x3a, 0x3a};
+    return p;
+}
+
 // The syntax colors keep the light table's familiar hues (a blue keyword, a
 // teal builtin, a red string, a magenta number) and lift each to a brighter,
 // lower-saturation tint for the dark table so the tokens read clearly on the
@@ -214,16 +269,29 @@ static ThemePalette const & macDarkThemePalette()
     return palette;
 }
 
+static ThemePalette const & windowsLightThemePalette()
+{
+    static ThemePalette const palette = makeWindowsLightPalette();
+    return palette;
+}
+
+static ThemePalette const & windowsDarkThemePalette()
+{
+    static ThemePalette const palette = makeWindowsDarkPalette();
+    return palette;
+}
+
 ThemePalette const & themePaletteFor(PlatformId platform, ThemeVariant variant)
 {
-    // macOS has its own room; the other platforms still draw from the shared
-    // curated tables until their rooms are furnished in later steps.
+    // macOS and Windows have their own rooms; Linux still draws from the shared
+    // curated tables until its room is furnished.
     bool const dark = variant == ThemeVariant::Dark;
     switch (platform)
     {
     case PlatformId::Mac:
         return dark ? macDarkThemePalette() : macLightThemePalette();
     case PlatformId::Windows:
+        return dark ? windowsDarkThemePalette() : windowsLightThemePalette();
     case PlatformId::Linux:
     default:
         return dark ? darkThemePalette() : lightThemePalette();

--- a/cpp/solvcon/pilot/theme.cpp
+++ b/cpp/solvcon/pilot/theme.cpp
@@ -66,6 +66,62 @@ static ThemePalette makeDarkPalette()
     return p;
 }
 
+// The macOS tables follow the Aqua conventions: a near-white light window and
+// a deep neutral dark window, both a touch cooler than the shared curated
+// greys, paired with the system blue the platform defaults to. A running mac
+// backend replaces the highlight with the user's chosen accent; these values
+// are the fallback when no accent is read.
+
+static ThemePalette makeMacLightPalette()
+{
+    ThemePalette p;
+    p.window = {0xec, 0xec, 0xec};
+    p.window_text = {0x1c, 0x1c, 0x1e};
+    p.base = {0xff, 0xff, 0xff};
+    p.alternate_base = {0xf4, 0xf5, 0xf5};
+    p.text = {0x1c, 0x1c, 0x1e};
+    p.button = {0xf6, 0xf6, 0xf6};
+    p.button_text = {0x1c, 0x1c, 0x1e};
+    p.bright_text = {0xff, 0x3b, 0x30};
+    p.highlight = {0x00, 0x7a, 0xff};
+    p.highlighted_text = {0xff, 0xff, 0xff};
+    p.tool_tip_base = {0xf9, 0xf9, 0xf9};
+    p.tool_tip_text = {0x1c, 0x1c, 0x1e};
+    p.placeholder_text = {0x9b, 0x9b, 0xa0};
+    p.link = {0x00, 0x66, 0xcc};
+    p.link_visited = {0x85, 0x4f, 0xd8};
+    p.disabled_text = {0xb0, 0xb0, 0xb4};
+    p.disabled_button_text = {0xb0, 0xb0, 0xb4};
+    p.disabled_window_text = {0xb0, 0xb0, 0xb4};
+    p.disabled_highlight = {0xc9, 0xc9, 0xcd};
+    return p;
+}
+
+static ThemePalette makeMacDarkPalette()
+{
+    ThemePalette p;
+    p.window = {0x28, 0x28, 0x2a};
+    p.window_text = {0xf2, 0xf2, 0xf7};
+    p.base = {0x1e, 0x1e, 0x1e};
+    p.alternate_base = {0x2a, 0x2a, 0x2c};
+    p.text = {0xf2, 0xf2, 0xf7};
+    p.button = {0x3a, 0x3a, 0x3c};
+    p.button_text = {0xf2, 0xf2, 0xf7};
+    p.bright_text = {0xff, 0x45, 0x3a};
+    p.highlight = {0x0a, 0x84, 0xff};
+    p.highlighted_text = {0xff, 0xff, 0xff};
+    p.tool_tip_base = {0x3a, 0x3a, 0x3c};
+    p.tool_tip_text = {0xf2, 0xf2, 0xf7};
+    p.placeholder_text = {0x8e, 0x8e, 0x93};
+    p.link = {0x41, 0x9c, 0xff};
+    p.link_visited = {0xbf, 0x5a, 0xf2};
+    p.disabled_text = {0x6b, 0x6b, 0x70};
+    p.disabled_button_text = {0x6b, 0x6b, 0x70};
+    p.disabled_window_text = {0x6b, 0x6b, 0x70};
+    p.disabled_highlight = {0x3a, 0x3a, 0x3c};
+    return p;
+}
+
 // The syntax colors keep the light table's familiar hues (a blue keyword, a
 // teal builtin, a red string, a magenta number) and lift each to a brighter,
 // lower-saturation tint for the dark table so the tokens read clearly on the
@@ -146,12 +202,32 @@ ThemePalette const & darkThemePalette()
     return palette;
 }
 
+static ThemePalette const & macLightThemePalette()
+{
+    static ThemePalette const palette = makeMacLightPalette();
+    return palette;
+}
+
+static ThemePalette const & macDarkThemePalette()
+{
+    static ThemePalette const palette = makeMacDarkPalette();
+    return palette;
+}
+
 ThemePalette const & themePaletteFor(PlatformId platform, ThemeVariant variant)
 {
-    // Every platform seeds from the curated tables; the platform rooms furnished
-    // in later steps replace this with their own tuned copies.
-    (void)platform;
-    return variant == ThemeVariant::Dark ? darkThemePalette() : lightThemePalette();
+    // macOS has its own room; the other platforms still draw from the shared
+    // curated tables until their rooms are furnished in later steps.
+    bool const dark = variant == ThemeVariant::Dark;
+    switch (platform)
+    {
+    case PlatformId::Mac:
+        return dark ? macDarkThemePalette() : macLightThemePalette();
+    case PlatformId::Windows:
+    case PlatformId::Linux:
+    default:
+        return dark ? darkThemePalette() : lightThemePalette();
+    }
 }
 
 SyntaxColors const & lightSyntaxColors()

--- a/cpp/solvcon/pilot/theme.cpp
+++ b/cpp/solvcon/pilot/theme.cpp
@@ -5,7 +5,9 @@
 
 #include <solvcon/pilot/theme.hpp>
 
+#include <cctype>
 #include <cstring>
+#include <string>
 
 namespace solvcon
 {
@@ -404,6 +406,24 @@ char const * platformIdName(PlatformId platform)
     default:
         return "linux";
     }
+}
+
+bool linuxDesktopHasNativeTheme(char const * xdg_current_desktop)
+{
+    if (xdg_current_desktop == nullptr)
+    {
+        return false;
+    }
+
+    // XDG_CURRENT_DESKTOP is a colon-separated, case-varying list such as
+    // "ubuntu:GNOME" or "KDE", so fold to lower case and look for a name whose
+    // Qt platform theme is worth honoring.
+    std::string desktop(xdg_current_desktop);
+    for (char & c : desktop)
+    {
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    return desktop.find("gnome") != std::string::npos || desktop.find("kde") != std::string::npos;
 }
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/theme.hpp
+++ b/cpp/solvcon/pilot/theme.hpp
@@ -201,6 +201,17 @@ ThemeMode themeModeFromId(char const * id);
 /// the Python boundary and in tests.
 char const * platformIdName(PlatformId platform);
 
+/**
+ * @brief Whether a Linux desktop names a theme the pilot recognizes.
+ *
+ * Reads the value of XDG_CURRENT_DESKTOP and reports true for GNOME or KDE,
+ * whose Qt platform themes expose a palette and an accent worth honoring. An
+ * empty or unrecognized value returns false, so the Linux room falls back to
+ * the curated palettes. The matching is Qt-free so it is tested on every
+ * runner.
+ */
+bool linuxDesktopHasNativeTheme(char const * xdg_current_desktop);
+
 } /* end namespace solvcon */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/gtests/test_nopython_pilot_theme.cpp
+++ b/gtests/test_nopython_pilot_theme.cpp
@@ -86,18 +86,40 @@ TEST(PilotThemePalette, LightAndDarkDifferAndAreConsistent)
 
 TEST(PilotThemePalette, EveryPlatformSelectsTheVariantTable)
 {
-    // The platform axis is seeded from the curated tables, so every platform
-    // resolves a variant to the same base table until its room is furnished.
-    // The lookup must still select the requested variant on each platform.
+    // Whatever table backs a platform, its light window must be brighter than
+    // its dark one, so the lookup never swaps a variant.
     for (PlatformId platform : {PlatformId::Linux, PlatformId::Mac, PlatformId::Windows})
     {
         EXPECT_GT(themePaletteFor(platform, ThemeVariant::Light).window.g,
                   themePaletteFor(platform, ThemeVariant::Dark).window.g);
+    }
+}
+
+TEST(PilotThemePalette, UnfurnishedPlatformsDrawFromTheCuratedTable)
+{
+    // Linux and Windows have no room yet, so they resolve to the shared curated
+    // tables. macOS is furnished, so it must not.
+    for (PlatformId platform : {PlatformId::Linux, PlatformId::Windows})
+    {
         EXPECT_EQ(themePaletteFor(platform, ThemeVariant::Light).window.r,
                   lightThemePalette().window.r);
         EXPECT_EQ(themePaletteFor(platform, ThemeVariant::Dark).window.r,
                   darkThemePalette().window.r);
     }
+}
+
+TEST(PilotThemeMacRoom, HasItsOwnTableDistinctFromTheCurated)
+{
+    // The macOS room is tuned separately, so its window differs from the shared
+    // curated table in both variants, yet stays a light-on-top, dark-on-bottom
+    // pair.
+    auto const & mac_light = themePaletteFor(PlatformId::Mac, ThemeVariant::Light);
+    auto const & mac_dark = themePaletteFor(PlatformId::Mac, ThemeVariant::Dark);
+
+    EXPECT_NE(mac_light.window.r, lightThemePalette().window.r);
+    EXPECT_NE(mac_dark.window.r, darkThemePalette().window.r);
+    EXPECT_GT(mac_light.window.g, mac_dark.window.g);
+    EXPECT_LT(mac_light.text.g, mac_dark.text.g);
 }
 
 TEST(PilotThemeSyntax, DarkTokensAreBrighterAndSelectByVariant)

--- a/gtests/test_nopython_pilot_theme.cpp
+++ b/gtests/test_nopython_pilot_theme.cpp
@@ -97,15 +97,11 @@ TEST(PilotThemePalette, EveryPlatformSelectsTheVariantTable)
 
 TEST(PilotThemePalette, UnfurnishedPlatformsDrawFromTheCuratedTable)
 {
-    // Linux and Windows have no room yet, so they resolve to the shared curated
-    // tables. macOS is furnished, so it must not.
-    for (PlatformId platform : {PlatformId::Linux, PlatformId::Windows})
-    {
-        EXPECT_EQ(themePaletteFor(platform, ThemeVariant::Light).window.r,
-                  lightThemePalette().window.r);
-        EXPECT_EQ(themePaletteFor(platform, ThemeVariant::Dark).window.r,
-                  darkThemePalette().window.r);
-    }
+    // Linux has no room yet, so it resolves to the shared curated tables.
+    EXPECT_EQ(themePaletteFor(PlatformId::Linux, ThemeVariant::Light).window.r,
+              lightThemePalette().window.r);
+    EXPECT_EQ(themePaletteFor(PlatformId::Linux, ThemeVariant::Dark).window.r,
+              darkThemePalette().window.r);
 }
 
 TEST(PilotThemeMacRoom, HasItsOwnTableDistinctFromTheCurated)
@@ -120,6 +116,20 @@ TEST(PilotThemeMacRoom, HasItsOwnTableDistinctFromTheCurated)
     EXPECT_NE(mac_dark.window.r, darkThemePalette().window.r);
     EXPECT_GT(mac_light.window.g, mac_dark.window.g);
     EXPECT_LT(mac_light.text.g, mac_dark.text.g);
+}
+
+TEST(PilotThemeWindowsRoom, HasItsOwnTableDistinctFromTheCuratedAndMac)
+{
+    // The Windows room is tuned separately, so its dark window differs from both
+    // the curated and the macOS tables, and it stays a light-on-top pair.
+    auto const & win_light = themePaletteFor(PlatformId::Windows, ThemeVariant::Light);
+    auto const & win_dark = themePaletteFor(PlatformId::Windows, ThemeVariant::Dark);
+    auto const & mac_dark = themePaletteFor(PlatformId::Mac, ThemeVariant::Dark);
+
+    EXPECT_NE(win_dark.window.r, darkThemePalette().window.r);
+    EXPECT_NE(win_dark.window.r, mac_dark.window.r);
+    EXPECT_GT(win_light.window.g, win_dark.window.g);
+    EXPECT_LT(win_light.text.g, win_dark.text.g);
 }
 
 TEST(PilotThemeSyntax, DarkTokensAreBrighterAndSelectByVariant)

--- a/gtests/test_nopython_pilot_theme.cpp
+++ b/gtests/test_nopython_pilot_theme.cpp
@@ -13,6 +13,7 @@ using solvcon::darkSyntaxColors;
 using solvcon::darkThemePalette;
 using solvcon::lightSyntaxColors;
 using solvcon::lightThemePalette;
+using solvcon::linuxDesktopHasNativeTheme;
 using solvcon::PlatformId;
 using solvcon::platformIdName;
 using solvcon::resolveThemeVariant;
@@ -156,6 +157,22 @@ TEST(PilotThemeSyntax, DarkTokensAreBrighterAndSelectByVariant)
         EXPECT_EQ(syntaxColorsFor(platform, ThemeVariant::Light).keyword.b, light.keyword.b);
         EXPECT_EQ(syntaxColorsFor(platform, ThemeVariant::Dark).keyword.b, dark.keyword.b);
     }
+}
+
+TEST(PilotThemeLinuxRoom, RecognizesGnomeAndKdeDesktops)
+{
+    // GNOME and KDE expose a Qt platform theme the room honors; the value may
+    // be a colon-separated, mixed-case list.
+    EXPECT_TRUE(linuxDesktopHasNativeTheme("GNOME"));
+    EXPECT_TRUE(linuxDesktopHasNativeTheme("ubuntu:GNOME"));
+    EXPECT_TRUE(linuxDesktopHasNativeTheme("KDE"));
+    EXPECT_TRUE(linuxDesktopHasNativeTheme("kde"));
+
+    // An unrecognized, empty, or missing desktop falls back to the curated
+    // palettes.
+    EXPECT_FALSE(linuxDesktopHasNativeTheme("XFCE"));
+    EXPECT_FALSE(linuxDesktopHasNativeTheme(""));
+    EXPECT_FALSE(linuxDesktopHasNativeTheme(nullptr));
 }
 
 TEST(PilotThemeCapabilities, DifferByPlatform)


### PR DESCRIPTION
Steps 5, 6, 7 of issue #1062.

Furnish all three platforms of mac, linux, and windows, the placeholder default backend is gone. Linux becomes the fallback for any platform without a room of its own.

### Step 5: macOS

Add a macOS color table tuned to Aqua conventions: a near-white light window and a deep neutral dark window, both a touch cooler than the curated greys, with the system blue as the fallback accent. Route `themePaletteFor(Mac, ...)` to it. Add `RMacThemeBackend`: it installs the native macos style, reads the user's system accent from the style's standard palette so the highlight follows the platform, and reports its capabilities. Pinning a variant rides the color-scheme hint the manager already sets, which on Qt 6.8 and newer flips the whole native appearance, title bar included; on older Qt the capability record drops title-bar control and the curated palette carries the forced variant. The whole backend body compiles only on macOS, and `makeThemeBackend()` selects it there; on other platforms it is an empty translation unit.

### Step 6: Windows

Add a Windows color table in the Fluent conventions of Windows 11: a light neutral window and a near-black dark window, with the default system blue as the fallback accent. Route `themePaletteFor(Windows, ...)` to it. Add `RWindowsThemeBackend`: it installs the windows11 style, falling back to windowsvista where that style is absent, reads the operating system accent from the style's standard palette, and switches the title bar to its dark variant through the desktop window manager. The chrome call loads dwmapi at runtime so the room needs no extra link dependency, and it is skipped under the offscreen and minimal platforms where there is no native window. The whole backend body compiles only on Windows, and `makeThemeBackend()` selects it there; on other platforms it is an empty translation unit.

### Step 7: Linux

Linux is the one with the most variety across desktops, so it leans hardest on the shared fallback. Add `RLinuxThemeBackend`: it keeps the desktop's own Qt style so the pilot looks native, honors the desktop accent when a recognized platform theme exposes one, and otherwise falls back to the curated palettes and reports no native accent. Whether a desktop is recognized is decided by `linuxDesktopHasNativeTheme`, a Qt-free reader of `XDG_CURRENT_DESKTOP` that reports true for GNOME or KDE. With all three rooms furnished, the factory no longer needs the placeholder `DefaultThemeBackend`, so drop it and select the Linux backend as the default for any platform without a room of its own.