### PR TITLE
Run AddressSanitizer on Windows via the gtest binary

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -554,8 +554,105 @@ jobs:
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_SANITIZER=ON"
         echo "::endgroup::"
 
+  sanitizer_windows:
+
+    needs: [check_skip]
+
+    # The MSVC counterpart of the sanitizer job. MSVC implements only
+    # AddressSanitizer (no leak or undefined), and the instrumented gtest
+    # binary links the ASan runtime directly so ASan initializes at process
+    # start; a stock python.exe loading an instrumented .pyd cannot. It is
+    # slow, so it runs on the nightly schedule only.
+    if: |
+      needs.check_skip.outputs.skip != 'true' &&
+      github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable'
+
+    name: sanitizer_${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+
+    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_BUILD || '60') }}
+
+    strategy:
+      matrix:
+        os: [windows-2022]
+        cmake_build_type: [Release]
+
+      fail-fast: false
+
+    steps:
+
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+
+    - name: event name
+      run: |
+        echo "github.event_name: ${{ github.event_name }}"
+
+    - uses: TheMrMilchmann/setup-msvc-dev@v4
+      with:
+        arch: 'x64'
+
+    # CMake in the windows-2022 image is 3.31.6; solvcon needs >= 4.0.1.
+    - name: install CMake>4.0.1
+      uses: lukka/get-cmake@latest
+
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Cache vcpkg (install artifacts)
+      uses: actions/cache@v4
+      with:
+        path: |
+          C:\vcpkg\installed
+          C:\vcpkg\downloads
+          C:\vcpkg\buildtrees
+          C:\vcpkg\packages
+        key: vcpkg-${{ runner.os }}-openblas-lapack
+        restore-keys: vcpkg-${{ runner.os }}-
+
+    - name: install BLAS and LAPACK
+      run: |
+        echo "::group::install BLAS and LAPACK"
+        vcpkg install openblas:x64-windows lapack:x64-windows
+        $vcpkg_bin_path = @(
+          "C:\vcpkg\installed\x64-windows\bin",
+          "C:\vcpkg\installed\x64-windows\debug\bin"
+        ) -join ";"
+        echo "$vcpkg_bin_path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "::endgroup::"
+
+    - name: dependency by pip
+      run: |
+        echo "::group::dependency by pip"
+        pip3 install -U numpy pytest pybind11
+        echo "::endgroup::"
+
+    - name: cmake run_gtest USE_SANITIZER=ON
+      run: |
+        echo "::group::cmake run_gtest USE_SANITIZER=ON"
+        # AddressSanitizer over the C++ gtest binary. BUILD_QT=OFF keeps the
+        # run headless and USE_GOOGLETEST=ON overrides the Windows preset so
+        # the gtest binary is built. The MSVC toolset bin dir that
+        # setup-msvc-dev puts on PATH also carries the ASan runtime DLL that
+        # the instrumented binary loads at start.
+        cmake -GNinja `
+          -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} `
+          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
+          -DVCPKG_TARGET_TRIPLET="x64-windows" `
+          -Dpybind11_DIR="$(pybind11-config --cmakedir)" `
+          -DBUILD_QT=OFF `
+          -DUSE_GOOGLETEST=ON `
+          -DUSE_SANITIZER=ON `
+          -S${{ github.workspace }} `
+          -B${{ github.workspace }}/build
+        cmake --build ${{ github.workspace }}/build --target run_gtest
+        echo "::endgroup::"
+
   send_email_on_failure:
-    needs: [standalone_buffer, build, build_windows, sanitizer]
+    needs: [standalone_buffer, build, build_windows, sanitizer, sanitizer_windows]
     # Run if any of the dependencies failed in master branch
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     uses: ./.github/workflows/send_email_on_fail.yml
@@ -565,6 +662,7 @@ jobs:
         - build: ${{ needs.build.result }}
         - build_windows: ${{ needs.build_windows.result }}
         - sanitizer: ${{ needs.sanitizer.result }}
+        - sanitizer_windows: ${{ needs.sanitizer_windows.result }}
     secrets:
       EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
       EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/build.ps1
+++ b/build.ps1
@@ -27,6 +27,8 @@
 #   .\build.ps1 -Pilot                then launch the pilot GUI
 #   .\build.ps1 -PilotTest            then run "pilot.exe --mode=pytest" headless
 #   .\build.ps1 -Gtest                also build and run the C++ gtest suite
+#   .\build.ps1 -Sanitize             build and run the gtest suite under
+#                                     AddressSanitizer (implies -Gtest, -NoQt)
 #
 # Overridable variables:
 #   SCDV_VS_VERSION: vswhere -version range picking the VS whose cl/vcvars
@@ -43,6 +45,7 @@ param(
     [switch]$Test,
     [switch]$Pilot,
     [switch]$PilotTest,
+    [switch]$Sanitize,
     [switch]$Help
 )
 
@@ -59,6 +62,18 @@ if ($Help) {
         ForEach-Object { if ($_ -notmatch '^\s*$') { $_ -replace '^#\s?', '' } } |
         Select-Object -First 40
     exit 0
+}
+
+# The sanitizer build runs the C++ gtest binary under AddressSanitizer, the
+# Windows counterpart of the Linux "make gtest USE_SANITIZER=ON" job. It reuses
+# the -Gtest build-and-run path and forces BUILD_QT=OFF to stay headless.
+if ($Sanitize) {
+    if ($Pilot -or $PilotTest) {
+        throw '-Sanitize runs the gtest binary and cannot be combined ' +
+            'with -Pilot or -PilotTest'
+    }
+    $Gtest = $true
+    $NoQt = $true
 }
 
 # This script lives at the repo root; build that checkout by default.
@@ -169,7 +184,12 @@ $extra = @(
     "-DCMAKE_PREFIX_PATH=$usr"
 )
 if ($NoQt) { $extra += '-DBUILD_QT=OFF' }
+# -Gtest turns on the gtest binary (USE_GOOGLETEST is OFF in the preset), and
+# -Sanitize (which implies -Gtest) builds it under AddressSanitizer. The gtest
+# binary links the ASan runtime directly so ASan initializes at process start,
+# unlike loading an instrumented .pyd into a stock python.exe.
 if ($Gtest) { $extra += '-DUSE_GOOGLETEST=ON' }
+if ($Sanitize) { $extra += '-DUSE_SANITIZER=ON' }
 
 Push-Location $Repo
 try {


### PR DESCRIPTION
This adds a way to run the project under AddressSanitizer on Windows.

AddressSanitizer has to run through the C++ gtest binary, because that binary links the sanitizer runtime directly and starts it at launch, while a normal python.exe loading an instrumented module starts it too late and crashes.

build.ps1 gets a -Sanitize switch that builds and runs the gtest suite under AddressSanitizer, reusing the existing -Gtest path with USE_SANITIZER=ON and BUILD_QT=OFF.

A new sanitizer_windows CI job does the same on an MSVC toolchain, gated to the nightly schedule like the Linux sanitizer job.

The build.ps1 path was checked on a Windows Server 2022 machine with MSVC 19.44, where all 213 gtest tests passed under AddressSanitizer with no diagnostics.

The sanitizer_windows CI job was also run once on this pull request and passed on a windows-2022 runner: https://github.com/solvcon/solvcon/actions/runs/29443432649
