### PR TITLE
Extract the shared platform axis and fix Doxygen comment markers

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RWindowsThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RLinuxThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/keymap.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp

--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -168,9 +168,11 @@ RDomainWidget * RManager::currentR3DWidget()
     return domainWidgetOf(m_mdiArea->currentSubWindow());
 }
 
-/// The RDomainWidget hosted by @p subwin, or nullptr when @p subwin holds
-/// some other widget. The viewer sits inside a plain container widget, so
-/// reach through the subwindow's direct child to find it.
+/**
+ * The RDomainWidget hosted by @p subwin, or nullptr when @p subwin holds
+ * some other widget. The viewer sits inside a plain container widget, so
+ * reach through the subwindow's direct child to find it.
+ */
 RDomainWidget * RManager::domainWidgetOf(QMdiSubWindow * subwin)
 {
     if (subwin == nullptr)

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -103,12 +103,16 @@ private:
     void setUpCentral();
     void setUpMenu();
 
-    /// Park a hidden QRhiWidget in the main window so the top-level adopts
-    /// render-to-texture composition once, up front, before any user content.
+    /**
+     * Park a hidden QRhiWidget in the main window so the top-level adopts
+     * render-to-texture composition once, up front, before any user content.
+     */
     void primeRhiComposition();
 
-    /// Push the active draw tool onto the focused 2D canvas, if any. A
-    /// no-op when the focused subwindow is not a 2D canvas.
+    /**
+     * Push the active draw tool onto the focused 2D canvas, if any. A
+     * no-op when the focused subwindow is not a 2D canvas.
+     */
     void applyDrawTool();
 
     void setUpEditMenuItems() const;
@@ -116,8 +120,10 @@ private:
     void setUpCameraControllersMenuItems() const;
     void setUpCameraMovementMenuItems() const;
 
-    /// Undo or redo the most recent shape change on the focused 2D canvas,
-    /// then repaint it. A no-op when no 2D canvas is focused.
+    /**
+     * Undo or redo the most recent shape change on the focused 2D canvas,
+     * then repaint it. A no-op when no 2D canvas is focused.
+     */
     void undoCanvas() const;
     void redoCanvas() const;
 
@@ -138,19 +144,25 @@ private:
     /// Live menu model owned by the widget tree (parented to the main window).
     RMenuModel * m_menuModel = nullptr;
 
-    /// Application-wide theme controller, parented to the manager so it and its
-    /// OS color-scheme connection outlive each rebuild of the main window.
+    /**
+     * Application-wide theme controller, parented to the manager so it and its
+     * OS color-scheme connection outlive each rebuild of the main window.
+     */
     RThemeManager * m_themeManager = nullptr;
 
     RPythonConsoleDockWidget * m_pycon = nullptr;
     QMdiArea * m_mdiArea = nullptr;
 
-    /// Hidden QRhiWidget that keeps the main window in render-to-texture
-    /// composition mode for the whole session. Owned by the widget tree.
+    /**
+     * Hidden QRhiWidget that keeps the main window in render-to-texture
+     * composition mode for the whole session. Owned by the widget tree.
+     */
     RDomainWidget * m_rhi_primer = nullptr;
 
-    /// Active canvas drawing tool, shared by every 2D canvas. Starts on
-    /// the default tool (pan navigation).
+    /**
+     * Active canvas drawing tool, shared by every 2D canvas. Starts on
+     * the default tool (pan navigation).
+     */
     std::string m_draw_tool = default_draw_tool_name();
 }; /* end class RManager */
 

--- a/cpp/solvcon/pilot/keymap.hpp
+++ b/cpp/solvcon/pilot/keymap.hpp
@@ -20,15 +20,10 @@
 #include <variant>
 #include <vector>
 
+#include <solvcon/pilot/platform.hpp>
+
 namespace solvcon
 {
-
-enum class PlatformId
-{
-    Linux,
-    Mac,
-    Windows
-};
 
 enum class ShortcutContext
 {

--- a/cpp/solvcon/pilot/keymap.hpp
+++ b/cpp/solvcon/pilot/keymap.hpp
@@ -51,10 +51,12 @@ enum class StandardAction
     Redo
 };
 
-/// A modifier role, written against the command modifier rather than a
-/// physical key: Primary is Command on macOS and Control elsewhere. A flag
-/// set so a chord can name more than one modifier; the roof adds the bitwise
-/// combine and test helpers when it resolves a chord into Qt modifiers.
+/**
+ * A modifier role, written against the command modifier rather than a
+ * physical key: Primary is Command on macOS and Control elsewhere. A flag
+ * set so a chord can name more than one modifier; the roof adds the bitwise
+ * combine and test helpers when it resolves a chord into Qt modifiers.
+ */
 enum class KeyMod : unsigned
 {
     None = 0,
@@ -63,10 +65,12 @@ enum class KeyMod : unsigned
     Alt = 1u << 2
 };
 
-/// A physical key a curated chord names. The vocabulary stays small: only the
-/// keys the pilot binds today, growing as later steps add curated chords.
-/// Arrow keys are deliberately absent; they belong to
-/// RDomainWidget::keyPressEvent, not the action system.
+/**
+ * A physical key a curated chord names. The vocabulary stays small: only the
+ * keys the pilot binds today, growing as later steps add curated chords.
+ * Arrow keys are deliberately absent; they belong to
+ * RDomainWidget::keyPressEvent, not the action system.
+ */
 enum class Key
 {
     Escape
@@ -87,15 +91,19 @@ struct Unbound
 {
 };
 
-/// A key spelling is either a standard action, a curated chord, or unbound.
-/// Unbound is a placeholder for a command that has no binding on a platform yet.
-/// StandardAction is a placeholder for a command that defers to Qt's standard sequence for that action.
-/// KeyChord is a curated chord that the pilot binds to a command.
+/**
+ * A key spelling is either a standard action, a curated chord, or unbound.
+ * Unbound is a placeholder for a command that has no binding on a platform yet.
+ * StandardAction is a placeholder for a command that defers to Qt's standard sequence for that action.
+ * KeyChord is a curated chord that the pilot binds to a command.
+ */
 using KeySpelling = std::variant<Unbound, StandardAction, KeyChord>;
 
-/// A command named by the objectName the pilot already gives its action, so
-/// the vocabulary names existing commands across both the C++ and Python
-/// layers rather than inventing ids.
+/**
+ * A command named by the objectName the pilot already gives its action, so
+ * the vocabulary names existing commands across both the C++ and Python
+ * layers rather than inventing ids.
+ */
 enum class ShortcutCommand
 {
     Undo,
@@ -131,15 +139,19 @@ std::string_view commandId(ShortcutCommand command);
 
 std::vector<ShortcutBinding> const & bindingTable(PlatformId platform);
 
-/// The binding for @p command on @p platform, or nullptr when the command
-/// carries none on that platform yet.
+/**
+ * The binding for @p command on @p platform, or nullptr when the command
+ * carries none on that platform yet.
+ */
 ShortcutBinding const * bindingFor(PlatformId platform, ShortcutCommand command);
 
 ShortcutCapabilities capabilitiesFor(PlatformId platform);
 
-/// Whether two contexts can be active together, under the conservative rule:
-/// Application overlaps every context, Window overlaps Window and Widget, and
-/// Widget overlaps Widget. Symmetric.
+/**
+ * Whether two contexts can be active together, under the conservative rule:
+ * Application overlaps every context, Window overlaps Window and Widget, and
+ * Widget overlaps Widget. Symmetric.
+ */
 bool contextsOverlap(ShortcutContext lhs, ShortcutContext rhs);
 
 std::vector<ShortcutConflict> findDeclaredConflicts(PlatformId platform);

--- a/cpp/solvcon/pilot/platform.hpp
+++ b/cpp/solvcon/pilot/platform.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * The platform axis shared by the pilot's Qt-free cores.
+ *
+ * Both the theme foundation and the keymap foundation carry a per-platform
+ * table, so they name the same axis here rather than each defining its own.
+ * Detecting the running platform is a thin Qt call made in an adapter and the
+ * result passed in, which keeps this header free of Qt.
+ *
+ * @ingroup group_domain
+ */
+
+namespace solvcon
+{
+
+/// The platform a per-platform table or capability record is written for.
+enum class PlatformId
+{
+    Linux,
+    Mac,
+    Windows
+};
+
+/**
+ * The stable identifier for a platform ("linux", "mac", "windows"), used at
+ * the Python boundary and in tests.
+ */
+inline char const * platformIdName(PlatformId platform)
+{
+    switch (platform)
+    {
+    case PlatformId::Linux:
+        return "linux";
+    case PlatformId::Mac:
+        return "mac";
+    case PlatformId::Windows:
+        return "windows";
+    }
+    return "linux";
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/theme.cpp
+++ b/cpp/solvcon/pilot/theme.cpp
@@ -413,20 +413,6 @@ ThemeLook themeLookFromId(char const * id)
     return ThemeLook::Curated;
 }
 
-char const * platformIdName(PlatformId platform)
-{
-    switch (platform)
-    {
-    case PlatformId::Mac:
-        return "mac";
-    case PlatformId::Windows:
-        return "windows";
-    case PlatformId::Linux:
-    default:
-        return "linux";
-    }
-}
-
 bool linuxDesktopHasNativeTheme(char const * xdg_current_desktop)
 {
     if (xdg_current_desktop == nullptr)

--- a/cpp/solvcon/pilot/theme.hpp
+++ b/cpp/solvcon/pilot/theme.hpp
@@ -171,8 +171,10 @@ struct ThemeCapabilities
     bool has_native_style = false;
 };
 
-/// The curated light palette, the shared fallback every platform table seeds
-/// from until its room is furnished.
+/**
+ * The curated light palette, the shared fallback every platform table seeds
+ * from until its room is furnished.
+ */
 ThemePalette const & lightThemePalette();
 
 /// The curated dark palette.
@@ -201,8 +203,10 @@ ThemeCapabilities const & themeCapabilitiesFor(PlatformId platform);
  */
 ThemeVariant resolveThemeVariant(ThemeMode mode, bool os_prefers_dark);
 
-/// The stable identifier for a mode, used as the menu action object name, at
-/// the Python boundary, and in tests ("system", "light", "dark").
+/**
+ * The stable identifier for a mode, used as the menu action object name, at
+ * the Python boundary, and in tests ("system", "light", "dark").
+ */
 char const * themeModeId(ThemeMode mode);
 
 /// The human-readable menu label for a mode.
@@ -211,8 +215,10 @@ char const * themeModeLabel(ThemeMode mode);
 /// The mode named by @p id, or ThemeMode::System when @p id matches none.
 ThemeMode themeModeFromId(char const * id);
 
-/// The stable identifier for a look ("system", "curated"), used as the menu
-/// action object name, at the Python boundary, and in tests.
+/**
+ * The stable identifier for a look ("system", "curated"), used as the menu
+ * action object name, at the Python boundary, and in tests.
+ */
 char const * themeLookId(ThemeLook look);
 
 /// The human-readable menu label for a look.

--- a/cpp/solvcon/pilot/theme.hpp
+++ b/cpp/solvcon/pilot/theme.hpp
@@ -23,6 +23,8 @@
 
 #include <cstdint>
 
+#include <solvcon/pilot/platform.hpp>
+
 namespace solvcon
 {
 
@@ -58,21 +60,6 @@ enum class ThemeLook
 {
     System,
     Curated,
-};
-
-/**
- * @brief The platform a color table and a capability record are written for.
- *
- * The palette lookup carries this axis so each platform's look is tuned in its
- * own table without disturbing the others. Detecting the running platform is a
- * thin Qt call made in the adapter and passed in here, which keeps this
- * foundation free of Qt.
- */
-enum class PlatformId
-{
-    Linux,
-    Mac,
-    Windows,
 };
 
 /**
@@ -226,10 +213,6 @@ char const * themeLookLabel(ThemeLook look);
 
 /// The look named by @p id, or ThemeLook::Curated when @p id matches none.
 ThemeLook themeLookFromId(char const * id);
-
-/// The stable identifier for a platform ("linux", "mac", "windows"), used at
-/// the Python boundary and in tests.
-char const * platformIdName(PlatformId platform);
 
 /**
  * @brief Whether a Linux desktop names a theme the pilot recognizes.


### PR DESCRIPTION
Preparatory cleanup split out of the shortcut-manager work (#1070): moves the duplicated PlatformId axis out of theme.hpp and keymap.hpp into a shared Qt-free platform.hpp both cores include, and converts the multi-line /// briefs in the pilot cores to /** */ as STYLE.md requires.

Related to #1070.
