### PR TITLE
Note the C++ 120-char line width in the agent style guidance

### DIFF
--- a/.claude/skills/cpp-style-review/SKILL.md
+++ b/.claude/skills/cpp-style-review/SKILL.md
@@ -66,6 +66,12 @@ it briefly but don't re-implement the check here.
 - Trivial bodies (single `return`, single assignment) as one-liners.
 
 **Line economy**
+- **Line width (C++).** STYLE.md sets no hard width limit for C++; a line is
+  fine up to ~120 characters. Do not wrap C++ down to the Python 79/80 limit,
+  and do not flag a line under ~120 for width. Prefer one readable statement
+  on one line over a split made only to satisfy a limit that does not apply to
+  C++. Wrap only when it genuinely aids readability. (This applies when you
+  generate or edit C++ too, not just when reviewing it.)
 - Prefer fewer lines per STYLE.md. Flag unnecessary blank lines inside
   short blocks and needlessly spread-out code. Do not flag structural
   blank lines (between functions, logical sections, access specifiers).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,8 @@ See "Build, Test, Lint, Format" above for the `make` invocations.
   Breathing Room".
 - **C++**: 4-space indent, `m_` prefix on member vars, angle-bracket includes,
   C++23, prefer `SimpleCollector` / `small_vector` over STL for fundamentals.
+  No hard line-width limit; a line up to ~120 chars is fine. Do not wrap C++
+  down to the Python 79/80 limit when generating or editing code.
 - **Python**: PEP-8, 79-char hard limit, flake8.
 - **Comments**: Default to none. Add one only for what the code cannot say
   (the why, units, invariants, a non-obvious algorithm). Never restate the


### PR DESCRIPTION
STYLE.md already says C++ has no hard line-width limit and that a line is good under about 120 characters, but the agent-facing guidance did not repeat it, so generated C++ was being wrapped down to the Python 79/80 width for no reason.

This states the rule where code generation actually reads it: a C++ bullet in CLAUDE.md and a line-width note in the cpp-style-review skill, both saying a line up to about 120 characters is fine and that C++ should not be wrapped to the Python limit. The Python 79-character rule is unchanged.

[skip-ci]
