### PR TITLE
Add a comment-review section to the C++ and Python style-review skills

### DIFF
--- a/.claude/skills/cpp-style-review/SKILL.md
+++ b/.claude/skills/cpp-style-review/SKILL.md
@@ -59,6 +59,10 @@ it briefly but don't re-implement the check here.
   (separated by `;`) on one line. A single-statement inline accessor body
   is one statement, not two, and stays the preferred form.
 
+**Comments**
+- **Comments are very important.** Check all comments in the diff for clarity, accuracy, and relevance. Flag any comment that is unclear, misleading, trivial, or outdated.
+- Refer to "C++ Comment" in STYLE.md for what counts as a comment and how to judge it.
+
 **pybind11**
 - Split constructors from other bindings (methods, properties) into two
   distinct `(*this)` sections.

--- a/.claude/skills/python-style-review/SKILL.md
+++ b/.claude/skills/python-style-review/SKILL.md
@@ -44,6 +44,10 @@ limit, flake8) are handled by `.claude/hooks/check-source.sh`
   statements (separated by `;`) on one line. (Line width is owned by the
   hooks; don't re-flag it here.)
 
+**Comments**
+- **Comments are very important.** Check all comments in the diff for clarity, accuracy, and relevance. Flag any comment that is unclear, misleading, trivial, or outdated.
+- Refer to "Python Comment" in STYLE.md for what counts as a comment and how to judge it.
+
 **Intent (Rule 9)**
 - Tests should encode why behavior matters, not just what. If a new test
   would still pass under an obvious bug in the code it exercises,


### PR DESCRIPTION
The cpp-style-review and python-style-review skills did not call out comments as a review dimension, so a reviewer working from the skill had no prompt to scrutinize the prose a diff introduces. This change adds a short "Comments" section to each skill that points the reviewer at the comment definition in STYLE.md and asks them to check every comment in the diff for clarity, accuracy, and relevance, flagging any that is unclear, misleading, trivial, or outdated. The C++ skill references the "C++ Comment" section and the Python skill the "Python Comment" section.

[skip-ci]
