### PR TITLE
Fix offscreen capture failure in headful test run

### DIFF
--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -169,9 +169,19 @@ QImage RDomainWidget::renderToImage(int width, int height, bool transparent)
     bool const old_transparent = m_transparent_capture;
     m_transparent_capture = transparent;
     resize(width, height);
-    QImage const image = grabFramebuffer();
+    QImage image = grabFramebuffer();
     resize(old_size.width(), old_size.height());
     m_transparent_capture = old_transparent;
+
+    // grabFramebuffer() returns physical pixels (logical size scaled by the
+    // screen's device pixel ratio), so on a HiDPI display the grab is larger
+    // than requested. Normalize to the requested pixel dimensions.
+    if (image.size() != QSize(width, height))
+    {
+        image = image.scaled(
+            width, height, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+    }
+    image.setDevicePixelRatio(1.0);
     return image;
 }
 


### PR DESCRIPTION
Commit 16e57cd "Item 16: High-resolution and transparent offscreen capture" from PR #1012 (Scene of multiple meshes and offscreen capture, items 15 and 16 of basic mesh visualization) introduced a bug. It fails `RDomainWidgetCaptureTC::test_capture_size_is_independent_of_widget_size` with `AssertionError: 1024 != 512` when running with a display head:

```
../../../../../tests/test_pilot_domain_widget.py::RDomainWidgetCaptureTC::test_capture_size_is_independent_of_widget_size FAILED [ 58%]

=================================== FAILURES ===================================
____ RDomainWidgetCaptureTC.test_capture_size_is_independent_of_widget_size ____

self = <test_pilot_domain_widget.RDomainWidgetCaptureTC testMethod=test_capture_size_is_independent_of_widget_size>

    def test_capture_size_is_independent_of_widget_size(self):
        """A capture is produced at the requested size regardless of the
        widget size."""
        widget = pilot.RDomainWidget()
        widget.resize(320, 240)
        widget.updateMesh(_make_2d_mesh())
        image = self._render_or_skip(widget, 512, 384)
>       self.assertEqual(image.width(), 512)
E       AssertionError: 1024 != 512

../../../../../tests/test_pilot_domain_widget.py:1312: AssertionError
=========================== short test summary info ============================
FAILED ../../../../../tests/test_pilot_domain_widget.py::RDomainWidgetCaptureTC::test_capture_size_is_independent_of_widget_size
== 1 failed, 874 passed, 10 skipped, 3 xfailed, 200 subtests passed in 9.09s ===
```

The issue does not show on a non-HiDPI CI display where the device pixel ratio is 1, which is why it slipped through.