### PR TITLE
 Add the system-versus-curated look choice and the final theme polish (steps 8, 9 of theme)

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -343,15 +343,11 @@ void RManager::setUpCentral()
                      { applyDrawTool(); });
 
     // The MDI area paints its own backdrop instead of reading the palette, so
-    // drive it from the theme's window color and follow theme changes;
-    // otherwise a stale slab shows through under the dark theme. Take the color
-    // from the theme model, not m_mainWindow->palette(): when themeChanged fires
-    // the freshly set application palette has not yet propagated to the window,
-    // so palette() would lag one switch behind.
-    auto paintBackdrop = [this](ThemeVariant variant)
+    // drive it from the theme's effective window color and follow theme
+    // changes; otherwise a stale slab shows through under the dark theme.
+    auto paintBackdrop = [this](ThemeVariant)
     {
-        ThemeColor const c = themePaletteFor(m_themeManager->platform(), variant).window;
-        m_mdiArea->setBackground(QColor(c.r, c.g, c.b));
+        m_mdiArea->setBackground(m_themeManager->windowColor());
     };
     paintBackdrop(m_themeManager->currentVariant());
     QObject::connect(m_themeManager, &RThemeManager::themeChanged, m_mdiArea, paintBackdrop);
@@ -442,6 +438,10 @@ void RManager::connectThemeMenuSync() const
         [this](ThemeVariant)
         {
             if (QAction * current = m_menuModel->action("theme.mode_" + m_themeManager->modeId()))
+            {
+                current->setChecked(true);
+            }
+            if (QAction * current = m_menuModel->action("theme.look_" + m_themeManager->lookId()))
             {
                 current->setChecked(true);
             }

--- a/cpp/solvcon/pilot/RScalarBar.cpp
+++ b/cpp/solvcon/pilot/RScalarBar.cpp
@@ -7,7 +7,9 @@
 
 #include <QColor>
 #include <QFont>
+#include <QGuiApplication>
 #include <QPainter>
+#include <QPalette>
 
 #include <algorithm>
 #include <utility>
@@ -66,11 +68,15 @@ QImage RScalarBar::renderImage() const
     QPainter painter(&image);
     painter.setRenderHint(QPainter::Antialiasing, true);
 
+    // Follow the application palette so the labels and the strip border stay
+    // legible when the theme turns dark, instead of forcing black.
+    QColor const ink = QGuiApplication::palette().color(QPalette::WindowText);
+
     QFont font;
     font.setPixelSize(15);
     font.setBold(true);
     painter.setFont(font);
-    painter.setPen(Qt::black);
+    painter.setPen(ink);
     painter.drawText(QRect(0, 4, BAR_WIDTH, 20), Qt::AlignHCenter | Qt::AlignVCenter, m_title);
 
     font.setPixelSize(13);
@@ -90,7 +96,7 @@ QImage RScalarBar::renderImage() const
     painter.rotate(-90.0);
     painter.drawImage(QRect(0, 0, strip.height(), strip.width()), lut);
     painter.restore();
-    painter.setPen(Qt::black);
+    painter.setPen(ink);
     painter.drawRect(strip.adjusted(0, 0, -1, -1));
 
     int const label_left = strip.right() + 7;

--- a/cpp/solvcon/pilot/RTextOverlay.cpp
+++ b/cpp/solvcon/pilot/RTextOverlay.cpp
@@ -7,7 +7,9 @@
 
 #include <QColor>
 #include <QFont>
+#include <QGuiApplication>
 #include <QPainter>
+#include <QPalette>
 
 #include <algorithm>
 
@@ -46,7 +48,9 @@ QImage RTextOverlay::renderImage() const
     font.setPixelSize(28);
     font.setBold(true);
     painter.setFont(font);
-    painter.setPen(Qt::black);
+    // Follow the application palette so the label stays legible when the theme
+    // turns dark, instead of forcing black.
+    painter.setPen(QGuiApplication::palette().color(QPalette::WindowText));
     painter.drawText(image.rect(), Qt::AlignHCenter | Qt::AlignVCenter, m_text);
     painter.end();
     return image;

--- a/cpp/solvcon/pilot/RThemeManager.cpp
+++ b/cpp/solvcon/pilot/RThemeManager.cpp
@@ -8,6 +8,7 @@
 #include <QApplication>
 #include <QColor>
 #include <QGuiApplication>
+#include <QStyle>
 #include <QStyleFactory>
 #include <QStyleHints>
 #include <QString>
@@ -64,8 +65,22 @@ void RThemeManager::apply()
     }
 
     ThemeVariant const variant = currentVariant();
-    QApplication::setPalette(
-        buildPalette(themePaletteFor(m_backend->platform(), variant), variant));
+    if (m_look == ThemeLook::System)
+    {
+        // Let the platform's own colors show through the native style. The
+        // color-scheme hint has already steered the style toward the requested
+        // variant, so its standard palette carries the right light or dark set.
+        QPalette const native = QApplication::style()->standardPalette();
+        m_window_color = native.color(QPalette::Window);
+        QApplication::setPalette(native);
+    }
+    else
+    {
+        QPalette const curated =
+            buildPalette(themePaletteFor(m_backend->platform(), variant), variant);
+        m_window_color = curated.color(QPalette::Window);
+        QApplication::setPalette(curated);
+    }
     if (m_window != nullptr)
     {
         m_backend->applyNativeChrome(m_window, variant);
@@ -94,6 +109,17 @@ void RThemeManager::setModeById(std::string const & id)
     setMode(themeModeFromId(id.c_str()));
 }
 
+void RThemeManager::setLook(ThemeLook look)
+{
+    m_look = look;
+    apply();
+}
+
+void RThemeManager::setLookById(std::string const & id)
+{
+    setLook(themeLookFromId(id.c_str()));
+}
+
 ThemeVariant RThemeManager::currentVariant() const
 {
     return resolveThemeVariant(m_mode, osPrefersDark());
@@ -112,6 +138,11 @@ ThemeCapabilities RThemeManager::capabilities() const
 std::string RThemeManager::modeId() const
 {
     return themeModeId(m_mode);
+}
+
+std::string RThemeManager::lookId() const
+{
+    return themeLookId(m_look);
 }
 
 std::string RThemeManager::variantId() const

--- a/cpp/solvcon/pilot/RThemeManager.cpp
+++ b/cpp/solvcon/pilot/RThemeManager.cpp
@@ -8,6 +8,7 @@
 #include <QApplication>
 #include <QColor>
 #include <QGuiApplication>
+#include <QSettings>
 #include <QStyle>
 #include <QStyleFactory>
 #include <QStyleHints>
@@ -24,6 +25,10 @@ RThemeManager::RThemeManager(QObject * parent)
     : QObject(parent)
     , m_backend(makeThemeBackend())
 {
+    // Start on the mode and look the last session left behind, so a chosen
+    // theme carries across restarts.
+    restorePersisted();
+
     // Track live operating-system color-scheme changes while in System mode.
     // The style-hints object is owned by the application and outlives the
     // manager, so the connection stays valid for the manager's lifetime.
@@ -73,6 +78,8 @@ void RThemeManager::apply()
         QPalette const native = QApplication::style()->standardPalette();
         m_window_color = native.color(QPalette::Window);
         QApplication::setPalette(native);
+        // Leave the native look untouched, including any style the platform set.
+        qApp->setStyleSheet(QString());
     }
     else
     {
@@ -80,6 +87,7 @@ void RThemeManager::apply()
             buildPalette(themePaletteFor(m_backend->platform(), variant), variant);
         m_window_color = curated.color(QPalette::Window);
         QApplication::setPalette(curated);
+        qApp->setStyleSheet(supplementalStyleSheet(curated));
     }
     if (m_window != nullptr)
     {
@@ -100,6 +108,7 @@ void RThemeManager::setWindow(QWidget * window)
 void RThemeManager::setMode(ThemeMode mode)
 {
     m_mode = mode;
+    persist();
     syncOsColorScheme();
     apply();
 }
@@ -112,6 +121,7 @@ void RThemeManager::setModeById(std::string const & id)
 void RThemeManager::setLook(ThemeLook look)
 {
     m_look = look;
+    persist();
     apply();
 }
 
@@ -203,6 +213,11 @@ QPalette RThemeManager::buildPalette(ThemePalette const & spec, ThemeVariant var
     pal.setColor(QPalette::ButtonText, color(spec.button_text));
     pal.setColor(QPalette::BrightText, color(spec.bright_text));
     pal.setColor(QPalette::Highlight, highlight);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    // The dedicated Accent role (Qt 6.6+) lets widgets that want the platform
+    // accent, distinct from a selection highlight, pick it up from the palette.
+    pal.setColor(QPalette::Accent, highlight);
+#endif
     pal.setColor(QPalette::HighlightedText, color(spec.highlighted_text));
     pal.setColor(QPalette::ToolTipBase, color(spec.tool_tip_base));
     pal.setColor(QPalette::ToolTipText, color(spec.tool_tip_text));
@@ -218,6 +233,36 @@ QPalette RThemeManager::buildPalette(ThemePalette const & spec, ThemeVariant var
     pal.setColor(QPalette::Disabled, QPalette::HighlightedText, color(spec.disabled_text));
     pal.setColor(QPalette::Disabled, QPalette::Highlight, color(spec.disabled_highlight));
     return pal;
+}
+
+QString RThemeManager::supplementalStyleSheet(QPalette const & pal) const
+{
+    // A QPalette cannot draw a tooltip border or a focus ring, so add just
+    // those two, colored from the theme, and nothing more, so the native style
+    // keeps drawing everything else.
+    QColor const border = pal.color(QPalette::WindowText);
+    QColor const focus = pal.color(QPalette::Highlight);
+    return QStringLiteral(
+               "QToolTip { border: 1px solid %1; }\n"
+               "QLineEdit:focus, QTextEdit:focus, QPlainTextEdit:focus"
+               " { border: 1px solid %2; }")
+        .arg(border.name(), focus.name());
+}
+
+void RThemeManager::restorePersisted()
+{
+    QSettings settings(QStringLiteral("solvcon"), QStringLiteral("pilot"));
+    m_mode = themeModeFromId(
+        settings.value(QStringLiteral("theme/mode")).toString().toUtf8().constData());
+    m_look = themeLookFromId(
+        settings.value(QStringLiteral("theme/look")).toString().toUtf8().constData());
+}
+
+void RThemeManager::persist() const
+{
+    QSettings settings(QStringLiteral("solvcon"), QStringLiteral("pilot"));
+    settings.setValue(QStringLiteral("theme/mode"), QString::fromStdString(modeId()));
+    settings.setValue(QStringLiteral("theme/look"), QString::fromStdString(lookId()));
 }
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/RThemeManager.hpp
+++ b/cpp/solvcon/pilot/RThemeManager.hpp
@@ -128,6 +128,17 @@ private:
     /// accent when the backend supplies one, and filling the disabled group.
     QPalette buildPalette(ThemePalette const & spec, ThemeVariant variant) const;
 
+    /// A thin stylesheet that adds what a QPalette cannot: a tooltip border and
+    /// a focus ring on text inputs, colored from @p pal. Applied under the
+    /// curated look and cleared under the system look, which stays native.
+    QString supplementalStyleSheet(QPalette const & pal) const;
+
+    /// Read the persisted mode and look, if any, into the current state.
+    void restorePersisted();
+
+    /// Write the current mode and look so the next session starts on them.
+    void persist() const;
+
     ThemeMode m_mode = ThemeMode::System;
 
     /// Where the colors come from. Curated is the controlled default; System is

--- a/cpp/solvcon/pilot/RThemeManager.hpp
+++ b/cpp/solvcon/pilot/RThemeManager.hpp
@@ -21,6 +21,7 @@
 #include <solvcon/pilot/theme.hpp>
 #include <solvcon/pilot/RThemeBackend.hpp>
 
+#include <QColor>
 #include <QObject>
 #include <QPalette>
 
@@ -71,7 +72,17 @@ public:
     /// falls back to System. Convenience for the Python console and menu.
     void setModeById(std::string const & id);
 
+    /// Switch where the colors come from and re-apply. System shows the
+    /// platform's own colors; Curated paints the plan's palettes over them.
+    void setLook(ThemeLook look);
+
+    /// Switch look by its string id ("system", "curated"); an unknown id falls
+    /// back to Curated.
+    void setLookById(std::string const & id);
+
     ThemeMode mode() const { return m_mode; }
+
+    ThemeLook look() const { return m_look; }
 
     /// The concrete variant the current mode resolves to right now.
     ThemeVariant currentVariant() const;
@@ -86,8 +97,16 @@ public:
     /// String id of the current mode, for the Python boundary.
     std::string modeId() const;
 
+    /// String id of the current look, for the Python boundary.
+    std::string lookId() const;
+
     /// "light" or "dark" for the current variant, for the Python boundary.
     std::string variantId() const;
+
+    /// The Window color of the palette in effect, whether curated or native, so
+    /// widgets that paint their own backdrop can match it without lagging a
+    /// switch behind the application palette.
+    QColor windowColor() const { return m_window_color; }
 
 signals:
 
@@ -110,6 +129,14 @@ private:
     QPalette buildPalette(ThemePalette const & spec, ThemeVariant variant) const;
 
     ThemeMode m_mode = ThemeMode::System;
+
+    /// Where the colors come from. Curated is the controlled default; System is
+    /// opted into for the platform's own colors.
+    ThemeLook m_look = ThemeLook::Curated;
+
+    /// The Window color of the palette last applied, cached so the backdrop can
+    /// read it without waiting for the application palette to propagate.
+    QColor m_window_color;
 
     /// The running platform's backend, the only object that touches native
     /// levers. Never null after construction.

--- a/cpp/solvcon/pilot/theme.cpp
+++ b/cpp/solvcon/pilot/theme.cpp
@@ -394,6 +394,25 @@ ThemeMode themeModeFromId(char const * id)
     return ThemeMode::System;
 }
 
+char const * themeLookId(ThemeLook look)
+{
+    return look == ThemeLook::System ? "system" : "curated";
+}
+
+char const * themeLookLabel(ThemeLook look)
+{
+    return look == ThemeLook::System ? "System colors" : "Curated colors";
+}
+
+ThemeLook themeLookFromId(char const * id)
+{
+    if (id != nullptr && 0 == std::strcmp(id, "system"))
+    {
+        return ThemeLook::System;
+    }
+    return ThemeLook::Curated;
+}
+
 char const * platformIdName(PlatformId platform)
 {
     switch (platform)

--- a/cpp/solvcon/pilot/theme.hpp
+++ b/cpp/solvcon/pilot/theme.hpp
@@ -47,6 +47,20 @@ enum class ThemeVariant
 };
 
 /**
+ * @brief Where the pilot's colors come from, independent of the light or dark
+ * mode.
+ *
+ * System lets the running platform's own colors show through the native style
+ * untouched; Curated paints the plan's palettes over that style for a
+ * controlled look that travels between machines.
+ */
+enum class ThemeLook
+{
+    System,
+    Curated,
+};
+
+/**
  * @brief The platform a color table and a capability record are written for.
  *
  * The palette lookup carries this axis so each platform's look is tuned in its
@@ -196,6 +210,16 @@ char const * themeModeLabel(ThemeMode mode);
 
 /// The mode named by @p id, or ThemeMode::System when @p id matches none.
 ThemeMode themeModeFromId(char const * id);
+
+/// The stable identifier for a look ("system", "curated"), used as the menu
+/// action object name, at the Python boundary, and in tests.
+char const * themeLookId(ThemeLook look);
+
+/// The human-readable menu label for a look.
+char const * themeLookLabel(ThemeLook look);
+
+/// The look named by @p id, or ThemeLook::Curated when @p id matches none.
+ThemeLook themeLookFromId(char const * id);
 
 /// The stable identifier for a platform ("linux", "mac", "windows"), used at
 /// the Python boundary and in tests.

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -905,6 +905,19 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 {
                     return self.themeManager()->variantId();
                 })
+            .def(
+                "set_look",
+                [](wrapped_type & self, std::string const & look)
+                {
+                    self.themeManager()->setLookById(look);
+                },
+                py::arg("look"))
+            .def_property_readonly(
+                "theme_look",
+                [](wrapped_type & self)
+                {
+                    return self.themeManager()->lookId();
+                })
             .def_property_readonly(
                 "theme_platform",
                 [](wrapped_type & self)
@@ -922,6 +935,12 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 [](wrapped_type & self)
                 {
                     return self.themeManager()->capabilities().can_force_variant;
+                })
+            .def_property_readonly(
+                "theme_has_native_style",
+                [](wrapped_type & self)
+                {
+                    return self.themeManager()->capabilities().has_native_style;
                 })
             .def(
                 "quit",

--- a/gtests/test_nopython_pilot_theme.cpp
+++ b/gtests/test_nopython_pilot_theme.cpp
@@ -19,6 +19,10 @@ using solvcon::platformIdName;
 using solvcon::resolveThemeVariant;
 using solvcon::syntaxColorsFor;
 using solvcon::themeCapabilitiesFor;
+using solvcon::ThemeLook;
+using solvcon::themeLookFromId;
+using solvcon::themeLookId;
+using solvcon::themeLookLabel;
 using solvcon::ThemeMode;
 using solvcon::themeModeFromId;
 using solvcon::themeModeId;
@@ -62,6 +66,22 @@ TEST(PilotThemeId, EveryModeHasALabel)
     EXPECT_GT(std::string(themeModeLabel(ThemeMode::System)).size(), 0U);
     EXPECT_GT(std::string(themeModeLabel(ThemeMode::Light)).size(), 0U);
     EXPECT_GT(std::string(themeModeLabel(ThemeMode::Dark)).size(), 0U);
+}
+
+TEST(PilotThemeLook, RoundTripsThroughItsId)
+{
+    EXPECT_EQ(std::string("system"), themeLookId(ThemeLook::System));
+    EXPECT_EQ(std::string("curated"), themeLookId(ThemeLook::Curated));
+
+    EXPECT_EQ(themeLookFromId("system"), ThemeLook::System);
+    EXPECT_EQ(themeLookFromId("curated"), ThemeLook::Curated);
+
+    // An unknown look falls back to Curated, the controlled default.
+    EXPECT_EQ(themeLookFromId("native"), ThemeLook::Curated);
+    EXPECT_EQ(themeLookFromId(nullptr), ThemeLook::Curated);
+
+    EXPECT_GT(std::string(themeLookLabel(ThemeLook::System)).size(), 0U);
+    EXPECT_GT(std::string(themeLookLabel(ThemeLook::Curated)).size(), 0U);
 }
 
 TEST(PilotThemePlatform, EveryPlatformHasAName)

--- a/solvcon/pilot/_theme.py
+++ b/solvcon/pilot/_theme.py
@@ -30,6 +30,18 @@ class ThemeMenu(_gui_common.PilotFeature):
             ],
             base_weight=10, setter=mgr.set_theme, current=mgr.theme_mode)
 
+        self._build_group(
+            "theme.look",
+            [
+                ("system", "System colors",
+                 "Show the platform's own colors through the native style",
+                 mgr.theme_has_native_style),
+                ("curated", "Curated colors",
+                 "Apply the curated palette for a look that travels between"
+                 " machines", True),
+            ],
+            base_weight=110, setter=mgr.set_look, current=mgr.theme_look)
+
     def _build_group(self, group_id, items, *, base_weight, setter, current):
         # The exclusive group lives in the C++ menu model under its id, so a
         # test and the manager's sync both reach the actions by that handle.

--- a/tests/test_pilot_theme.py
+++ b/tests/test_pilot_theme.py
@@ -11,7 +11,11 @@ try:
     from solvcon import pilot
     from solvcon.pilot import _gui
     from PySide6 import QtWidgets
+    from PySide6.QtCore import QSettings, QStandardPaths
     from PySide6.QtGui import QPalette
+    # Redirect QSettings to a throwaway location so the theme's persistence
+    # does not touch the developer's real configuration during the tests.
+    QStandardPaths.setTestModeEnabled(True)
 except ImportError:
     pilot = None
 
@@ -172,6 +176,42 @@ class ThemeLookTC(unittest.TestCase):
         group = self.model.group("theme.look")
         self.assertEqual(group.checkedAction().objectName(),
                          "theme.look_system")
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class ThemePolishTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.app = QtWidgets.QApplication.instance()
+
+    def tearDown(self):
+        self.mgr.set_look("curated")
+        self.mgr.set_theme("system")
+
+    def test_accent_role_matches_the_highlight(self):
+        self.mgr.set_look("curated")
+        self.mgr.set_theme("light")
+        pal = self.app.palette()
+        self.assertEqual(pal.color(QPalette.Accent),
+                         pal.color(QPalette.Highlight))
+
+    def test_curated_look_adds_a_supplemental_stylesheet(self):
+        self.mgr.set_look("curated")
+        self.assertIn("QToolTip", self.app.styleSheet())
+
+    def test_system_look_clears_the_stylesheet(self):
+        self.mgr.set_look("system")
+        self.assertEqual(self.app.styleSheet(), "")
+
+    def test_mode_and_look_persist_across_sessions(self):
+        self.mgr.set_theme("dark")
+        self.mgr.set_look("system")
+        # A new session reads these back through the same store to start on the
+        # last chosen theme.
+        settings = QSettings("solvcon", "pilot")
+        self.assertEqual(settings.value("theme/mode"), "dark")
+        self.assertEqual(settings.value("theme/look"), "system")
 
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,

--- a/tests/test_pilot_theme.py
+++ b/tests/test_pilot_theme.py
@@ -79,7 +79,10 @@ class ThemeMenuTC(unittest.TestCase):
         return app.palette().color(QPalette.Window).lightness()
 
     def test_theme_menu_lists_the_three_modes(self):
-        items = [a.text() for a in self.model.menu("View/Theme").actions()]
+        # The Theme menu also carries the look choices, so filter to the mode
+        # actions by their object-name prefix.
+        items = [a.text() for a in self.model.menu("View/Theme").actions()
+                 if a.objectName().startswith("theme.mode_")]
         self.assertEqual(items, ["Follow system", "Light", "Dark"])
 
     def test_theme_group_is_exclusive_and_defaults_to_system(self):
@@ -116,6 +119,59 @@ class ThemeMenuTC(unittest.TestCase):
         # never disagrees with the applied palette.
         checked = group.checkedAction()
         self.assertEqual(checked.objectName(), "theme.mode_dark")
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class ThemeLookTC(unittest.TestCase):
+    def setUp(self):
+        # The theme menu is built in Python by the controller, so build the
+        # full bar rather than only the C++ manager.
+        self.mgr = _gui.controller.build()
+        self.model = self.mgr.menu_model
+        self.app = QtWidgets.QApplication.instance()
+
+    def tearDown(self):
+        # The manager is a shared singleton, so restore the controlled default
+        # to keep the tests independent of the order they run in.
+        self.mgr.set_look("curated")
+        self.mgr.set_theme("system")
+
+    def test_look_menu_lists_the_two_looks(self):
+        items = [a.text() for a in self.model.menu("View/Theme").actions()
+                 if a.objectName().startswith("theme.look_")]
+        self.assertEqual(items, ["System colors", "Curated colors"])
+
+    def test_look_group_is_exclusive_and_defaults_to_curated(self):
+        group = self.model.group("theme.look")
+        self.assertEqual(len(group.actions()), 2)
+        self.assertTrue(group.isExclusive())
+        self.assertEqual(group.checkedAction().objectName(),
+                         "theme.look_curated")
+
+    def test_both_looks_are_enabled_on_this_platform(self):
+        for look in ("system", "curated"):
+            self.assertTrue(
+                self.model.action("theme.look_" + look).isEnabled())
+
+    def test_curated_look_paints_the_curated_dark_window(self):
+        self.mgr.set_look("curated")
+        self.mgr.set_theme("dark")
+        self.assertEqual(self.mgr.theme_look, "curated")
+        self.assertLess(
+            self.app.palette().color(QPalette.Window).lightness(), 100)
+
+    def test_system_look_uses_the_native_style_palette(self):
+        self.mgr.set_look("system")
+        self.assertEqual(self.mgr.theme_look, "system")
+        native = self.app.style().standardPalette().color(QPalette.Window)
+        self.assertEqual(self.app.palette().color(QPalette.Window), native)
+
+    def test_look_menu_check_follows_scripting(self):
+        self.mgr.set_look("system")
+        group = self.model.group("theme.look")
+        self.assertEqual(group.checkedAction().objectName(),
+                         "theme.look_system")
 
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,


### PR DESCRIPTION
Steps 8, 9 of issue #1062.

Add a look preference (System or Curated) alongside the light or dark mode, so the user chooses between a native feel and a controlled look that travels between machines.

### Step 8: the system-versus-curated look choice

Add a look preference alongside the light or dark mode. System lets the platform's own colors show through the native style untouched, while Curated paints the plan's palettes over that style for a controlled look that carries between machines. Curated stays the default.

Add the `ThemeLook` vocabulary to the Qt-free core and route it through the manager: `apply()` paints the curated palette or the style's native standard palette by the current look, caching the effective window color so the MDI backdrop matches whichever is in force. Surface the choice as a second group in the Python theme menu, gated by the capability record now exposed as `theme_has_native_style`, so System greys out where no native style can carry it. Expose `set_look` and `theme_look` to Python, and extend the C++ menu sync so the look radio also keeps step when the theme moves from outside the menu.

### Step 9: accent role, chrome, overlays, and persistence

Round off the theme system with the touches a palette alone does not reach.

Set the dedicated `QPalette::Accent` role (Qt 6.6+) from the highlight, so widgets that want the platform accent distinct from a selection highlight pick it up. Add a thin supplemental stylesheet for the one thing a palette cannot draw, a tooltip border and a focus ring on text inputs, colored from the theme under the curated look and cleared under the system look so the native style stays untouched.

Recolor the two remaining hardcoded overlays, the axis text (`RTextOverlay`) and the scalar bar (`RScalarBar`), from the application palette so their labels stay legible when the theme turns dark instead of forcing black.

Persist the chosen mode and look through `QSettings` and read them back when the manager is built, so a theme carries across restarts.
