### PR TITLE
Route undo, redo, and camera reset through the shortcut manager

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -20,7 +20,6 @@
 #include <QAction>
 #include <QActionGroup>
 #include <QColor>
-#include <QKeySequence>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -55,8 +54,8 @@ RManager::RManager()
     m_mainWindow->setWindowIcon(QIcon(QString(":/icon.ico")));
     // Parented to the manager to make color-scheme survive a window rebuild.
     m_themeManager = new RThemeManager(this);
-    // The shortcut resolver is parented likewise. No action routes through it
-    // yet; later steps adopt its bindings on both the C++ and Python sides.
+    // The shortcut resolver is parented likewise. Undo, redo, and camera reset
+    // route through it; later steps adopt the remaining bindings.
     m_shortcutManager = new RShortcutManager(this);
     // Do not call setUp() from the constructor.  Windows may crash with
     // "exited with code -1073740791".  The reason is not yet clarified.
@@ -420,7 +419,7 @@ void RManager::setUpEditMenuItems() const
         { undoCanvas(); },
         m_menuModel);
     undo_action->setObjectName("edit.undo");
-    undo_action->setShortcut(QKeySequence::Undo);
+    m_shortcutManager->applyTo(undo_action, ShortcutCommand::Undo);
 
     auto * redo_action = new RAction(
         QString("Redo"),
@@ -429,7 +428,7 @@ void RManager::setUpEditMenuItems() const
         { redoCanvas(); },
         m_menuModel);
     redo_action->setObjectName("edit.redo");
-    redo_action->setShortcut(QKeySequence::Redo);
+    m_shortcutManager->applyTo(redo_action, ShortcutCommand::Redo);
 
     m_menuModel->place("Edit", undo_action, 10);
     m_menuModel->place("Edit", redo_action, 20);
@@ -559,11 +558,10 @@ void RManager::setUpCameraMovementMenuItems() const
     }
 
     // Escape resets the camera; add3DWidget attaches this action to each
-    // viewer so its Qt::WidgetShortcut context can fire.
+    // viewer so its WidgetShortcut context can fire.
     if (QAction * reset = m_menuModel->action("camera.reset"))
     {
-        reset->setShortcut(QKeySequence(Qt::Key_Escape));
-        reset->setShortcutContext(Qt::WidgetShortcut);
+        m_shortcutManager->applyTo(reset, ShortcutCommand::CameraReset);
     }
 }
 

--- a/tests/test_pilot_shortcut.py
+++ b/tests/test_pilot_shortcut.py
@@ -9,6 +9,7 @@ import solvcon
 
 try:
     from solvcon import pilot
+    from PySide6 import QtCore, QtGui
 except ImportError:
     pilot = None
 
@@ -19,7 +20,7 @@ GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
                  "GUI is not available in GitHub Actions")
 class ShortcutResolutionTC(unittest.TestCase):
     """The roof resolves a command id to portable values the Python layer can
-    apply. No action is routed through it yet; these check the resolution."""
+    apply."""
 
     def setUp(self):
         self.mgr = pilot.RManager.instance.setUp()
@@ -62,6 +63,40 @@ class ShortcutResolutionTC(unittest.TestCase):
 
     def test_resolved_bindings_do_not_collide(self):
         self.assertEqual(self.mgr.shortcut_conflicts(), [])
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class ShortcutTC(unittest.TestCase):
+    """Live QAction bindings for the commands routed through the roof."""
+
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.model = self.mgr.menu_model
+
+    def _live_sequences(self, action):
+        return [s.toString(QtGui.QKeySequence.PortableText)
+                for s in action.shortcuts()]
+
+    def _assert_action_matches_resolved(self, object_name, qt_context):
+        action = self.model.action(object_name)
+        self.assertIsNotNone(action)
+        resolved = self.mgr.resolve_shortcut(object_name)
+        self.assertTrue(resolved["bound"])
+        self.assertEqual(self._live_sequences(action), resolved["sequences"])
+        self.assertEqual(action.shortcutContext(), qt_context)
+
+    def test_undo_action_carries_the_resolved_binding(self):
+        self._assert_action_matches_resolved(
+            "edit.undo", QtCore.Qt.WindowShortcut)
+
+    def test_redo_action_carries_the_resolved_binding(self):
+        self._assert_action_matches_resolved(
+            "edit.redo", QtCore.Qt.WindowShortcut)
+
+    def test_camera_reset_action_carries_the_resolved_binding(self):
+        self._assert_action_matches_resolved(
+            "camera.reset", QtCore.Qt.WidgetShortcut)
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Step 3 of the pilot shortcut work: undo, redo, and camera-reset bindings now resolve from the keymap tables through RShortcutManager::applyTo instead of hardcoded setShortcut calls, reset keeps its widget context and add3DWidget attachment, and new Python tests cover the live bindings. Related to #1070.
