### PR TITLE
Make SimpleArray treat size-1 axes as contiguous like NumPy

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -2078,16 +2078,18 @@ private:
     static bool is_c_contiguous(shape_type const & shape,
                                 sshape_type const & stride)
     {
-        if (stride[stride.size() - 1] != 1)
+        if (shape.empty())
         {
-            return false;
+            return true;
         }
-        for (size_t it = 0; it < shape.size() - 1; ++it)
+        ssize_t expected = 1;
+        for (ssize_t i = static_cast<ssize_t>(shape.size()) - 1; i >= 0; --i)
         {
-            if (stride[it] != shape[it + 1] * stride[it + 1])
+            if (stride[i] != expected && shape[i] > 1)
             {
                 return false;
             }
+            expected *= shape[i];
         }
         return true;
     }
@@ -2095,16 +2097,18 @@ private:
     static bool is_f_contiguous(shape_type const & shape,
                                 sshape_type const & stride)
     {
-        if (stride[0] != 1)
+        if (shape.empty())
         {
-            return false;
+            return true;
         }
-        for (size_t it = 0; it < shape.size() - 1; ++it)
+        ssize_t expected = 1;
+        for (size_t i = 0; i < shape.size(); ++i)
         {
-            if (stride[it + 1] != shape[it] * stride[it])
+            if (stride[i] != expected && shape[i] > 1)
             {
                 return false;
             }
+            expected *= shape[i];
         }
         return true;
     }
@@ -2118,8 +2122,8 @@ private:
         }
     }
 
-    void check_f_contiguous(shape_type const & shape,
-                            sshape_type const & stride) const
+    static void check_f_contiguous(shape_type const & shape,
+                                   sshape_type const & stride)
     {
         if (!is_f_contiguous(shape, stride))
         {

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -289,6 +289,35 @@ class SimpleArrayBasicTC(unittest.TestCase):
         ):
             solvcon.SimpleArrayFloat64((-1, 2))
 
+    def test_SimpleArray_fortran_empty(self):
+        ndarr = np.empty((0, 0), order='F')
+        sarr = solvcon.SimpleArrayFloat64(array=ndarr)
+
+        self.assertTrue(sarr.is_c_contiguous)
+        self.assertTrue(sarr.is_f_contiguous)
+        np.testing.assert_array_equal(ndarr, sarr.ndarray)
+
+    def test_SimpleArray_fortran_1x2(self):
+        ndarr = np.asfortranarray([[1.0, 0.1]])
+        sarr = solvcon.SimpleArrayFloat64(array=ndarr)
+        self.assertTrue(sarr.is_c_contiguous)
+        self.assertTrue(sarr.is_f_contiguous)
+        np.testing.assert_array_equal(ndarr, sarr.ndarray)
+
+    def test_SimpleArray_fortran_2x1(self):
+        ndarr = np.asfortranarray([[1.0], [0.0]])
+        sarr = solvcon.SimpleArrayFloat64(array=ndarr)
+        self.assertTrue(sarr.is_c_contiguous)
+        self.assertTrue(sarr.is_f_contiguous)
+        np.testing.assert_array_equal(ndarr, sarr.ndarray)
+
+    def test_SimpleArray_fortran_2x2(self):
+        ndarr = np.asfortranarray([[1.0, 0.1], [0.0, 1.0]])
+        sarr = solvcon.SimpleArrayFloat64(array=ndarr)
+        self.assertFalse(sarr.is_c_contiguous)
+        self.assertTrue(sarr.is_f_contiguous)
+        np.testing.assert_array_equal(ndarr, sarr.ndarray)
+
     def test_SimpleArray_from_numpy_negative_stride(self):
         ndarr = np.arange(2 * 3, dtype='float64').reshape((2, 3))
         view = ndarr[::-1, ::-1]


### PR DESCRIPTION
Make SimpleArray treat size-1 axes as contiguous like NumPy and add tests.

This changes contiguous-detection logic to follow NumPy semantics: when a dimension has length 1 its stride may be arbitrary and does not break C-contiguity or F-contiguity. Also made check_f_contiguous static to match check_c_contiguous. Added tests that exercise 1x2, 2x1, and 2x2 Fortran views and assert contiguity flags and ndarray equality.

Related to #603.
<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
