### PR TITLE
Add Codex agent tooling

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/hooks/check-source.sh
+++ b/.claude/hooks/check-source.sh
@@ -2,41 +2,65 @@
 # .claude/hooks/check-source.sh
 #
 # PostToolUse hook for Write|Edit on solvcon source files (Claude Code).
+# PostToolUse hook for Edit|Write in Codex (via .codex/hooks.json).
 # postToolUse / afterFileEdit hook for Cursor (via .cursor/hooks.json).
 # Deterministic checks (per Rule 5): ASCII-only, no trailing
 # whitespace, modeline at EOF, Python <=79-char lines.
 # Claude: exit 2 with violations on stderr. Cursor postToolUse: JSON
-# additional_context on stdout. Cursor afterFileEdit: stderr only.
+# additional_context on stdout. Cursor afterFileEdit: stderr only. Codex:
+# JSON systemMessage on stdout.
 
 input=$(cat)
 
 hook_event=""
+codex_hook=""
+files=""
 if command -v jq >/dev/null 2>&1; then
     hook_event=$(printf '%s' "$input" | jq -r '.hook_event_name // empty')
-    file=$(printf '%s' "$input" | jq -r '
+    codex_hook=$(printf '%s' "$input" | jq -r '
+        if has("model") then "1" else empty end
+    ')
+    files=$(printf '%s' "$input" | jq -r '
         .file_path //
         .tool_input.file_path //
         .tool_input.path //
         empty
     ')
+
+    if [ -z "$files" ]; then
+        patch=$(printf '%s' "$input" | jq -r '
+            .tool_input.patch //
+            .tool_input.input //
+            (if (.tool_input | type) == "string" then .tool_input
+             else empty end) //
+            empty
+        ')
+        files=$(printf '%s\n' "$patch" | sed -nE \
+            -e 's/^\*\*\* (Add|Update) File: (.*)$/\2/p' \
+            -e 's/^\*\*\* Move to: (.*)$/\1/p')
+    fi
 else
-    file=$(printf '%s' "$input" \
+    files=$(printf '%s' "$input" \
         | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
         | head -1)
 fi
 
-[ -z "$file" ] && exit 0
-[ ! -f "$file" ] && exit 0
-case "$file" in
-    *.py|*.cpp|*.hpp|*.c|*.h|*.cxx|*.hxx) ;;
-    *) exit 0 ;;
-esac
+[ -z "$files" ] && exit 0
 
 violations=""
 add() { violations="${violations}  $1"$'\n'; }
 
-# Non-ASCII bytes (Python is portable; bash byte-class is not).
-nonascii_line=$(python3 - "$file" <<'PY'
+check_file() {
+    file="$1"
+
+    [ ! -f "$file" ] && return
+    case "$file" in
+        *.py|*.cpp|*.hpp|*.c|*.h|*.cxx|*.hxx) ;;
+        *) return ;;
+    esac
+
+    # Non-ASCII bytes (Python is portable; bash byte-class is not).
+    nonascii_line=$(python3 - "$file" <<'PY'
 import sys
 with open(sys.argv[1], "rb") as f:
     for i, line in enumerate(f, 1):
@@ -44,31 +68,36 @@ with open(sys.argv[1], "rb") as f:
             print(i)
             break
 PY
-)
-[ -n "$nonascii_line" ] && add "$file:$nonascii_line -- non-ASCII byte -- replace with ASCII (run \`make checkascii\`)"
+    )
+    [ -n "$nonascii_line" ] && add "$file:$nonascii_line -- non-ASCII byte -- replace with ASCII (run \`make checkascii\`)"
 
-# Trailing whitespace.
-tws_line=$(grep -nE $'[ \t]+$' "$file" | head -1 | cut -d: -f1)
-[ -n "$tws_line" ] && add "$file:$tws_line -- trailing whitespace -- strip (run \`make checktws\`)"
+    # Trailing whitespace.
+    tws_line=$(grep -nE $'[ \t]+$' "$file" | head -1 | cut -d: -f1)
+    [ -n "$tws_line" ] && add "$file:$tws_line -- trailing whitespace -- strip (run \`make checktws\`)"
 
-# Modeline at EOF (last non-empty line).
-last=$(awk 'NF { l = $0 } END { print l }' "$file")
-case "$file" in
-    *.py)
-        echo "$last" | grep -qE '^[[:space:]]*#[[:space:]]*vim:[[:space:]]+set' \
-            || add "$file:EOF -- missing modeline -- append \`# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:\`"
-        ;;
-    *)
-        echo "$last" | grep -qE '^[[:space:]]*//[[:space:]]*vim:[[:space:]]+set' \
-            || add "$file:EOF -- missing modeline -- append \`// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:\`"
-        ;;
-esac
+    # Modeline at EOF (last non-empty line).
+    last=$(awk 'NF { l = $0 } END { print l }' "$file")
+    case "$file" in
+        *.py)
+            echo "$last" | grep -qE '^[[:space:]]*#[[:space:]]*vim:[[:space:]]+set' \
+                || add "$file:EOF -- missing modeline -- append \`# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:\`"
+            ;;
+        *)
+            echo "$last" | grep -qE '^[[:space:]]*//[[:space:]]*vim:[[:space:]]+set' \
+                || add "$file:EOF -- missing modeline -- append \`// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:\`"
+            ;;
+    esac
 
-# Python <=79 chars per line.
-if [[ "$file" == *.py ]]; then
-    long_line=$(awk 'length > 79 { print NR; exit }' "$file")
-    [ -n "$long_line" ] && add "$file:$long_line -- line >79 chars -- wrap (PEP-8)"
-fi
+    # Python <=79 chars per line.
+    if [[ "$file" == *.py ]]; then
+        long_line=$(awk 'length > 79 { print NR; exit }' "$file")
+        [ -n "$long_line" ] && add "$file:$long_line -- line >79 chars -- wrap (PEP-8)"
+    fi
+}
+
+while IFS= read -r file; do
+    [ -n "$file" ] && check_file "$file"
+done < <(printf '%s\n' "$files" | awk '!seen[$0]++')
 
 if [ -z "$violations" ]; then
     exit 0
@@ -87,6 +116,12 @@ if [ -n "$hook_event" ]; then
     afterFileEdit)
         printf '%s' "$msg" >&2
         exit 0
+        ;;
+    PostToolUse)
+        if [ -n "$codex_hook" ] && command -v jq >/dev/null 2>&1; then
+            jq -n --arg message "$msg" '{systemMessage: $message}'
+            exit 0
+        fi
         ;;
     esac
 fi

--- a/.codex/hooks
+++ b/.codex/hooks
@@ -1,0 +1,1 @@
+../.claude/hooks

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/.codex/hooks/check-doc-images.sh\"",
+            "statusMessage": "Checking staged documentation images"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/.codex/hooks/check-source.sh\"",
+            "statusMessage": "Checking source style"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Agent Instructions
 
 This file provides guidance to AI coding agents working in this repository
-(Claude Code and Cursor). `AGENTS.md` at the repo root and
+(Claude Code, Codex, and Cursor). `AGENTS.md` at the repo root and
 `.cursor/AGENTS.md` are symlinks to this file.
 
 ## Project Overview
@@ -16,12 +16,23 @@ unstructured meshes. The codebase emphasizes:
 - Qt-based GUI (pilot) for spatial data visualization
 - Integrated runtime profiler for performance analysis
 
-## Agent Tooling (Claude Code and Cursor)
+## Agent Tooling (Claude Code, Codex, and Cursor)
 
-This repository ships `.claude/` and `.cursor/` directories with permissions,
-hooks, and skills tuned to this codebase. General behavioral rules live in
-`contrib/prompt/general-rule.md` (not auto-imported). This section indexes
-the tools.
+This repository ships `.claude/`, `.codex/`, `.agents/`, and `.cursor/`
+directories with hooks, skills, and settings tuned to this codebase. General
+behavioral rules live in `contrib/prompt/general-rule.md` (not auto-imported).
+This section indexes the tools.
+
+### Codex (`.codex/` and `.agents/`)
+
+- `AGENTS.md` at the repository root is a symlink to `CLAUDE.md`.
+- `.agents/skills/` is a symlink to `.claude/skills/`, the repository skill
+  location recognized by Codex.
+- `.codex/hooks.json` wires Codex `PreToolUse` and `PostToolUse` events to the
+  shared hook scripts.
+- `.codex/hooks/` is a symlink to `.claude/hooks/`.
+- Project hooks load only for a trusted repository. Review and trust them with
+  `/hooks` when Codex first discovers them.
 
 ### Cursor (`.cursor/`)
 


### PR DESCRIPTION
Add repository-level Codex support while continuing to share the existing Claude instructions, skills, and hook scripts. Codex now discovers the shared skills through `.agents/skills`, loads native lifecycle hook configuration from `.codex/hooks.json`, and reports source-hook violations in Codex's supported output format without changing Claude or Cursor behavior.

Document the Codex layout alongside the existing Cursor integration and retain `CLAUDE.md` as the single source of repository guidance.

[skip-ci]
