### PR TITLE
Add missing C++ class, struct, and namespace ending marks

### DIFF
--- a/.claude/skills/cpp-style-review/SKILL.md
+++ b/.claude/skills/cpp-style-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cpp-style-review
-description: Apply solvcon's judgment-call C++ style rules (m_ prefix, function-body placement, SimpleCollector preference, pybind11 binding split, const_cast) to changed lines in cpp/ or gtests/. Use after editing C++ sources.
+description: Apply solvcon's judgment-call C++ style rules (m_ prefix, class/struct/namespace ending marks, function-body placement, SimpleCollector preference, pybind11 binding split, const_cast) to changed lines in cpp/ or gtests/. Use after editing C++ sources.
 tools: Read, Grep, Glob, Edit, Bash
 ---
 
@@ -43,6 +43,21 @@ it briefly but don't re-implement the check here.
 - STL containers in non-prototype member data require a `TODO` comment plus a
   follow-up PR/issue link.
 - STL in local variables is tolerated but discouraged.
+
+**Ending marks (easy to forget -- check every class, struct, and namespace)**
+- Per STYLE.md "C++ Ending Mark", every class, struct, and namespace closing
+  brace carries a trailing comment naming what it closes:
+  `}; /* end class MyClass */`, `}; /* end struct MyStruct */`,
+  `} /* end namespace solvcon */` (anonymous: `} /* end namespace */`).
+- These are routinely omitted (by humans and by AI). If the diff adds or
+  changes a class, struct, or namespace, verify the closing brace has the mark
+  and that the name matches the declaration.
+- Flag: a missing mark; a wrong name; the wrong keyword (`class` vs `struct`
+  vs `namespace`); a `//` mark instead of `/* ... */`; and stale wording. The
+  form is exactly `end <keyword> <name>` -- not `end of ...`, and not
+  `/* namespace X */` with the word "end" dropped.
+- A single-line definition (open and close on one line, e.g.
+  `struct is_complex : std::false_type {};`) needs no mark.
 
 **Function-body placement**
 - Move non-accessor function bodies outside the class declaration when the body

--- a/cpp/solvcon/base.hpp
+++ b/cpp/solvcon/base.hpp
@@ -49,13 +49,13 @@ namespace detail
 template <template <typename...> class Template, typename T>
 struct is_specialization_of : std::false_type
 {
-};
+}; /* end struct is_specialization_of */
 
 /// Helper trait to check if a type is a specialization of a given template
 template <template <typename...> class Template, typename... Args>
 struct is_specialization_of<Template, Template<Args...>> : std::true_type
 {
-};
+}; /* end struct is_specialization_of */
 
 /// Helper trait to check if a type is a specialization of a given template
 template <template <typename...> class Template, typename T>

--- a/cpp/solvcon/buffer/BufferExpander.hpp
+++ b/cpp/solvcon/buffer/BufferExpander.hpp
@@ -30,7 +30,7 @@ private:
 
     struct ctor_passkey
     {
-    };
+    }; /* end struct ctor_passkey */
 
 public:
 
@@ -173,7 +173,7 @@ private:
             std::free(ptr); // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
 #endif
         }
-    };
+    }; /* end struct aligned_deleter */
 
     using unique_ptr_type = std::unique_ptr<int8_t, aligned_deleter>;
 

--- a/cpp/solvcon/buffer/ConcreteBuffer.hpp
+++ b/cpp/solvcon/buffer/ConcreteBuffer.hpp
@@ -129,7 +129,7 @@ private:
 
     struct ctor_passkey
     {
-    };
+    }; /* end struct ctor_passkey */
 
     using data_deleter_type = detail::ConcreteBufferDataDeleter;
 

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -194,7 +194,7 @@ private:
     {
         return lower_bound(array, dim) + array.shape(dim);
     }
-};
+}; /* end class IndexRange */
 
 std::string format_shape(shape_type const & shape);
 std::string format_flat_index(shape_type const & shape, ssize_t offset);
@@ -206,7 +206,7 @@ struct SimpleArrayInternalTypes
     using shape_type = detail::shape_type;
     using sshape_type = detail::sshape_type;
     using buffer_type = ConcreteBuffer;
-}; /* end class SimpleArrayInternalType */
+}; /* end struct SimpleArrayInternalTypes */
 
 template <typename A, typename T>
 class SimpleArrayMixinModifiers
@@ -233,13 +233,13 @@ template <typename U>
 struct select_real_t
 {
     using type = U;
-};
+}; /* end struct select_real_t */
 
 template <typename U>
 struct select_real_t<Complex<U>>
 {
     using type = U;
-};
+}; /* end struct select_real_t */
 
 template <typename A, typename T>
 class SimpleArrayMixinSum
@@ -1579,7 +1579,7 @@ A SimpleArrayMixinMatrix<A, T>::pow(ssize_t n) const
 // Tag type for explicit alignment constructor
 struct with_alignment_t
 {
-};
+}; /* end struct with_alignment_t */
 
 /**
  * Simple array type for contiguous memory storage. Size does not change. The

--- a/cpp/solvcon/buffer/pymod/SimpleArrayCaster.hpp
+++ b/cpp/solvcon/buffer/pymod/SimpleArrayCaster.hpp
@@ -62,7 +62,7 @@ namespace detail
         {                                                                                                                                                     \
             return base::cast(src, policy, parent);                                                                                                           \
         }                                                                                                                                                     \
-    }
+    } /* end struct type_caster */
 
 DECL_MM_SIMPLE_ARRAY_CASTER(Bool);
 DECL_MM_SIMPLE_ARRAY_CASTER(Int8);

--- a/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
+++ b/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
@@ -243,7 +243,7 @@ struct TypeBroadcast
 
         throw std::runtime_error(msg.str());
     }
-}; /* end struct TypeBroadCast */
+}; /* end struct TypeBroadcast */
 
 } /* end namespace python */
 } /* end namespace solvcon */

--- a/cpp/solvcon/buffer/pymod/array_common.hpp
+++ b/cpp/solvcon/buffer/pymod/array_common.hpp
@@ -76,7 +76,7 @@ private:
         }
         return false;
     }
-};
+}; /* end struct npy_format_descriptor */
 
 template <>
 struct npy_format_descriptor<solvcon::Complex<float>>
@@ -128,7 +128,7 @@ private:
         }
         return false;
     }
-};
+}; /* end struct npy_format_descriptor */
 
 } /* end namespace detail */
 
@@ -461,7 +461,7 @@ private:
             arr_out.set_nghost(nghost);
         }
     }
-};
+}; /* end class ArrayPropertyHelper */
 
 } /* end namespace python */
 } /* end namespace solvcon */

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -425,7 +425,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
 
 #undef DECL_MM_EXECUTE_TYPED_ARRAY_METHOD
 
-}; /* end of class WrapSimpleArrayPlex*/
+}; /* end class WrapSimpleArrayPlex */
 
 void wrap_SimpleArrayPlex(pybind11::module & mod)
 {

--- a/cpp/solvcon/inout/inout_util.cpp
+++ b/cpp/solvcon/inout/inout_util.cpp
@@ -36,8 +36,8 @@ std::vector<std::string> tokenize(const std::string & str, const char delim)
     return output;
 }
 
-} // namespace inout
+} /* end namespace inout */
 
-} // namespace solvcon
+} /* end namespace solvcon */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/inout/inout_util.hpp
+++ b/cpp/solvcon/inout/inout_util.hpp
@@ -21,8 +21,8 @@ namespace inout
 std::vector<std::string> tokenize(const std::string & str, const std::regex & regex_delim);
 std::vector<std::string> tokenize(const std::string & str, char delim);
 
-} // namespace inout
+} /* end namespace inout */
 
-} // namespace solvcon
+} /* end namespace solvcon */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/inout/plot3d.cpp
+++ b/cpp/solvcon/inout/plot3d.cpp
@@ -148,8 +148,8 @@ void Plot3d::build_interior(const std::shared_ptr<StaticMesh> & blk)
     blk->build_ghost();
 }
 
-} // namespace inout
+} /* end namespace inout */
 
-} // namespace solvcon
+} /* end namespace solvcon */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/inout/plot3d.hpp
+++ b/cpp/solvcon/inout/plot3d.hpp
@@ -78,10 +78,10 @@ private:
     SimpleArray<uint_type> m_blk_sizes;
 
     std::unordered_map<uint_type, small_vector<uint_type>> m_elems;
-};
+}; /* end class Plot3d */
 
-} // namespace inout
+} /* end namespace inout */
 
-} // namespace solvcon
+} /* end namespace solvcon */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/linalg/EigenSystem.hpp
+++ b/cpp/solvcon/linalg/EigenSystem.hpp
@@ -58,7 +58,7 @@ private:
 
     struct ctor_passkey
     {
-    };
+    }; /* end struct ctor_passkey */
 
 public:
 

--- a/cpp/solvcon/linalg/pymod/wrap_kalman_filter.cpp
+++ b/cpp/solvcon/linalg/pymod/wrap_kalman_filter.cpp
@@ -47,7 +47,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapKalmanStateInfo
                 "posterior_states_covariance", &wrapped_type::posterior_states_covariance);
     }
 
-}; /* end class KalmanStateInfo */
+}; /* end class WrapKalmanStateInfo */
 
 template <typename T>
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapKalmanFilter

--- a/cpp/solvcon/mesh/StaticMesh.hpp
+++ b/cpp/solvcon/mesh/StaticMesh.hpp
@@ -255,7 +255,7 @@ private:
 
     class ctor_passkey
     {
-    };
+    }; /* end class ctor_passkey */
 
 public:
 

--- a/cpp/solvcon/mesh/pymod/wrap_StaticGrid.cpp
+++ b/cpp/solvcon/mesh/pymod/wrap_StaticGrid.cpp
@@ -117,7 +117,7 @@ protected: \
       : base_type(mod, pyname, pydoc) \
     {} \
 \
-}
+} /* end class WrapStaticGrid##NDIM##d */
 // clang-format on
 
 MM_DECL_StaticGridMD(2);

--- a/cpp/solvcon/multidim/euler.hpp
+++ b/cpp/solvcon/multidim/euler.hpp
@@ -62,7 +62,7 @@ private:
 
     class ctor_passkey
     {
-    };
+    }; /* end class ctor_passkey */
 
 public:
 

--- a/cpp/solvcon/multidim/pymod/multidim_pymod.cpp
+++ b/cpp/solvcon/multidim/pymod/multidim_pymod.cpp
@@ -17,7 +17,7 @@ namespace python
 
 struct multidim_pymod_tag
 {
-};
+}; /* end struct multidim_pymod_tag */
 
 template <>
 OneTimeInitializer<multidim_pymod_tag> & OneTimeInitializer<multidim_pymod_tag>::me()

--- a/cpp/solvcon/oasis/oasis_device.cpp
+++ b/cpp/solvcon/oasis/oasis_device.cpp
@@ -274,6 +274,6 @@ void OasisDevice::append_record_bytes(std::vector<uint8_t> & bytes, const T & re
     bytes.insert(bytes.end(), rec_bytes.begin(), rec_bytes.end());
 }
 
-} // namespace solvcon
+} /* end namespace solvcon */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/oasis/oasis_device.hpp
+++ b/cpp/solvcon/oasis/oasis_device.hpp
@@ -118,6 +118,6 @@ private:
     int m_left, m_lower, m_w, m_h;
 }; /* end class OasisRecordRect */
 
-} // namespace solvcon
+} /* end namespace solvcon */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/oasis/pymod/oasis_pymod.cpp
+++ b/cpp/solvcon/oasis/pymod/oasis_pymod.cpp
@@ -16,7 +16,7 @@ namespace python
 
 struct oasis_pymod_tag
 {
-};
+}; /* end struct oasis_pymod_tag */
 
 template <>
 OneTimeInitializer<oasis_pymod_tag> & OneTimeInitializer<oasis_pymod_tag>::me()

--- a/cpp/solvcon/onedim/Euler1DCore.hpp
+++ b/cpp/solvcon/onedim/Euler1DCore.hpp
@@ -51,7 +51,7 @@ private:
 
     struct ctor_passkey
     {
-    };
+    }; /* end struct ctor_passkey */
 
 public:
 

--- a/cpp/solvcon/onedim/pymod/onedim_pymod.cpp
+++ b/cpp/solvcon/onedim/pymod/onedim_pymod.cpp
@@ -17,7 +17,7 @@ namespace python
 
 struct onedim_pymod_tag
 {
-};
+}; /* end struct onedim_pymod_tag */
 
 template <>
 OneTimeInitializer<onedim_pymod_tag> & OneTimeInitializer<onedim_pymod_tag>::me()

--- a/cpp/solvcon/pilot/DrawTool.cpp
+++ b/cpp/solvcon/pilot/DrawTool.cpp
@@ -298,7 +298,7 @@ struct ToolEntry
 {
     char const * name;
     std::unique_ptr<DrawToolBase> (*make)();
-};
+}; /* end struct ToolEntry */
 
 ToolEntry const TOOL_TABLE[] = {
     {PanTool::NAME, []() -> std::unique_ptr<DrawToolBase>
@@ -315,7 +315,7 @@ ToolEntry const TOOL_TABLE[] = {
      { return std::make_unique<CircleTool>(); }},
 };
 
-} /* end anonymous namespace */
+} /* end namespace */
 
 std::vector<std::string> const & draw_tool_names()
 {

--- a/cpp/solvcon/pilot/R2DWidget.cpp
+++ b/cpp/solvcon/pilot/R2DWidget.cpp
@@ -69,7 +69,7 @@ bool is_finite_view(ViewTransform2dFp64 const & v)
     return std::isfinite(v.pan_x()) && std::isfinite(v.pan_y()) && std::isfinite(v.zoom());
 }
 
-} // unnamed namespace
+} /* end namespace */
 
 R2DWidget::R2DWidget(QWidget * parent, Qt::WindowFlags f)
     : QWidget(parent, f)

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -154,7 +154,7 @@ public:
         QVector3D centroid;
 
         bool hit() const { return "none" != kind; }
-    };
+    }; /* end struct PickResult */
 
     // Pick the entity under the widget pixel (x, y): a cell (by ray-cast
     // against the surface), the nearest node, or the nearest boundary face.
@@ -390,7 +390,7 @@ private:
     {
         RDrawable * drawable = nullptr;
         std::shared_ptr<StaticMesh> mesh;
-    };
+    }; /* end struct ObjectEntry */
     std::map<std::string, ObjectEntry> m_objects;
     std::vector<float> m_ticks_x; ///< Cube-axes tick coordinates per axis.
     std::vector<float> m_ticks_y;

--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -467,7 +467,7 @@ void RManager::setUpCameraControllersMenuItems() const
         QString text;
         QString tip;
         std::string mode;
-    };
+    }; /* end struct CameraMode */
     std::vector<CameraMode> const modes = {
         {"camera.mode_orbit", QString("Orbit camera (3D)"), QString("Orbit the domain around its center"), "orbit"},
         {"camera.mode_fps", QString("First-person camera (3D)"), QString("Fly through the domain in first person"), "fps"},
@@ -507,7 +507,7 @@ void RManager::setUpCameraMovementMenuItems() const
         char const * id;
         QString text;
         std::function<void(RDomainWidget *)> act;
-    };
+    }; /* end struct CameraMove */
     // The keyboard hints the labels used to carry were wrong: those keys are
     // handled in RDomainWidget::keyPressEvent with different behavior, so they
     // are dropped here rather than advertised.

--- a/cpp/solvcon/pilot/RMenuModel.hpp
+++ b/cpp/solvcon/pilot/RMenuModel.hpp
@@ -97,7 +97,7 @@ private:
         QPointer<QAction> action; // the entry's QAction (item, separator, or
                                   // a submenu's menuAction)
         std::unique_ptr<Node> submenu; // non-null only for a submenu entry
-    };
+    }; /* end struct Entry */
 
     struct Node
     {
@@ -106,7 +106,7 @@ private:
         QPointer<QMenu> menu; // nullptr for the root, which stands for the bar
         Node * parent = nullptr;
         std::vector<Entry> entries;
-    };
+    }; /* end struct Node */
 
     Node * resolve(std::string const & path, int weight);
     Node * ensureChild(Node * parent, QString const & name, int weight);

--- a/cpp/solvcon/pilot/RPythonSyntaxRules.hpp
+++ b/cpp/solvcon/pilot/RPythonSyntaxRules.hpp
@@ -37,7 +37,7 @@ struct SyntaxSpan
     std::size_t start;
     std::size_t length;
     SyntaxTokenKind kind;
-};
+}; /* end struct SyntaxSpan */
 
 constexpr std::size_t syntax_npos = static_cast<std::size_t>(-1);
 

--- a/cpp/solvcon/pilot/RWorldRenderer2d.cpp
+++ b/cpp/solvcon/pilot/RWorldRenderer2d.cpp
@@ -102,7 +102,7 @@ public:
     private:
         double m_pos;
         double m_spacing;
-    };
+    }; /* end class Iterator */
 
     Iterator begin() const { return Iterator(m_first, m_spacing); }
     double end() const { return m_extent; }
@@ -121,7 +121,7 @@ private:
     double m_spacing;
     double m_extent;
     double m_first;
-};
+}; /* end class GridLineRange */
 
 void paint_chrome(QPainter & painter, ViewTransform2dFp64 const & view, int width, int height)
 {
@@ -330,7 +330,7 @@ private:
     double m_ascent;
     double m_text_h;
     std::vector<QRectF> m_placed;
-};
+}; /* end class CoordinateLabelPainter */
 
 /// Compact number for shape annotations: enough digits to read, no trailing noise.
 QString format_measure(double value)
@@ -513,7 +513,7 @@ struct LabelObstacles
         }
         return false;
     }
-};
+}; /* end struct LabelObstacles */
 
 /**
  * Top-left for a block_w by block_h label placed outside `box`, on-canvas and
@@ -610,7 +610,7 @@ QPointF place_label_block(
     return have_fallback ? fallback : best;
 }
 
-} // anonymous namespace
+} /* end namespace */
 
 QPointF RWorldRenderer2d::map(double world_x, double world_y) const
 {

--- a/cpp/solvcon/pilot/keymap.hpp
+++ b/cpp/solvcon/pilot/keymap.hpp
@@ -76,7 +76,7 @@ struct KeyChord
 {
     KeyMod mods;
     Key key;
-};
+}; /* end struct KeyChord */
 
 constexpr bool operator==(KeyChord lhs, KeyChord rhs)
 {
@@ -85,7 +85,7 @@ constexpr bool operator==(KeyChord lhs, KeyChord rhs)
 
 struct Unbound
 {
-};
+}; /* end struct Unbound */
 
 /// A key spelling is either a standard action, a curated chord, or unbound.
 /// Unbound is a placeholder for a command that has no binding on a platform yet.
@@ -112,20 +112,20 @@ struct ShortcutBinding
     KeySpelling key;
     ShortcutContext context;
     MenuRole role = MenuRole::None;
-};
+}; /* end struct ShortcutBinding */
 
 struct ShortcutCapabilities
 {
     PlatformId platform;
     bool movesItemsToApplicationMenu;
     std::vector<KeyChord> reservedSequences;
-};
+}; /* end struct ShortcutCapabilities */
 
 struct ShortcutConflict
 {
     ShortcutCommand first;
     ShortcutCommand second;
-};
+}; /* end struct ShortcutConflict */
 
 std::string_view commandId(ShortcutCommand command);
 

--- a/cpp/solvcon/pilot/theme.hpp
+++ b/cpp/solvcon/pilot/theme.hpp
@@ -95,7 +95,7 @@ struct ThemeColor
         , b(blue)
     {
     }
-};
+}; /* end struct ThemeColor */
 
 /**
  * @brief The colors a palette assigns to the widget roles the pilot uses.
@@ -126,7 +126,7 @@ struct ThemePalette
     ThemeColor disabled_button_text;
     ThemeColor disabled_window_text;
     ThemeColor disabled_highlight;
-};
+}; /* end struct ThemePalette */
 
 /**
  * @brief The colors the console's Python highlighter and its matching-bracket
@@ -146,7 +146,7 @@ struct SyntaxColors
     ThemeColor comment;
     ThemeColor number;
     ThemeColor bracket_match;
-};
+}; /* end struct SyntaxColors */
 
 /**
  * @brief What a platform's theme is able to honor.
@@ -169,7 +169,7 @@ struct ThemeCapabilities
     bool controls_titlebar = false;
     /// Installs a platform-native widget style rather than a portable one.
     bool has_native_style = false;
-};
+}; /* end struct ThemeCapabilities */
 
 /// The curated light palette, the shared fallback every platform table seeds
 /// from until its room is furnished.

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -34,7 +34,7 @@ namespace PySide
 PyTypeObject * getTypeForQObject(const QObject * cppSelf);
 PyObject * getWrapperForQObject(QObject * cppSelf, PyTypeObject * sbk_type);
 QObject * convertToQObject(PyObject * object, bool raiseError);
-} // end namespace PySide
+} /* end namespace PySide */
 #endif // SOLVCON_PYSIDE6_FULL
 
 namespace pybind11
@@ -101,14 +101,14 @@ public:
         }
         return pybind11::handle(p);
     }
-};
+}; /* end struct qt_type_caster */
 
 #define QT_TYPE_CASTER(type, py_name)                      \
     template <>                                            \
     struct type_caster<type> : public qt_type_caster<type> \
     {                                                      \
         static constexpr auto name = py_name;              \
-    }
+    } /* end struct type_caster */
 
 QT_TYPE_CASTER(QWidget, _("QWidget"));
 QT_TYPE_CASTER(QAction, _("QAction"));
@@ -1012,7 +1012,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
 
 struct RManagerProxy
 {
-};
+}; /* end struct RManagerProxy */
 
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManagerProxy
     : public WrapBase<WrapRManagerProxy, RManagerProxy>

--- a/cpp/solvcon/profiling/RadixTree.hpp
+++ b/cpp/solvcon/profiling/RadixTree.hpp
@@ -363,7 +363,7 @@ private:
     const char * m_caller_name;
     bool m_cancel = false;
     CallProfiler & m_profiler;
-}; /* end struct CallProfilerProbe */
+}; /* end class CallProfilerProbe */
 
 // TODO: https://github.com/solvcon/solvcon/pull/559
 #ifdef SOLVCON_PROFILE

--- a/cpp/solvcon/profiling/profile.hpp
+++ b/cpp/solvcon/profiling/profile.hpp
@@ -83,7 +83,7 @@ private:
     time_type m_start;
     time_type m_stop;
 
-}; /* end struct StopWatch */
+}; /* end class StopWatch */
 
 } /* end namespace solvcon */
 

--- a/cpp/solvcon/profiling/pymod/wrap_profile.cpp
+++ b/cpp/solvcon/profiling/pymod/wrap_profile.cpp
@@ -43,7 +43,7 @@ protected:
         mod.attr("wrapper_profiler_status") = mod.attr("WrapperProfilerStatus").attr("me");
     }
 
-}; /* end class WrapWrapperTimerStatus */
+}; /* end class WrapWrapperProfilerStatus */
 
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapStopWatch
     : public WrapBase<WrapStopWatch, StopWatch>

--- a/cpp/solvcon/python/common.hpp
+++ b/cpp/solvcon/python/common.hpp
@@ -87,7 +87,7 @@ private:
 
 struct mmtag
 {
-};
+}; /* end struct mmtag */
 
 } /* end namespace python */
 } /* end namespace solvcon */
@@ -125,7 +125,7 @@ private:
         function_record const & r = call.func;
         return std::string(str(r.scope.attr("__name__"))) + std::string(".") + r.name;
     }
-};
+}; /* end struct process_attribute */
 
 } /* end namespace detail */
 } /* end namespace pybind11 */

--- a/cpp/solvcon/simd/neon/neon.hpp
+++ b/cpp/solvcon/simd/neon/neon.hpp
@@ -81,22 +81,22 @@ struct vec_add
 {
     template <typename V>
     static auto operator()(V a, V b) -> decltype(vaddq(a, b)) { return vaddq(a, b); }
-};
+}; /* end struct vec_add */
 struct vec_sub
 {
     template <typename V>
     static auto operator()(V a, V b) -> decltype(vsubq(a, b)) { return vsubq(a, b); }
-};
+}; /* end struct vec_sub */
 struct vec_mul
 {
     template <typename V>
     static auto operator()(V a, V b) -> decltype(vmulq(a, b)) { return vmulq(a, b); }
-};
+}; /* end struct vec_mul */
 struct vec_div
 {
     template <typename V>
     static auto operator()(V a, V b) -> decltype(vdivq(a, b)) { return vdivq(a, b); }
-};
+}; /* end struct vec_div */
 // NOLINTEND(fuchsia-trailing-return)
 
 template <typename T, std::invocable<T, T> ScalarOp, typename VecOp>
@@ -277,10 +277,10 @@ void div(T * dest, T const * dest_end, T const * src1, T const * src2)
 
 #endif /* defined(__aarch64__) */
 
-} /* namespace neon */
+} /* end namespace neon */
 
-} /* namespace simd */
+} /* end namespace simd */
 
-} /* namespace solvcon */
+} /* end namespace solvcon */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/simd/neon/neon_alias.hpp
+++ b/cpp/solvcon/simd/neon/neon_alias.hpp
@@ -290,10 +290,10 @@ inline static type::vector_t<double> vdivq(type::vector_t<double> vec_a, type::v
 #undef stype_t
 #undef utype_t
 
-} // namespace neon
+} /* end namespace neon */
 
-} // namespace simd
+} /* end namespace simd */
 
-} /* namespace solvcon */
+} /* end namespace solvcon */
 
 #endif /* defined(__aarch64__) */

--- a/cpp/solvcon/simd/neon/neon_type.hpp
+++ b/cpp/solvcon/simd/neon/neon_type.hpp
@@ -29,79 +29,79 @@ template <typename T>
 struct vector
 {
     static constexpr size_t N_lane = 0;
-};
+}; /* end struct vector */
 
 template <>
 struct vector<uint8_t>
 {
     using type = uint8x16_t;
     static constexpr size_t N_lane = 16;
-};
+}; /* end struct vector */
 
 template <>
 struct vector<uint16_t>
 {
     using type = uint16x8_t;
     static constexpr size_t N_lane = 8;
-};
+}; /* end struct vector */
 
 template <>
 struct vector<uint32_t>
 {
     using type = uint32x4_t;
     static constexpr size_t N_lane = 4;
-};
+}; /* end struct vector */
 
 template <>
 struct vector<uint64_t>
 {
     using type = uint64x2_t;
     static constexpr size_t N_lane = 2;
-};
+}; /* end struct vector */
 
 template <>
 struct vector<int8_t>
 {
     using type = int8x16_t;
     static constexpr size_t N_lane = 16;
-};
+}; /* end struct vector */
 
 template <>
 struct vector<int16_t>
 {
     using type = int16x8_t;
     static constexpr size_t N_lane = 8;
-};
+}; /* end struct vector */
 
 template <>
 struct vector<int32_t>
 {
     using type = int32x4_t;
     static constexpr size_t N_lane = 4;
-};
+}; /* end struct vector */
 
 template <>
 struct vector<int64_t>
 {
     using type = int64x2_t;
     static constexpr size_t N_lane = 2;
-};
+}; /* end struct vector */
 
 template <>
 struct vector<float>
 {
     using type = float32x4_t;
     static constexpr size_t N_lane = 4;
-};
+}; /* end struct vector */
 
 template <>
 struct vector<double>
 {
     using type = float64x2_t;
     static constexpr size_t N_lane = 2;
-};
+}; /* end struct vector */
 
-} /* namespace detail */
+} /* end namespace detail */
 
 template <typename T>
 using vector_t = typename detail::vector<T>::type;
@@ -112,12 +112,12 @@ inline constexpr size_t vector_lane = detail::vector<T>::N_lane;
 template <typename T>
 inline constexpr bool has_vectype = detail::vector<T>::N_lane > 0;
 
-} /* namespace type */
+} /* end namespace type */
 
-} /* namespace neon */
+} /* end namespace neon */
 
-} /* namespace simd */
+} /* end namespace simd */
 
-} /* namespace solvcon */
+} /* end namespace solvcon */
 
 #endif /* defined(__aarch64__) */

--- a/cpp/solvcon/simd/simd.hpp
+++ b/cpp/solvcon/simd/simd.hpp
@@ -97,6 +97,6 @@ T max(T const * start, T const * end)
     return generic::max<T>(start, end);
 }
 
-} /* namespace simd */
+} /* end namespace simd */
 
-} /* namespace solvcon */
+} /* end namespace solvcon */

--- a/cpp/solvcon/simd/simd_generic.hpp
+++ b/cpp/solvcon/simd/simd_generic.hpp
@@ -81,8 +81,8 @@ T max(T const * start, T const * end)
     return max_val;
 }
 
-} /* namespace generic */
+} /* end namespace generic */
 
-} /* namespace simd */
+} /* end namespace simd */
 
-} /* namespace solvcon */
+} /* end namespace solvcon */

--- a/cpp/solvcon/simd/simd_support.cpp
+++ b/cpp/solvcon/simd/simd_support.cpp
@@ -67,8 +67,8 @@ SimdFeature detect_simd()
     return CurrentFeature;
 }
 
-} /* namespace detail */
+} /* end namespace detail */
 
-} /* namespace simd */
+} /* end namespace simd */
 
-} /* namespace solvcon */
+} /* end namespace solvcon */

--- a/cpp/solvcon/simd/simd_support.hpp
+++ b/cpp/solvcon/simd/simd_support.hpp
@@ -34,8 +34,8 @@ enum SimdFeature : std::uint8_t
 
 SimdFeature detect_simd();
 
-} /* namespace detail */
+} /* end namespace detail */
 
-} /* namespace simd */
+} /* end namespace simd */
 
-} /* namespace solvcon */
+} /* end namespace solvcon */

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -210,7 +210,7 @@ struct ToggleTypeTraits;
     {                                                   \
         static constexpr DynamicToggleIndex::Type tag = \
             DynamicToggleIndex::TAG;                    \
-    };
+    }; /* end struct ToggleTypeTraits */
 MM_TOGGLE_TYPE_TRAITS(bool, TYPE_BOOL)
 MM_TOGGLE_TYPE_TRAITS(int8_t, TYPE_INT8)
 MM_TOGGLE_TYPE_TRAITS(int16_t, TYPE_INT16)
@@ -976,7 +976,7 @@ public:
     class PopulatePasskey
     {
         friend ProcessInfo;
-    };
+    }; /* end class PopulatePasskey */
 
     void populate(int argc, char ** argv, PopulatePasskey const &)
     {

--- a/cpp/solvcon/transform/fourier.cpp
+++ b/cpp/solvcon/transform/fourier.cpp
@@ -31,4 +31,4 @@ size_t next_power_of_two(size_t n)
 
 } /* end namespace detail */
 
-} // namespace solvcon
+} /* end namespace solvcon */

--- a/cpp/solvcon/transform/fourier.hpp
+++ b/cpp/solvcon/transform/fourier.hpp
@@ -136,7 +136,7 @@ public:
             }
         }
     }
-};
+}; /* end class FourierTransform */
 
 namespace detail
 {
@@ -188,7 +188,7 @@ void fft_bluestein(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
     }
 }
 
-} /* end of namespace detail */
+} /* end namespace detail */
 
 } /* end namespace solvcon */
 

--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -237,7 +237,7 @@ struct ShapeRecord
     bbox_array_type obb_x;
     /// OBB corner y's in world coordinates, ordered TL, TR, BR, BL.
     bbox_array_type obb_y;
-}; /* end of struct ShapeRecord */
+}; /* end struct ShapeRecord */
 
 /**
  * Entry stored in the R-tree: shape ID + bounding box.
@@ -250,7 +250,7 @@ struct ShapeEntry
     int32_t shape_id;
     BoundBox3d<T> bbox;
     bool operator==(ShapeEntry const & other) const { return shape_id == other.shape_id; }
-}; /* end of struct ShapeEntry */
+}; /* end struct ShapeEntry */
 
 /**
  * RTreeValueOps specialization that gives the R-tree the bounding box of a
@@ -262,7 +262,7 @@ template <typename T>
 struct RTreeValueOps<ShapeEntry<T>, BoundBox3d<T>>
 {
     static BoundBox3d<T> calc_bound_box(ShapeEntry<T> const & entry) { return entry.bbox; }
-}; /* end of struct RTreeValueOps */
+}; /* end struct RTreeValueOps */
 
 /**
  * Manage all geometry entities.
@@ -279,7 +279,7 @@ private:
 
     class ctor_passkey
     {
-    };
+    }; /* end class ctor_passkey */
 
 public:
 
@@ -708,7 +708,7 @@ private:
         value_type angle = 0; ///< Net angle of a ROTATE, in radians.
         value_type cx = 0; ///< Pivot x of a ROTATE.
         value_type cy = 0; ///< Pivot y of a ROTATE.
-    }; /* end of struct ShapeOperationRecord */
+    }; /* end struct ShapeOperationRecord */
 
     /// Translate a shape's geometry in place and reindex it.
     void apply_translate(int32_t shape_id, value_type dx, value_type dy);

--- a/cpp/solvcon/universe/bezier.hpp
+++ b/cpp/solvcon/universe/bezier.hpp
@@ -212,7 +212,7 @@ private:
 
     detail::Bezier3dData<T> m_data;
 
-}; // namespace solvcon
+}; /* end class Bezier3d */
 
 using Bezier3dFp32 = Bezier3d<float>;
 using Bezier3dFp64 = Bezier3d<double>;
@@ -233,7 +233,7 @@ private:
 
     struct ctor_passkey
     {
-    };
+    }; /* end struct ctor_passkey */
 
 public:
 

--- a/cpp/solvcon/universe/coord.hpp
+++ b/cpp/solvcon/universe/coord.hpp
@@ -286,7 +286,7 @@ private:
 
     struct ctor_passkey
     {
-    };
+    }; /* end struct ctor_passkey */
 
 public:
 
@@ -922,7 +922,7 @@ private:
 
     struct ctor_passkey
     {
-    };
+    }; /* end struct ctor_passkey */
 
 public:
 

--- a/cpp/solvcon/universe/polygon.hpp
+++ b/cpp/solvcon/universe/polygon.hpp
@@ -297,7 +297,7 @@ private:
 
     struct ctor_passkey
     {
-    };
+    }; /* end struct ctor_passkey */
 
 public:
 
@@ -1519,7 +1519,7 @@ private:
 
     struct ctor_passkey
     {
-    };
+    }; /* end struct ctor_passkey */
 
 public:
 
@@ -2068,7 +2068,7 @@ private:
 
     struct ctor_passkey
     {
-    };
+    }; /* end struct ctor_passkey */
 
 public:
 
@@ -2210,7 +2210,7 @@ private:
 
     struct ctor_passkey
     {
-    };
+    }; /* end struct ctor_passkey */
 
 public:
 
@@ -2501,7 +2501,7 @@ struct RTreeValueOps<Segment3d<T>, BoundBox3d<T>>
         }
         return result;
     }
-};
+}; /* end struct RTreeValueOps */
 
 template <typename T>
 Polygon3d<T> PolygonPad<T>::add_polygon(std::vector<point_type> const & nodes)

--- a/cpp/solvcon/universe/pymod/wrap_World.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_World.cpp
@@ -40,8 +40,7 @@ protected:
     WrapWorld & wrap_segment();
     WrapWorld & wrap_bezier();
     WrapWorld & wrap_shape();
-};
-/* end class WrapWorld */
+}; /* end class WrapWorld */
 
 template <typename T>
 WrapWorld<T>::WrapWorld(pybind11::module & mod, const char * pyname, const char * pydoc)

--- a/cpp/solvcon/universe/pymod/wrap_shape0d.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_shape0d.cpp
@@ -34,8 +34,7 @@ protected:
     WrapPoint3d & wrap_operator();
     WrapPoint3d & wrap_accessor();
     WrapPoint3d & wrap_geometry();
-};
-/* end class WrapPoint3d */
+}; /* end class WrapPoint3d */
 
 template <typename T>
 WrapPoint3d<T>::WrapPoint3d(pybind11::module & mod, const char * pyname, const char * pydoc)

--- a/cpp/solvcon/universe/pymod/wrap_shape2d.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_shape2d.cpp
@@ -522,7 +522,7 @@ public:
 
 protected:
     WrapPolygon(pybind11::module & mod, char const * pyname, char const * pydoc);
-};
+}; /* end class WrapPolygon */
 
 template <typename T>
 WrapPolygon<T>::WrapPolygon(pybind11::module & mod, const char * pyname, const char * pydoc)
@@ -706,7 +706,7 @@ public:
 
 protected:
     WrapTrapezoidPad(pybind11::module & mod, char const * pyname, char const * pydoc);
-};
+}; /* end class WrapTrapezoidPad */
 
 template <typename T>
 WrapTrapezoidPad<T>::WrapTrapezoidPad(pybind11::module & mod, const char * pyname, const char * pydoc)
@@ -753,7 +753,7 @@ public:
 
 protected:
     WrapTrapezoidalDecomposer(pybind11::module & mod, char const * pyname, char const * pydoc);
-};
+}; /* end class WrapTrapezoidalDecomposer */
 
 template <typename T>
 WrapTrapezoidalDecomposer<T>::WrapTrapezoidalDecomposer(pybind11::module & mod, const char * pyname, const char * pydoc)

--- a/cpp/solvcon/universe/rtree.hpp
+++ b/cpp/solvcon/universe/rtree.hpp
@@ -114,7 +114,7 @@ public:
         m_max_y = std::max(m_max_y, other.m_max_y);
         m_max_z = std::max(m_max_z, other.m_max_z);
     }
-}; /* end of struct BoundBox3d */
+}; /* end class BoundBox3d */
 
 /**
  * Value operations traits for the R-tree.
@@ -132,7 +132,7 @@ struct RTreeValueOps
 
     /// Calculate bounding box for a group of items
     static B calc_group_bound_box(std::vector<E> const & items);
-}; /* end of struct RTreeValueOps */
+}; /* end struct RTreeValueOps */
 
 /**
  * R-tree node structure.
@@ -224,7 +224,7 @@ struct RTreeNode
 
         bbox = result_box;
     }
-}; /* end of struct RTreeNode */
+}; /* end struct RTreeNode */
 
 /**
  * R-tree spatial index based on Guttman's 1984 R-tree paper.
@@ -675,8 +675,8 @@ private:
         }
     }
 
-}; /* end of class RTree */
+}; /* end class RTree */
 
-} /* end of namespace solvcon */
+} /* end namespace solvcon */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/gtests/test_nopython_callprofiler.cpp
+++ b/gtests/test_nopython_callprofiler.cpp
@@ -27,7 +27,7 @@ protected:
     }
 
     CallProfiler * pProfiler;
-};
+}; /* end class CallProfilerTest */
 
 constexpr int uniqueTime1 = 19;
 constexpr int uniqueTime2 = 35;
@@ -206,7 +206,7 @@ TEST_F(CallProfilerTest, cancel)
     EXPECT_EQ(radix_tree().get_unique_node(), 0);
 }
 
-} // namespace detail
-} // namespace solvcon
+} /* end namespace detail */
+} /* end namespace solvcon */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/gtests/test_nopython_rtree.cpp
+++ b/gtests/test_nopython_rtree.cpp
@@ -21,7 +21,7 @@ struct Point2D
     {
         return x == other.x && y == other.y;
     }
-};
+}; /* end struct Point2D */
 
 using TestBoundBox3d = solvcon::BoundBox3d<double>;
 
@@ -48,7 +48,7 @@ struct Point2DValueOps
         }
         return TestBoundBox3d(min_x, min_y, 0.0, max_x, max_y, 0.0);
     }
-};
+}; /* end struct Point2DValueOps */
 
 struct Point3D
 {
@@ -60,7 +60,7 @@ struct Point3D
     {
         return x == other.x && y == other.y && z == other.z;
     }
-};
+}; /* end struct Point3D */
 
 struct Point3DValueOps
 {
@@ -89,7 +89,7 @@ struct Point3DValueOps
         }
         return TestBoundBox3d(min_x, min_y, min_z, max_x, max_y, max_z);
     }
-};
+}; /* end struct Point3DValueOps */
 
 TEST(RTree, basic_operations)
 {

--- a/gtests/test_nopython_serializable.cpp
+++ b/gtests/test_nopython_serializable.cpp
@@ -23,7 +23,7 @@ struct Address : SerializableItem
         register_member("city", city);
         register_member("phone_numbers", phone_numbers);
         register_member("zip_codes", zip_codes);)
-}; // end struct Address
+}; /* end struct Address */
 
 struct Pet : SerializableItem
 {
@@ -37,7 +37,7 @@ struct Pet : SerializableItem
         register_member("age", age);
         register_member("is_dog", is_dog);
         register_member("is_cat", is_cat);)
-}; // end struct Pet
+}; /* end struct Pet */
 
 struct Person : SerializableItem
 {
@@ -53,7 +53,7 @@ struct Person : SerializableItem
         register_member("is_student", is_student);
         register_member("address", address);
         register_member("pets", pets);)
-}; // end struct Person
+}; /* end struct Person */
 
 Pet create_dog()
 {
@@ -101,7 +101,7 @@ public:
     MM_DECL_SERIALIZABLE(
         /* not expose public_info */
         register_member("private_info", private_info);)
-}; // end struct SecretItem
+}; /* end struct SecretItem */
 
 struct EscapeItem : SerializableItem
 {
@@ -109,7 +109,7 @@ struct EscapeItem : SerializableItem
 
     MM_DECL_SERIALIZABLE(
         register_member("escape_string", escape_string);)
-}; // end struct EscapeItem
+}; /* end struct EscapeItem */
 
 struct TestUnorderedMapItem : SerializableItem
 {
@@ -119,9 +119,9 @@ struct TestUnorderedMapItem : SerializableItem
     MM_DECL_SERIALIZABLE(
         register_member("numer_map", numer_map);
         register_member("pet_map", pet_map);)
-}; // end struct TestUnorderedMapItem
+}; /* end struct TestUnorderedMapItem */
 
-} // end namespace detail
+} /* end namespace detail */
 
 TEST(Json, serialize_private_member_partial_exposure)
 {
@@ -541,6 +541,6 @@ TEST(Json, round_trip_string_with_comma)
     EXPECT_EQ(restored.zip_codes.size(), 0);
 }
 
-} // namespace solvcon
+} /* end namespace solvcon */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/gtests/test_nopython_transform.cpp
+++ b/gtests/test_nopython_transform.cpp
@@ -12,7 +12,7 @@ struct FFTTestParams
 {
     using Type = T;
     static constexpr bool is_pow_2 = IsPow2;
-};
+}; /* end struct FFTTestParams */
 
 template <typename TestParam>
 class ParsevalTest : public ::testing::Test
@@ -59,7 +59,7 @@ protected:
         // Expect the total energy in the time and frequency domains to be equal
         EXPECT_NEAR(psd_sig, psd_out, (std::is_same<T, float>::value ? (T)1e-2 : (T)1e-10));
     }
-};
+}; /* end class ParsevalTest */
 
 template <typename TestParam>
 class DeltaFunctionTest : public ::testing::Test
@@ -93,7 +93,7 @@ protected:
             EXPECT_NEAR(mag, expected_mag, (std::is_same<T, float>::value ? (T)1e-2 : (T)1e-10));
         }
     }
-};
+}; /* end class DeltaFunctionTest */
 
 template <typename TestParam>
 class InverseTest : public ::testing::Test
@@ -133,7 +133,7 @@ protected:
             EXPECT_NEAR(signal[i].imag(), time_domain[i].imag(), (std::is_same<T, float>::value ? (T)1e-2 : (T)1e-10));
         }
     }
-};
+}; /* end class InverseTest */
 
 typedef ::testing::Types<
     FFTTestParams<float, true>,


### PR DESCRIPTION
Sweep cpp/ and gtests/ to add the STYLE.md-required class, struct, and namespace ending marks, correct marks that named the wrong type or keyword, and normalize stale wording ("//", "end of ...", dropped "end"), plus add a cpp-style-review skill rule so future diffs get checked; the spacetime/ reference implementation is left untouched.
