### PR TITLE
Add the RShortcutManager roof over the keymap core

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/platform.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/keymap.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RShortcutManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxHighlighter.hpp
@@ -72,6 +73,7 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RLinuxThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/keymap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RShortcutManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxHighlighter.cpp

--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -12,6 +12,7 @@
 #include <solvcon/pilot/DrawTool.hpp>
 #include <solvcon/pilot/RAction.hpp>
 #include <solvcon/pilot/RMenuModel.hpp>
+#include <solvcon/pilot/RShortcutManager.hpp>
 #include <solvcon/pilot/RThemeManager.hpp>
 #include <Qt>
 #include <QMenuBar>
@@ -54,6 +55,9 @@ RManager::RManager()
     m_mainWindow->setWindowIcon(QIcon(QString(":/icon.ico")));
     // Parented to the manager to make color-scheme survive a window rebuild.
     m_themeManager = new RThemeManager(this);
+    // The shortcut resolver is parented likewise. No action routes through it
+    // yet; later steps adopt its bindings on both the C++ and Python sides.
+    m_shortcutManager = new RShortcutManager(this);
     // Do not call setUp() from the constructor.  Windows may crash with
     // "exited with code -1073740791".  The reason is not yet clarified.
 }
@@ -65,6 +69,10 @@ RManager & RManager::setUp()
         if (m_themeManager == nullptr)
         {
             m_themeManager = new RThemeManager(this);
+        }
+        if (m_shortcutManager == nullptr)
+        {
+            m_shortcutManager = new RShortcutManager(this);
         }
         // Paint the style and palette for widgets to follow.
         this->m_themeManager->setWindow(m_mainWindow);
@@ -95,6 +103,8 @@ void RManager::reset()
     // its OS color-scheme connection unwinds while that application is alive.
     delete m_themeManager;
     m_themeManager = nullptr;
+    delete m_shortcutManager;
+    m_shortcutManager = nullptr;
     m_owned_core.reset(); // Deletes the application only if the pilot made it.
     m_core = nullptr;
     m_mainWindow = nullptr;

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -33,6 +33,7 @@ namespace solvcon
 
 class RMenuModel;
 class RThemeManager;
+class RShortcutManager;
 
 /**
  * @brief Singleton that owns the pilot main window and coordinates its
@@ -87,6 +88,12 @@ public:
 
     /// The application-wide theme controller, scriptable from Python.
     RThemeManager * themeManager() { return m_themeManager; }
+
+    /**
+     * The keyboard-shortcut resolver, scriptable from Python. Nothing routes
+     * its bindings through the pilot yet; later steps adopt them.
+     */
+    RShortcutManager * shortcutManager() { return m_shortcutManager; }
 
     void quit() { m_core->quit(); }
 
@@ -149,6 +156,12 @@ private:
      * OS color-scheme connection outlive each rebuild of the main window.
      */
     RThemeManager * m_themeManager = nullptr;
+
+    /**
+     * Keyboard-shortcut resolver, parented to the manager so it outlives each
+     * rebuild of the main window like the theme controller.
+     */
+    RShortcutManager * m_shortcutManager = nullptr;
 
     RPythonConsoleDockWidget * m_pycon = nullptr;
     QMdiArea * m_mdiArea = nullptr;

--- a/cpp/solvcon/pilot/RShortcutManager.cpp
+++ b/cpp/solvcon/pilot/RShortcutManager.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RShortcutManager.hpp> // Must be the first include.
+
+#include <cstddef>
+#include <stdexcept>
+#include <variant>
+
+#include <QAction>
+#include <QKeyCombination>
+#include <Qt>
+#include <QtGlobal>
+
+namespace solvcon
+{
+
+namespace
+{
+
+PlatformId detectRunningPlatform()
+{
+    // A thin Qt call, the one place the roof asks the operating system which
+    // phrasebook to read. The keymap core stays free of this branch.
+#if defined(Q_OS_MACOS)
+    return PlatformId::Mac;
+#elif defined(Q_OS_WIN)
+    return PlatformId::Windows;
+#else
+    return PlatformId::Linux;
+#endif
+}
+
+bool hasMod(KeyMod set, KeyMod flag)
+{
+    return (static_cast<unsigned>(set) & static_cast<unsigned>(flag)) != 0;
+}
+
+QKeySequence::StandardKey toStandardKey(StandardAction action)
+{
+    switch (action)
+    {
+    case StandardAction::Undo:
+        return QKeySequence::Undo;
+    case StandardAction::Redo:
+        return QKeySequence::Redo;
+    }
+    throw std::logic_error("Unexpected standard action");
+}
+
+std::string standardKeyName(StandardAction action)
+{
+    switch (action)
+    {
+    case StandardAction::Undo:
+        return "Undo";
+    case StandardAction::Redo:
+        return "Redo";
+    }
+    throw std::logic_error("Unexpected standard action");
+}
+
+Qt::Key toQtKey(Key key)
+{
+    switch (key)
+    {
+    case Key::Escape:
+        return Qt::Key_Escape;
+    }
+    throw std::logic_error("Unexpected key");
+}
+
+Qt::ShortcutContext toQtContext(ShortcutContext context)
+{
+    switch (context)
+    {
+    case ShortcutContext::Application:
+        return Qt::ApplicationShortcut;
+    case ShortcutContext::Window:
+        return Qt::WindowShortcut;
+    case ShortcutContext::Widget:
+        return Qt::WidgetShortcut;
+    }
+    throw std::logic_error("Unexpected context");
+}
+
+QAction::MenuRole toQtMenuRole(MenuRole role)
+{
+    switch (role)
+    {
+    case MenuRole::None:
+        return QAction::NoRole;
+    case MenuRole::Quit:
+        return QAction::QuitRole;
+    case MenuRole::Preferences:
+        return QAction::PreferencesRole;
+    case MenuRole::About:
+        return QAction::AboutRole;
+    }
+    throw std::logic_error("Unexpected role");
+}
+
+} /* end namespace */
+
+RShortcutManager::RShortcutManager(QObject * parent)
+    : QObject(parent)
+    , m_platform(detectRunningPlatform())
+{
+}
+
+RShortcutManager::~RShortcutManager() = default;
+
+ShortcutCapabilities RShortcutManager::capabilities() const
+{
+    return capabilitiesFor(m_platform);
+}
+
+QList<QKeySequence> RShortcutManager::sequencesForBinding(ShortcutBinding const & binding) const
+{
+    if (auto const * standard = std::get_if<StandardAction>(&binding.key))
+    {
+        return QKeySequence::keyBindings(toStandardKey(*standard));
+    }
+    if (auto const * chord = std::get_if<KeyChord>(&binding.key))
+    {
+        // Qt maps ControlModifier to Command on macOS, so a Primary chord
+        // pronounces itself on every platform without a native branch here.
+        Qt::KeyboardModifiers mods = Qt::NoModifier;
+        if (hasMod(chord->mods, KeyMod::Primary))
+        {
+            mods |= Qt::ControlModifier;
+        }
+        if (hasMod(chord->mods, KeyMod::Shift))
+        {
+            mods |= Qt::ShiftModifier;
+        }
+        if (hasMod(chord->mods, KeyMod::Alt))
+        {
+            mods |= Qt::AltModifier;
+        }
+        return {QKeySequence(QKeyCombination(mods, toQtKey(chord->key)))};
+    }
+    return {};
+}
+
+QList<QKeySequence> RShortcutManager::sequencesFor(ShortcutCommand command) const
+{
+    ShortcutBinding const * binding = bindingFor(m_platform, command);
+    if (binding == nullptr)
+    {
+        return {};
+    }
+    return sequencesForBinding(*binding);
+}
+
+void RShortcutManager::applyTo(QAction * action, ShortcutCommand command) const
+{
+    if (action == nullptr)
+    {
+        return;
+    }
+    ShortcutBinding const * binding = bindingFor(m_platform, command);
+    if (binding == nullptr)
+    {
+        return;
+    }
+
+    // The role is set before the action reaches a menu, as macOS requires to
+    // move Quit into the application menu. The context applies to every case,
+    // so re-applying a binding never leaves a stale scope behind.
+    action->setMenuRole(toQtMenuRole(binding->role));
+    action->setShortcutContext(toQtContext(binding->context));
+
+    action->setShortcuts(sequencesForBinding(*binding));
+}
+
+ResolvedShortcut RShortcutManager::resolve(ShortcutCommand command) const
+{
+    ResolvedShortcut resolved;
+    ShortcutBinding const * binding = bindingFor(m_platform, command);
+    if (binding == nullptr)
+    {
+        return resolved;
+    }
+
+    resolved.context = binding->context;
+    resolved.role = binding->role;
+
+    if (auto const * standard = std::get_if<StandardAction>(&binding->key))
+    {
+        resolved.bound = true;
+        resolved.standard = true;
+        resolved.standard_key = standardKeyName(*standard);
+    }
+    else if (std::holds_alternative<KeyChord>(binding->key))
+    {
+        resolved.bound = true;
+    }
+
+    for (QKeySequence const & seq : sequencesForBinding(*binding))
+    {
+        resolved.sequences.push_back(seq.toString(QKeySequence::PortableText).toStdString());
+    }
+    return resolved;
+}
+
+ResolvedShortcut RShortcutManager::resolveById(std::string const & id) const
+{
+    if (auto command = commandFromId(id))
+    {
+        return resolve(*command);
+    }
+    return {};
+}
+
+std::vector<ShortcutConflict> RShortcutManager::findResolvedConflicts() const
+{
+    std::vector<ShortcutBinding> const & table = bindingTable(m_platform);
+
+    std::vector<QList<QKeySequence>> resolved;
+    resolved.reserve(table.size());
+    for (ShortcutBinding const & binding : table)
+    {
+        resolved.push_back(sequencesForBinding(binding));
+    }
+
+    auto bound = [&resolved](std::size_t i)
+    { return !resolved[i].isEmpty(); };
+    auto sequencesClash = [&resolved](std::size_t i, std::size_t j)
+    {
+        for (QKeySequence const & lhs : resolved[i])
+        {
+            if (resolved[j].contains(lhs))
+            {
+                return true;
+            }
+        }
+        return false;
+    };
+    return findConflicts(m_platform, bound, sequencesClash);
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RShortcutManager.hpp
+++ b/cpp/solvcon/pilot/RShortcutManager.hpp
@@ -1,0 +1,132 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * The Qt adapter over the keymap core: the roof of the pilot's shortcut
+ * system. It detects the running platform, turns a command id into the native
+ * key sequences that platform spells it with, applies them to a QAction, and
+ * checks the resolved bindings for collisions Qt's standard keys can hide from
+ * the Qt-free core. Half the pilot's commands are born in Python, so it also
+ * reports a binding as portable values a PySide helper can apply.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/common_detail.hpp> // Must be the first include.
+
+#include <string>
+#include <vector>
+
+#include <solvcon/pilot/keymap.hpp>
+
+#include <QList>
+#include <QKeySequence>
+#include <QObject>
+
+class QAction;
+
+namespace solvcon
+{
+
+/**
+ * @brief A command's binding resolved to values that cross the Python boundary.
+ *
+ * The manager cannot hand a QAction across the pybind and PySide divide, so a
+ * Python-registered action is bound from these plain values instead. A standard
+ * binding names its Qt standard key so PySide can call setShortcuts with it;
+ * a curated binding carries its resolved sequence strings. bound is false when
+ * the command has no key on this platform, though role and context still apply
+ * (macOS Quit is unbound but keeps its application-menu role).
+ */
+struct ResolvedShortcut
+{
+    bool bound = false;
+    bool standard = false;
+    std::string standard_key;
+    std::vector<std::string> sequences;
+    ShortcutContext context = ShortcutContext::Window;
+    MenuRole role = MenuRole::None;
+};
+
+/**
+ * @brief Resolves the keymap core's per-platform tables into live Qt bindings.
+ *
+ * @ingroup group_domain
+ *
+ * Built once and asked for a command's binding by id. The C++ side applies a
+ * binding straight to its QAction through applyTo; the Python side asks for the
+ * same binding as portable values and applies them with PySide. shortcutsChanged
+ * is scaffolding for the later customization layer and has no consumer yet.
+ */
+class RShortcutManager
+    : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    explicit RShortcutManager(QObject * parent = nullptr);
+
+    ~RShortcutManager() override;
+
+    /// The running platform, naming the table the bindings resolve from.
+    PlatformId platform() const { return m_platform; }
+
+    /// What the running platform's keymap can honor.
+    ShortcutCapabilities capabilities() const;
+
+    /**
+     * The native key sequences for @p command on the running platform, empty
+     * when the command carries no binding. A standard action can expose more
+     * than one native sequence, so the result is a list.
+     */
+    QList<QKeySequence> sequencesFor(ShortcutCommand command) const;
+
+    /**
+     * Apply @p command's binding to @p action: its sequences, shortcut context,
+     * and menu role. The role is set first, as macOS requires before placement.
+     * A no-op on a null action or a command with no binding.
+     */
+    void applyTo(QAction * action, ShortcutCommand command) const;
+
+    /// @p command's binding as portable values for the Python layer to apply.
+    ResolvedShortcut resolve(ShortcutCommand command) const;
+
+    /**
+     * The binding for the action objectName @p id, or an unbound result when
+     * no command carries that id.
+     */
+    ResolvedShortcut resolveById(std::string const & id) const;
+
+    /**
+     * Commands whose resolved sequences collide in contexts that can be active
+     * together, under the same conservative overlap rule the core uses. This
+     * catches a curated chord clashing with a Qt standard key, which the
+     * declared checker cannot see because it leaves standard keys symbolic.
+     */
+    std::vector<ShortcutConflict> findResolvedConflicts() const;
+
+signals:
+
+    /**
+     * Emitted when the resolved bindings change. No caller consumes it in the
+     * default-binding steps; it is scaffolding for user rebinding later.
+     */
+    void shortcutsChanged();
+
+private:
+
+    QList<QKeySequence> sequencesForBinding(ShortcutBinding const & binding) const;
+
+    PlatformId m_platform;
+
+}; /* end class RShortcutManager */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/keymap.cpp
+++ b/cpp/solvcon/pilot/keymap.cpp
@@ -5,6 +5,7 @@
 
 #include <solvcon/pilot/keymap.hpp>
 
+#include <array>
 #include <cstddef>
 #include <stdexcept>
 #include <variant>
@@ -69,6 +70,48 @@ std::string_view commandId(ShortcutCommand command)
     throw std::logic_error("Unexpected command");
 }
 
+std::string_view contextName(ShortcutContext context)
+{
+    switch (context)
+    {
+    case ShortcutContext::Application:
+        return "application";
+    case ShortcutContext::Window:
+        return "window";
+    case ShortcutContext::Widget:
+        return "widget";
+    }
+    throw std::logic_error("Unexpected context");
+}
+
+std::string_view roleName(MenuRole role)
+{
+    switch (role)
+    {
+    case MenuRole::None:
+        return "none";
+    case MenuRole::Quit:
+        return "quit";
+    case MenuRole::Preferences:
+        return "preferences";
+    case MenuRole::About:
+        return "about";
+    }
+    throw std::logic_error("Unexpected role");
+}
+
+std::optional<ShortcutCommand> commandFromId(std::string_view id)
+{
+    for (auto command : ALL_SHORTCUT_COMMANDS)
+    {
+        if (commandId(command) == id)
+        {
+            return command;
+        }
+    }
+    return std::nullopt;
+}
+
 std::vector<ShortcutBinding> const & bindingTable(PlatformId platform)
 {
     switch (platform)
@@ -121,29 +164,12 @@ bool contextsOverlap(ShortcutContext lhs, ShortcutContext rhs)
 
 std::vector<ShortcutConflict> findDeclaredConflicts(PlatformId platform)
 {
-    std::vector<ShortcutConflict> conflicts;
-    auto const & table = bindingTable(platform);
-    for (std::size_t i = 0; i < table.size(); ++i)
-    {
-        auto const * chord_i = std::get_if<KeyChord>(&table[i].key);
-        if (chord_i == nullptr)
-        {
-            continue;
-        }
-        for (std::size_t j = i + 1; j < table.size(); ++j)
-        {
-            auto const * chord_j = std::get_if<KeyChord>(&table[j].key);
-            if (chord_j == nullptr)
-            {
-                continue;
-            }
-            if (*chord_i == *chord_j && contextsOverlap(table[i].context, table[j].context))
-            {
-                conflicts.push_back({table[i].command, table[j].command});
-            }
-        }
-    }
-    return conflicts;
+    std::vector<ShortcutBinding> const & table = bindingTable(platform);
+    auto isChord = [&table](std::size_t i)
+    { return std::holds_alternative<KeyChord>(table[i].key); };
+    auto chordsEqual = [&table](std::size_t i, std::size_t j)
+    { return std::get<KeyChord>(table[i].key) == std::get<KeyChord>(table[j].key); };
+    return findConflicts(platform, isChord, chordsEqual);
 }
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/keymap.hpp
+++ b/cpp/solvcon/pilot/keymap.hpp
@@ -16,6 +16,9 @@
  * @ingroup group_domain
  */
 
+#include <array>
+#include <cstddef>
+#include <optional>
 #include <string_view>
 #include <variant>
 #include <vector>
@@ -117,6 +120,19 @@ struct ShortcutBinding
     MenuRole role = MenuRole::None;
 };
 
+/**
+ * Every command the vocabulary names, the single list the id lookups and their
+ * tests iterate. Adding a command here is what forces commandId and
+ * commandFromId to stay in step, so neither can silently miss one.
+ */
+inline constexpr auto ALL_SHORTCUT_COMMANDS = std::to_array<ShortcutCommand>(
+    {ShortcutCommand::Undo,
+     ShortcutCommand::Redo,
+     ShortcutCommand::CameraReset,
+     ShortcutCommand::Exit,
+     ShortcutCommand::Console,
+     ShortcutCommand::AgentPanel});
+
 struct ShortcutCapabilities
 {
     PlatformId platform;
@@ -131,6 +147,25 @@ struct ShortcutConflict
 };
 
 std::string_view commandId(ShortcutCommand command);
+
+/**
+ * The stable id of a context ("application", "window", "widget"), for the
+ * Python boundary and tests.
+ */
+std::string_view contextName(ShortcutContext context);
+
+/**
+ * The stable id of a menu role ("none", "quit", "preferences", "about"), for
+ * the Python boundary and tests.
+ */
+std::string_view roleName(MenuRole role);
+
+/**
+ * The command named by @p id (the action objectName), or an empty optional
+ * when no command carries that id. The inverse of commandId, so the Python
+ * layer can resolve a binding from an action's objectName.
+ */
+std::optional<ShortcutCommand> commandFromId(std::string_view id);
 
 std::vector<ShortcutBinding> const & bindingTable(PlatformId platform);
 
@@ -148,6 +183,41 @@ ShortcutCapabilities capabilitiesFor(PlatformId platform);
  * Widget overlaps Widget. Symmetric.
  */
 bool contextsOverlap(ShortcutContext lhs, ShortcutContext rhs);
+
+/**
+ * The pairwise-conflict skeleton over @p platform's binding table: a command
+ * pair collides when both indices are @p eligible, their contexts overlap, and
+ * @p equal reports their keys the same. The core injects a symbolic chord
+ * comparison; the Qt roof injects a resolved-sequence comparison, so the loop
+ * and the overlap rule live here once. Both predicates take table indices.
+ */
+template <typename Eligible, typename Equal>
+std::vector<ShortcutConflict>
+findConflicts(PlatformId platform, Eligible eligible, Equal equal)
+{
+    std::vector<ShortcutBinding> const & table = bindingTable(platform);
+
+    std::vector<ShortcutConflict> conflicts;
+    for (std::size_t i = 0; i < table.size(); ++i)
+    {
+        if (!eligible(i))
+        {
+            continue;
+        }
+        for (std::size_t j = i + 1; j < table.size(); ++j)
+        {
+            if (!eligible(j) || !contextsOverlap(table[i].context, table[j].context))
+            {
+                continue;
+            }
+            if (equal(i, j))
+            {
+                conflicts.push_back({table[i].command, table[j].command});
+            }
+        }
+    }
+    return conflicts;
+}
 
 std::vector<ShortcutConflict> findDeclaredConflicts(PlatformId platform);
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -10,6 +10,7 @@
 
 #include <solvcon/pilot/R2DWidget.hpp>
 #include <solvcon/pilot/RMenuModel.hpp>
+#include <solvcon/pilot/RShortcutManager.hpp>
 #include <solvcon/pilot/RThemeManager.hpp>
 #include <solvcon/pilot/pilot.hpp>
 
@@ -961,6 +962,39 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 [](wrapped_type & self)
                 {
                     return self.themeManager()->capabilities().has_native_style;
+                })
+            .def_property_readonly(
+                "shortcut_platform",
+                [](wrapped_type & self)
+                {
+                    return std::string(platformIdName(self.shortcutManager()->platform()));
+                })
+            .def(
+                "resolve_shortcut",
+                [](wrapped_type & self, std::string const & command_id)
+                {
+                    ResolvedShortcut const r = self.shortcutManager()->resolveById(command_id);
+                    py::dict out;
+                    out["bound"] = r.bound;
+                    out["standard"] = r.standard;
+                    out["standard_key"] = r.standard_key;
+                    out["sequences"] = r.sequences;
+                    out["context"] = std::string(contextName(r.context));
+                    out["role"] = std::string(roleName(r.role));
+                    return out;
+                },
+                py::arg("command_id"))
+            .def(
+                "shortcut_conflicts",
+                [](wrapped_type & self)
+                {
+                    std::vector<std::pair<std::string, std::string>> pairs;
+                    for (auto const & conflict : self.shortcutManager()->findResolvedConflicts())
+                    {
+                        pairs.emplace_back(
+                            std::string(commandId(conflict.first)), std::string(commandId(conflict.second)));
+                    }
+                    return pairs;
                 })
             .def(
                 "quit",

--- a/gtests/test_nopython_pilot_keymap.cpp
+++ b/gtests/test_nopython_pilot_keymap.cpp
@@ -6,6 +6,7 @@
 #include <solvcon/pilot/keymap.hpp>
 
 #include <array>
+#include <optional>
 #include <variant>
 
 #include <gtest/gtest.h>
@@ -73,6 +74,26 @@ TEST(PilotKeymapConflicts, DefaultTablesHaveNoDeclaredConflicts)
     {
         EXPECT_TRUE(solvcon::findDeclaredConflicts(platform).empty());
     }
+}
+
+TEST(PilotKeymapId, CommandFromIdInvertsCommandId)
+{
+    for (auto command : solvcon::ALL_SHORTCUT_COMMANDS)
+    {
+        auto found = solvcon::commandFromId(solvcon::commandId(command));
+        ASSERT_TRUE(found.has_value());
+        EXPECT_EQ(*found, command);
+    }
+    EXPECT_FALSE(solvcon::commandFromId("no.such.command").has_value());
+}
+
+TEST(PilotKeymapId, ContextAndRoleHaveStableNames)
+{
+    EXPECT_EQ(solvcon::contextName(solvcon::ShortcutContext::Application), "application");
+    EXPECT_EQ(solvcon::contextName(solvcon::ShortcutContext::Window), "window");
+    EXPECT_EQ(solvcon::contextName(solvcon::ShortcutContext::Widget), "widget");
+    EXPECT_EQ(solvcon::roleName(solvcon::MenuRole::None), "none");
+    EXPECT_EQ(solvcon::roleName(solvcon::MenuRole::Quit), "quit");
 }
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_shortcut.py
+++ b/tests/test_pilot_shortcut.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class ShortcutResolutionTC(unittest.TestCase):
+    """The roof resolves a command id to portable values the Python layer can
+    apply. No action is routed through it yet; these check the resolution."""
+
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+
+    def test_platform_is_recognized(self):
+        self.assertIn(self.mgr.shortcut_platform, ("linux", "mac", "windows"))
+
+    def test_undo_resolves_to_its_standard_key(self):
+        r = self.mgr.resolve_shortcut("edit.undo")
+        self.assertTrue(r["bound"])
+        self.assertTrue(r["standard"])
+        self.assertEqual(r["standard_key"], "Undo")
+        self.assertEqual(r["context"], "window")
+        self.assertTrue(r["sequences"])
+
+    def test_camera_reset_resolves_to_a_curated_chord(self):
+        r = self.mgr.resolve_shortcut("camera.reset")
+        self.assertTrue(r["bound"])
+        self.assertFalse(r["standard"])
+        self.assertEqual(r["context"], "widget")
+        self.assertEqual(r["role"], "none")
+        self.assertEqual(r["sequences"], ["Esc"])
+
+    def test_exit_role_follows_the_platform(self):
+        r = self.mgr.resolve_shortcut("file.exit")
+        if self.mgr.shortcut_platform == "mac":
+            # macOS carries the Quit application-menu role with no key yet.
+            self.assertFalse(r["bound"])
+            self.assertEqual(r["role"], "quit")
+            self.assertEqual(r["context"], "application")
+        else:
+            # No Exit entry off macOS until a later step binds it.
+            self.assertFalse(r["bound"])
+            self.assertEqual(r["role"], "none")
+
+    def test_unknown_command_is_unbound(self):
+        r = self.mgr.resolve_shortcut("no.such.command")
+        self.assertFalse(r["bound"])
+        self.assertEqual(r["sequences"], [])
+
+    def test_resolved_bindings_do_not_collide(self):
+        self.assertEqual(self.mgr.shortcut_conflicts(), [])
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Step 2 of the pilot keyboard-shortcut system (#1070): adds RShortcutManager, the Qt roof that resolves a command id into native QKeySequence bindings and exposes them to Python, and extends the keymap core with the id and name lookups it needs, wiring the manager into RManager without routing any action through it yet.

Stacked on #1104 (shared platform axis and comment-marker cleanup); until that merges to master this PR's diff also carries those two commits. Review #1104 first.

Related to #1070.
