### PR TITLE
Speed up builds with precompiled third-party headers

### DIFF
--- a/.github/workflows/pch_experiment.yml
+++ b/.github/workflows/pch_experiment.yml
@@ -1,0 +1,71 @@
+name: pch_experiment
+
+# Temporary workflow to validate the SOLVCON_USE_PCH build-time effect on
+# the real CI runners. It runs the same dependency setup as devbuild but
+# deliberately omits the ccache step, because PR 1124 force-disables the
+# PCH whenever a compiler cache is present. Each configuration is built
+# from scratch so the only difference between them is the PCH itself.
+# Drop this file (and contrib/pch_experiment.py) before merging.
+
+on:
+  push:
+    branches:
+      - feat/build-pch
+  workflow_dispatch:
+
+concurrency:
+  group: pch_experiment-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  pch:
+
+    name: pch_${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+
+    timeout-minutes: 300
+
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, macos-26]
+      fail-fast: false
+
+    env:
+      PCH_REPS: '3'
+      PCH_PARALLEL: '2'
+      PIP_BREAK_SYSTEM_PACKAGES: 1
+      AQT_CONFIG: "thirdparty/aqt_settings.ini"
+
+    steps:
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: setup dependencies for Linux
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/setup_linux
+        with:
+          workflow: 'build'
+
+      - name: setup dependencies for macOS
+        if: runner.os == 'macOS'
+        uses: ./.github/actions/setup_macos
+        with:
+          workflow: 'build'
+
+      - name: run pch experiment
+        run: |
+          echo "::group::run pch experiment"
+          python3 contrib/pch_experiment.py
+          echo "::endgroup::"
+
+      - name: upload result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pch-result-${{ matrix.os }}
+          path: pch_experiment_result.md
+          if-no-files-found: ignore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,25 @@ if(SOLVCON_PROFILE)
     endif()
 endif()
 
+# Precompiled headers cut the repeated parse of the heavy third-party
+# headers (pybind11, Qt) in every translation unit. They do not compose
+# with compiler caches (ccache/sccache fall back to uncached real compiles
+# on PCH translation units) nor with clang-tidy (it cannot replay another
+# compiler's PCH), so force OFF whenever either is in play. The set()
+# shadows the cached option with a normal variable so the gate also holds
+# when an existing build tree is reconfigured into an incompatible mode.
+option(SOLVCON_USE_PCH "precompile heavy third-party headers" ON)
+file(REAL_PATH "${CMAKE_CXX_COMPILER}" SOLVCON_CXX_COMPILER_REALPATH)
+if(SOLVCON_USE_PCH
+   AND (USE_CLANG_TIDY
+        OR CMAKE_CXX_COMPILER_LAUNCHER
+        OR SOLVCON_CXX_COMPILER_REALPATH MATCHES "ccache|sccache"))
+    message(STATUS
+        "force SOLVCON_USE_PCH=OFF: clang-tidy or a compiler cache is on")
+    set(SOLVCON_USE_PCH OFF)
+endif()
+message(STATUS "SOLVCON_USE_PCH: ${SOLVCON_USE_PCH}")
+
 if(BUILD_METAL)
 include_directories(SYSTEM "${CMAKE_CURRENT_LIST_DIR}/thirdparty/install/metal-cpp")
 endif()

--- a/contrib/pch_experiment.py
+++ b/contrib/pch_experiment.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Measure the SOLVCON_USE_PCH build-time effect on a CI runner.
+
+For each repetition and each PCH setting, wipe the build tree, configure
+with BUILD_QT=ON and no compiler cache, then time a from-scratch build of
+the ``_solvcon_py`` target (which compiles ``solvcon_primary``, the only
+target the precompiled headers attach to). Wall time comes from a
+monotonic clock; CPU time (user + system, including every compiler child)
+comes from ``getrusage(RUSAGE_CHILDREN)``, the portable equivalent of
+``/usr/bin/time`` that works the same on Linux and macOS.
+
+The point is a clean A/B: the two configurations differ only in the PCH,
+so the delta is the PCH effect and nothing else.
+"""
+
+import os
+import re
+import resource
+import shutil
+import subprocess
+import sys
+import time
+
+REPS = int(os.environ.get("PCH_REPS", "3"))
+PARALLEL = os.environ.get("PCH_PARALLEL", "2")
+TARGET = "_solvcon_py"
+
+_vi = sys.version_info
+BUILD_PATH = f"build/rel{_vi.major}{_vi.minor}"
+PYTHON_EXE = shutil.which("python3")
+
+
+def configure(pch):
+    """Reconfigure from scratch and confirm the effective PCH state."""
+    if os.path.isdir("build"):
+        shutil.rmtree("build")
+    cmake_args = f"-DPYTHON_EXECUTABLE={PYTHON_EXE} -DSOLVCON_USE_PCH={pch}"
+    proc = subprocess.run(
+        ["make", "cmake", "VERBOSE=0", "USE_CLANG_TIDY=OFF", "BUILD_QT=ON",
+         "CMAKE_BUILD_TYPE=Release", f"CMAKE_ARGS={cmake_args}"],
+        capture_output=True, text=True)
+    log = proc.stdout + proc.stderr
+    if proc.returncode != 0:
+        sys.stderr.write(log)
+        raise SystemExit(f"configure failed for PCH={pch}")
+    match = re.search(r"SOLVCON_USE_PCH:\s*(\w+)", log)
+    effective = match.group(1) if match else "UNKNOWN"
+    if effective != pch:
+        sys.stderr.write(log)
+        raise SystemExit(
+            f"PCH gate mismatch: requested {pch}, effective {effective}")
+    return effective
+
+
+def timed_build():
+    """Build the target once, returning (wall_seconds, cpu_seconds)."""
+    before = resource.getrusage(resource.RUSAGE_CHILDREN)
+    start = time.perf_counter()
+    proc = subprocess.run(
+        ["cmake", "--build", BUILD_PATH, "--target", TARGET,
+         "--parallel", PARALLEL])
+    wall = time.perf_counter() - start
+    after = resource.getrusage(resource.RUSAGE_CHILDREN)
+    cpu = ((after.ru_utime - before.ru_utime)
+           + (after.ru_stime - before.ru_stime))
+    if proc.returncode != 0:
+        raise SystemExit("build failed")
+    return wall, cpu
+
+
+def mean(values):
+    return sum(values) / len(values) if values else 0.0
+
+
+def main():
+    rows = []
+    for rep in range(1, REPS + 1):
+        for pch in ("ON", "OFF"):
+            configure(pch)
+            wall, cpu = timed_build()
+            rows.append((rep, pch, wall, cpu))
+            print(f"REP {rep} PCH {pch}: wall={wall:.1f}s cpu={cpu:.1f}s",
+                  flush=True)
+
+    on_wall = [w for _, p, w, _ in rows if p == "ON"]
+    off_wall = [w for _, p, w, _ in rows if p == "OFF"]
+    on_cpu = [c for _, p, _, c in rows if p == "ON"]
+    off_cpu = [c for _, p, _, c in rows if p == "OFF"]
+
+    out = [
+        "| rep | pch | wall_s | cpu_s |",
+        "| --- | --- | ---: | ---: |",
+    ]
+    for rep, pch, wall, cpu in rows:
+        out.append(f"| {rep} | {pch} | {wall:.1f} | {cpu:.1f} |")
+    out.append("")
+    out.append(f"platform: {sys.platform}, python {_vi.major}.{_vi.minor}, "
+               f"parallel {PARALLEL}, reps {REPS}")
+    out.append(f"mean wall ON  {mean(on_wall):.1f}s  "
+               f"OFF {mean(off_wall):.1f}s")
+    out.append(f"mean cpu  ON  {mean(on_cpu):.1f}s  "
+               f"OFF {mean(off_cpu):.1f}s")
+    if mean(off_cpu):
+        cpu_cut = (mean(off_cpu) - mean(on_cpu)) / mean(off_cpu) * 100.0
+        out.append(f"cpu reduction with PCH: {cpu_cut:.1f}%")
+    if mean(off_wall):
+        wall_cut = (mean(off_wall) - mean(on_wall)) / mean(off_wall) * 100.0
+        out.append(f"wall reduction with PCH: {wall_cut:.1f}%")
+
+    report = "\n".join(out)
+    print("\n" + report, flush=True)
+    with open("pch_experiment_result.md", "w") as handle:
+        handle.write(report + "\n")
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a") as handle:
+            handle.write(report + "\n")
+
+
+if __name__ == "__main__":
+    main()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/cpp/solvcon/CMakeLists.txt
+++ b/cpp/solvcon/CMakeLists.txt
@@ -293,4 +293,30 @@ else () # MSVC
     )
 endif () # MSVC
 
+# Only the caster-neutral pybind11 headers go into the PCH. Force-including
+# a caster-adding header (stl.h, functional.h, complex.h) would silently
+# change conversion semantics in translation units that deliberately omit
+# it.
+if (SOLVCON_USE_PCH)
+    target_precompile_headers(
+        solvcon_primary PRIVATE
+        <pybind11/pybind11.h>
+        <pybind11/numpy.h>
+        <pybind11/embed.h>
+    )
+    if (BUILD_QT)
+        target_precompile_headers(
+            solvcon_primary PRIVATE
+            <QtWidgets/QtWidgets>
+        )
+        # python/common.cpp includes the raw numpy C API headers, whose
+        # struct member named "slots" collides with the Qt keyword macro
+        # that the QtWidgets PCH force-includes.
+        set_source_files_properties(
+            ${CMAKE_CURRENT_SOURCE_DIR}/python/common.cpp
+            PROPERTIES SKIP_PRECOMPILE_HEADERS ON
+        )
+    endif () # BUILD_QT
+endif () # SOLVCON_USE_PCH
+
 # vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Adds `SOLVCON_USE_PCH` (enabled by default) to precompile expensive pybind11 and Qt headers. Across five clean builds, compile CPU fell by about 6% (465s to 436s). Wall time at full parallelism changed from 51.0s to 50.2s, which is within run-to-run noise, so the main benefit is for core-limited or thermally constrained machines.

| rep (-j14) | PCH ON wall | PCH ON CPU | PCH OFF wall | PCH OFF CPU |
|---|---|---|---|---|
| 1 | 50.3s | 442.5s | 53.2s | 463.2s |
| 2 | 49.9s | 432.7s | 48.4s | 460.3s |
| 3 | 48.0s | 428.1s | 52.8s | 466.6s |
| 4 | 50.9s | 438.8s | 50.9s | 471.5s |
| 5 | 51.8s | 438.1s | 49.8s | 463.3s |
| mean | 50.2s | 436.0s | 51.0s | 465.0s |

| rep (-j4) | PCH ON wall | PCH OFF wall |
|---|---|---|
| 1 | 105.1s | 105.3s |
| 2 | 101.2s | 105.3s |

PCH is automatically disabled with clang-tidy, ccache, and sccache, keeping CI behavior unchanged. It includes only caster-neutral pybind11 headers, and `python/common.cpp` opts out to avoid a Qt `slots` macro conflict.

Verified with `make lint`, pytest (1588 passed), gtest (213 passed), pilot builds, and `BUILD_QT=OFF`.