### PR TITLE
Upgrade CI Qt to 6.11.1

### DIFF
--- a/.github/actions/setup_linux/action.yml
+++ b/.github/actions/setup_linux/action.yml
@@ -43,10 +43,10 @@ runs:
         # The "-st" suffix tracks the qtshadertools addition; bumping it forces
         # a clean install so the new module is present rather than masked by a
         # stale cache.
-        key: ${{ runner.os }}-qt-6.8.1-st-linux_gcc_64
+        key: ${{ runner.os }}-qt-6.11.1-st-linux_gcc_64
         # fallback to any previous Qt cache on this OS
         restore-keys: |
-          ${{ runner.os }}-qt-6.8.1-st-
+          ${{ runner.os }}-qt-6.11.1-st-
 
     - name: dependency by apt
       shell: bash
@@ -121,7 +121,7 @@ runs:
       if: "${{ inputs.workflow == 'lint' || inputs.workflow == 'build' }}"
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.1'
+        version: '6.11.1'
         host: 'linux'
         target: 'desktop'
         arch: 'linux_gcc_64'

--- a/.github/actions/setup_macos/action.yml
+++ b/.github/actions/setup_macos/action.yml
@@ -61,7 +61,7 @@ runs:
       with:
         # Use a newer Qt build to avoid -framework AGL linker failures on Tahoe.
         # Ref: https://qt-project.atlassian.net/browse/QTBUG-137687
-        version: '6.9.2'
+        version: '6.11.1'
         host: 'mac'
         target: 'desktop'
         arch: 'clang_64'

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -311,7 +311,11 @@ jobs:
       - name: install qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.8.1'
+          # aqtinstall 3.3.0 cannot resolve Qt 6.11's new split Windows
+          # desktop repository, so Windows stays on 6.10.3 while Linux and
+          # macOS run 6.11.1.
+          # Ref: https://github.com/miurahr/aqtinstall/issues/1007
+          version: '6.10.3'
           host: 'windows'
           target: 'desktop'
           arch: 'win64_msvc2022_64'
@@ -610,7 +614,11 @@ jobs:
     - name: install qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.1'
+        # aqtinstall 3.3.0 cannot resolve Qt 6.11's new split Windows
+        # desktop repository, so Windows stays on 6.10.3 while Linux and
+        # macOS run 6.11.1.
+        # Ref: https://github.com/miurahr/aqtinstall/issues/1007
+        version: '6.10.3'
         host: 'windows'
         target: 'desktop'
         arch: 'win64_msvc2022_64'


### PR DESCRIPTION
Bump the Qt installed on Linux and macOS from 6.8.1 and 6.9.2 to 6.11.1, the latest 6.11 patch. The Linux Qt download cache key embeds the version, so bump it and its restore-key fallback so a fresh Qt is fetched instead of restoring the stale 6.8.1 tree.

Windows stays on 6.10.3. Qt 6.11 splits the Windows desktop repository into per-toolchain subfolders, a layout aqtinstall 3.3.0 cannot resolve, so it fails to fetch the Updates.xml checksum. 6.10.3 is the newest Qt aqtinstall can install on Windows today. The fix is merged upstream but unreleased, so revisit once a release ships it (aqtinstall#1007).

The Windows and macOS jobs install pyside6 pinned to the Qt version via pyside6==$(qmake -query QT_VERSION); pyside6 6.11.1 and 6.10.3 are both on PyPI, so the pinned installs resolve.