### PR TITLE
Stop master CI runs from cancelling each other

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -9,7 +9,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # A push to master must never cancel an earlier master run, so every
+  # merge keeps its own CI result. Superseded pull request and branch
+  # runs still cancel.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # A push to master must never cancel an earlier master run, so every
+  # merge keeps its own CI result. Superseded pull request and branch
+  # runs still cancel.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
 

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -9,7 +9,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # A push to master must never cancel an earlier master run, so every
+  # merge keeps its own CI result. Superseded pull request and branch
+  # runs still cancel.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
 


### PR DESCRIPTION
An older CI run is cancelled by a latter one when merged to master, because the lint, devbuild, and nouse_install workflows share a concurrency group keyed on the pull request number when one is present and on the ref otherwise.

Gate the cancellation on the ref instead, so a push to master is never cancelled.