### PR TITLE
Make USE_SANITIZER apply AddressSanitizer on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,10 +139,24 @@ endif()
 
 if(USE_SANITIZER)
     message(STATUS "use sanitizer")
-    set(SANITIZER_LIST "undefined,leak,address")
-    add_compile_options(-fsanitize=${SANITIZER_LIST})
     add_compile_options(-DUSE_SANITIZER)
-    add_link_options(-fsanitize=${SANITIZER_LIST})
+    if(MSVC)
+        # MSVC ships only AddressSanitizer; it has no leak or undefined
+        # sanitizer, and it does not accept the GCC/Clang
+        # -fsanitize=undefined,leak,address spelling (it drops it with
+        # warning D9002). Use its own /fsanitize=address. ASan is incompatible
+        # with the /GL whole-program optimization that pybind11 turns on for
+        # the module (see cpp/binary/pymod_solvcon/CMakeLists.txt) and with
+        # incremental linking, so those are disabled alongside it. /Zi emits
+        # the compiler debug info ASan needs to symbolize its reports; without
+        # it MSVC raises warning C5072, which /WX turns into a build error.
+        add_compile_options(/fsanitize=address /Zi)
+        add_link_options(/INCREMENTAL:NO)
+    else()
+        set(SANITIZER_LIST "undefined,leak,address")
+        add_compile_options(-fsanitize=${SANITIZER_LIST})
+        add_link_options(-fsanitize=${SANITIZER_LIST})
+    endif()
 else()
     message(STATUS "not use sanitizer")
 endif()

--- a/cpp/binary/pymod_solvcon/CMakeLists.txt
+++ b/cpp/binary/pymod_solvcon/CMakeLists.txt
@@ -4,10 +4,20 @@
 cmake_minimum_required(VERSION 4.0.1)
 project(solvcon_pymod)
 
-pybind11_add_module(
-    _solvcon
-    module.cpp
-)
+# NO_EXTRAS under USE_SANITIZER turns off pybind11's link-time optimization
+# (/GL + /LTCG on MSVC), which AddressSanitizer cannot be combined with.
+if(USE_SANITIZER AND MSVC)
+    pybind11_add_module(
+        _solvcon
+        NO_EXTRAS
+        module.cpp
+    )
+else()
+    pybind11_add_module(
+        _solvcon
+        module.cpp
+    )
+endif()
 
 target_link_libraries(
     _solvcon PUBLIC


### PR DESCRIPTION
On MSVC the USE_SANITIZER block emitted GCC/Clang -fsanitize flags that cl.exe silently dropped with warning D9002, leaving the build uninstrumented. Branch the block so MSVC uses /fsanitize=address (plus /Zi, /INCREMENTAL:NO, and NO_EXTRAS on the pybind11 module) while GCC and Clang keep the existing undefined,leak,address set.
