### PR TITLE
Drive terminal multiline from the interpreter's push (step 2 of terminal)

### DIFF
--- a/cpp/solvcon/pilot/RPythonTerminalDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonTerminalDockWidget.cpp
@@ -5,6 +5,8 @@
 
 #include <solvcon/pilot/RPythonTerminalDockWidget.hpp>
 
+#include <solvcon/pilot/RPythonSyntaxRules.hpp>
+
 #include <algorithm>
 
 #include <QFont>
@@ -224,24 +226,34 @@ void RPythonTerminalDockWidget::writeToHistory(std::string const & data)
 
 void RPythonTerminalDockWidget::executeCommand()
 {
+    // The command runs Python. When the Enter key arrives through the Qt
+    // event dispatch, the caller may not hold the GIL, so take it here, the
+    // way the completion path does, before touching the interpreter.
+    pybind11::gil_scoped_acquire const gil;
+
     QString const input = m_edit->inputText();
-    std::string const command = input.trimmed().toStdString();
+    QStringList const lines = input.split('\n');
 
     // Freeze the typed line into the transcript by ending it.
     m_edit->appendCommitted("\n");
 
-    if (command.empty())
-    {
-        m_edit->startInput(">>> ");
-        return;
-    }
-
-    m_history.add(command);
-    m_current_command_index = static_cast<int>(m_history.size());
-
+    // Feed the input to the interpreter one line at a time. The last push
+    // reports whether the statement is still open, which drives the choice
+    // between the primary and continuation prompts. A single push runs the
+    // code and captures its output when the statement closes.
+    bool more = false;
+    std::string last_line;
     auto & interp = solvcon::python::Interpreter::instance();
     m_python_redirect.activate();
-    interp.exec_code(command);
+    for (QString const & line : lines)
+    {
+        last_line = line.toStdString();
+        // A whitespace-only line closes an open block, the way a blank line
+        // does in the interactive interpreter, so the pre-filled indent of a
+        // continuation line does not keep the block open by itself.
+        std::string const to_push = line.trimmed().isEmpty() ? std::string() : last_line;
+        more = interp.push_code(to_push);
+    }
     if (m_python_redirect.is_activated())
     {
         std::string const out = m_python_redirect.stdout_string();
@@ -257,11 +269,53 @@ void RPythonTerminalDockWidget::executeCommand()
     }
     m_python_redirect.deactivate();
 
+    if (!m_pending_statement.empty())
+    {
+        m_pending_statement += '\n';
+    }
+    m_pending_statement += input.toStdString();
+
+    if (more)
+    {
+        // The statement is open; continue it on a "... " line, carrying the
+        // block's indentation forward so the caret starts where the next
+        // line belongs.
+        m_edit->startInput("... ");
+        std::string const indent = nextLineIndent(last_line);
+        if (!indent.empty())
+        {
+            m_edit->setInputText(QString::fromStdString(indent));
+        }
+    }
+    else
+    {
+        m_history.add(m_pending_statement);
+        m_current_command_index = static_cast<int>(m_history.size());
+        m_pending_statement.clear();
+        m_edit->startInput(">>> ");
+    }
+}
+
+void RPythonTerminalDockWidget::resetInput()
+{
+    // Abandon a partly entered block and return to a fresh primary prompt.
+    pybind11::gil_scoped_acquire const gil;
+    solvcon::python::Interpreter::instance().reset_console();
+    m_pending_statement.clear();
+    m_edit->setInputText("");
+    m_edit->appendCommitted("\n");
     m_edit->startInput(">>> ");
 }
 
 void RPythonTerminalDockWidget::navigateCommand(int offset)
 {
+    // History recall replaces a whole statement, so it only applies at the
+    // primary prompt, not in the middle of a continuation block.
+    if (!m_pending_statement.empty())
+    {
+        return;
+    }
+
     int const commands_num = static_cast<int>(m_history.size());
     if (commands_num == m_current_command_index)
     {

--- a/cpp/solvcon/pilot/RPythonTerminalDockWidget.hpp
+++ b/cpp/solvcon/pilot/RPythonTerminalDockWidget.hpp
@@ -133,12 +133,17 @@ public:
 public slots:
     void executeCommand();
     void navigateCommand(int offset);
+    void resetInput();
 
 private:
     RPythonTerminalTextEdit * m_edit = nullptr;
     std::string m_draft_command;
     RPythonConsoleHistory m_history;
     int m_current_command_index = 0;
+
+    // The lines of the statement being entered, accumulated across
+    // continuation prompts until the interpreter reports it complete.
+    std::string m_pending_statement;
 
     python::PythonStreamRedirect m_python_redirect;
 }; /* end class RPythonTerminalDockWidget */

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -719,6 +719,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRPythonTerminalDockWidget
         (*this)
             .def("writeToHistory", &wrapped_type::writeToHistory)
             .def("executeCommand", &wrapped_type::executeCommand)
+            .def("resetInput", &wrapped_type::resetInput)
             .def_property_readonly(
                 "textEdit",
                 [](wrapped_type & self)

--- a/cpp/solvcon/python/common.cpp
+++ b/cpp/solvcon/python/common.cpp
@@ -184,6 +184,38 @@ void Interpreter::exec_code(std::string const & code)
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+bool Interpreter::push_code(std::string const & line)
+{
+    try
+    {
+        // NOLINTNEXTLINE(misc-const-correctness)
+        pybind11::object mod_sys = pybind11::module_::import("solvcon.system");
+        pybind11::object const py_more = mod_sys.attr("push_code")(line);
+        return py_more.cast<bool>();
+    }
+    catch (const pybind11::error_already_set & e)
+    {
+        std::cerr << e.what() << std::endl;
+        return false;
+    }
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+void Interpreter::reset_console()
+{
+    try
+    {
+        // NOLINTNEXTLINE(misc-const-correctness)
+        pybind11::object mod_sys = pybind11::module_::import("solvcon.system");
+        mod_sys.attr("reset_console")();
+    }
+    catch (const pybind11::error_already_set & e)
+    {
+        std::cerr << e.what() << std::endl;
+    }
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::vector<std::string> Interpreter::get_completions(std::string const & text)
 {
     std::vector<std::string> result;

--- a/cpp/solvcon/python/common.hpp
+++ b/cpp/solvcon/python/common.hpp
@@ -499,6 +499,8 @@ public:
 
     int enter_main();
     void exec_code(std::string const & code);
+    bool push_code(std::string const & line);
+    void reset_console();
     std::vector<std::string> get_completions(std::string const & text);
     std::string get_call_tip(std::string const & text);
 

--- a/solvcon/apputil.py
+++ b/solvcon/apputil.py
@@ -32,6 +32,8 @@ __all__ = [
     'get_completions',
     'get_call_tip',
     'run_code',
+    'push_code',
+    'reset_console',
     'run_worker',
     'stop_code',
     'build_pilot_namespace',
@@ -159,6 +161,25 @@ class AppEnvironment:
                 more = self.console.push('')
         return more
 
+    def push_line(self, line):
+        """
+        Push a single line to the persistent interpreter, interactively.
+
+        Unlike :meth:`run_code`, this does not close an open block with a
+        trailing blank line: it hands the interpreter one line and reports
+        whether the statement is still incomplete, so a terminal UI can show
+        a continuation prompt and keep collecting input. The namespace is
+        refreshed once at the start of a statement, when no partial input is
+        buffered.
+
+        :return: True when the interpreter is waiting for more input.
+        """
+        if not self.console.buffer:
+            for refresh in self.namespace_refreshers:
+                refresh(self.globals)
+        with _stdin_at_eof():
+            return self.console.push(line)
+
 
 def get_appenv(name=None):
     if None is name:
@@ -237,6 +258,16 @@ def get_call_tip(expr):
 def run_code(source):
     aenv = get_current_appenv()
     return aenv.run_code(source)
+
+
+def push_code(line):
+    aenv = get_current_appenv()
+    return aenv.push_line(line)
+
+
+def reset_console():
+    """Abandon any partially entered statement in the current console."""
+    get_current_appenv().console.resetbuffer()
 
 
 def run_worker(func, *args, **kwargs):

--- a/solvcon/system.py
+++ b/solvcon/system.py
@@ -138,6 +138,19 @@ def exec_code(code):
     return apputil.run_code(code)
 
 
+def push_code(line):
+    # Interactive per-line entry for the terminal console: feed one line and
+    # report whether the statement is still incomplete, so the terminal can
+    # switch between the primary and continuation prompts.
+    return apputil.push_code(line)
+
+
+def reset_console():
+    # Abandon a partially entered statement, so the terminal can return to
+    # the primary prompt without running the incomplete block.
+    return apputil.reset_console()
+
+
 def get_completions(text):
     try:
         return apputil.get_completions(text)

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -67,6 +67,23 @@ class PythonConsoleBackendTC(unittest.TestCase):
             self.assertFalse(self.env.console.push(''))
         self.assertEqual(out.getvalue(), '0\n1\n2\n')
 
+    def test_push_line_drives_interactive_multiline(self):
+        # push_line feeds one line at a time and reports whether the
+        # statement is still open, without closing it on the caller's behalf,
+        # so a terminal can show a continuation prompt.
+        import io
+        from contextlib import redirect_stdout
+        # A complete statement closes at once.
+        self.assertFalse(self.env.push_line('total = 0'))
+        # An open block stays open until a blank line closes it.
+        self.assertTrue(self.env.push_line('for i in range(3):'))
+        self.assertTrue(self.env.push_line('    total += i'))
+        self.assertFalse(self.env.push_line(''))
+        out = io.StringIO()
+        with redirect_stdout(out):
+            self.assertFalse(self.env.push_line('total'))
+        self.assertEqual(out.getvalue().strip(), '3')
+
     def test_exception_reports_user_traceback(self):
         _, out, err = self._run('raise ValueError("boom")')
         self.assertIn('ValueError: boom', err)

--- a/tests/test_pilot_terminal.py
+++ b/tests/test_pilot_terminal.py
@@ -46,8 +46,9 @@ class TerminalWidgetTC(unittest.TestCase):
     def setUp(self):
         self.term = self.mgr.pyterm
         self.edit = self.term.textEdit
-        # Start each test from an empty input region after the prompt.
-        self.term.command = ""
+        # Start each test from a clean primary prompt, abandoning any block a
+        # previous test left open in the shared interpreter.
+        self.term.resetInput()
 
     def _type(self, text):
         for ch in text:
@@ -126,6 +127,40 @@ class TerminalWidgetTC(unittest.TestCase):
         self.assertEqual(self.term.command, "history_one = 1")
         self._key(QtCore.Qt.Key_Down)
         self.assertEqual(self.term.command, "history_two = 2")
+
+    def test_incomplete_statement_shows_continuation_prompt(self):
+        self._type("for i in range(2):")
+        self._key(QtCore.Qt.Key_Return)
+        # The current line carries the continuation prompt.
+        last_line = self.edit.toPlainText().split("\n")[-1]
+        self.assertTrue(last_line.startswith("... "))
+        # The next line is auto-indented into the block.
+        self.assertEqual(self.term.command, "    ")
+
+    def test_multiline_block_runs_when_closed(self):
+        self._type("for i in range(2):")
+        self._key(QtCore.Qt.Key_Return)
+        # Continue at the auto-indented continuation line.
+        self._type("print(i)")
+        self._key(QtCore.Qt.Key_Return)
+        # A blank line (the pre-filled indent alone) closes and runs it.
+        self._key(QtCore.Qt.Key_Return)
+        text = self.edit.toPlainText()
+        # The body was echoed on a continuation line and the block ran.
+        self.assertIn("print(i)", text)
+        self.assertRegex(text, r"\.\.\. +print\(i\)")
+        self.assertIn("0", text)
+        self.assertIn("1", text)
+        self.assertTrue(text.endswith(">>> "))
+
+    def test_up_does_not_recall_mid_block(self):
+        self.term.command = "recall_me = 1"
+        self.term.executeCommand()
+        self._type("while False:")
+        self._key(QtCore.Qt.Key_Return)
+        # Mid-continuation, Up must not overwrite the input with history.
+        self._key(QtCore.Qt.Key_Up)
+        self.assertEqual(self.term.command, "    ")
 
     def test_write_to_history_appends_above_the_prompt(self):
         self._type("keep")


### PR DESCRIPTION
Step 2 of issue #1023.

The terminal collects a multiline statement by splitting the input on newlines and running it at once, so it cannot show a continuation prompt as a block is entered. Make it collect the statement the way a read-eval-print loop does, one line per Enter, with the interpreter deciding when the block is complete.

Add a per-line entry through the stack: AppEnvironment.push_line feeds one line and reports whether the statement is still open without closing it, apputil.push_code and system.push_code expose it, and Interpreter::push_code surfaces the flag to the widget. reset_console abandons a partly entered block.

On Enter the terminal pushes the current line; an open statement switches
to the continuation prompt with the block's indentation carried forward, and a whitespace-only line closes the block the way a blank line does in the interactive interpreter. The completed statement is recorded in history as one entry, and Up and Down recall only at the primary prompt, not in the middle of a block.

Guard executeCommand and resetInput with the GIL: when Enter arrives through the Qt event dispatch the caller may not hold it, the same reason the completion path already acquires it.