### PR TITLE
Import the agent package as a module in its tests

### DIFF
--- a/tests/test_agent_backend.py
+++ b/tests/test_agent_backend.py
@@ -10,26 +10,18 @@ GUI-free: only the pure-Python backend module is imported, never an
 
 import unittest
 
-from solvcon.agent import (
-    AgentBackend,
-    BackendResponse,
-    EchoBackend,
-    all_backends,
-    available_backends,
-    get_backend,
-    register,
-)
+from solvcon import agent
 
 
 class AgentBackendABCTC(unittest.TestCase):
     def test_abstract_cannot_instantiate(self):
         with self.assertRaises(TypeError):
-            AgentBackend()
+            agent.AgentBackend()
 
     def test_partial_subclass_cannot_instantiate(self):
         # Missing send() leaves an abstract method, guarding the contract that
         # every concrete backend (Claude, Codex, ...) fills all three.
-        class Partial(AgentBackend):
+        class Partial(agent.AgentBackend):
             name = "partial"
 
             def available(self):
@@ -42,44 +34,47 @@ class AgentBackendABCTC(unittest.TestCase):
 class EchoBackendTC(unittest.TestCase):
     def test_available_true_without_config(self):
         # Needs no key or process, so it is the guaranteed default backend.
-        self.assertTrue(EchoBackend().available())
+        self.assertTrue(agent.EchoBackend().available())
 
     def test_send_is_deterministic_and_safe(self):
-        backend = EchoBackend()
+        backend = agent.EchoBackend()
         first = backend.send("hello", "scene", [])
         second = backend.send("hello", "scene", [])
         self.assertEqual(first, second)
-        self.assertIsInstance(first, BackendResponse)
+        self.assertIsInstance(first, agent.BackendResponse)
         self.assertEqual(first.commands, [])  # no drawing: safe no-op
         self.assertIn("hello", first.text)
 
 
 class RegistryTC(unittest.TestCase):
     def test_echo_is_always_available(self):
-        # EchoBackend registers on import, so the selector always has an entry.
-        names = [b.name for b in available_backends()]
-        self.assertIn(EchoBackend().name, names)
+        # EchoBackend registers on import, so the selector always has an
+        # entry.
+        names = [b.name for b in agent.available_backends()]
+        self.assertIn(agent.EchoBackend().name, names)
 
     def test_get_backend_by_name(self):
-        backend = get_backend(EchoBackend().name)
+        backend = agent.get_backend(agent.EchoBackend().name)
         self.assertIsNotNone(backend)
-        self.assertEqual(backend.name, EchoBackend().name)
+        self.assertEqual(backend.name, agent.EchoBackend().name)
 
     def test_register_replaces_same_name(self):
         # Re-registering a name swaps the instance, so a re-import cannot grow
         # the registry.
-        before = len(all_backends())
+        before = len(agent.all_backends())
 
-        class Echo2(EchoBackend):
+        class Echo2(agent.EchoBackend):
             pass
 
         replacement = Echo2()
         try:
-            register(replacement)
-            self.assertEqual(len(all_backends()), before)
-            self.assertIs(get_backend(EchoBackend().name), replacement)
+            agent.register(replacement)
+            self.assertEqual(len(agent.all_backends()), before)
+            self.assertIs(agent.get_backend(agent.EchoBackend().name),
+                          replacement)
         finally:
-            register(EchoBackend())  # restore default for other tests
+            # Restore the default for other tests.
+            agent.register(agent.EchoBackend())
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_backends_impl.py
+++ b/tests/test_agent_backends_impl.py
@@ -16,14 +16,7 @@ import subprocess
 import unittest
 from unittest import mock
 
-from solvcon.agent import (
-    BackendResponse,
-    ClaudeCliBackend,
-    OpenAIHttpBackend,
-    SubprocessBackend,
-    get_backend,
-    parse_tool_calls,
-)
+from solvcon import agent
 
 
 _WHICH = "solvcon.agent._backends_impl.shutil.which"
@@ -38,77 +31,77 @@ class ParseToolCallsTC(unittest.TestCase):
     def test_plain_json_array(self):
         text = '[{"op": "add_circle", "r": 1.0}]'
         self.assertEqual(
-            parse_tool_calls(text, _TOOLS),
+            agent.parse_tool_calls(text, _TOOLS),
             [{"op": "add_circle", "r": 1.0}])
 
     def test_lone_object_becomes_one_command(self):
-        commands = parse_tool_calls('{"op": "add_line"}', _TOOLS)
+        commands = agent.parse_tool_calls('{"op": "add_line"}', _TOOLS)
         self.assertEqual(commands, [{"op": "add_line"}])
 
     def test_strips_code_fence(self):
         text = '```json\n[{"op": "add_circle"}]\n```'
-        self.assertEqual(parse_tool_calls(text, _TOOLS),
+        self.assertEqual(agent.parse_tool_calls(text, _TOOLS),
                          [{"op": "add_circle"}])
 
     def test_extracts_array_from_surrounding_prose(self):
         text = 'Sure! Here you go:\n[{"op": "add_circle"}]\nThanks.'
-        self.assertEqual(parse_tool_calls(text, _TOOLS),
+        self.assertEqual(agent.parse_tool_calls(text, _TOOLS),
                          [{"op": "add_circle"}])
 
     def test_empty_array_is_empty(self):
-        self.assertEqual(parse_tool_calls("[]", _TOOLS), [])
+        self.assertEqual(agent.parse_tool_calls("[]", _TOOLS), [])
 
     def test_no_json_yields_empty(self):
-        self.assertEqual(parse_tool_calls("I cannot help.", _TOOLS), [])
+        self.assertEqual(agent.parse_tool_calls("I cannot help.", _TOOLS), [])
 
     def test_malformed_json_rejected(self):
         # A JSON-looking but invalid payload must not become a successful
         # empty batch; send() should record a parser error instead.
         with self.assertRaises(ValueError):
-            parse_tool_calls('[{"op": "add_circle",}]', _TOOLS)
+            agent.parse_tool_calls('[{"op": "add_circle",}]', _TOOLS)
         with self.assertRaises(ValueError):
-            parse_tool_calls('[{"op": "add_circle"', _TOOLS)
+            agent.parse_tool_calls('[{"op": "add_circle"', _TOOLS)
 
     def test_unknown_op_rejected(self):
         with self.assertRaises(ValueError):
-            parse_tool_calls('[{"op": "delete_universe"}]', _TOOLS)
+            agent.parse_tool_calls('[{"op": "delete_universe"}]', _TOOLS)
 
     def test_missing_op_rejected(self):
         with self.assertRaises(ValueError):
-            parse_tool_calls('[{"r": 1.0}]', _TOOLS)
+            agent.parse_tool_calls('[{"r": 1.0}]', _TOOLS)
 
     def test_non_string_op_raises_valueerror_not_typeerror(self):
         # An unhashable op (list/object) must not blow past the ValueError
         # contract into a set-membership TypeError, or send() would crash
         # instead of recording an error.
         with self.assertRaises(ValueError):
-            parse_tool_calls('[{"op": {"nested": 1}}]', _TOOLS)
+            agent.parse_tool_calls('[{"op": {"nested": 1}}]', _TOOLS)
         with self.assertRaises(ValueError):
-            parse_tool_calls('[{"op": ["a", "b"]}]', _TOOLS)
+            agent.parse_tool_calls('[{"op": ["a", "b"]}]', _TOOLS)
 
     def test_no_tool_surface_skips_op_validation(self):
         # With no advertised ops (e.g. Agent Draw absent) any op is accepted,
         # so the pipeline still runs rather than rejecting everything.
-        commands = parse_tool_calls('[{"op": "anything"}]', [])
+        commands = agent.parse_tool_calls('[{"op": "anything"}]', [])
         self.assertEqual(commands, [{"op": "anything"}])
 
 
 class SubprocessBackendDiscoveryTC(unittest.TestCase):
     def test_available_true_when_on_path(self):
-        backend = ClaudeCliBackend()
+        backend = agent.ClaudeCliBackend()
         with mock.patch(_WHICH, lambda name: "/usr/bin/" + name):
             self.assertTrue(backend.available())
             self.assertEqual(backend.executable(), "/usr/bin/claude")
 
     def test_available_false_when_absent(self):
-        backend = ClaudeCliBackend()
+        backend = agent.ClaudeCliBackend()
         with mock.patch(_WHICH, lambda name: None):
             self.assertFalse(backend.available())
 
     def test_command_none_never_resolves(self):
         # A subclass that names no executable is never available even though
         # which() would answer for a real name.
-        class Nameless(SubprocessBackend):
+        class Nameless(agent.SubprocessBackend):
             def _build_argv(self, exe, prompt):
                 return [exe]
 
@@ -119,7 +112,7 @@ class SubprocessBackendDiscoveryTC(unittest.TestCase):
 
 class ClaudeCliSendTC(unittest.TestCase):
     def setUp(self):
-        self.backend = ClaudeCliBackend()
+        self.backend = agent.ClaudeCliBackend()
         patcher = mock.patch(_WHICH, lambda name: "/usr/bin/" + name)
         self.which = patcher.start()
         self.addCleanup(patcher.stop)
@@ -131,7 +124,7 @@ class ClaudeCliSendTC(unittest.TestCase):
         reply = self._envelope('[{"op": "add_circle", "r": 2.0}]')
         self.backend._communicate = lambda argv: (0, reply, "")
         response = self.backend.send("draw a circle", "empty world", _TOOLS)
-        self.assertIsInstance(response, BackendResponse)
+        self.assertIsInstance(response, agent.BackendResponse)
         self.assertIsNone(response.error)
         self.assertEqual(response.commands, [{"op": "add_circle", "r": 2.0}])
 
@@ -200,19 +193,19 @@ class ClaudeCliSendTC(unittest.TestCase):
 
 class RegistrationTC(unittest.TestCase):
     def test_claude_registers_on_import(self):
-        backend = get_backend("claude (cli)")
+        backend = agent.get_backend("claude (cli)")
         self.assertIsNotNone(backend)
-        self.assertIsInstance(backend, ClaudeCliBackend)
+        self.assertIsInstance(backend, agent.ClaudeCliBackend)
 
     def test_openai_http_registers_on_import(self):
-        backend = get_backend("openai (http)")
+        backend = agent.get_backend("openai (http)")
         self.assertIsNotNone(backend)
-        self.assertIsInstance(backend, OpenAIHttpBackend)
+        self.assertIsInstance(backend, agent.OpenAIHttpBackend)
 
 
 class OpenAIHttpBackendTC(unittest.TestCase):
     def setUp(self):
-        self.backend = OpenAIHttpBackend(
+        self.backend = agent.OpenAIHttpBackend(
             base_url="http://127.0.0.1:11434/v1",
             model="qwen2.5vl:7b",
             api_key="")
@@ -225,16 +218,16 @@ class OpenAIHttpBackendTC(unittest.TestCase):
 
     def test_available_needs_url_and_model(self):
         self.assertTrue(self.backend.available())
-        self.assertFalse(OpenAIHttpBackend(
+        self.assertFalse(agent.OpenAIHttpBackend(
             base_url="", model="m").available())
-        self.assertFalse(OpenAIHttpBackend(
+        self.assertFalse(agent.OpenAIHttpBackend(
             base_url="http://127.0.0.1:11434/v1", model="").available())
 
     def test_send_parses_commands(self):
         raw = self._chat_body('[{"op": "add_circle", "r": 2.0}]')
         self.backend._post_chat = lambda body: (200, raw)
         response = self.backend.send("draw a circle", "empty world", _TOOLS)
-        self.assertIsInstance(response, BackendResponse)
+        self.assertIsInstance(response, agent.BackendResponse)
         self.assertIsNone(response.error)
         self.assertEqual(response.commands, [{"op": "add_circle", "r": 2.0}])
 
@@ -293,7 +286,7 @@ class OpenAIHttpBackendTC(unittest.TestCase):
         self.assertEqual(response.commands, [])
 
     def test_parse_chat_payload_joins_content_parts(self):
-        text = OpenAIHttpBackend._parse_chat_payload({
+        text = agent.OpenAIHttpBackend._parse_chat_payload({
             "choices": [{
                 "message": {
                     "role": "assistant",
@@ -313,7 +306,7 @@ class OpenAIHttpBackendTC(unittest.TestCase):
             "SOLVCON_OPENAI_API_KEY": "secret",
         }
         with mock.patch.dict(os.environ, env, clear=False):
-            backend = OpenAIHttpBackend()
+            backend = agent.OpenAIHttpBackend()
         self.assertEqual(backend.base_url, "http://example.test/v1")
         self.assertEqual(backend.model, "demo-model")
         self.assertEqual(backend._api_key, "secret")
@@ -379,7 +372,7 @@ class ClaudeCliRealTC(unittest.TestCase):
     """
 
     def setUp(self):
-        self.backend = ClaudeCliBackend()
+        self.backend = agent.ClaudeCliBackend()
         if not self.backend.available():
             self.skipTest("claude CLI not found on PATH")
 
@@ -415,7 +408,7 @@ class OpenAIHttpRealTC(unittest.TestCase):
     """
 
     def setUp(self):
-        self.backend = OpenAIHttpBackend()
+        self.backend = agent.OpenAIHttpBackend()
         if not self.backend.available():
             self.skipTest("openai http backend not configured")
 

--- a/tests/test_agent_core.py
+++ b/tests/test_agent_core.py
@@ -10,7 +10,7 @@ import json
 import unittest
 
 import solvcon
-from solvcon.agent import AgentSession, BackendResponse
+from solvcon import agent
 
 try:
     from solvcon.pilot import agentdraw  # noqa: F401
@@ -61,7 +61,7 @@ class _FakeWorld:
 class ApplyCommandsTC(unittest.TestCase):
     def test_applies_each_command_and_records_one_turn(self):
         runner = _RecordingRunner()
-        session = AgentSession(runner=runner)
+        session = agent.AgentSession(runner=runner)
         cmds = [{"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0},
                 {"op": "add_circle", "cx": 2.0, "cy": 0.0, "r": 1.0}]
         results = session.apply_commands(cmds)
@@ -76,7 +76,7 @@ class ApplyCommandsTC(unittest.TestCase):
 
     def test_failed_command_is_recorded_not_raised(self):
         runner = _RecordingRunner(fail_ops={"remove_shape"})
-        session = AgentSession(runner=runner)
+        session = agent.AgentSession(runner=runner)
         results = session.apply_commands(
             [{"op": "remove_shape", "shape_id": 99}])
         self.assertFalse(results[0].ok)
@@ -88,7 +88,7 @@ class ApplyCommandsTC(unittest.TestCase):
             def run(self, command):
                 raise ValueError("boom")
 
-        session = AgentSession(runner=_Boom())
+        session = agent.AgentSession(runner=_Boom())
         results = session.apply_commands([{"op": "add_circle"}])
         self.assertFalse(results[0].ok)
         self.assertIn("boom", results[0].error)
@@ -96,7 +96,7 @@ class ApplyCommandsTC(unittest.TestCase):
 
     def test_empty_batch_is_a_noop_without_runner(self):
         # No commands must not build the runner.
-        session = AgentSession()
+        session = agent.AgentSession()
         self.assertEqual(session.apply_commands([]), [])
         self.assertEqual(session.transcript, [])
 
@@ -116,9 +116,10 @@ class _FakeBackend:
 class RunTurnTC(unittest.TestCase):
     def test_records_user_and_agent_turns_and_runs_commands(self):
         cmds = [{"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0}]
-        backend = _FakeBackend(BackendResponse(text="drawing", commands=cmds))
+        backend = _FakeBackend(
+            agent.BackendResponse(text="drawing", commands=cmds))
         runner = _RecordingRunner()
-        session = AgentSession(backend=backend, runner=runner)
+        session = agent.AgentSession(backend=backend, runner=runner)
         turn = session.run_turn("draw a circle")
         self.assertEqual(runner.commands, cmds)
         self.assertEqual([t.role for t in session.transcript],
@@ -129,13 +130,15 @@ class RunTurnTC(unittest.TestCase):
         self.assertTrue(turn.results[0].ok)
 
     def test_no_backend_records_only_the_user_turn(self):
-        session = AgentSession()
+        session = agent.AgentSession()
         self.assertIsNone(session.run_turn("hello"))
         self.assertEqual([t.role for t in session.transcript], ["user"])
 
     def test_empty_command_batch_builds_no_runner(self):
-        backend = _FakeBackend(BackendResponse(text="echo: hi", commands=[]))
-        session = AgentSession(backend=backend)  # no runner, no agentdraw
+        backend = _FakeBackend(
+            agent.BackendResponse(text="echo: hi", commands=[]))
+        # No runner, no agentdraw.
+        session = agent.AgentSession(backend=backend)
         turn = session.run_turn("hi")
         self.assertEqual(turn.text, "echo: hi")
         self.assertEqual(turn.results, [])
@@ -147,7 +150,7 @@ class RunTurnTC(unittest.TestCase):
             def send(self, *a):
                 raise RuntimeError("backend down")
 
-        session = AgentSession(backend=_Boom())
+        session = agent.AgentSession(backend=_Boom())
         turn = session.run_turn("draw")
         # The turn is recorded, not propagated, so a headless caller still
         # gets a transcript with the failure.
@@ -156,12 +159,12 @@ class RunTurnTC(unittest.TestCase):
         self.assertIn("backend down", turn.text)
 
     def test_runner_build_failure_yields_one_result_per_command(self):
-        class _Session(AgentSession):
+        class _Session(agent.AgentSession):
             @property
             def runner(self):
                 raise ImportError("no agentdraw")
 
-        backend = _FakeBackend(BackendResponse(
+        backend = _FakeBackend(agent.BackendResponse(
             commands=[{"op": "add_circle"}, {"op": "add_square"}]))
         session = _Session(backend=backend)
         turn = session.run_turn("draw two shapes")
@@ -172,30 +175,31 @@ class RunTurnTC(unittest.TestCase):
                          ["add_circle", "add_square"])
 
     def test_backend_error_is_folded_into_the_reply(self):
-        backend = _FakeBackend(BackendResponse(error="claude timed out"))
-        session = AgentSession(backend=backend)
+        backend = _FakeBackend(agent.BackendResponse(error="claude timed out"))
+        session = agent.AgentSession(backend=backend)
         turn = session.run_turn("draw")
         self.assertIn("claude timed out", turn.text)
 
     def test_bind_world_drops_the_lazy_runner(self):
-        session = AgentSession(world=_FakeWorld(["circle"]))
+        session = agent.AgentSession(world=_FakeWorld(["circle"]))
         session._runner = object()  # stand in for a built runner
         session.bind_world(_FakeWorld([]))
         self.assertIsNone(session._runner)
 
     def test_bind_world_keeps_an_injected_runner(self):
         runner = _RecordingRunner()
-        session = AgentSession(runner=runner)
+        session = agent.AgentSession(runner=runner)
         session.bind_world(_FakeWorld([]))
         self.assertIs(session._runner, runner)
 
 
 class SceneContextTC(unittest.TestCase):
     def test_no_world(self):
-        self.assertEqual(AgentSession().scene_context(), "no active world")
+        self.assertEqual(agent.AgentSession().scene_context(),
+                         "no active world")
 
     def test_reports_shape_count_and_types(self):
-        session = AgentSession(world=_FakeWorld(["circle", "rectangle"]))
+        session = agent.AgentSession(world=_FakeWorld(["circle", "rectangle"]))
         context = session.scene_context()
         self.assertIn("2 shapes", context)
         self.assertIn("circle", context)
@@ -206,7 +210,7 @@ class SceneContextTC(unittest.TestCase):
 class AgentDrawIntegrationTC(unittest.TestCase):
     def test_default_runner_mutates_world(self):
         world = solvcon.WorldFp64()
-        session = AgentSession(world=world)
+        session = agent.AgentSession(world=world)
         results = session.apply_commands([
             {"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0},
             {"op": "add_circle", "cx": 3.0, "cy": 0.0, "r": 1.0}])
@@ -214,7 +218,7 @@ class AgentDrawIntegrationTC(unittest.TestCase):
         self.assertEqual(world.nshape, 2)
 
     def test_tool_surface_matches_agentdraw(self):
-        self.assertEqual(AgentSession().tool_surface(),
+        self.assertEqual(agent.AgentSession().tool_surface(),
                          agentdraw.tool_definitions())
 
 

--- a/tests/test_pilot_agent.py
+++ b/tests/test_pilot_agent.py
@@ -9,8 +9,8 @@ import solvcon
 
 try:
     from solvcon import pilot
+    from solvcon import agent
     from solvcon.pilot import _agent_gui
-    from solvcon.agent import BackendResponse
     from PySide6.QtCore import Qt
 except ImportError:
     pilot = None
@@ -28,7 +28,7 @@ class _PingBackend:
         return True
 
     def send(self, prompt, scene_context, tool_surface):
-        return BackendResponse(text="pong", commands=[{"op": "ping"}])
+        return agent.BackendResponse(text="pong", commands=[{"op": "ping"}])
 
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,


### PR DESCRIPTION
The agent test modules imported classes and functions directly from solvcon.agent, but the style guide imports only modules and accesses their content through the module name. This converts those tests to import the package as solvcon.agent and reach the names through it, matching the rest of the test suite. No test behavior changes.

Related to #966.
