### PR TITLE
Support negative strides in SimpleArray mdspan

### DIFF
--- a/cpp/solvcon/buffer/CMakeLists.txt
+++ b/cpp/solvcon/buffer/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOLVCON_BUFFER_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/buffer.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BufferBase.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/small_vector.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/signed_stride_layout.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ConcreteBuffer.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BufferExpander.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SimpleArray.hpp

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -14,6 +14,7 @@
 
 #include <solvcon/buffer/ConcreteBuffer.hpp>
 #include <solvcon/buffer/matmul.hpp>
+#include <solvcon/buffer/signed_stride_layout.hpp>
 #include <solvcon/math/math.hpp>
 #include <solvcon/simd/simd.hpp>
 
@@ -2086,28 +2087,10 @@ public:
     }
 
     template <size_t N>
-    std::mdspan<value_type, std::dextents<ssize_t, N>, std::layout_stride> as_mdspan()
-    {
-        if (ndim() != N)
-        {
-            throw std::out_of_range(
-                std::format("SimpleArray::as_mdspan: rank {} does not match ndim() {}", N, ndim()));
-        }
-        return std::mdspan<value_type, std::dextents<ssize_t, N>, std::layout_stride>(
-            logical_data(), make_mdspan_mapping<N>());
-    }
+    std::mdspan<value_type, std::dextents<ssize_t, N>, detail::SignedStrideLayout> as_mdspan();
 
     template <size_t N>
-    std::mdspan<value_type const, std::dextents<ssize_t, N>, std::layout_stride> as_mdspan() const
-    {
-        if (ndim() != N)
-        {
-            throw std::out_of_range(
-                std::format("SimpleArray::as_mdspan: rank {} does not match ndim() {}", N, ndim()));
-        }
-        return std::mdspan<value_type const, std::dextents<ssize_t, N>, std::layout_stride>(
-            logical_data(), make_mdspan_mapping<N>());
-    }
+    std::mdspan<value_type const, std::dextents<ssize_t, N>, detail::SignedStrideLayout> as_mdspan() const;
 
     /* Backdoor */
     value_type const & data(size_t it) const { return data()[it]; }
@@ -2133,23 +2116,16 @@ private:
     void copy_logical_into(SimpleArray & out) const;
 
     template <size_t N, size_t... I>
-    std::layout_stride::mapping<std::dextents<ssize_t, N>> make_mdspan_mapping_impl(std::index_sequence<I...>) const
+    detail::SignedStrideLayout::mapping<std::dextents<ssize_t, N>> make_mdspan_mapping_impl(
+        std::index_sequence<I...>) const
     {
-        std::array<ssize_t, N> strides;
-        for (size_t i = 0; i < N; ++i)
-        {
-            if (stride(i) < 0)
-            {
-                throw std::runtime_error("SimpleArray::as_mdspan: negative stride is not supported");
-            }
-            strides[i] = stride(i);
-        }
-        return std::layout_stride::mapping<std::dextents<ssize_t, N>>(
-            std::dextents<ssize_t, N>(shape(I)...), strides);
+        return detail::SignedStrideLayout::mapping<std::dextents<ssize_t, N>>(
+            std::dextents<ssize_t, N>(shape(I)...),
+            std::array<ssize_t, N>{stride(I)...});
     }
 
     template <size_t N>
-    std::layout_stride::mapping<std::dextents<ssize_t, N>> make_mdspan_mapping() const
+    detail::SignedStrideLayout::mapping<std::dextents<ssize_t, N>> make_mdspan_mapping() const
     {
         return make_mdspan_mapping_impl<N>(std::make_index_sequence<N>{});
     }
@@ -2382,6 +2358,44 @@ private:
     ssize_t m_nghost = 0;
     value_type * m_body = nullptr;
 }; /* end class SimpleArray */
+
+template <typename T>
+template <size_t N>
+std::mdspan<typename SimpleArray<T>::value_type, std::dextents<ssize_t, N>, detail::SignedStrideLayout>
+SimpleArray<T>::as_mdspan()
+{
+    if (ndim() != N)
+    {
+        throw std::out_of_range(
+            std::format("SimpleArray::as_mdspan: rank {} does not match ndim() {}", N, ndim()));
+    }
+    auto const mapping = make_mdspan_mapping<N>();
+    value_type * data_handle = logical_data();
+    if (data_handle)
+    {
+        data_handle -= mapping.origin_offset();
+    }
+    return std::mdspan<value_type, std::dextents<ssize_t, N>, detail::SignedStrideLayout>(data_handle, mapping);
+}
+
+template <typename T>
+template <size_t N>
+std::mdspan<typename SimpleArray<T>::value_type const, std::dextents<ssize_t, N>, detail::SignedStrideLayout>
+SimpleArray<T>::as_mdspan() const
+{
+    if (ndim() != N)
+    {
+        throw std::out_of_range(
+            std::format("SimpleArray::as_mdspan: rank {} does not match ndim() {}", N, ndim()));
+    }
+    auto const mapping = make_mdspan_mapping<N>();
+    value_type const * data_handle = logical_data();
+    if (data_handle)
+    {
+        data_handle -= mapping.origin_offset();
+    }
+    return std::mdspan<value_type const, std::dextents<ssize_t, N>, detail::SignedStrideLayout>(data_handle, mapping);
+}
 
 template <typename T>
 size_t SimpleArray<T>::logical_data_offset() const

--- a/cpp/solvcon/buffer/signed_stride_layout.hpp
+++ b/cpp/solvcon/buffer/signed_stride_layout.hpp
@@ -1,0 +1,174 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <array>
+#include <cstddef>
+#include <type_traits>
+
+namespace solvcon
+{
+
+namespace detail
+{
+
+/**
+ * Internal mdspan layout for unique mappings with signed strides.
+ *
+ * The mapping shifts the logical origin so that every valid index maps to a
+ * non-negative offset from the beginning of the storage span. The caller must
+ * provide strides that form a unique mapping and whose normalized offsets are
+ * representable by the index type.
+ *
+ * References:
+ * https://eel.is/c++draft/mdspan.layout.reqmts
+ * https://eel.is/c++draft/mdspan.layout.stride
+ */
+struct SignedStrideLayout
+{
+    template <typename Extents>
+    class mapping;
+};
+
+template <typename Extents>
+class SignedStrideLayout::mapping
+{
+public:
+
+    using extents_type = Extents;
+    using index_type = typename extents_type::index_type;
+    using size_type = typename extents_type::size_type;
+    using rank_type = typename extents_type::rank_type;
+    using layout_type = SignedStrideLayout;
+
+    static_assert(std::is_signed_v<index_type>, "SignedStrideLayout requires a signed index type");
+
+    constexpr mapping() noexcept;
+    constexpr mapping(extents_type const & extents, std::array<index_type, extents_type::rank()> const & strides) noexcept;
+
+    friend constexpr bool operator==(mapping const &, mapping const &) noexcept = default;
+
+    constexpr extents_type const & extents() const noexcept { return m_extents; }
+
+    template <typename... Indices>
+    requires(
+        sizeof...(Indices) == Extents::rank() &&
+        (std::is_convertible_v<Indices, typename Extents::index_type> && ...) &&
+        (std::is_nothrow_constructible_v<typename Extents::index_type, Indices> && ...))
+    constexpr typename Extents::index_type operator()(Indices... indices) const noexcept;
+
+    constexpr index_type required_span_size() const noexcept { return m_required_span_size; }
+
+    constexpr bool is_unique() const noexcept { return true; }
+    constexpr bool is_exhaustive() const noexcept;
+    constexpr bool is_strided() const noexcept { return true; }
+    constexpr index_type stride(rank_type rank) const noexcept { return m_strides[rank]; }
+
+    static constexpr bool is_always_unique() noexcept { return true; }
+    static constexpr bool is_always_exhaustive() noexcept { return false; }
+    static constexpr bool is_always_strided() noexcept { return true; }
+
+    constexpr index_type origin_offset() const noexcept { return m_origin_offset; }
+    constexpr std::array<index_type, extents_type::rank()> const & strides() const noexcept { return m_strides; }
+
+private:
+
+    extents_type m_extents{};
+    std::array<index_type, extents_type::rank()> m_strides{};
+    index_type m_origin_offset{0};
+    index_type m_required_span_size{0};
+
+    constexpr void initialize_offsets() noexcept;
+};
+
+template <typename Extents>
+constexpr SignedStrideLayout::mapping<Extents>::mapping() noexcept
+{
+    index_type stride = 1;
+    for (rank_type rank = extents_type::rank(); rank > 0; --rank)
+    {
+        m_strides[rank - 1] = stride;
+        stride *= m_extents.extent(rank - 1);
+    }
+    initialize_offsets();
+}
+
+template <typename Extents>
+constexpr SignedStrideLayout::mapping<Extents>::mapping(
+    extents_type const & extents,
+    std::array<index_type, extents_type::rank()> const & strides) noexcept
+    : m_extents(extents)
+    , m_strides(strides)
+{
+    initialize_offsets();
+}
+
+template <typename Extents>
+template <typename... Indices>
+requires(
+    sizeof...(Indices) == Extents::rank() &&
+    (std::is_convertible_v<Indices, typename Extents::index_type> && ...) &&
+    (std::is_nothrow_constructible_v<typename Extents::index_type, Indices> && ...))
+constexpr typename Extents::index_type
+SignedStrideLayout::mapping<Extents>::operator()(Indices... indices) const noexcept
+{
+    index_type offset = m_origin_offset;
+    rank_type rank = 0;
+    ((offset += static_cast<index_type>(indices) * m_strides[rank++]), ...);
+    return offset;
+}
+
+template <typename Extents>
+constexpr bool SignedStrideLayout::mapping<Extents>::is_exhaustive() const noexcept
+{
+    if (m_required_span_size == 0)
+    {
+        return true;
+    }
+
+    index_type element_count = 1;
+    for (rank_type rank = 0; rank < extents_type::rank(); ++rank)
+    {
+        element_count *= m_extents.extent(rank);
+    }
+    return element_count == m_required_span_size;
+}
+
+template <typename Extents>
+constexpr void SignedStrideLayout::mapping<Extents>::initialize_offsets() noexcept
+{
+    index_type min_offset = 0;
+    index_type max_offset = 0;
+
+    for (rank_type rank = 0; rank < extents_type::rank(); ++rank)
+    {
+        if (m_extents.extent(rank) == 0)
+        {
+            m_origin_offset = 0;
+            m_required_span_size = 0;
+            return;
+        }
+
+        index_type const axis_offset = (m_extents.extent(rank) - 1) * m_strides[rank];
+        if (axis_offset < 0)
+        {
+            min_offset += axis_offset;
+        }
+        else
+        {
+            max_offset += axis_offset;
+        }
+    }
+
+    m_origin_offset = -min_offset;
+    m_required_span_size = max_offset - min_offset + 1;
+}
+
+} /* end namespace detail */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/gtests/test_nopython_mdspan.cpp
+++ b/gtests/test_nopython_mdspan.cpp
@@ -4,12 +4,144 @@
  */
 
 #include <solvcon/buffer/buffer.hpp>
+#include <solvcon/buffer/signed_stride_layout.hpp>
+
+#include <array>
+#include <concepts>
+#include <cstddef>
+#include <mdspan>
+#include <type_traits>
 
 #include <gtest/gtest.h>
 
 #ifdef Py_PYTHON_H
 #error "Python.h should not be included."
 #endif
+
+TEST(SignedStrideLayout, positive_strides)
+{
+    namespace mm = solvcon;
+
+    using extents_type = std::dextents<ssize_t, 2>;
+    using mapping_type = mm::detail::SignedStrideLayout::mapping<extents_type>;
+
+    mapping_type const mapping(extents_type(2, 3), std::array<ssize_t, 2>{4, 1});
+
+    EXPECT_EQ(mapping.origin_offset(), 0);
+    EXPECT_EQ(mapping.required_span_size(), 7);
+    EXPECT_EQ(mapping(0, 0), 0);
+    EXPECT_EQ(mapping(1, 2), 6);
+    EXPECT_FALSE(mapping.is_exhaustive());
+}
+
+TEST(SignedStrideLayout, negative_strides)
+{
+    namespace mm = solvcon;
+
+    using extents_type = std::dextents<ssize_t, 2>;
+    using layout_type = mm::detail::SignedStrideLayout;
+    using mapping_type = layout_type::mapping<extents_type>;
+
+    static_assert(std::regular<mapping_type>);
+    static_assert(std::is_nothrow_move_constructible_v<mapping_type>);
+    static_assert(std::is_nothrow_move_assignable_v<mapping_type>);
+    static_assert(std::is_nothrow_swappable_v<mapping_type>);
+
+    mapping_type const mapping(extents_type(3, 4), std::array<ssize_t, 2>{-4, 1});
+
+    static_assert(mapping_type::is_always_unique());
+    static_assert(mapping_type::is_always_strided());
+    EXPECT_EQ(mapping.origin_offset(), 8);
+    EXPECT_EQ(mapping.required_span_size(), 12);
+    EXPECT_EQ(mapping(0, 0), 8);
+    EXPECT_EQ(mapping(0, 3), 11);
+    EXPECT_EQ(mapping(1, 0), 4);
+    EXPECT_EQ(mapping(2, 3), 3);
+    EXPECT_TRUE(mapping.is_exhaustive());
+}
+
+TEST(SignedStrideLayout, mixed_strides_with_padding)
+{
+    namespace mm = solvcon;
+
+    using extents_type = std::dextents<ssize_t, 3>;
+    using mapping_type = mm::detail::SignedStrideLayout::mapping<extents_type>;
+
+    mapping_type const mapping(extents_type(2, 3, 4), std::array<ssize_t, 3>{-16, 4, -1});
+
+    EXPECT_EQ(mapping.origin_offset(), 19);
+    EXPECT_EQ(mapping.required_span_size(), 28);
+    EXPECT_EQ(mapping(0, 0, 0), 19);
+    EXPECT_EQ(mapping(0, 2, 3), 24);
+    EXPECT_EQ(mapping(1, 0, 0), 3);
+    EXPECT_EQ(mapping(1, 2, 3), 8);
+    EXPECT_FALSE(mapping.is_exhaustive());
+}
+
+TEST(SignedStrideLayout, empty_extent)
+{
+    namespace mm = solvcon;
+
+    using extents_type = std::dextents<ssize_t, 3>;
+    using mapping_type = mm::detail::SignedStrideLayout::mapping<extents_type>;
+
+    mapping_type const mapping(extents_type(2, 0, 3), std::array<ssize_t, 3>{-3, 3, 1});
+
+    EXPECT_EQ(mapping.origin_offset(), 0);
+    EXPECT_EQ(mapping.required_span_size(), 0);
+    EXPECT_TRUE(mapping.is_exhaustive());
+}
+
+TEST(SignedStrideLayout, scalar)
+{
+    namespace mm = solvcon;
+
+    using extents_type = std::extents<ssize_t>;
+    using mapping_type = mm::detail::SignedStrideLayout::mapping<extents_type>;
+
+    mapping_type const mapping;
+
+    EXPECT_EQ(mapping.origin_offset(), 0);
+    EXPECT_EQ(mapping.required_span_size(), 1);
+    EXPECT_EQ(mapping(), 0);
+    EXPECT_TRUE(mapping.is_exhaustive());
+}
+
+TEST(SignedStrideLayout, mdspan_with_positive_strides)
+{
+    namespace mm = solvcon;
+
+    using extents_type = std::dextents<ssize_t, 2>;
+    using layout_type = mm::detail::SignedStrideLayout;
+    using mapping_type = layout_type::mapping<extents_type>;
+
+    mapping_type const mapping(extents_type(2, 3), std::array<ssize_t, 2>{4, 1});
+
+    std::array<int, 7> storage{};
+    std::mdspan<int, extents_type, layout_type> view(storage.data(), mapping);
+    view[0, 0] = 10;
+    view[1, 2] = 20;
+    EXPECT_EQ(storage[0], 10);
+    EXPECT_EQ(storage[6], 20);
+}
+
+TEST(SignedStrideLayout, mdspan_with_negative_strides)
+{
+    namespace mm = solvcon;
+
+    using extents_type = std::dextents<ssize_t, 2>;
+    using layout_type = mm::detail::SignedStrideLayout;
+    using mapping_type = layout_type::mapping<extents_type>;
+
+    mapping_type const mapping(extents_type(3, 4), std::array<ssize_t, 2>{-4, 1});
+
+    std::array<int, 12> storage{};
+    std::mdspan<int, extents_type, layout_type> view(storage.data(), mapping);
+    view[0, 0] = 8;
+    view[2, 3] = 3;
+    EXPECT_EQ(storage[8], 8);
+    EXPECT_EQ(storage[3], 3);
+}
 
 TEST(SimpleArray, mdspan_1d)
 {
@@ -384,10 +516,11 @@ TEST(SimpleArray, mdspan_non_contiguous)
 
     // Build a 3x4 view whose stride differs from the row-major layout, so the
     // array is neither C- nor F-contiguous over the underlying buffer.
-    mm::small_vector<ssize_t> shape{3, 4};
-    mm::small_vector<ssize_t> stride{8, 1};
+    using array_type = mm::SimpleArray<double>;
+    array_type::shape_type const shape{3, 4};
+    array_type::sshape_type const stride{8, 1};
     auto buffer = mm::ConcreteBuffer::construct(3 * 8 * sizeof(double));
-    mm::SimpleArray<double> arr(shape, stride, buffer);
+    array_type arr(shape, stride, buffer);
     for (size_t i = 0; i < 24; ++i) { arr.data(i) = static_cast<double>(i); }
 
     EXPECT_FALSE(arr.is_c_contiguous());
@@ -425,6 +558,122 @@ TEST(SimpleArray, mdspan_non_contiguous)
     static_assert(std::is_same_v<decltype(csp)::element_type, const double>);
     EXPECT_EQ(csp.size(), 24u);
     EXPECT_EQ(csp[2 * 8 + 3], 99.0);
+}
+
+TEST(SimpleArray, mdspan_positive_strides_with_data_offset)
+{
+    namespace mm = solvcon;
+
+    auto buffer = mm::ConcreteBuffer::construct(6 * sizeof(double));
+    for (size_t i = 0; i < 6; ++i) { buffer->data<double>()[i] = static_cast<double>(i); }
+
+    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{4}, buffer, 2 * sizeof(double));
+    auto ms = arr.as_mdspan<1>();
+
+    static_assert(std::is_same_v<typename decltype(ms)::layout_type, mm::detail::SignedStrideLayout>);
+    EXPECT_EQ(ms.mapping().origin_offset(), 0);
+    EXPECT_EQ(&ms[0], arr.logical_data());
+    for (size_t i = 0; i < 4; ++i) { EXPECT_EQ(ms[i], arr(i)); }
+
+    ms[1] = 42.0;
+    EXPECT_EQ(arr(1), 42.0);
+    EXPECT_EQ(buffer->data<double>()[3], 42.0);
+}
+
+TEST(SimpleArray, mdspan_negative_strides)
+{
+    namespace mm = solvcon;
+
+    using array_type = mm::SimpleArray<double>;
+    array_type::shape_type const shape{2, 3};
+    array_type::sshape_type const stride{-3, -1};
+    auto buffer = mm::ConcreteBuffer::construct(6 * sizeof(double));
+    for (size_t i = 0; i < 6; ++i) { buffer->data<double>()[i] = static_cast<double>(i); }
+
+    array_type arr(shape, stride, buffer, 5 * sizeof(double));
+    auto ms = arr.as_mdspan<2>();
+
+    EXPECT_EQ(ms.mapping().origin_offset(), 5);
+    EXPECT_EQ(ms.mapping().required_span_size(), 6);
+    EXPECT_EQ(ms.mapping().stride(0), -3);
+    EXPECT_EQ(ms.mapping().stride(1), -1);
+    EXPECT_EQ((&ms[0, 0]), arr.logical_data());
+    EXPECT_EQ((&ms[1, 2]), arr.data());
+    for (size_t i = 0; i < 2; ++i)
+    {
+        for (size_t j = 0; j < 3; ++j)
+        {
+            EXPECT_EQ((ms[i, j]), arr(i, j));
+        }
+    }
+
+    ms[0, 1] = 42.0;
+    EXPECT_EQ(arr(0, 1), 42.0);
+    EXPECT_EQ(buffer->data<double>()[4], 42.0);
+
+    mm::SimpleArray<double> const & carr = arr;
+    auto cms = carr.as_mdspan<2>();
+    static_assert(std::is_same_v<typename decltype(cms)::element_type, double const>);
+    EXPECT_EQ((cms[0, 1]), 42.0);
+}
+
+TEST(SimpleArray, mdspan_mixed_strides_with_padding)
+{
+    namespace mm = solvcon;
+
+    using array_type = mm::SimpleArray<double>;
+    array_type::shape_type const shape{2, 3, 2, 4};
+    array_type::sshape_type const stride{-40, 10, -5, 1};
+    auto buffer = mm::ConcreteBuffer::construct(72 * sizeof(double));
+    for (size_t i = 0; i < 72; ++i) { buffer->data<double>()[i] = static_cast<double>(i); }
+
+    array_type arr(shape, stride, buffer, 47 * sizeof(double));
+    auto ms = arr.as_mdspan<4>();
+
+    EXPECT_EQ(ms.mapping().origin_offset(), 45);
+    EXPECT_EQ(ms.mapping().required_span_size(), 69);
+    EXPECT_FALSE(ms.mapping().is_exhaustive());
+    EXPECT_EQ((&ms[0, 0, 0, 0]), arr.logical_data());
+    EXPECT_EQ((&ms[1, 0, 1, 0]), buffer->data<double>() + 2);
+    EXPECT_EQ((&ms[0, 2, 0, 3]), buffer->data<double>() + 70);
+    for (size_t i = 0; i < 2; ++i)
+    {
+        for (size_t j = 0; j < 3; ++j)
+        {
+            for (size_t k = 0; k < 2; ++k)
+            {
+                for (size_t l = 0; l < 4; ++l)
+                {
+                    EXPECT_EQ((ms[i, j, k, l]), arr(i, j, k, l));
+                }
+            }
+        }
+    }
+
+    ms[1, 2, 1, 3] = 99.0;
+    EXPECT_EQ(arr(1, 2, 1, 3), 99.0);
+    EXPECT_EQ(buffer->data<double>()[25], 99.0);
+}
+
+TEST(SimpleArray, mdspan_empty_extent)
+{
+    namespace mm = solvcon;
+
+    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{2, 0, 3});
+    auto ms = arr.as_mdspan<3>();
+
+    EXPECT_EQ(ms.extent(0), 2);
+    EXPECT_EQ(ms.extent(1), 0);
+    EXPECT_EQ(ms.extent(2), 3);
+    EXPECT_EQ(ms.size(), 0);
+    EXPECT_EQ(ms.mapping().origin_offset(), 0);
+    EXPECT_EQ(ms.mapping().required_span_size(), 0);
+    EXPECT_EQ(ms.data_handle(), nullptr);
+
+    mm::SimpleArray<double> const & carr = arr;
+    auto cms = carr.as_mdspan<3>();
+    EXPECT_EQ(cms.size(), 0);
+    EXPECT_EQ(cms.data_handle(), nullptr);
 }
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`std::layout_stride` requires positive strides, so `SimpleArray::as_mdspan()` cannot expose reversed or mixed-sign views.

Add an internal `SignedStrideLayout` that normalizes signed offsets into a non-negative mapped span. Use it in `SimpleArray::as_mdspan()` and anchor the data handle at `logical_data() - origin_offset()` so logical index zero and the storage span remain consistent.

Related to #856.