### PR TITLE
Tune pilot shortcut accents per platform

### DIFF
--- a/cpp/solvcon/pilot/RShortcutManager.cpp
+++ b/cpp/solvcon/pilot/RShortcutManager.cpp
@@ -78,12 +78,26 @@ Qt::Key toQtKey(Key key)
         return Qt::Key_Escape;
     case Key::Grave:
         return Qt::Key_QuoteLeft;
+    case Key::Tab:
+        return Qt::Key_Tab;
+    case Key::Space:
+        return Qt::Key_Space;
+    case Key::F4:
+        return Qt::Key_F4;
     case Key::A:
         return Qt::Key_A;
+    case Key::D:
+        return Qt::Key_D;
     case Key::I:
         return Qt::Key_I;
     case Key::P:
         return Qt::Key_P;
+    case Key::S:
+        return Qt::Key_S;
+    case Key::W:
+        return Qt::Key_W;
+    case Key::Z:
+        return Qt::Key_Z;
     }
     throw std::logic_error("Unexpected key");
 }
@@ -143,10 +157,16 @@ QList<QKeySequence> RShortcutManager::sequencesForBinding(ShortcutBinding const 
     {
         // Qt maps ControlModifier to Command on macOS, so a Primary chord
         // pronounces itself on every platform without a native branch here.
+        // The physical Control key is a separate key on macOS, reached
+        // through MetaModifier because Qt swaps Control and Meta there.
         Qt::KeyboardModifiers mods = Qt::NoModifier;
         if (hasMod(chord->mods, KeyMod::Primary))
         {
             mods |= Qt::ControlModifier;
+        }
+        if (hasMod(chord->mods, KeyMod::Control))
+        {
+            mods |= m_platform == PlatformId::Mac ? Qt::MetaModifier : Qt::ControlModifier;
         }
         if (hasMod(chord->mods, KeyMod::Shift))
         {
@@ -233,8 +253,11 @@ ResolvedShortcut RShortcutManager::resolveById(std::string const & id) const
 
 std::vector<ShortcutConflict> RShortcutManager::findResolvedConflicts() const
 {
-    std::vector<ShortcutBinding> const & table = bindingTable(m_platform);
+    return findResolvedConflictsIn(bindingTable(m_platform));
+}
 
+std::vector<ShortcutConflict> RShortcutManager::findResolvedConflictsIn(std::vector<ShortcutBinding> const & table) const
+{
     std::vector<QList<QKeySequence>> resolved;
     resolved.reserve(table.size());
     for (ShortcutBinding const & binding : table)
@@ -255,7 +278,7 @@ std::vector<ShortcutConflict> RShortcutManager::findResolvedConflicts() const
         }
         return false;
     };
-    return findConflicts(m_platform, bound, sequencesClash);
+    return findConflictsIn(table, bound, sequencesClash);
 }
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/RShortcutManager.hpp
+++ b/cpp/solvcon/pilot/RShortcutManager.hpp
@@ -111,6 +111,12 @@ public:
      */
     std::vector<ShortcutConflict> findResolvedConflicts() const;
 
+    /**
+     * Same as findResolvedConflicts, but over an explicit table so a test can
+     * rebind one command and prove the resolved checker reports the clash.
+     */
+    std::vector<ShortcutConflict> findResolvedConflictsIn(std::vector<ShortcutBinding> const & table) const;
+
 signals:
 
     /**

--- a/cpp/solvcon/pilot/keymap.cpp
+++ b/cpp/solvcon/pilot/keymap.cpp
@@ -16,15 +16,16 @@ namespace solvcon
 namespace
 {
 
-std::vector<ShortcutBinding> tableWith(std::vector<ShortcutBinding> extra)
+/**
+ * Bindings shared by every platform. The per-platform tables append only
+ * their Exit accent on top of this seed.
+ */
+std::vector<ShortcutBinding> sharedSeed()
 {
-    std::vector<ShortcutBinding> rows = {
+    return {
         {ShortcutCommand::Undo, StandardAction::Undo, ShortcutContext::Window},
         {ShortcutCommand::Redo, StandardAction::Redo, ShortcutContext::Window},
         {ShortcutCommand::CameraReset, KeyChord{KeyMod::None, Key::Escape}, ShortcutContext::Widget},
-        // Primary+` toggles the console. Panel toggles use Primary+Shift
-        // chords and leave plain W/A/S/D and arrows to keyPressEvent.
-        {ShortcutCommand::Console, KeyChord{KeyMod::Primary, Key::Grave}, ShortcutContext::Window},
         {ShortcutCommand::AgentPanel,
          KeyChord{KeyMod::Primary | KeyMod::Shift, Key::A},
          ShortcutContext::Window},
@@ -35,35 +36,42 @@ std::vector<ShortcutBinding> tableWith(std::vector<ShortcutBinding> extra)
          KeyChord{KeyMod::Primary | KeyMod::Shift, Key::P},
          ShortcutContext::Window},
         {ShortcutCommand::New2DCanvas, StandardAction::New, ShortcutContext::Window},
+
+        // Like VSCode, the pilot binds Console to physical Ctrl+Grave on every platform.
+        {ShortcutCommand::Console, KeyChord{KeyMod::Control, Key::Grave}, ShortcutContext::Window},
     };
+}
+
+std::vector<ShortcutBinding> tableWith(std::vector<ShortcutBinding> extra)
+{
+    std::vector<ShortcutBinding> rows = sharedSeed();
     rows.insert(rows.end(), extra.begin(), extra.end());
     return rows;
 }
 
-std::vector<ShortcutBinding> const & nonMacTable()
-{
-    static std::vector<ShortcutBinding> const table = tableWith(
-        {{ShortcutCommand::Exit, StandardAction::Quit, ShortcutContext::Application}});
-    return table;
-}
-
 std::vector<ShortcutBinding> const & linuxTable()
 {
-    return nonMacTable();
+    static std::vector<ShortcutBinding> const table = tableWith({
+        {ShortcutCommand::Exit, StandardAction::Quit, ShortcutContext::Application},
+    });
+    return table;
 }
 
 std::vector<ShortcutBinding> const & windowsTable()
 {
-    return nonMacTable();
+    // Windows shares the Linux Control accent for curated chords.
+    return linuxTable();
 }
 
 std::vector<ShortcutBinding> const & macTable()
 {
-    static std::vector<ShortcutBinding> const table = tableWith(
-        {{ShortcutCommand::Exit,
-          StandardAction::Quit,
-          ShortcutContext::Application,
-          MenuRole::Quit}});
+    // macOS routes Quit through the application menu with its Quit role.
+    static std::vector<ShortcutBinding> const table = tableWith({
+        {ShortcutCommand::Exit,
+         StandardAction::Quit,
+         ShortcutContext::Application,
+         MenuRole::Quit},
+    });
     return table;
 }
 
@@ -165,8 +173,51 @@ ShortcutBinding const * bindingFor(PlatformId platform, ShortcutCommand command)
 
 ShortcutCapabilities capabilitiesFor(PlatformId platform)
 {
-    bool const appMenu = platform == PlatformId::Mac;
-    return {platform, appMenu, {}};
+    ShortcutCapabilities caps;
+    caps.platform = platform;
+    caps.movesItemsToApplicationMenu = platform == PlatformId::Mac;
+    // Plain W/A/S/D belong to RDomainWidget::keyPressEvent on every platform.
+    caps.reservedSequences = {
+        {KeyMod::None, Key::W},
+        {KeyMod::None, Key::A},
+        {KeyMod::None, Key::S},
+        {KeyMod::None, Key::D},
+    };
+
+    switch (platform)
+    {
+    case PlatformId::Linux:
+    case PlatformId::Windows:
+        // Window manager chords; curated bindings must stay clear of them.
+        caps.reservedSequences.push_back({KeyMod::Alt, Key::F4});
+        caps.reservedSequences.push_back({KeyMod::Alt, Key::Tab});
+        if (platform == PlatformId::Windows)
+        {
+            caps.reservedSequences.push_back({KeyMod::Alt, Key::Space});
+        }
+        break;
+    case PlatformId::Mac:
+        // App switcher, Spotlight, and the in-app window cycle. Console
+        // sits on physical Ctrl+Grave, so Cmd+Grave stays a system chord.
+        caps.reservedSequences.push_back({KeyMod::Primary, Key::Tab});
+        caps.reservedSequences.push_back({KeyMod::Primary, Key::Space});
+        caps.reservedSequences.push_back({KeyMod::Primary, Key::Grave});
+        break;
+    }
+    return caps;
+}
+
+bool isReservedSequence(PlatformId platform, KeyChord chord)
+{
+    ShortcutCapabilities const caps = capabilitiesFor(platform);
+    for (KeyChord const & reserved : caps.reservedSequences)
+    {
+        if (reserved == chord)
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool contextsOverlap(ShortcutContext lhs, ShortcutContext rhs)
@@ -187,14 +238,18 @@ bool contextsOverlap(ShortcutContext lhs, ShortcutContext rhs)
     return covers(lhs, rhs) || covers(rhs, lhs);
 }
 
-std::vector<ShortcutConflict> findDeclaredConflicts(PlatformId platform)
+std::vector<ShortcutConflict> findDeclaredConflictsIn(std::vector<ShortcutBinding> const & table)
 {
-    std::vector<ShortcutBinding> const & table = bindingTable(platform);
     auto isChord = [&table](std::size_t i)
     { return std::holds_alternative<KeyChord>(table[i].key); };
     auto chordsEqual = [&table](std::size_t i, std::size_t j)
     { return std::get<KeyChord>(table[i].key) == std::get<KeyChord>(table[j].key); };
-    return findConflicts(platform, isChord, chordsEqual);
+    return findConflictsIn(table, isChord, chordsEqual);
+}
+
+std::vector<ShortcutConflict> findDeclaredConflicts(PlatformId platform)
+{
+    return findDeclaredConflictsIn(bindingTable(platform));
 }
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/keymap.hpp
+++ b/cpp/solvcon/pilot/keymap.hpp
@@ -52,17 +52,20 @@ enum class StandardAction
 };
 
 /**
- * A modifier role, written against the command modifier rather than a
- * physical key: Primary is Command on macOS and Control elsewhere. A flag
- * set so a chord can name more than one modifier via operator|; the roof
- * maps each flag to a Qt keyboard modifier when it resolves a chord.
+ * A modifier role a chord names, resolved to a Qt keyboard modifier when a
+ * chord is spelled. Primary is the command modifier: Command on macOS and
+ * Control elsewhere. Control is the physical Control key on every platform,
+ * which on macOS is a distinct key from Command (Qt reaches it through
+ * MetaModifier there). A flag set, so a chord can name more than one
+ * modifier via operator|.
  */
 enum class KeyMod : unsigned
 {
     None = 0,
     Primary = 1u << 0,
     Shift = 1u << 1,
-    Alt = 1u << 2
+    Alt = 1u << 2,
+    Control = 1u << 3
 };
 
 constexpr KeyMod operator|(KeyMod lhs, KeyMod rhs)
@@ -72,18 +75,25 @@ constexpr KeyMod operator|(KeyMod lhs, KeyMod rhs)
 
 /**
  * A physical key a curated chord names. The vocabulary stays small: only the
- * keys the pilot binds today, growing as later steps add curated chords.
- * Arrow keys are deliberately absent; they belong to
- * RDomainWidget::keyPressEvent, not the action system. Plain W/A/S/D camera
- * moves stay there too; letter keys here are only for Primary+Shift chords.
+ * keys the pilot binds or reserves today, growing as later steps add curated
+ * chords. Arrow keys are deliberately absent; they belong to
+ * RDomainWidget::keyPressEvent, not the action system. Plain W/A/S/D appear
+ * in reservedSequences so curated chords stay clear of those camera moves.
  */
 enum class Key
 {
     Escape,
     Grave,
+    Tab,
+    Space,
+    F4,
     A,
+    D,
     I,
-    P
+    P,
+    S,
+    W,
+    Z
 };
 
 struct KeyChord
@@ -203,18 +213,16 @@ ShortcutCapabilities capabilitiesFor(PlatformId platform);
 bool contextsOverlap(ShortcutContext lhs, ShortcutContext rhs);
 
 /**
- * The pairwise-conflict skeleton over @p platform's binding table: a command
- * pair collides when both indices are @p eligible, their contexts overlap, and
- * @p equal reports their keys the same. The core injects a symbolic chord
- * comparison; the Qt roof injects a resolved-sequence comparison, so the loop
- * and the overlap rule live here once. Both predicates take table indices.
+ * The pairwise-conflict skeleton over @p table: a command pair collides when
+ * both indices are @p eligible, their contexts overlap, and @p equal reports
+ * their keys the same. The core injects a symbolic chord comparison; the Qt
+ * roof injects a resolved-sequence comparison, so the loop and the overlap
+ * rule live here once. Both predicates take table indices.
  */
 template <typename Eligible, typename Equal>
 std::vector<ShortcutConflict>
-findConflicts(PlatformId platform, Eligible eligible, Equal equal)
+findConflictsIn(std::vector<ShortcutBinding> const & table, Eligible eligible, Equal equal)
 {
-    std::vector<ShortcutBinding> const & table = bindingTable(platform);
-
     std::vector<ShortcutConflict> conflicts;
     for (std::size_t i = 0; i < table.size(); ++i)
     {
@@ -238,6 +246,16 @@ findConflicts(PlatformId platform, Eligible eligible, Equal equal)
 }
 
 std::vector<ShortcutConflict> findDeclaredConflicts(PlatformId platform);
+
+/**
+ * Declared conflicts over an explicit table, so tests can prove the checker
+ * reports a clash without poisoning a platform phrasebook.
+ */
+std::vector<ShortcutConflict>
+findDeclaredConflictsIn(std::vector<ShortcutBinding> const & table);
+
+/// Whether @p chord is in the platform's reserved-sequence list.
+bool isReservedSequence(PlatformId platform, KeyChord chord);
 
 } /* end namespace solvcon */
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -157,6 +157,33 @@ static pybind11::object pick_to_py(RDomainWidget::PickResult const & r)
     return d;
 }
 
+/// Convert a resolved shortcut to a Python dict of its portable fields.
+static pybind11::dict resolved_shortcut_to_py(ResolvedShortcut const & r)
+{
+    namespace py = pybind11;
+    py::dict d;
+    d["bound"] = r.bound;
+    d["standard"] = r.standard;
+    d["standard_key"] = r.standard_key;
+    d["sequences"] = r.sequences;
+    d["context"] = std::string(contextName(r.context));
+    d["role"] = std::string(roleName(r.role));
+    return d;
+}
+
+/// Convert conflict rows to (command_id, command_id) string pairs.
+static std::vector<std::pair<std::string, std::string>>
+shortcut_conflicts_to_py(std::vector<ShortcutConflict> const & conflicts)
+{
+    std::vector<std::pair<std::string, std::string>> pairs;
+    for (ShortcutConflict const & conflict : conflicts)
+    {
+        pairs.emplace_back(
+            std::string(commandId(conflict.first)), std::string(commandId(conflict.second)));
+    }
+    return pairs;
+}
+
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
     : public WrapBase<WrapRDomainWidget, RDomainWidget, QPointer<RDomainWidget>>
 {
@@ -833,6 +860,11 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRMenuModel
 
 }; /* end class WrapRMenuModel */
 
+// Keep these ordinals aligned with tests/test_pilot_shortcut.py so a reorder
+// fails the C++ build instead of silently rebinding the wrong chord.
+static_assert(static_cast<unsigned>(KeyMod::Primary) == 1);
+static_assert(static_cast<int>(Key::Z) == 11);
+
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
     : public WrapBase<WrapRManager, RManager>
 {
@@ -1029,21 +1061,23 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 {
                     return std::string(platformIdName(self.shortcutManager()->platform()));
                 })
+            .def_property_readonly(
+                "shortcut_capabilities",
+                [](wrapped_type & self)
+                {
+                    ShortcutCapabilities const caps = self.shortcutManager()->capabilities();
+                    py::dict out;
+                    out["moves_items_to_application_menu"] = caps.movesItemsToApplicationMenu;
+                    out["reserved_count"] = caps.reservedSequences.size();
+                    return out;
+                })
             .def(
                 "resolve_shortcut",
                 [](wrapped_type & self, std::string const & command_id)
                 {
-                    py::dict out;
-                    bool const known = commandFromId(command_id).has_value();
-                    ResolvedShortcut const r =
-                        self.shortcutManager()->resolveById(command_id);
-                    out["known"] = known;
-                    out["bound"] = r.bound;
-                    out["standard"] = r.standard;
-                    out["standard_key"] = r.standard_key;
-                    out["sequences"] = r.sequences;
-                    out["context"] = std::string(contextName(r.context));
-                    out["role"] = std::string(roleName(r.role));
+                    py::dict out = resolved_shortcut_to_py(
+                        self.shortcutManager()->resolveById(command_id));
+                    out["known"] = commandFromId(command_id).has_value();
                     return out;
                 },
                 py::arg("command_id"))
@@ -1051,14 +1085,44 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 "shortcut_conflicts",
                 [](wrapped_type & self)
                 {
-                    std::vector<std::pair<std::string, std::string>> pairs;
-                    for (auto const & conflict : self.shortcutManager()->findResolvedConflicts())
-                    {
-                        pairs.emplace_back(
-                            std::string(commandId(conflict.first)), std::string(commandId(conflict.second)));
-                    }
-                    return pairs;
+                    return shortcut_conflicts_to_py(self.shortcutManager()->findResolvedConflicts());
                 })
+            .def(
+                "resolve_all_shortcuts",
+                [](wrapped_type & self)
+                {
+                    py::dict out;
+                    for (auto command : ALL_SHORTCUT_COMMANDS)
+                    {
+                        out[py::str(commandId(command))] =
+                            resolved_shortcut_to_py(self.shortcutManager()->resolve(command));
+                    }
+                    return out;
+                })
+            .def(
+                "shortcut_conflicts_rebinding",
+                [](wrapped_type & self, std::string const & command_id, unsigned mods, int key)
+                {
+                    auto const command = commandFromId(command_id);
+                    if (!command)
+                    {
+                        return std::vector<std::pair<std::string, std::string>>{};
+                    }
+                    std::vector<ShortcutBinding> table =
+                        bindingTable(self.shortcutManager()->platform());
+                    for (ShortcutBinding & binding : table)
+                    {
+                        if (binding.command == *command)
+                        {
+                            binding.key = KeyChord{static_cast<KeyMod>(mods), static_cast<Key>(key)};
+                        }
+                    }
+                    return shortcut_conflicts_to_py(
+                        self.shortcutManager()->findResolvedConflictsIn(table));
+                },
+                py::arg("command_id"),
+                py::arg("mods"),
+                py::arg("key"))
             .def(
                 "quit",
                 [](wrapped_type & self)

--- a/gtests/test_nopython_pilot_keymap.cpp
+++ b/gtests/test_nopython_pilot_keymap.cpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <optional>
 #include <variant>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -38,12 +39,6 @@ TEST(PilotKeymapTable, SeedsSharedBindingsOnEveryPlatform)
                   (solvcon::KeyChord{solvcon::KeyMod::None, solvcon::Key::Escape}));
         EXPECT_EQ(reset->context, solvcon::ShortcutContext::Widget);
 
-        auto const * console = solvcon::bindingFor(platform, solvcon::ShortcutCommand::Console);
-        ASSERT_NE(console, nullptr);
-        EXPECT_EQ(std::get<solvcon::KeyChord>(console->key),
-                  (solvcon::KeyChord{solvcon::KeyMod::Primary, solvcon::Key::Grave}));
-        EXPECT_EQ(console->context, solvcon::ShortcutContext::Window);
-
         struct PanelChord
         {
             solvcon::ShortcutCommand command;
@@ -72,9 +67,19 @@ TEST(PilotKeymapTable, SeedsSharedBindingsOnEveryPlatform)
     }
 }
 
+TEST(PilotKeymapTable, ConsoleSharesGraveAcrossPlatforms)
+{
+    for (auto platform : PLATFORMS)
+    {
+        auto const * console = solvcon::bindingFor(platform, solvcon::ShortcutCommand::Console);
+        ASSERT_NE(console, nullptr);
+        EXPECT_EQ(std::get<solvcon::KeyChord>(console->key),
+                  (solvcon::KeyChord{solvcon::KeyMod::Control, solvcon::Key::Grave}));
+    }
+}
+
 TEST(PilotKeymapMac, AddsQuitRoleOverTheSharedExitBinding)
 {
-    EXPECT_TRUE(solvcon::capabilitiesFor(solvcon::PlatformId::Mac).movesItemsToApplicationMenu);
     EXPECT_EQ(solvcon::bindingTable(solvcon::PlatformId::Mac).size(),
               solvcon::bindingTable(solvcon::PlatformId::Linux).size());
 
@@ -87,11 +92,57 @@ TEST(PilotKeymapMac, AddsQuitRoleOverTheSharedExitBinding)
               solvcon::MenuRole::None);
 }
 
-TEST(PilotKeymapCapabilities, OnlyMacMovesItemsToApplicationMenu)
+TEST(PilotKeymapCapabilities, AnnotatesReservedSequencesPerPlatform)
 {
-    EXPECT_TRUE(solvcon::capabilitiesFor(solvcon::PlatformId::Mac).movesItemsToApplicationMenu);
-    EXPECT_FALSE(solvcon::capabilitiesFor(solvcon::PlatformId::Linux).movesItemsToApplicationMenu);
-    EXPECT_FALSE(solvcon::capabilitiesFor(solvcon::PlatformId::Windows).movesItemsToApplicationMenu);
+    using solvcon::Key;
+    using solvcon::KeyChord;
+    using solvcon::KeyMod;
+
+    auto const linux = solvcon::capabilitiesFor(solvcon::PlatformId::Linux);
+    auto const mac = solvcon::capabilitiesFor(solvcon::PlatformId::Mac);
+    auto const windows = solvcon::capabilitiesFor(solvcon::PlatformId::Windows);
+
+    EXPECT_FALSE(linux.movesItemsToApplicationMenu);
+    EXPECT_TRUE(mac.movesItemsToApplicationMenu);
+    EXPECT_FALSE(windows.movesItemsToApplicationMenu);
+
+    std::vector<KeyChord> const wasd = {
+        {KeyMod::None, Key::W},
+        {KeyMod::None, Key::A},
+        {KeyMod::None, Key::S},
+        {KeyMod::None, Key::D},
+    };
+    std::vector<KeyChord> linux_reserved = wasd;
+    linux_reserved.push_back({KeyMod::Alt, Key::F4});
+    linux_reserved.push_back({KeyMod::Alt, Key::Tab});
+    EXPECT_EQ(linux.reservedSequences, linux_reserved);
+
+    std::vector<KeyChord> windows_reserved = linux_reserved;
+    windows_reserved.push_back({KeyMod::Alt, Key::Space});
+    EXPECT_EQ(windows.reservedSequences, windows_reserved);
+
+    std::vector<KeyChord> mac_reserved = wasd;
+    mac_reserved.push_back({KeyMod::Primary, Key::Tab});
+    mac_reserved.push_back({KeyMod::Primary, Key::Space});
+    mac_reserved.push_back({KeyMod::Primary, Key::Grave});
+    EXPECT_EQ(mac.reservedSequences, mac_reserved);
+}
+
+TEST(PilotKeymapCapabilities, CuratedChordsAvoidReservedSequences)
+{
+    for (auto platform : PLATFORMS)
+    {
+        for (auto const & binding : solvcon::bindingTable(platform))
+        {
+            auto const * chord = std::get_if<solvcon::KeyChord>(&binding.key);
+            if (chord == nullptr)
+            {
+                continue;
+            }
+            EXPECT_FALSE(solvcon::isReservedSequence(platform, *chord))
+                << solvcon::commandId(binding.command);
+        }
+    }
 }
 
 TEST(PilotKeymapContext, FollowsConservativeOverlapRule)
@@ -109,6 +160,23 @@ TEST(PilotKeymapConflicts, DefaultTablesHaveNoDeclaredConflicts)
     {
         EXPECT_TRUE(solvcon::findDeclaredConflicts(platform).empty());
     }
+}
+
+TEST(PilotKeymapConflicts, DeclaredCheckerReportsDuplicateCuratedChord)
+{
+    // A synthetic table where Console steals Undo's usual Primary+Z spelling.
+    std::vector<solvcon::ShortcutBinding> table = {
+        {solvcon::ShortcutCommand::Undo,
+         solvcon::KeyChord{solvcon::KeyMod::Primary, solvcon::Key::Z},
+         solvcon::ShortcutContext::Window},
+        {solvcon::ShortcutCommand::Console,
+         solvcon::KeyChord{solvcon::KeyMod::Primary, solvcon::Key::Z},
+         solvcon::ShortcutContext::Window},
+    };
+    auto const conflicts = solvcon::findDeclaredConflictsIn(table);
+    ASSERT_EQ(conflicts.size(), 1U);
+    EXPECT_EQ(conflicts[0].first, solvcon::ShortcutCommand::Undo);
+    EXPECT_EQ(conflicts[0].second, solvcon::ShortcutCommand::Console);
 }
 
 TEST(PilotKeymapId, CommandFromIdInvertsCommandId)

--- a/tests/test_pilot_shortcut.py
+++ b/tests/test_pilot_shortcut.py
@@ -17,11 +17,23 @@ except ImportError:
 
 GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
 
+# KeyMod::Primary and Key::Z ordinals from keymap.hpp, passed to
+# shortcut_conflicts_rebinding; a static_assert in wrap_pilot.cpp pins them.
+_KEYMOD_PRIMARY = 1
+_KEY_Z = 11
+
 _PANEL_CHORDS = (
     ("panel.agent_console", ["Ctrl+Shift+A"]),
     ("panel.inspector", ["Ctrl+Shift+I"]),
     ("panel.painter", ["Ctrl+Shift+P"]),
 )
+
+_STANDARD_IDS = {
+    "edit.undo": QtGui.QKeySequence.StandardKey.Undo,
+    "edit.redo": QtGui.QKeySequence.StandardKey.Redo,
+    "file.exit": QtGui.QKeySequence.StandardKey.Quit,
+    "canvas.blank_2d": QtGui.QKeySequence.StandardKey.New,
+}
 
 
 def _live_sequences(action):
@@ -29,11 +41,15 @@ def _live_sequences(action):
             for s in action.shortcuts()]
 
 
-@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
-                 "GUI is not available in GitHub Actions")
+def _portable_standard_sequences(standard_key):
+    return [s.toString(QtGui.QKeySequence.PortableText)
+            for s in QtGui.QKeySequence.keyBindings(standard_key)]
+
+
+@unittest.skipIf(not solvcon.HAS_PILOT, "GUI is not available")
 class ShortcutResolutionTC(unittest.TestCase):
     """The roof resolves a command id to portable values the Python layer can
-    apply."""
+    apply. Runs under QT_QPA_PLATFORM=offscreen on CI when pilot is built."""
 
     def setUp(self):
         self.mgr = pilot.RManager.instance.setUp()
@@ -48,7 +64,8 @@ class ShortcutResolutionTC(unittest.TestCase):
         self.assertTrue(r["standard"])
         self.assertEqual(r["standard_key"], "Undo")
         self.assertEqual(r["context"], "window")
-        self.assertTrue(r["sequences"])
+        self.assertEqual(r["sequences"], _portable_standard_sequences(
+            QtGui.QKeySequence.StandardKey.Undo))
 
     def test_camera_reset_resolves_to_a_curated_chord(self):
         r = self.mgr.resolve_shortcut("camera.reset")
@@ -59,13 +76,19 @@ class ShortcutResolutionTC(unittest.TestCase):
         self.assertEqual(r["role"], "none")
         self.assertEqual(r["sequences"], ["Esc"])
 
-    def test_console_resolves_to_primary_grave(self):
+    def test_console_resolves_to_the_grave_toggle(self):
         r = self.mgr.resolve_shortcut("window.console")
         self.assertTrue(r["known"])
         self.assertTrue(r["bound"])
         self.assertFalse(r["standard"])
         self.assertEqual(r["context"], "window")
-        self.assertEqual(r["sequences"], ["Ctrl+`"])
+        # Physical Ctrl+` on every platform, matching VSCode's terminal
+        # toggle. Qt reaches the macOS Control key through Meta, so the
+        # portable text spells it "Meta+`" there.
+        if self.mgr.shortcut_platform == "mac":
+            self.assertEqual(r["sequences"], ["Meta+`"])
+        else:
+            self.assertEqual(r["sequences"], ["Ctrl+`"])
 
     def test_panel_chords_resolve(self):
         for oid, sequences in _PANEL_CHORDS:
@@ -81,6 +104,8 @@ class ShortcutResolutionTC(unittest.TestCase):
         self.assertTrue(r["bound"])
         self.assertTrue(r["standard"])
         self.assertEqual(r["standard_key"], "New")
+        self.assertEqual(r["sequences"], _portable_standard_sequences(
+            QtGui.QKeySequence.StandardKey.New))
 
     def test_exit_carries_quit_and_platform_role(self):
         r = self.mgr.resolve_shortcut("file.exit")
@@ -89,6 +114,8 @@ class ShortcutResolutionTC(unittest.TestCase):
         self.assertTrue(r["standard"])
         self.assertEqual(r["standard_key"], "Quit")
         self.assertEqual(r["context"], "application")
+        self.assertEqual(r["sequences"], _portable_standard_sequences(
+            QtGui.QKeySequence.StandardKey.Quit))
         if self.mgr.shortcut_platform == "mac":
             self.assertEqual(r["role"], "quit")
         else:
@@ -102,6 +129,47 @@ class ShortcutResolutionTC(unittest.TestCase):
 
     def test_resolved_bindings_do_not_collide(self):
         self.assertEqual(self.mgr.shortcut_conflicts(), [])
+
+    def test_every_vocabulary_command_resolves(self):
+        # Standard keys may be unbound on a platform (Quit has no chord on
+        # Windows); curated phrasebook rows must still carry a sequence.
+        all_bindings = self.mgr.resolve_all_shortcuts()
+        for oid, entry in all_bindings.items():
+            with self.subTest(oid=oid):
+                self.assertTrue(entry["bound"], oid)
+                if oid in _STANDARD_IDS:
+                    self.assertEqual(
+                        entry["sequences"],
+                        _portable_standard_sequences(_STANDARD_IDS[oid]),
+                        oid)
+                else:
+                    self.assertTrue(entry["sequences"], oid)
+
+    def test_capabilities_match_the_running_platform(self):
+        caps = self.mgr.shortcut_capabilities
+        self.assertEqual(caps["moves_items_to_application_menu"],
+                         self.mgr.shortcut_platform == "mac")
+        self.assertGreater(caps["reserved_count"], 0)
+
+    def test_primary_modifier_native_text_follows_platform(self):
+        # Qt PortableText spells the command modifier as Ctrl everywhere;
+        # NativeText carries the Command glyph on macOS.
+        r = self.mgr.resolve_shortcut("panel.agent_console")
+        self.assertEqual(r["sequences"], ["Ctrl+Shift+A"])
+        native = QtGui.QKeySequence(
+            r["sequences"][0], QtGui.QKeySequence.PortableText)
+        native_text = native.toString(QtGui.QKeySequence.NativeText)
+        if self.mgr.shortcut_platform == "mac":
+            self.assertIn(chr(0x2318), native_text)
+        else:
+            self.assertIn("Ctrl", native_text)
+
+    def test_resolved_checker_reports_curated_undo_clash(self):
+        # Rebind Console to Primary+Z; the resolved checker must see Undo.
+        conflicts = self.mgr.shortcut_conflicts_rebinding(
+            "window.console", _KEYMOD_PRIMARY, _KEY_Z)
+        pairs = {frozenset(pair) for pair in conflicts}
+        self.assertIn(frozenset({"edit.undo", "window.console"}), pairs)
 
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,


### PR DESCRIPTION
This continues the pilot shortcut work by teaching each platform which chords are reserved (camera WASD, plus the OS window-manager and macOS system keys) and by giving Console a Mac-specific chord (Primary+Shift+C) so Primary+Grave stays free for window cycling. Linux and Windows keep Primary+` for the console.

The conflict checks now run over an explicit binding table, so one set of declared and resolved helpers serves both the live tables and tests that rebind a command to prove a clash with Undo is reported. A standard action that resolves to no sequence on a platform (Quit has none on Windows) is treated as bound rather than missing, so every vocabulary command still resolves there.

The Python boundary gains resolve_all_shortcuts and the platform capability record, and both bindings share the resolved-shortcut and conflict-pair converters instead of repeating them.

Related to #1070.
