### PR TITLE
Preserve NumPy view origins in SimpleArray buffers

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -270,7 +270,7 @@ public:
         {
             return sum_contiguous(athis->data(), n);
         }
-        return sum_strided(athis->data(), athis->shape(), athis->stride());
+        return sum_strided(athis->logical_data(), athis->shape(), athis->stride());
     }
 
 private:
@@ -1610,6 +1610,24 @@ public:
     using sshape_type = typename internal_types::sshape_type;
     using buffer_type = typename internal_types::buffer_type;
 
+    enum class ArrayOrder : std::uint8_t
+    {
+        Unspecified = 0,
+        CType = 1U << 0,
+        FType = 1U << 1,
+    };
+
+    friend constexpr ArrayOrder operator|(ArrayOrder lhs, ArrayOrder rhs) noexcept
+    {
+        return static_cast<ArrayOrder>(std::to_underlying(lhs) | std::to_underlying(rhs));
+    }
+
+    friend constexpr ArrayOrder & operator|=(ArrayOrder & lhs, ArrayOrder rhs) noexcept
+    {
+        lhs = lhs | rhs;
+        return lhs;
+    }
+
     static constexpr size_t ITEMSIZE = sizeof(value_type);
 
     static constexpr size_t itemsize() { return ITEMSIZE; }
@@ -1637,7 +1655,7 @@ public:
         if (!m_shape.empty())
         {
             m_buffer = buffer_type::construct(static_cast<size_t>(storage_size(m_shape, m_stride)) * ITEMSIZE, 0);
-            m_body = m_buffer->template data<T>();
+            update_data_pointers();
         }
     }
 
@@ -1649,7 +1667,7 @@ public:
         if (!m_shape.empty())
         {
             m_buffer = buffer_type::construct(static_cast<size_t>(storage_size(m_shape, m_stride)) * ITEMSIZE, alignment);
-            m_body = m_buffer->template data<T>();
+            update_data_pointers();
         }
     }
 
@@ -1697,7 +1715,7 @@ public:
             m_shape = shape_type{static_cast<ssize_t>(nitem)};
             m_stride = sshape_type{1};
             m_buffer = buffer;
-            m_body = m_buffer->template data<T>();
+            update_data_pointers();
         }
         else
         {
@@ -1706,6 +1724,13 @@ public:
     }
 
     explicit SimpleArray(shape_type const & shape, std::shared_ptr<buffer_type> const & buffer)
+        : SimpleArray(shape, buffer, 0)
+    {
+    }
+
+    explicit SimpleArray(shape_type const & shape,
+                         std::shared_ptr<buffer_type> const & buffer,
+                         size_t data_offset)
         : SimpleArray(buffer)
     {
         if (buffer)
@@ -1713,32 +1738,50 @@ public:
             m_shape = shape;
             m_stride = calc_stride(m_shape);
             const size_t nbytes = static_cast<size_t>(storage_size(m_shape, m_stride)) * ITEMSIZE;
-            if (nbytes != buffer->nbytes())
+            if (data_offset % ITEMSIZE != 0)
+            {
+                throw std::runtime_error("SimpleArray: data offset must be divisible by item size");
+            }
+            if (data_offset > buffer->nbytes())
             {
                 throw std::runtime_error(
-                    std::format("SimpleArray: shape byte count {} differs from buffer {}",
-                                nbytes,
+                    std::format("SimpleArray: data offset {} exceeds buffer byte count {}",
+                                data_offset,
                                 buffer->nbytes()));
             }
+            size_t const available_nbytes = buffer->nbytes() - data_offset;
+            if (nbytes != available_nbytes)
+            {
+                throw std::runtime_error(
+                    std::format("SimpleArray: shape byte count {} differs from available buffer byte count {} at data offset {}",
+                                nbytes,
+                                available_nbytes,
+                                data_offset));
+            }
+            update_data_pointers(data_offset);
         }
     }
 
     explicit SimpleArray(shape_type const & shape,
                          sshape_type const & stride,
                          std::shared_ptr<buffer_type> const & buffer,
-                         bool c_contiguous,
-                         bool f_contiguous)
-        : SimpleArray(shape, stride, buffer)
+                         ArrayOrder array_order)
+        : SimpleArray(shape, stride, buffer, 0, array_order)
     {
-        if (shape.size() != stride.size())
-        {
-            throw std::runtime_error("SimpleArray: shape and stride size mismatch");
-        }
-        if (c_contiguous)
+    }
+
+    explicit SimpleArray(shape_type const & shape,
+                         sshape_type const & stride,
+                         std::shared_ptr<buffer_type> const & buffer,
+                         size_t data_offset,
+                         ArrayOrder array_order)
+        : SimpleArray(shape, stride, buffer, data_offset)
+    {
+        if (has_order(array_order, ArrayOrder::CType))
         {
             check_c_contiguous(shape, stride);
         }
-        if (f_contiguous)
+        if (has_order(array_order, ArrayOrder::FType))
         {
             check_f_contiguous(shape, stride);
         }
@@ -1747,12 +1790,22 @@ public:
     explicit SimpleArray(shape_type const & shape,
                          sshape_type const & stride,
                          std::shared_ptr<buffer_type> const & buffer)
+        : SimpleArray(shape, stride, buffer, 0)
+    {
+    }
+
+    explicit SimpleArray(shape_type const & shape,
+                         sshape_type const & stride,
+                         std::shared_ptr<buffer_type> const & buffer,
+                         size_t data_offset)
         : SimpleArray(buffer)
     {
         if (buffer)
         {
+            validate_layout(shape, stride, buffer->nbytes(), data_offset);
             m_shape = shape;
             m_stride = stride;
+            update_data_pointers(data_offset);
         }
     }
 
@@ -1772,14 +1825,15 @@ public:
         , m_shape(other.m_shape)
         , m_stride(other.m_stride)
         , m_nghost(other.m_nghost)
-        , m_body(calc_body(m_buffer->template data<T>(), m_stride, other.m_nghost))
     {
+        update_data_pointers(other.logical_data_offset());
     }
 
     SimpleArray(SimpleArray && other) noexcept
         : m_buffer(std::move(other.m_buffer))
         , m_shape(std::move(other.m_shape))
         , m_stride(std::move(other.m_stride))
+        , m_logical_data(other.m_logical_data)
         , m_nghost(other.m_nghost)
         , m_body(other.m_body)
     {
@@ -1793,7 +1847,7 @@ public:
             m_shape = other.m_shape;
             m_stride = other.m_stride;
             m_nghost = other.m_nghost;
-            m_body = calc_body(m_buffer->template data<T>(), m_stride, other.m_nghost);
+            update_data_pointers(other.logical_data_offset());
         }
         return *this;
     }
@@ -1805,6 +1859,7 @@ public:
             m_buffer = std::move(other.m_buffer);
             m_shape = std::move(other.m_shape);
             m_stride = std::move(other.m_stride);
+            m_logical_data = other.m_logical_data;
             m_nghost = other.m_nghost;
             m_body = other.m_body;
         }
@@ -1889,13 +1944,13 @@ public:
     {
         sshape_type const idx{normalize_index(it)};
         ssize_t const offset = buffer_offset(m_stride, idx);
-        return *(data() + offset);
+        return *(logical_data() + offset);
     }
     value_type & at(ssize_t it)
     {
         sshape_type const idx{normalize_index(it)};
         ssize_t const offset = buffer_offset(m_stride, idx);
-        return *(data() + offset);
+        return *(logical_data() + offset);
     }
 
     value_type const & at(std::vector<ssize_t> const & idx) const { return at(sshape_type(idx)); }
@@ -1905,13 +1960,13 @@ public:
     {
         sshape_type const idx = normalize_index(sidx);
         ssize_t const offset = buffer_offset(m_stride, idx);
-        return *(data() + offset);
+        return *(logical_data() + offset);
     }
     value_type & at(sshape_type const & sidx)
     {
         sshape_type const idx = normalize_index(sidx);
         ssize_t const offset = buffer_offset(m_stride, idx);
-        return *(data() + offset);
+        return *(logical_data() + offset);
     }
 
     ssize_t ndim() const noexcept { return static_cast<ssize_t>(m_shape.size()); }
@@ -1950,24 +2005,24 @@ public:
         m_nghost = nghost;
         if (bool(*this))
         {
-            m_body = calc_body(m_buffer->template data<T>(), m_stride, m_nghost);
+            m_body = calc_body(logical_data(), m_stride, m_nghost);
         }
     }
 
     template <typename U>
     SimpleArray<U> reshape(shape_type const & shape) const
     {
-        return SimpleArray<U>(shape, m_buffer);
+        return SimpleArray<U>(shape, m_buffer, logical_data_offset());
     }
 
     SimpleArray reshape(shape_type const & shape) const
     {
-        return SimpleArray(shape, m_buffer);
+        return SimpleArray(shape, m_buffer, logical_data_offset());
     }
 
     SimpleArray reshape() const
     {
-        return SimpleArray(m_shape, m_buffer);
+        return SimpleArray(m_shape, m_buffer, logical_data_offset());
     }
 
     void swap(SimpleArray & other) noexcept
@@ -1977,6 +2032,7 @@ public:
             std::swap(m_buffer, other.m_buffer);
             std::swap(m_shape, other.m_shape);
             std::swap(m_stride, other.m_stride);
+            std::swap(m_logical_data, other.m_logical_data);
             std::swap(m_nghost, other.m_nghost);
             std::swap(m_body, other.m_body);
         }
@@ -2020,7 +2076,7 @@ public:
                 std::format("SimpleArray::as_mdspan: rank {} does not match ndim() {}", N, ndim()));
         }
         return std::mdspan<value_type, std::dextents<ssize_t, N>, std::layout_stride>(
-            data(), make_mdspan_mapping<N>());
+            logical_data(), make_mdspan_mapping<N>());
     }
 
     template <size_t N>
@@ -2032,7 +2088,7 @@ public:
                 std::format("SimpleArray::as_mdspan: rank {} does not match ndim() {}", N, ndim()));
         }
         return std::mdspan<value_type const, std::dextents<ssize_t, N>, std::layout_stride>(
-            data(), make_mdspan_mapping<N>());
+            logical_data(), make_mdspan_mapping<N>());
     }
 
     /* Backdoor */
@@ -2040,6 +2096,9 @@ public:
     value_type & data(size_t it) { return data()[it]; }
     value_type const * data() const { return buffer().template data<value_type>(); }
     value_type * data() { return buffer().template data<value_type>(); }
+
+    value_type const * logical_data() const { return m_logical_data; }
+    value_type * logical_data() { return m_logical_data; }
 
     buffer_type const & buffer() const { return *m_buffer; }
     buffer_type & buffer() { return *m_buffer; }
@@ -2051,6 +2110,8 @@ public:
     bool is_f_contiguous() const { return is_f_contiguous(m_shape, m_stride); }
 
 private:
+    size_t logical_data_offset() const;
+    void update_data_pointers(size_t data_offset = 0);
     void copy_logical_into(SimpleArray & out) const;
 
     template <size_t N, size_t... I>
@@ -2111,6 +2172,11 @@ private:
             expected *= shape[i];
         }
         return true;
+    }
+
+    static constexpr bool has_order(ArrayOrder orders, ArrayOrder order) noexcept
+    {
+        return (std::to_underlying(orders) & std::to_underlying(order)) != 0;
     }
 
     static void check_c_contiguous(shape_type const & shape,
@@ -2270,6 +2336,11 @@ private:
         }
     }
 
+    static void validate_layout(shape_type const & shape,
+                                sshape_type const & stride,
+                                size_t buffer_nbytes,
+                                size_t data_offset);
+
     static ssize_t storage_size(shape_type const & shape, sshape_type const & stride)
     {
         if (shape.empty())
@@ -2288,9 +2359,77 @@ private:
     /// bytes) to skip for advancing an index in the corresponding dimension.
     sshape_type m_stride;
 
+    /// Pointer to the array's logical origin within the buffer.
+    value_type * m_logical_data = nullptr;
     ssize_t m_nghost = 0;
     value_type * m_body = nullptr;
 }; /* end class SimpleArray */
+
+template <typename T>
+size_t SimpleArray<T>::logical_data_offset() const
+{
+    if (!m_logical_data)
+    {
+        return 0;
+    }
+    value_type const * data_ptr = m_buffer->template data<value_type>();
+    return static_cast<size_t>(m_logical_data - data_ptr) * ITEMSIZE;
+}
+
+template <typename T>
+void SimpleArray<T>::update_data_pointers(size_t data_offset)
+{
+    value_type * data_ptr = m_buffer ? m_buffer->template data<value_type>() : nullptr;
+    m_logical_data = data_ptr ? data_ptr + data_offset / ITEMSIZE : nullptr;
+    m_body = calc_body(m_logical_data, m_stride, m_nghost);
+}
+
+template <typename T>
+void SimpleArray<T>::validate_layout(shape_type const & shape,
+                                     sshape_type const & stride,
+                                     size_t buffer_nbytes,
+                                     size_t data_offset)
+{
+    validate_shape(shape);
+    if (shape.size() != stride.size())
+    {
+        throw std::runtime_error("SimpleArray: shape and stride size mismatch");
+    }
+    if (data_offset % ITEMSIZE != 0)
+    {
+        throw std::runtime_error("SimpleArray: data offset must be divisible by item size");
+    }
+    if (data_offset > buffer_nbytes)
+    {
+        throw std::runtime_error("SimpleArray: data offset exceeds buffer size");
+    }
+
+    ssize_t min_offset = 0;
+    ssize_t max_offset = 0;
+    for (size_t it = 0; it < shape.size(); ++it)
+    {
+        if (shape[it] == 0)
+        {
+            return;
+        }
+        ssize_t const axis_offset = (shape[it] - 1) * stride[it];
+        if (axis_offset < 0)
+        {
+            min_offset += axis_offset;
+        }
+        else
+        {
+            max_offset += axis_offset;
+        }
+    }
+
+    auto const data_item_offset = static_cast<ssize_t>(data_offset / ITEMSIZE);
+    auto const buffer_nitem = static_cast<ssize_t>(buffer_nbytes / ITEMSIZE);
+    if (data_item_offset + min_offset < 0 || data_item_offset + max_offset >= buffer_nitem)
+    {
+        throw std::runtime_error("SimpleArray: shape and stride exceed buffer storage");
+    }
+}
 
 template <typename A, typename T>
 template <typename Cmp>
@@ -2529,7 +2668,7 @@ void SimpleArray<T>::transpose(shape_type const & axis, bool copy)
         return;
     }
     // Deep-copy path: 1. stage a strided view with the permuted shape/stride.
-    SimpleArray const view(new_shape, new_stride, m_buffer);
+    SimpleArray const view(new_shape, new_stride, m_buffer, logical_data_offset());
     SimpleArray out(new_shape);
     // 2. Use the same helper to keep the iteration logic the same as the other
     // deep-copy variants.

--- a/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
+++ b/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
@@ -81,7 +81,7 @@ struct TypeBroadcastImpl
 
             if constexpr (valid_conversion)
             {
-                auto * ptr_out = arr_out.data() + offset_out;
+                auto * ptr_out = arr_out.logical_data() + offset_out;
                 // FIXME: NOLINTNEXTLINE(bugprone-signed-char-misuse,cert-str34-c)
                 *ptr_out = static_cast<out_type>(*ptr_in);
             }

--- a/cpp/solvcon/buffer/pymod/array_common.hpp
+++ b/cpp/solvcon/buffer/pymod/array_common.hpp
@@ -276,7 +276,7 @@ public:
         }
 
         return pybind11::buffer_info(
-            array.data(), /* Pointer to buffer */
+            array.logical_data(), /* Pointer to buffer */
             sizeof(T), /* Size of one scalar */
             format, /* Python struct-style format descriptor */
             array.ndim(), /* Number of dimensions */

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -9,6 +9,8 @@
 
 #include <solvcon/buffer/pymod/array_common.hpp>
 
+#include <cstdint>
+
 namespace solvcon
 {
 
@@ -24,9 +26,12 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
     using wrapped_type = typename root_base_type::wrapped_type;
     using wrapper_type = typename root_base_type::wrapper_type;
     using value_type = typename wrapped_type::value_type;
+    using array_order_type = typename wrapped_type::ArrayOrder;
     using property_helper = ArrayPropertyHelper<T>;
 
     friend root_base_type;
+
+    static wrapped_type make_array_from_numpy(pybind11::array & arr_in);
 
     WrapSimpleArray(pybind11::module & mod, char const * pyname, char const * pydoc)
         : root_base_type(mod, pyname, pydoc, pybind11::buffer_protocol())
@@ -58,74 +63,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 py::arg("shape"),
                 py::arg("value"),
                 py::arg("alignment"))
-            .def(
-                py::init(
-                    [](py::array & arr_in)
-                    {
-                        if (!dtype_is_type<T>(arr_in))
-                        {
-                            throw std::runtime_error("dtype mismatch");
-                        }
-
-                        solvcon::detail::shape_type shape;
-                        solvcon::detail::sshape_type stride;
-                        constexpr auto itemsize = static_cast<ssize_t>(wrapped_type::itemsize());
-                        constexpr size_t span = 0;
-                        for (ssize_t i = 0; i < arr_in.ndim(); ++i)
-                        {
-                            shape.push_back(arr_in.shape(i));
-                            stride.push_back(arr_in.strides(i) / itemsize);
-                        }
-
-                        const bool is_c_contiguous = (arr_in.flags() & py::array::c_style) == py::array::c_style;
-                        const bool is_f_contiguous = (arr_in.flags() & py::array::f_style) == py::array::f_style;
-
-                        py::array owner = arr_in;
-                        /*
-                         * In the following document, it introduces the base object in ndarray.
-                         * https://numpy.org/doc/2.2/reference/generated/numpy.ndarray.base.html
-                         * The `array.base` is base object if memory is from some other object.
-                         * If object owns its memory, base is None.
-                         */
-                        while (true)
-                        {
-                            const py::object b = owner.attr("base");
-                            if (b.is_none() || !py::isinstance<py::array>(b))
-                            {
-                                break;
-                            }
-                            auto next = b.cast<py::array>();
-                            /*
-                             * Prevent the infinite loop.
-                             * For example, the following code will create a loop:
-                             * nparr = np.arange(24, dtype='float64').reshape((2, 3, 4))
-                             * nparr = nparr[::2, ::2, ::2]
-                             */
-                            if (next.ptr() == owner.ptr())
-                            {
-                                break;
-                            }
-                            owner = next;
-                        }
-
-                        char const * base_ptr = static_cast<char *>(owner.mutable_data());
-                        char * view_ptr = static_cast<char *>(arr_in.mutable_data());
-                        const ptrdiff_t offset_bytes = view_ptr - base_ptr;
-                        if (offset_bytes < 0)
-                        {
-                            throw std::runtime_error("Unexpected negative offset!");
-                        }
-                        const size_t true_owner_nbytes = owner.nbytes();
-                        const size_t view_nbytes = true_owner_nbytes - static_cast<size_t>(offset_bytes);
-                        auto remover = std::make_unique<ConcreteBufferNdarrayRemover>(owner);
-                        const std::shared_ptr<ConcreteBuffer> buffer =
-                            ConcreteBuffer::construct(
-                                view_nbytes,
-                                view_ptr,
-                                std::move(remover));
-                        return wrapped_type(shape, stride, buffer, is_c_contiguous, is_f_contiguous);
-                    }),
-                py::arg("array"))
+            .def(py::init(&WrapSimpleArray::make_array_from_numpy), py::arg("array"))
             .def_buffer(&property_helper::get_buffer_info)
             .def("clone",
                  [](wrapped_type const & self)
@@ -763,6 +701,112 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
         throw std::invalid_argument("SimpleArray::where(): unsupported dtype");
     }
 }; /* end class WrapSimpleArray */
+
+template <typename T>
+typename WrapSimpleArray<T>::wrapped_type
+WrapSimpleArray<T>::make_array_from_numpy(pybind11::array & arr_in)
+{
+    namespace py = pybind11;
+
+    if (!dtype_is_type<T>(arr_in))
+    {
+        throw std::runtime_error("dtype mismatch");
+    }
+
+    solvcon::detail::shape_type shape;
+    solvcon::detail::sshape_type stride;
+    constexpr auto itemsize = static_cast<ssize_t>(sizeof(value_type));
+    ssize_t byte_span_begin = 0;
+    ssize_t byte_span_end = 0;
+    bool has_element = true;
+    for (ssize_t i = 0; i < arr_in.ndim(); ++i)
+    {
+        shape.push_back(arr_in.shape(i));
+        ssize_t const byte_stride = arr_in.strides(i);
+        if (byte_stride % itemsize != 0)
+        {
+            throw std::runtime_error(
+                std::format("NumPy byte stride {} in dimension {} is not divisible by item size {}",
+                            byte_stride,
+                            i,
+                            itemsize));
+        }
+        stride.push_back(byte_stride / itemsize);
+        if (shape[i] == 0)
+        {
+            has_element = false;
+            continue;
+        }
+        ssize_t const axis_byte_offset = (shape[i] - 1) * byte_stride;
+        if (axis_byte_offset < 0)
+        {
+            byte_span_begin += axis_byte_offset;
+        }
+        else
+        {
+            byte_span_end += axis_byte_offset;
+        }
+    }
+    if (!has_element)
+    {
+        byte_span_begin = 0;
+        byte_span_end = 0;
+    }
+
+    array_order_type array_order = array_order_type::Unspecified;
+    if ((arr_in.flags() & py::array::c_style) == py::array::c_style)
+    {
+        array_order |= array_order_type::CType;
+    }
+    if ((arr_in.flags() & py::array::f_style) == py::array::f_style)
+    {
+        array_order |= array_order_type::FType;
+    }
+
+    py::array owner = arr_in;
+    /*
+     * In the following document, it introduces the base object in ndarray.
+     * https://numpy.org/doc/2.2/reference/generated/numpy.ndarray.base.html
+     * The `array.base` is base object if memory is from some other object.
+     * If object owns its memory, base is None.
+     */
+    while (true)
+    {
+        const py::object b = owner.attr("base");
+        if (b.is_none() || !py::isinstance<py::array>(b))
+        {
+            break;
+        }
+        auto next = b.cast<py::array>();
+        /*
+         * Prevent the infinite loop.
+         * For example, the following code will create a loop:
+         * nparr = np.arange(24, dtype='float64').reshape((2, 3, 4))
+         * nparr = nparr[::2, ::2, ::2]
+         */
+        if (next.ptr() == owner.ptr())
+        {
+            break;
+        }
+        owner = next;
+    }
+
+    char * view_ptr = static_cast<char *>(arr_in.mutable_data());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    if (reinterpret_cast<std::uintptr_t>(view_ptr) % alignof(value_type) != 0)
+    {
+        throw std::runtime_error(
+            std::format("NumPy data pointer is not aligned for item alignment {}", alignof(value_type)));
+    }
+    char * storage_ptr = view_ptr + byte_span_begin;
+    const size_t storage_nbytes = has_element
+                                      ? static_cast<size_t>(byte_span_end - byte_span_begin + itemsize)
+                                      : 0;
+    const auto data_offset = static_cast<size_t>(-byte_span_begin);
+    auto remover = std::make_unique<ConcreteBufferNdarrayRemover>(owner);
+    const auto buffer = ConcreteBuffer::construct(storage_nbytes, storage_ptr, std::move(remover));
+    return wrapped_type(shape, stride, buffer, data_offset, array_order);
+}
 
 template <typename T>
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleCollector

--- a/cpp/solvcon/python/common.hpp
+++ b/cpp/solvcon/python/common.hpp
@@ -188,7 +188,7 @@ std::enable_if_t<is_simple_array_v<S>, pybind11::array> to_ndarray(S && sarr)
         py::detail::npy_format_descriptor<T>::dtype(), // Numpy dtype
         shape, // Buffer dimensions
         stride, // Strides (in bytes) for each index
-        sarr.data(), // Pointer to buffer
+        sarr.logical_data(), // Pointer to buffer
         py::cast(sarr.buffer().shared_from_this()) // Create the Python object owning the buffer
     );
 }

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -94,6 +94,44 @@ TEST(SimpleArray, iterator)
     }
 }
 
+TEST(SimpleArray, logical_data)
+{
+    using namespace solvcon;
+
+    auto buffer = ConcreteBuffer::construct(6 * sizeof(double));
+    double * const raw_data = buffer->data<double>();
+    for (ssize_t it = 0; it < 6; ++it)
+    {
+        raw_data[it] = static_cast<double>(it);
+    }
+
+    SimpleArray<double> array(
+        small_vector<ssize_t>{2, 3},
+        small_vector<ssize_t>{-3, -1},
+        buffer,
+        5 * sizeof(double));
+    EXPECT_EQ(raw_data, array.data());
+    EXPECT_EQ(raw_data + 5, array.logical_data());
+    EXPECT_EQ(5.0, array.at(small_vector<ssize_t>{0, 0}));
+    EXPECT_EQ(0.0, array.at(small_vector<ssize_t>{1, 2}));
+
+    SimpleArray<double> copy(array);
+    EXPECT_NE(array.data(), copy.data());
+    EXPECT_EQ(copy.data() + 5, copy.logical_data());
+    EXPECT_EQ(5.0, copy.at(small_vector<ssize_t>{0, 0}));
+    EXPECT_EQ(0.0, copy.at(small_vector<ssize_t>{1, 2}));
+
+    auto shifted_buffer = ConcreteBuffer::construct(6 * sizeof(double));
+    SimpleArray<double> shifted(
+        small_vector<ssize_t>{4},
+        shifted_buffer,
+        2 * sizeof(double));
+    SimpleArray<double> reshaped = shifted.reshape(
+        small_vector<ssize_t>{2, 2});
+    EXPECT_EQ(shifted.data(), reshaped.data());
+    EXPECT_EQ(shifted.logical_data(), reshaped.logical_data());
+}
+
 TEST(SimpleArray_DataType, from_type)
 {
     solvcon::DataType dt_double = solvcon::DataType::from<double>();

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -263,7 +263,8 @@ class SimpleArrayBasicTC(unittest.TestCase):
 
         with self.assertRaisesRegex(
                 RuntimeError,
-                "SimpleArray: shape byte count 184 differs from buffer 192"
+                "SimpleArray: shape byte count 184 differs from available "
+                "buffer byte count 192 at data offset 0"
         ):
             sarr.reshape(23)
 
@@ -337,8 +338,16 @@ class SimpleArrayBasicTC(unittest.TestCase):
         self.assertTrue(row_major.is_c_contiguous)
         np.testing.assert_array_equal(rhs, row_major.ndarray)
 
-        sarr.ndarray[0, 0] = 100
-        self.assertEqual(100, ndarr[1, 2])
+        transposed = sarr.transpose(inplace=False, copy=True)
+        np.testing.assert_array_equal(rhs.T, transposed.ndarray)
+
+        clone = sarr.clone()
+        self.assertFalse(clone.is_from_python)
+        np.testing.assert_array_equal(rhs, clone.ndarray)
+
+        sarr.ndarray[0, 0] = 200
+        self.assertEqual(200, ndarr[1, 2])
+        self.assertEqual(100, clone.ndarray[0, 0])
 
     def test_SimpleArray_clone(self):
         sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
@@ -803,6 +812,27 @@ class SimpleArrayBasicTC(unittest.TestCase):
         self.assertTupleEqual(shape, py_sarr.shape)
         self.assertEqual(np_sarr.nbytes, py_sarr.nbytes)
         self.assertEqual(np_sarr.size, py_sarr.size)
+
+    def test_SimpleArray_from_ndarray_rejects_byte_stride(self):
+        ndarr = np.ndarray(
+            (3,), dtype='int32', buffer=bytearray(range(32)), strides=(1,))
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "NumPy byte stride 1 in dimension 0 is not divisible by "
+                "item size 4"
+        ):
+            solvcon.SimpleArrayInt32(array=ndarr)
+
+    def test_SimpleArray_from_ndarray_rejects_unaligned_data(self):
+        ndarr = np.ndarray(
+            (3,), dtype='int32', buffer=bytearray(range(32)), offset=1)
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "NumPy data pointer is not aligned for item alignment 4"
+        ):
+            solvcon.SimpleArrayInt32(array=ndarr)
 
     def test_SimpleArray_from_ndarray_content(self):
 


### PR DESCRIPTION
`SimpleArray` used the logical origin of a NumPy view as the start of its `ConcreteBuffer`. For a negative-strided view, valid elements may lie before that pointer.

```python
ndarr = np.arange(6, dtype="float64").reshape((2, 3))
view = ndarr[::-1, ::-1]
sarr = solvcon.SimpleArrayFloat64(array=view)

clone = sarr.clone()
np.testing.assert_array_equal(clone.ndarray, view)
```

The original `sarr` could still read the view because the complete NumPy allocation remained alive. However, `clone()` copied only the incomplete range declared by `ConcreteBuffer` while retaining the negative strides. Reading `clone.ndarray` then accessed memory before the cloned allocation.

This PR stores the complete reachable storage span in `ConcreteBuffer` and records the byte offset to the logical origin. It also validates every strided `SimpleArray` constructor, preserves `data_offset` in copied transposes, and rejects NumPy views whose byte strides or data alignment cannot be represented safely.

Regression tests cover cloning and transposing a negative-strided view, and rejecting unrepresentable NumPy strides and alignment.

Related to #856.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->