### PR TITLE
Bind silent pilot commands through the shortcut manager

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -54,8 +54,7 @@ RManager::RManager()
     m_mainWindow->setWindowIcon(QIcon(QString(":/icon.ico")));
     // Parented to the manager to make color-scheme survive a window rebuild.
     m_themeManager = new RThemeManager(this);
-    // The shortcut resolver is parented likewise. Undo, redo, and camera reset
-    // route through it; later steps adopt the remaining bindings.
+    // Shortcut resolver: C++ uses applyTo; Python uses apply_shortcut.
     m_shortcutManager = new RShortcutManager(this);
     // Do not call setUp() from the constructor.  Windows may crash with
     // "exited with code -1073740791".  The reason is not yet clarified.

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -89,10 +89,7 @@ public:
     /// The application-wide theme controller, scriptable from Python.
     RThemeManager * themeManager() { return m_themeManager; }
 
-    /**
-     * The keyboard-shortcut resolver, scriptable from Python. Nothing routes
-     * its bindings through the pilot yet; later steps adopt them.
-     */
+    /// Keyboard-shortcut resolver. C++ uses applyTo; Python uses apply_shortcut.
     RShortcutManager * shortcutManager() { return m_shortcutManager; }
 
     void quit() { m_core->quit(); }

--- a/cpp/solvcon/pilot/RShortcutManager.cpp
+++ b/cpp/solvcon/pilot/RShortcutManager.cpp
@@ -46,6 +46,10 @@ QKeySequence::StandardKey toStandardKey(StandardAction action)
         return QKeySequence::Undo;
     case StandardAction::Redo:
         return QKeySequence::Redo;
+    case StandardAction::Quit:
+        return QKeySequence::Quit;
+    case StandardAction::New:
+        return QKeySequence::New;
     }
     throw std::logic_error("Unexpected standard action");
 }
@@ -58,6 +62,10 @@ std::string standardKeyName(StandardAction action)
         return "Undo";
     case StandardAction::Redo:
         return "Redo";
+    case StandardAction::Quit:
+        return "Quit";
+    case StandardAction::New:
+        return "New";
     }
     throw std::logic_error("Unexpected standard action");
 }
@@ -68,6 +76,14 @@ Qt::Key toQtKey(Key key)
     {
     case Key::Escape:
         return Qt::Key_Escape;
+    case Key::Grave:
+        return Qt::Key_QuoteLeft;
+    case Key::A:
+        return Qt::Key_A;
+    case Key::I:
+        return Qt::Key_I;
+    case Key::P:
+        return Qt::Key_P;
     }
     throw std::logic_error("Unexpected key");
 }

--- a/cpp/solvcon/pilot/RShortcutManager.hpp
+++ b/cpp/solvcon/pilot/RShortcutManager.hpp
@@ -41,7 +41,7 @@ namespace solvcon
  * binding names its Qt standard key so PySide can call setShortcuts with it;
  * a curated binding carries its resolved sequence strings. bound is false when
  * the command has no key on this platform, though role and context still apply
- * (macOS Quit is unbound but keeps its application-menu role).
+ * for an Unbound table entry.
  */
 struct ResolvedShortcut
 {

--- a/cpp/solvcon/pilot/keymap.cpp
+++ b/cpp/solvcon/pilot/keymap.cpp
@@ -22,29 +22,48 @@ std::vector<ShortcutBinding> tableWith(std::vector<ShortcutBinding> extra)
         {ShortcutCommand::Undo, StandardAction::Undo, ShortcutContext::Window},
         {ShortcutCommand::Redo, StandardAction::Redo, ShortcutContext::Window},
         {ShortcutCommand::CameraReset, KeyChord{KeyMod::None, Key::Escape}, ShortcutContext::Widget},
+        // Primary+` toggles the console. Panel toggles use Primary+Shift
+        // chords and leave plain W/A/S/D and arrows to keyPressEvent.
+        {ShortcutCommand::Console, KeyChord{KeyMod::Primary, Key::Grave}, ShortcutContext::Window},
+        {ShortcutCommand::AgentPanel,
+         KeyChord{KeyMod::Primary | KeyMod::Shift, Key::A},
+         ShortcutContext::Window},
+        {ShortcutCommand::InspectorPanel,
+         KeyChord{KeyMod::Primary | KeyMod::Shift, Key::I},
+         ShortcutContext::Window},
+        {ShortcutCommand::PainterPanel,
+         KeyChord{KeyMod::Primary | KeyMod::Shift, Key::P},
+         ShortcutContext::Window},
+        {ShortcutCommand::New2DCanvas, StandardAction::New, ShortcutContext::Window},
     };
     rows.insert(rows.end(), extra.begin(), extra.end());
     return rows;
 }
 
+std::vector<ShortcutBinding> const & nonMacTable()
+{
+    static std::vector<ShortcutBinding> const table = tableWith(
+        {{ShortcutCommand::Exit, StandardAction::Quit, ShortcutContext::Application}});
+    return table;
+}
+
 std::vector<ShortcutBinding> const & linuxTable()
 {
-    static std::vector<ShortcutBinding> const table = tableWith({});
-    return table;
+    return nonMacTable();
 }
 
 std::vector<ShortcutBinding> const & windowsTable()
 {
-    static std::vector<ShortcutBinding> const table = tableWith({});
-    return table;
+    return nonMacTable();
 }
 
 std::vector<ShortcutBinding> const & macTable()
 {
-    // macOS carries the Quit role from the start; the key sequence for Quit
-    // is added when file.exit begins routing through the manager.
-    static std::vector<ShortcutBinding> const table =
-        tableWith({{ShortcutCommand::Exit, Unbound{}, ShortcutContext::Application, MenuRole::Quit}});
+    static std::vector<ShortcutBinding> const table = tableWith(
+        {{ShortcutCommand::Exit,
+          StandardAction::Quit,
+          ShortcutContext::Application,
+          MenuRole::Quit}});
     return table;
 }
 
@@ -66,6 +85,12 @@ std::string_view commandId(ShortcutCommand command)
         return "window.console";
     case ShortcutCommand::AgentPanel:
         return "panel.agent_console";
+    case ShortcutCommand::InspectorPanel:
+        return "panel.inspector";
+    case ShortcutCommand::PainterPanel:
+        return "panel.painter";
+    case ShortcutCommand::New2DCanvas:
+        return "canvas.blank_2d";
     }
     throw std::logic_error("Unexpected command");
 }

--- a/cpp/solvcon/pilot/keymap.hpp
+++ b/cpp/solvcon/pilot/keymap.hpp
@@ -46,14 +46,16 @@ enum class MenuRole
 enum class StandardAction
 {
     Undo,
-    Redo
+    Redo,
+    Quit,
+    New
 };
 
 /**
  * A modifier role, written against the command modifier rather than a
  * physical key: Primary is Command on macOS and Control elsewhere. A flag
- * set so a chord can name more than one modifier; the roof adds the bitwise
- * combine and test helpers when it resolves a chord into Qt modifiers.
+ * set so a chord can name more than one modifier via operator|; the roof
+ * maps each flag to a Qt keyboard modifier when it resolves a chord.
  */
 enum class KeyMod : unsigned
 {
@@ -63,15 +65,25 @@ enum class KeyMod : unsigned
     Alt = 1u << 2
 };
 
+constexpr KeyMod operator|(KeyMod lhs, KeyMod rhs)
+{
+    return static_cast<KeyMod>(static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs));
+}
+
 /**
  * A physical key a curated chord names. The vocabulary stays small: only the
  * keys the pilot binds today, growing as later steps add curated chords.
  * Arrow keys are deliberately absent; they belong to
- * RDomainWidget::keyPressEvent, not the action system.
+ * RDomainWidget::keyPressEvent, not the action system. Plain W/A/S/D camera
+ * moves stay there too; letter keys here are only for Primary+Shift chords.
  */
 enum class Key
 {
-    Escape
+    Escape,
+    Grave,
+    A,
+    I,
+    P
 };
 
 struct KeyChord
@@ -109,7 +121,10 @@ enum class ShortcutCommand
     CameraReset,
     Exit,
     Console,
-    AgentPanel
+    AgentPanel,
+    InspectorPanel,
+    PainterPanel,
+    New2DCanvas
 };
 
 struct ShortcutBinding
@@ -131,7 +146,10 @@ inline constexpr auto ALL_SHORTCUT_COMMANDS = std::to_array<ShortcutCommand>(
      ShortcutCommand::CameraReset,
      ShortcutCommand::Exit,
      ShortcutCommand::Console,
-     ShortcutCommand::AgentPanel});
+     ShortcutCommand::AgentPanel,
+     ShortcutCommand::InspectorPanel,
+     ShortcutCommand::PainterPanel,
+     ShortcutCommand::New2DCanvas});
 
 struct ShortcutCapabilities
 {

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -973,8 +973,11 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 "resolve_shortcut",
                 [](wrapped_type & self, std::string const & command_id)
                 {
-                    ResolvedShortcut const r = self.shortcutManager()->resolveById(command_id);
                     py::dict out;
+                    bool const known = commandFromId(command_id).has_value();
+                    ResolvedShortcut const r =
+                        self.shortcutManager()->resolveById(command_id);
+                    out["known"] = known;
                     out["bound"] = r.bound;
                     out["standard"] = r.standard;
                     out["standard_key"] = r.standard_key;

--- a/gtests/test_nopython_pilot_keymap.cpp
+++ b/gtests/test_nopython_pilot_keymap.cpp
@@ -19,7 +19,7 @@ constexpr std::array<solvcon::PlatformId, 3> PLATFORMS = {
 
 } /* end namespace */
 
-TEST(PilotKeymapTable, SeedsUndoRedoAndResetOnEveryPlatform)
+TEST(PilotKeymapTable, SeedsSharedBindingsOnEveryPlatform)
 {
     for (auto platform : PLATFORMS)
     {
@@ -37,19 +37,54 @@ TEST(PilotKeymapTable, SeedsUndoRedoAndResetOnEveryPlatform)
         EXPECT_EQ(std::get<solvcon::KeyChord>(reset->key),
                   (solvcon::KeyChord{solvcon::KeyMod::None, solvcon::Key::Escape}));
         EXPECT_EQ(reset->context, solvcon::ShortcutContext::Widget);
+
+        auto const * console = solvcon::bindingFor(platform, solvcon::ShortcutCommand::Console);
+        ASSERT_NE(console, nullptr);
+        EXPECT_EQ(std::get<solvcon::KeyChord>(console->key),
+                  (solvcon::KeyChord{solvcon::KeyMod::Primary, solvcon::Key::Grave}));
+        EXPECT_EQ(console->context, solvcon::ShortcutContext::Window);
+
+        struct PanelChord
+        {
+            solvcon::ShortcutCommand command;
+            solvcon::Key key;
+        }; /* end struct PanelChord */
+        for (auto const & panel : {
+                 PanelChord{solvcon::ShortcutCommand::AgentPanel, solvcon::Key::A},
+                 PanelChord{solvcon::ShortcutCommand::InspectorPanel, solvcon::Key::I},
+                 PanelChord{solvcon::ShortcutCommand::PainterPanel, solvcon::Key::P},
+             })
+        {
+            auto const * binding = solvcon::bindingFor(platform, panel.command);
+            ASSERT_NE(binding, nullptr);
+            EXPECT_EQ(std::get<solvcon::KeyChord>(binding->key),
+                      (solvcon::KeyChord{solvcon::KeyMod::Primary | solvcon::KeyMod::Shift, panel.key}));
+        }
+
+        auto const * blank = solvcon::bindingFor(platform, solvcon::ShortcutCommand::New2DCanvas);
+        ASSERT_NE(blank, nullptr);
+        EXPECT_EQ(std::get<solvcon::StandardAction>(blank->key), solvcon::StandardAction::New);
+
+        auto const * exit = solvcon::bindingFor(platform, solvcon::ShortcutCommand::Exit);
+        ASSERT_NE(exit, nullptr);
+        EXPECT_EQ(std::get<solvcon::StandardAction>(exit->key), solvcon::StandardAction::Quit);
+        EXPECT_EQ(exit->context, solvcon::ShortcutContext::Application);
     }
 }
 
-TEST(PilotKeymapMac, AddsQuitRoleAndAppMenuOverTheSeed)
+TEST(PilotKeymapMac, AddsQuitRoleOverTheSharedExitBinding)
 {
     EXPECT_TRUE(solvcon::capabilitiesFor(solvcon::PlatformId::Mac).movesItemsToApplicationMenu);
     EXPECT_EQ(solvcon::bindingTable(solvcon::PlatformId::Mac).size(),
-              solvcon::bindingTable(solvcon::PlatformId::Linux).size() + 1);
+              solvcon::bindingTable(solvcon::PlatformId::Linux).size());
 
     auto const * exit = solvcon::bindingFor(solvcon::PlatformId::Mac, solvcon::ShortcutCommand::Exit);
     ASSERT_NE(exit, nullptr);
-    EXPECT_TRUE(std::holds_alternative<solvcon::Unbound>(exit->key));
+    EXPECT_EQ(std::get<solvcon::StandardAction>(exit->key), solvcon::StandardAction::Quit);
     EXPECT_EQ(exit->role, solvcon::MenuRole::Quit);
+
+    EXPECT_EQ(solvcon::bindingFor(solvcon::PlatformId::Linux, solvcon::ShortcutCommand::Exit)->role,
+              solvcon::MenuRole::None);
 }
 
 TEST(PilotKeymapCapabilities, OnlyMacMovesItemsToApplicationMenu)

--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -14,7 +14,6 @@ from . import _pilot_core as _pcore
 from . import airfoil
 
 if _pcore.enable:
-    from PySide6.QtGui import QAction
     from . import _gui_common
     from . import _mesh
     from . import _tree_panel
@@ -165,20 +164,17 @@ class _Controller(metaclass=_Singleton):
         self.theme_menu.populate_menu()
         self.window_manager.populate_menu()
 
-        # An explicit QuitRole lets macOS relocate Exit into the application
-        # menu, so no platform special case is needed.
         wm.menu_model.place(
             "File",
             _gui_common.build_action(
                 wm.mainWindow, "Exit", "Exit the application",
-                lambda: wm.quit(), id="file.exit",
-                menu_role=QAction.MenuRole.QuitRole),
+                lambda: wm.quit(), id="file.exit"),
             100)
         wm.menu_model.place(
             "View/Panels",
             _gui_common.build_action(
                 wm.mainWindow, "Console", "Open / Close Console",
-                wm.toggleConsole, id="panel.console",
+                wm.toggleConsole, id="window.console",
                 checkable=True, checked=True),
             30)
 

--- a/solvcon/pilot/_gui_common.py
+++ b/solvcon/pilot/_gui_common.py
@@ -70,6 +70,50 @@ class ToggleActionBridge(QtCore.QObject):
         self._store_changed.emit(tg.get(self._key, self._action.isChecked()))
 
 
+_SHORTCUT_CONTEXTS = {
+    "application": QtCore.Qt.ApplicationShortcut,
+    "window": QtCore.Qt.WindowShortcut,
+    "widget": QtCore.Qt.WidgetShortcut,
+}
+
+_MENU_ROLES = {
+    "none": QtGui.QAction.NoRole,
+    "quit": QtGui.QAction.QuitRole,
+    "preferences": QtGui.QAction.PreferencesRole,
+    "about": QtGui.QAction.AboutRole,
+}
+
+
+def apply_shortcut(action, mgr=None):
+    """Apply the keymap binding for ``action``'s objectName from the roof.
+
+    Resolves the command id through ``RManager.resolve_shortcut`` and sets the
+    menu role, shortcut context, and sequences with PySide. Unknown ids are a
+    no-op so feature actions outside the vocabulary stay untouched. The role is
+    set first, as macOS requires before the action reaches a menu.
+    """
+    oid = action.objectName()
+    if not oid:
+        return
+    if mgr is None:
+        mgr = _pcore.RManager.instance
+    resolved = mgr.resolve_shortcut(oid)
+    if not resolved["known"]:
+        return
+
+    action.setMenuRole(_MENU_ROLES[resolved["role"]])
+    action.setShortcutContext(_SHORTCUT_CONTEXTS[resolved["context"]])
+    if resolved["standard"]:
+        standard = getattr(QtGui.QKeySequence.StandardKey,
+                           resolved["standard_key"])
+        action.setShortcuts(standard)
+    else:
+        action.setShortcuts([
+            QtGui.QKeySequence(s, QtGui.QKeySequence.PortableText)
+            for s in resolved["sequences"]
+        ])
+
+
 def build_action(parent, text, tip, func, *, id=None, checkable=False,
                  checked=False, shortcut=None, menu_role=None,
                  toggle_key=None):
@@ -83,6 +127,9 @@ def build_action(parent, text, tip, func, *, id=None, checkable=False,
     When ``toggle_key`` is given, the action is bound two-way to that store
     toggle through a ToggleActionBridge, so its state persists, round-trips to
     JSON, and can be observed by a solver or a second widget.
+
+    When ``id`` names a keymap command, ``apply_shortcut`` installs its
+    platform binding and overwrites any explicit ``shortcut`` or ``menu_role``.
     """
     act = QtGui.QAction(text, parent)
     if id:
@@ -99,6 +146,8 @@ def build_action(parent, text, tip, func, *, id=None, checkable=False,
         act.triggered.connect(lambda *a: func())
     if toggle_key is not None:
         ToggleActionBridge(act, toggle_key)
+    if id:
+        apply_shortcut(act)
     return act
 
 

--- a/tests/test_pilot_bar.py
+++ b/tests/test_pilot_bar.py
@@ -51,7 +51,7 @@ class BarStructureTC(unittest.TestCase):
 
         # The Console toggle lives with the other panel toggles; the Window
         # menu holds only the dynamic sub-window list.
-        self.assertIsNotNone(model.action("panel.console"))
+        self.assertIsNotNone(model.action("window.console"))
         self.assertNotIn("Console",
                          [a.text() for a in model.menu("Window").actions()])
 

--- a/tests/test_pilot_shortcut.py
+++ b/tests/test_pilot_shortcut.py
@@ -9,11 +9,24 @@ import solvcon
 
 try:
     from solvcon import pilot
+    from solvcon.pilot import _gui
+    from solvcon.pilot import _gui_common
     from PySide6 import QtCore, QtGui
 except ImportError:
     pilot = None
 
 GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+_PANEL_CHORDS = (
+    ("panel.agent_console", ["Ctrl+Shift+A"]),
+    ("panel.inspector", ["Ctrl+Shift+I"]),
+    ("panel.painter", ["Ctrl+Shift+P"]),
+)
+
+
+def _live_sequences(action):
+    return [s.toString(QtGui.QKeySequence.PortableText)
+            for s in action.shortcuts()]
 
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
@@ -30,6 +43,7 @@ class ShortcutResolutionTC(unittest.TestCase):
 
     def test_undo_resolves_to_its_standard_key(self):
         r = self.mgr.resolve_shortcut("edit.undo")
+        self.assertTrue(r["known"])
         self.assertTrue(r["bound"])
         self.assertTrue(r["standard"])
         self.assertEqual(r["standard_key"], "Undo")
@@ -38,26 +52,51 @@ class ShortcutResolutionTC(unittest.TestCase):
 
     def test_camera_reset_resolves_to_a_curated_chord(self):
         r = self.mgr.resolve_shortcut("camera.reset")
+        self.assertTrue(r["known"])
         self.assertTrue(r["bound"])
         self.assertFalse(r["standard"])
         self.assertEqual(r["context"], "widget")
         self.assertEqual(r["role"], "none")
         self.assertEqual(r["sequences"], ["Esc"])
 
-    def test_exit_role_follows_the_platform(self):
+    def test_console_resolves_to_primary_grave(self):
+        r = self.mgr.resolve_shortcut("window.console")
+        self.assertTrue(r["known"])
+        self.assertTrue(r["bound"])
+        self.assertFalse(r["standard"])
+        self.assertEqual(r["context"], "window")
+        self.assertEqual(r["sequences"], ["Ctrl+`"])
+
+    def test_panel_chords_resolve(self):
+        for oid, sequences in _PANEL_CHORDS:
+            with self.subTest(oid=oid):
+                r = self.mgr.resolve_shortcut(oid)
+                self.assertTrue(r["known"])
+                self.assertTrue(r["bound"])
+                self.assertEqual(r["sequences"], sequences)
+
+    def test_new_2d_canvas_resolves_to_new(self):
+        r = self.mgr.resolve_shortcut("canvas.blank_2d")
+        self.assertTrue(r["known"])
+        self.assertTrue(r["bound"])
+        self.assertTrue(r["standard"])
+        self.assertEqual(r["standard_key"], "New")
+
+    def test_exit_carries_quit_and_platform_role(self):
         r = self.mgr.resolve_shortcut("file.exit")
+        self.assertTrue(r["known"])
+        self.assertTrue(r["bound"])
+        self.assertTrue(r["standard"])
+        self.assertEqual(r["standard_key"], "Quit")
+        self.assertEqual(r["context"], "application")
         if self.mgr.shortcut_platform == "mac":
-            # macOS carries the Quit application-menu role with no key yet.
-            self.assertFalse(r["bound"])
             self.assertEqual(r["role"], "quit")
-            self.assertEqual(r["context"], "application")
         else:
-            # No Exit entry off macOS until a later step binds it.
-            self.assertFalse(r["bound"])
             self.assertEqual(r["role"], "none")
 
     def test_unknown_command_is_unbound(self):
         r = self.mgr.resolve_shortcut("no.such.command")
+        self.assertFalse(r["known"])
         self.assertFalse(r["bound"])
         self.assertEqual(r["sequences"], [])
 
@@ -71,19 +110,16 @@ class ShortcutTC(unittest.TestCase):
     """Live QAction bindings for the commands routed through the roof."""
 
     def setUp(self):
-        self.mgr = pilot.RManager.instance.setUp()
+        self.mgr = _gui.controller.build()
         self.model = self.mgr.menu_model
-
-    def _live_sequences(self, action):
-        return [s.toString(QtGui.QKeySequence.PortableText)
-                for s in action.shortcuts()]
 
     def _assert_action_matches_resolved(self, object_name, qt_context):
         action = self.model.action(object_name)
         self.assertIsNotNone(action)
         resolved = self.mgr.resolve_shortcut(object_name)
+        self.assertTrue(resolved["known"])
         self.assertTrue(resolved["bound"])
-        self.assertEqual(self._live_sequences(action), resolved["sequences"])
+        self.assertEqual(_live_sequences(action), resolved["sequences"])
         self.assertEqual(action.shortcutContext(), qt_context)
 
     def test_undo_action_carries_the_resolved_binding(self):
@@ -97,6 +133,59 @@ class ShortcutTC(unittest.TestCase):
     def test_camera_reset_action_carries_the_resolved_binding(self):
         self._assert_action_matches_resolved(
             "camera.reset", QtCore.Qt.WidgetShortcut)
+
+    def test_console_action_carries_the_resolved_binding(self):
+        self._assert_action_matches_resolved(
+            "window.console", QtCore.Qt.WindowShortcut)
+
+    def test_panel_actions_carry_the_resolved_bindings(self):
+        for oid, _ in _PANEL_CHORDS:
+            with self.subTest(oid=oid):
+                self._assert_action_matches_resolved(
+                    oid, QtCore.Qt.WindowShortcut)
+
+    def test_new_2d_canvas_action_carries_the_resolved_binding(self):
+        self._assert_action_matches_resolved(
+            "canvas.blank_2d", QtCore.Qt.WindowShortcut)
+
+    def test_exit_action_carries_quit_and_platform_role(self):
+        self._assert_action_matches_resolved(
+            "file.exit", QtCore.Qt.ApplicationShortcut)
+        action = self.model.action("file.exit")
+        if self.mgr.shortcut_platform == "mac":
+            self.assertEqual(action.menuRole(), QtGui.QAction.QuitRole)
+        else:
+            self.assertEqual(action.menuRole(), QtGui.QAction.NoRole)
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class ApplyShortcutHelperTC(unittest.TestCase):
+    """apply_shortcut installs a binding by objectName without hand wiring."""
+
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+
+    def test_applies_a_known_command_to_a_fresh_action(self):
+        act = QtGui.QAction("Console", self.mgr.mainWindow)
+        act.setObjectName("window.console")
+        _gui_common.apply_shortcut(act, mgr=self.mgr)
+        resolved = self.mgr.resolve_shortcut("window.console")
+        self.assertEqual(_live_sequences(act), resolved["sequences"])
+        self.assertEqual(act.shortcutContext(), QtCore.Qt.WindowShortcut)
+
+    def test_unknown_id_is_a_noop(self):
+        act = QtGui.QAction("Scratch", self.mgr.mainWindow)
+        act.setObjectName("no.such.command")
+        act.setShortcut("Ctrl+X")
+        act.setShortcutContext(QtCore.Qt.ApplicationShortcut)
+        act.setMenuRole(QtGui.QAction.AboutRole)
+        _gui_common.apply_shortcut(act, mgr=self.mgr)
+        self.assertEqual(act.shortcut().toString(
+            QtGui.QKeySequence.PortableText), "Ctrl+X")
+        self.assertEqual(act.shortcutContext(),
+                         QtCore.Qt.ApplicationShortcut)
+        self.assertEqual(act.menuRole(), QtGui.QAction.AboutRole)
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Step 4 of the pilot shortcut work gives the previously silent commands (Exit, Console, the View panels, and new blank 2D canvas) platform bindings from the keymap tables. A small Python helper, apply_shortcut, applies each binding by objectName so PilotFeature.add_action and the direct build_action callers pick up the same keys as the C++ path, without hand-wiring each action.

| Command | Menu id | Shortcut |
| --- | --- | --- |
| Exit | `file.exit` | Quit (Ctrl+Q / Cmd+Q); QuitRole on macOS |
| Console | `window.console` | Primary+` (Ctrl+` / Cmd+`) |
| Agent Console | `panel.agent_console` | Primary+Shift+A |
| Inspector | `panel.inspector` | Primary+Shift+I |
| Painter | `panel.painter` | Primary+Shift+P |
| Create blank 2D canvas | `canvas.blank_2d` | New (Ctrl+N / Cmd+N) |

Primary is Control on Linux and Windows, and Command on macOS. Undo, redo, and camera reset are unchanged from Step 3. WASD and arrow keys in the 3D viewer stay in keyPressEvent and are not part of this table.

Related to #1070.
