### PR TITLE
Force the Windows Debug build to use the release Qt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,31 @@ project(solvcon)
 
 cmake_policy(SET CMP0148 OLD)
 
+# The Python, Qt6, and PySide6 that MSVC links ship release binaries only, so a
+# Debug build must match their runtime and configuration or it corrupts the heap
+# (issue #1058). Both default on; turn one off to link debug dependencies when
+# they are available.
+option(SOLVCON_MSVC_FORCE_RELEASE_RUNTIME
+    "MSVC: use the release C runtime (/MD) in every config" ON)
+option(SOLVCON_MSVC_FORCE_RELEASE_IMPORTS
+    "MSVC: import dependencies from their release config in a Debug build" ON)
+
 if(MSVC)
-    # Use the release C runtime (/MD) in every config, matching the
-    # release-only Python, Qt6, and PySide6 we link. A Debug build would
-    # default to /MDd, whose different STL layout corrupts an std::string
-    # passed from a /MD dependency (e.g. QString::toStdString) and hangs the
-    # pilot at start-up. /Zi keeps the Debug build debuggable.
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+    # "MultiThreadedDLL" selects /MD for linking. If not specifying it, a
+    # debug build will choose "MultiThreadedDebugDLL" for /MDd that uses a
+    # different STL layout and crashes the debug build. See
+    # https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html
+    # The debug build will use /Zi to keep it still debuggable.
+    if(SOLVCON_MSVC_FORCE_RELEASE_RUNTIME)
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+    endif()
+
+    # Without this a Debug pilot links the debug Qt (Qt6Cored.dll) while PySide6
+    # loads the release Qt6Core.dll; two Qt runtimes then run at once and a
+    # QString freed across the /MDd and /MD split corrupts the heap.
+    if(SOLVCON_MSVC_FORCE_RELEASE_IMPORTS)
+        set(CMAKE_MAP_IMPORTED_CONFIG_DEBUG "Release;")
+    endif()
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")


### PR DESCRIPTION
The latest update in issue #1058 described that the nightly Windows Debug pilot pytest aborts with a heap corruption (`0xc0000374`) in `test_pilot_2d.py::R2DWidgetWorldTC`, the first call that builds the pilot with `RManager.setUp().add2DWidget()`.

Running it under cdb with page heap places the fault in `RThemeManager::apply`, freeing the `QStyleFactory::keys()` string list, and the loaded-module list gives the reason: the Debug `pilot.exe` pulls in `Qt6Cored.dll`, `Qt6Guid.dll`, and `Qt6Widgetsd.dll` (the debug Qt), while `PySide6` loads the release `Qt6Core.dll`. Two Qt runtimes then share the process, one built `/MDd` and one `/MD`. Qt rejects every release plugin ("Cannot mix debug and release libraries") and loads the debug style plugin, and a `QString` handed across the split is allocated by the debug heap and freed by the release one, which corrupts it. AddressSanitizer never saw it because that job builds Release, where only the one release Qt loads.

The build already forces the release C runtime (`/MD`) in every config for the same reason, but that governs only our own objects; CMake still imported the debug configuration of Qt because the build type is Debug. Set `CMAKE_MAP_IMPORTED_CONFIG_DEBUG` to Release so imported targets resolve to their release libraries, and the Debug pilot links the one release Qt the rest of the process already uses.

Let's see what will happen in the coming nightly.
