### PR TITLE
Run the agent turn off the Qt thread to keep the pilot responsive

### DIFF
--- a/solvcon/agent/_core.py
+++ b/solvcon/agent/_core.py
@@ -184,6 +184,31 @@ class AgentSession:
         self._record_agent("", commands, results)
         return results
 
+    def record_prompt(self, prompt):
+        """Record the user's ``prompt`` as a turn.
+
+        Split out of :meth:`run_turn` so a GUI can record the prompt, run the
+        slow backend call off the main thread, and finish the turn later with
+        :meth:`complete_turn` or :meth:`fail_turn`.
+        """
+        self._transcript.append(TranscriptTurn(role="user", text=prompt))
+
+    def complete_turn(self, response):
+        """Finish a turn from a :class:`~solvcon.agent.BackendResponse`: run
+        its commands and record one agent turn carrying the reply, commands,
+        and results.  Any backend ``error`` is folded into the reply text."""
+        parts = [response.text] if response.text else []
+        if response.error:
+            parts.append("[error] %s" % response.error)
+        commands = list(response.commands)
+        return self._record_agent(
+            "\n".join(parts), commands, self._execute(commands))
+
+    def fail_turn(self, error):
+        """Record a failed agent turn for a backend that raised, so the turn
+        still lands in the transcript instead of propagating."""
+        return self._record_agent("[error] %s" % error)
+
     def run_turn(self, prompt):
         """Drive one request end to end for a single-turn chat.
 
@@ -195,20 +220,14 @@ class AgentSession:
         headless caller always gets a turn back.  No prior turns are replayed:
         multi-turn chat history is a later addition.
         """
-        self._transcript.append(TranscriptTurn(role="user", text=prompt))
+        self.record_prompt(prompt)
         if self.backend is None:
             return None
         try:
             response = self.backend.send(
                 prompt, self.scene_context(), self.tool_surface())
         except Exception as exc:
-            return self._record_agent(
-                "[error] %s: %s" % (type(exc).__name__, exc))
-        parts = [response.text] if response.text else []
-        if response.error:
-            parts.append("[error] %s" % response.error)
-        commands = list(response.commands)
-        return self._record_agent(
-            "\n".join(parts), commands, self._execute(commands))
+            return self.fail_turn("%s: %s" % (type(exc).__name__, exc))
+        return self.complete_turn(response)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/_agent_gui.py
+++ b/solvcon/pilot/_agent_gui.py
@@ -13,7 +13,7 @@ prompt is an independent single turn.
 
 from itertools import zip_longest
 
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt, QCoreApplication, QThread, QTimer, Signal
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QDockWidget,
                                QLabel, QComboBox, QTextEdit, QLineEdit,
                                QPushButton)
@@ -22,9 +22,41 @@ from ..agent import AgentSession, available_backends
 from . import _gui_common
 
 __all__ = [  # noqa: F822
+    'AgentBackendWorker',
     'AgentConsoleWidget',
     'AgentPanel',
 ]
+
+
+class AgentBackendWorker(QThread):
+    """Run one backend call off the Qt thread.
+
+    Only the backend call runs here, the slow subprocess or HTTP round trip;
+    it reads neither Qt nor the world, so it is safe off the main thread.  The
+    reply returns through :attr:`succeeded` (a ``BackendResponse``) or
+    :attr:`failed` (an error string); the owning panel applies the commands and
+    repaints on the main thread, where the connected slots run.
+    """
+
+    succeeded = Signal(object)
+    failed = Signal(str)
+
+    def __init__(self, backend, prompt, scene_context, tool_surface,
+                 parent=None):
+        super().__init__(parent)
+        self._backend = backend
+        self._prompt = prompt
+        self._scene_context = scene_context
+        self._tool_surface = tool_surface
+
+    def run(self):
+        try:
+            response = self._backend.send(
+                self._prompt, self._scene_context, self._tool_surface)
+        except Exception as exc:
+            self.failed.emit("%s: %s" % (type(exc).__name__, exc))
+        else:
+            self.succeeded.emit(response)
 
 
 class AgentConsoleWidget(QWidget):
@@ -46,6 +78,9 @@ class AgentConsoleWidget(QWidget):
         self._transcript = QTextEdit()
         self._transcript.setReadOnly(True)
 
+        self._status = QLabel("")
+        self._status.setVisible(False)
+
         self._input = QLineEdit()
         self._input.setPlaceholderText("Ask the agent to draw...")
         self._send = QPushButton("Send")
@@ -64,7 +99,13 @@ class AgentConsoleWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addLayout(selector)
         layout.addWidget(self._transcript, 1)
+        layout.addWidget(self._status)
         layout.addLayout(entry)
+
+        self._working_step = 0
+        self._working_timer = QTimer(self)
+        self._working_timer.setInterval(400)
+        self._working_timer.timeout.connect(self._tick_working)
 
         self._input.returnPressed.connect(self._emit)
         self._send.clicked.connect(self._emit)
@@ -87,6 +128,25 @@ class AgentConsoleWidget(QWidget):
         self._input.setEnabled(not busy)
         self._send.setEnabled(not busy)
 
+    def start_working(self):
+        """Show an animated ``working ...`` line while a turn runs, so a slow
+        backend reads as busy rather than as a frozen, silent console."""
+        self._working_step = 0
+        self._status.setText("Agent is working .")
+        self._status.setVisible(True)
+        self._working_timer.start()
+
+    def stop_working(self):
+        """Hide the working line once the turn has finished."""
+        self._working_timer.stop()
+        self._status.clear()
+        self._status.setVisible(False)
+
+    def _tick_working(self):
+        self._working_step = (self._working_step + 1) % 3
+        self._status.setText(
+            "Agent is working " + "." * (self._working_step + 1))
+
     def append_message(self, role, text):
         """Append one labelled block, e.g. ``You: ...`` or ``Agent: ...``."""
         label = {"user": "You", "agent": "Agent"}.get(role, role)
@@ -107,6 +167,17 @@ class AgentPanel(_gui_common.PilotFeature):
         self._dock = None
         self._panel = None
         self._session = AgentSession()
+        self._worker = None
+        self._active_widget = None
+        # Make sure the worker thread is joined before the main thread exits.
+        app = QCoreApplication.instance()
+        if app is not None:
+            app.aboutToQuit.connect(self._join_worker)
+
+    def _join_worker(self):
+        """Wait for the worker to finish before the main thread exits."""
+        if self._worker is not None:
+            self._worker.wait()
 
     def populate_menu(self):
         self._action = self.add_action(
@@ -147,26 +218,59 @@ class AgentPanel(_gui_common.PilotFeature):
         self._dock.visibilityChanged.connect(self._action.setChecked)
 
     def _on_submitted(self, prompt):
-        """Run one turn on the active canvas: rebind the session, send the
-        prompt, render the reply, and repaint the canvas the commands may have
-        changed."""
+        """Start one turn on the active canvas without blocking the GUI."""
+        if self._worker is not None:
+            return
         widget = self._mgr.currentR2DWidget()
         session = self._session
         session.backend = self._panel.selected_backend()
         session.bind_world(None if widget is None else widget.world)
         self._panel.append_message("user", prompt)
+        self._panel.clear_input()
+        session.record_prompt(prompt)
+        if session.backend is None:
+            self._panel.append_message("agent", self._format_turn(None))
+            return
+        self._active_widget = widget
         self._panel.set_busy(True)
-        try:
-            turn = session.run_turn(prompt)
-        except Exception as exc:
-            self._panel.append_message("agent", "[error] %s" % exc)
-        else:
-            self._panel.append_message("agent", self._format_turn(turn))
-            if widget is not None:
+        self._panel.start_working()
+        self._worker = AgentBackendWorker(
+            session.backend, prompt, session.scene_context(),
+            session.tool_surface(), parent=self._panel)
+        self._worker.succeeded.connect(self._on_backend_succeeded)
+        self._worker.failed.connect(self._on_backend_failed)
+        self._worker.finished.connect(self._on_worker_finished)
+        self._worker.start()
+
+    def _on_backend_succeeded(self, response):
+        """Apply the backend's commands to the world and repaint the canvas.
+        """
+        # TODO(#966): potential race condition here. capture a world revision
+        # at submit and skip by-id commands when the world advanced.
+        turn = self._session.complete_turn(response)
+        self._panel.append_message("agent", self._format_turn(turn))
+        widget = self._active_widget
+        if widget is not None:
+            try:
                 widget.requestRepaint()
-        finally:
-            self._panel.set_busy(False)
-            self._panel.clear_input()
+            except RuntimeError:
+                # TODO: the widget may have been deleted while the backend was
+                # running, so the repaint request fails. Need a better way to
+                # track the widget's lifetime and avoid this.
+                pass
+
+    def _on_backend_failed(self, error):
+        """Record a backend that raised as a failed agent turn."""
+        turn = self._session.fail_turn(error)
+        self._panel.append_message("agent", self._format_turn(turn))
+
+    def _on_worker_finished(self):
+        """Release the worker and re-enable the prompt for the next turn."""
+        self._worker.deleteLater()
+        self._worker = None
+        self._active_widget = None
+        self._panel.stop_working()
+        self._panel.set_busy(False)
 
     @staticmethod
     def _format_turn(turn):

--- a/tests/test_pilot_agent.py
+++ b/tests/test_pilot_agent.py
@@ -11,7 +11,7 @@ try:
     from solvcon import pilot
     from solvcon import agent
     from solvcon.pilot import _agent_gui
-    from PySide6.QtCore import Qt
+    from PySide6.QtCore import Qt, QCoreApplication
 except ImportError:
     pilot = None
 
@@ -29,6 +29,27 @@ class _CircleBackend:
     def send(self, prompt, scene_context, tool_surface):
         return agent.BackendResponse(text="circle added", commands=[
             {"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0}])
+
+
+class _TranslateBackend:
+    """Test backend that asks to translate a fixed shape id, so a GUI test can
+    drive a by-id command whose target may have been removed meanwhile.  It
+    uses an update op, not a delete, so the session's destructive gating does
+    not intercept it before the shape-liveness check."""
+
+    name = "translate (test)"
+
+    def __init__(self, shape_id):
+        self._shape_id = shape_id
+
+    def available(self):
+        return True
+
+    def send(self, prompt, scene_context, tool_surface):
+        return agent.BackendResponse(
+            text="translating", commands=[
+                {"op": "translate_shape", "shape_id": self._shape_id,
+                 "dx": 1.0, "dy": 0.0}])
 
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
@@ -50,6 +71,19 @@ class AgentPanelTC(unittest.TestCase):
                 combo.setCurrentIndex(i)
                 return
         self.fail("echo backend is not in the selector")
+
+    def _select_backend(self, panel, backend):
+        panel._backend_combo.addItem(backend.name, backend)
+        panel._backend_combo.setCurrentIndex(panel._backend_combo.count() - 1)
+
+    def _finish_turn(self, feature):
+        """Drive the pending async turn to completion: wait for the backend
+        worker, then pump the event loop so its queued reply reaches the main
+        thread and finishes the turn."""
+        worker = feature._worker
+        if worker is not None:
+            self.assertTrue(worker.wait(5000))
+        QCoreApplication.processEvents()
 
     def test_toggle_is_placed_under_view_panels(self):
         feature = _agent_gui.AgentPanel(mgr=self.mgr)
@@ -76,6 +110,7 @@ class AgentPanelTC(unittest.TestCase):
         self._select_echo(widget)
         widget._input.setText("draw a circle")
         widget._emit()
+        self._finish_turn(feature)
         text = widget._transcript.toPlainText()
         self.assertIn("You: draw a circle", text)
         self.assertIn("Agent: echo: draw a circle", text)
@@ -91,17 +126,93 @@ class AgentPanelTC(unittest.TestCase):
         world = solvcon.WorldFp64()
         widget.updateWorld(world)
         panel = feature._panel
-        backend = _CircleBackend()
-        panel._backend_combo.addItem(backend.name, backend)
-        panel._backend_combo.setCurrentIndex(panel._backend_combo.count() - 1)
+        self._select_backend(panel, _CircleBackend())
         panel._input.setText("draw a circle")
         panel._emit()
         self.assertIs(feature._session.world, world)
+        self._finish_turn(feature)
         self.assertEqual(world.nshape, 1)
         text = panel._transcript.toPlainText()
         self.assertIn("You: draw a circle", text)
         self.assertIn("circle added", text)
         self.assertIn("add_circle: ok", text)
+
+    def test_turn_runs_off_the_main_thread(self):
+        feature = self._panel_on()
+        panel = feature._panel
+        self._select_echo(panel)
+        panel._input.setText("draw a circle")
+        panel._emit()
+        # A worker is live and the prompt is locked, but no reply has landed:
+        # the main thread was never blocked on the backend call.
+        self.assertIsNotNone(feature._worker)
+        self.assertFalse(panel._input.isEnabled())
+        self.assertNotIn("Agent:", panel._transcript.toPlainText())
+        self._finish_turn(feature)
+        self.assertIsNone(feature._worker)
+        self.assertTrue(panel._input.isEnabled())
+        self.assertIn("Agent: echo: draw a circle",
+                      panel._transcript.toPlainText())
+
+    def test_working_indicator_shows_while_a_turn_runs(self):
+        # Assert on the animation timer and text rather than isVisible(), which
+        # is false for an unshown dock in a headless test.
+        feature = self._panel_on()
+        panel = feature._panel
+        self._select_echo(panel)
+        panel._input.setText("draw a circle")
+        panel._emit()
+        self.assertTrue(panel._working_timer.isActive())
+        self.assertIn("working", panel._status.text())
+        self._finish_turn(feature)
+        self.assertFalse(panel._working_timer.isActive())
+        self.assertEqual(panel._status.text(), "")
+
+    def test_second_submit_is_dropped_while_a_turn_runs(self):
+        feature = self._panel_on()
+        panel = feature._panel
+        self._select_echo(panel)
+        panel._input.setText("first")
+        panel._emit()
+        running = feature._worker
+        panel.submitted.emit("second")
+        self.assertIs(feature._worker, running)
+        self._finish_turn(feature)
+        text = panel._transcript.toPlainText()
+        self.assertIn("You: first", text)
+        self.assertNotIn("You: second", text)
+
+    def test_shutdown_joins_the_running_worker(self):
+        # The teardown path waits for an in-flight worker so its QThread is
+        # never destroyed while still running (which would abort the process).
+        feature = self._panel_on()
+        panel = feature._panel
+        self._select_echo(panel)
+        panel._input.setText("draw a circle")
+        panel._emit()
+        worker = feature._worker
+        self.assertIsNotNone(worker)
+        feature._join_worker()
+        self.assertTrue(worker.isFinished())
+        QCoreApplication.processEvents()
+
+    def test_stale_by_id_command_fails_cleanly(self):
+        # The race workaround: a command that names a shape the user removed
+        # while the model was thinking fails as a not-live shape rather than
+        # crashing the turn.  The empty world stands in for that removal.
+        feature = self._panel_on()
+        widget = self.mgr.add2DWidget()
+        world = solvcon.WorldFp64()
+        widget.updateWorld(world)
+        panel = feature._panel
+        self._select_backend(panel, _TranslateBackend(4242))
+        panel._input.setText("move shape 4242 right")
+        panel._emit()
+        self._finish_turn(feature)
+        text = panel._transcript.toPlainText()
+        self.assertIn("translate_shape", text)
+        self.assertNotIn("ok", text.split("translate_shape", 1)[1])
+        self.assertTrue(panel._input.isEnabled())
 
     def test_blank_prompt_is_ignored(self):
         feature = self._panel_on()


### PR DESCRIPTION
The Agent Console applied each turn synchronously on the Qt main thread, so the whole pilot froze for the length of the backend call, a subprocess or HTTP round trip, while the model was thinking.

This moves only the backend call onto an AgentBackendWorker QThread. That call touches neither Qt nor the world, so it is safe off the main thread. The reply returns through a signal and the resulting commands are applied back on the main thread, serialized with the user's own edits through the event loop, so nothing races the world's C++ buffers. The prompt box locks for the duration of a turn so turns never overlap, but the canvas stays live and the user can keep drawing while the model thinks. On quit the panel joins an in-flight worker so its thread is never destroyed while still running.

While a turn runs the console shows an animated "Agent is working ..." line and clears it when the turn ends, so a slow or misconfigured backend reads as busy and its eventual reply or error is always shown, rather than the console looking frozen and silent.

A command that names a shape the user removed while the model was thinking now fails cleanly as a not-live shape and shows in the transcript rather than crashing the batch. This is the basic race workaround; a richer scheme that diffs the scene the model saw against the live world, and responsive cancellation that reaches the backend subprocess, are noted as follow-ups.

To support this without duplicating logic, AgentSession.run_turn is split into record_prompt, complete_turn, and fail_turn so the GUI can record the prompt, run the backend off the main thread, and finish the turn later. run_turn keeps its previous behavior for headless callers.

Related to #966.
