### PR TITLE
Add the Agent Window command family for canvas windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ def main():
             'solvcon',
             'solvcon.agent',
             'solvcon.agent.draw',
+            'solvcon.agent.window',
             'solvcon.multidim',
             'solvcon.multidim.euler',
             'solvcon.onedim',

--- a/solvcon/agent/_command.py
+++ b/solvcon/agent/_command.py
@@ -235,6 +235,45 @@ class CommandSet:
         return grouped
 
 
+# CommandSet attributes a fronting module re-exports so it doubles as its set.
+COMMAND_API = (
+    "apply_defaults",
+    "categories",
+    "command_from_tool_call",
+    "command_schemas",
+    "commands",
+    "commands_by_category",
+    "description",
+    "result_schemas",
+    "schema",
+    "title",
+    "tool_definitions",
+    "validate_command",
+    "validate_result",
+    "validate_script",
+)
+
+
+def install_command_api(namespace, command_set):
+    """Wire a module to double as ``command_set``'s command API.
+
+    Pass the module's ``globals()`` as ``namespace``; installs
+    ``__getattr__``/``__dir__`` and returns the name tuple for ``__all__``.
+    """
+    def __getattr__(name):
+        if name in COMMAND_API:
+            return getattr(command_set, name)
+        raise AttributeError(
+            f"module {namespace['__name__']!r} has no attribute {name!r}")
+
+    def __dir__():
+        return sorted(set(namespace) | set(COMMAND_API))
+
+    namespace["__getattr__"] = __getattr__
+    namespace["__dir__"] = __dir__
+    return COMMAND_API
+
+
 @dataclasses.dataclass
 class CommandResult:
     """The outcome of applying one command."""

--- a/solvcon/agent/window/__init__.py
+++ b/solvcon/agent/window/__init__.py
@@ -3,13 +3,7 @@
 
 
 """
-Agent Draw front-end for the ``World`` API.
-
-The command vocabulary lives in ``command.py`` (one ``Command`` subclass per
-command); the schema documents, validators, and tool definitions are derived
-from one private command set. This module delegates its command-family API to
-that set, so the harness and MCP adapters ride on the same commands.
-``Executor`` applies validated commands to a ``World``.
+Agent Window front-end for the pilot canvas windowing API.
 """
 
 from .. import _command as _cmd
@@ -21,7 +15,6 @@ from .._command import (  # noqa: F401
 )
 from .command import _command_set
 from .executor import Executor  # noqa: F401
-
 
 __all__ = (
     "CRUD_CATEGORIES",

--- a/solvcon/agent/window/command.py
+++ b/solvcon/agent/window/command.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+The Agent Window command family: the canvas windowing surface for an agent.
+
+The commands drive a window manager, a duck-typed target the GUI
+``WindowController`` will bind to the pilot's ``RManager`` and ``QMdiArea``
+(tests bind an in-memory fake). The manager surface:
+
+    new_canvas() -> int
+        Open a new 2D canvas window and return its stable id.
+    list_windows() -> list of {"id": int, "title": str, "active": bool}
+        Every open canvas window, in tab order.
+    activate_window(window_id) -> None
+        Make the window with the given id active.
+    close_window(window_id) -> None
+        Close the window with the given id.
+    save_image(window_id, path) -> None
+        Save the window's canvas image to ``path``.
+"""
+
+from .. import _command as _cmd
+
+
+# Shared JSON Schema fragments, used by reference; treat as immutable.
+INTEGER = {"type": "integer"}
+BOOLEAN = {"type": "boolean"}
+STRING = {"type": "string"}
+
+
+def _int(description):
+    return {**INTEGER, "description": description}
+
+
+WINDOW = {"type": "object",
+          "description": "One open canvas window: id, title, active flag.",
+          "properties": {
+              "id": _int("Stable id of the canvas window."),
+              "title": {**STRING, "description": "Window title text."},
+              "active": {**BOOLEAN,
+                         "description": "True for the active window."}},
+          "required": ["id", "title", "active"],
+          "additionalProperties": False}
+
+
+def _require_window(manager, window_id):
+    # Fail by-id commands cleanly instead of leaking a KeyError from the
+    # manager or the Qt layer.
+    if not any(w["id"] == window_id for w in manager.list_windows()):
+        raise _cmd.CommandError(f"no open window with id {window_id}")
+
+
+_command_set = _cmd.CommandSet(
+    "Agent Window command", "Any single command in the Agent Window schema.")
+
+
+@_command_set.register
+class NewCanvas(_cmd.Command):
+    op = "new_canvas"
+    category = "create"
+    summary = "Open a new 2D canvas window and make it the active one."
+    returns = {"window_id": _int("Id of the newly opened window.")}
+
+    def apply(self, manager, args, ctx):
+        return {"window_id": manager.new_canvas()}
+
+
+@_command_set.register
+class ListWindows(_cmd.Command):
+    op = "list_windows"
+    category = "read"
+    summary = "List every open canvas window with id, title, and active flag."
+    returns = {"windows": {"type": "array", "items": WINDOW,
+                           "description": "Open canvas windows, tab order."}}
+
+    def apply(self, manager, args, ctx):
+        return {"windows": list(manager.list_windows())}
+
+
+@_command_set.register
+class ActivateWindow(_cmd.Command):
+    op = "activate_window"
+    category = "update"
+    summary = "Make the canvas window with the given id the active one."
+    arguments = {"window_id": _int("Id of the window to activate.")}
+
+    def apply(self, manager, args, ctx):
+        _require_window(manager, args["window_id"])
+        manager.activate_window(args["window_id"])
+        return {}
+
+
+@_command_set.register
+class CloseWindow(_cmd.Command):
+    op = "close_window"
+    category = "delete"
+    summary = "Close the canvas window with the given id."
+    arguments = {"window_id": _int("Id of the window to close.")}
+
+    def apply(self, manager, args, ctx):
+        _require_window(manager, args["window_id"])
+        manager.close_window(args["window_id"])
+        return {}
+
+
+@_command_set.register
+class SaveImage(_cmd.Command):
+    op = "save_image"
+    category = "update"
+    summary = "Save a canvas window's image to a file path."
+    arguments = {"window_id": _int("Id of the window to save."),
+                 "path": {**STRING,
+                          "description": "Filesystem path to write the image "
+                                         "to; the suffix picks the format."}}
+
+    def apply(self, manager, args, ctx):
+        _require_window(manager, args["window_id"])
+        # The contract returns None, but a Qt backend delegating to
+        # R2DWidget.saveImage() returns False when the write fails; surface
+        # that as a clean failure instead of a bogus success.
+        if manager.save_image(args["window_id"], args["path"]) is False:
+            raise _cmd.CommandError(
+                f"could not save window {args['window_id']} "
+                f"to {args['path']!r}")
+        return {}
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/agent/window/executor.py
+++ b/solvcon/agent/window/executor.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Apply validated Agent Window commands to a window manager."""
+
+from .. import _command as _cmd
+from . import command
+
+
+class Executor(_cmd.CommandProcessor):
+    """Bind the window command set to a window-manager target."""
+
+    def __init__(self, manager, validate_results=False, reraise=False):
+        super().__init__(manager, command._command_set,
+                         validate_results=validate_results, reraise=reraise)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_window_command.py
+++ b/tests/test_agent_window_command.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""The Agent Window lifecycle suite: schema documents and the Executor run
+against an in-memory window manager. The view-transform half is covered in
+test_agent_view_command.py."""
+
+import unittest
+
+import jsonschema
+
+from solvcon.agent import Command, CommandError, CommandProcessor
+from solvcon.agent import window
+from solvcon.agent.window import (
+    Executor,
+    command_schemas,
+    commands,
+    commands_by_category,
+    result_schemas,
+    schema,
+    tool_definitions,
+    validate_command,
+    validate_script,
+)
+
+
+class FakeWindowManager:
+    """In-memory window manager for headless tests; ``save_image`` records
+    the request instead of writing a file."""
+
+    def __init__(self):
+        self._next_id = 1
+        self._windows = []
+        self._active = None
+        self.saved = []
+
+    def new_canvas(self):
+        window_id = self._next_id
+        self._next_id += 1
+        self._windows.append({"id": window_id, "title": "2D canvas"})
+        self._active = window_id
+        return window_id
+
+    def list_windows(self):
+        return [{"id": w["id"], "title": w["title"],
+                 "active": w["id"] == self._active}
+                for w in self._windows]
+
+    def activate_window(self, window_id):
+        self._active = window_id
+
+    def close_window(self, window_id):
+        self._windows = [w for w in self._windows if w["id"] != window_id]
+        if self._active == window_id:
+            self._active = self._windows[-1]["id"] if self._windows else None
+
+    def save_image(self, window_id, path):
+        self.saved.append((window_id, path))
+
+
+class SchemaDocumentTC(unittest.TestCase):
+    """The schema documents themselves are well-formed and consistent."""
+
+    def test_schema_is_derived_from_the_commands(self):
+        self.assertEqual(len(schema["oneOf"]), len(commands))
+        grouped = commands_by_category()
+        self.assertIn("new_canvas", grouped["create"])
+        self.assertIn("list_windows", grouped["read"])
+        self.assertIn("save_image", grouped["update"])
+        self.assertIn("activate_window", grouped["update"])
+        self.assertIn("close_window", grouped["delete"])
+
+    def test_command_schemas_are_valid_and_closed(self):
+        for op, cmd_schema in command_schemas.items():
+            jsonschema.Draft202012Validator.check_schema(cmd_schema)
+            self.assertEqual(cmd_schema["properties"]["op"]["const"], op)
+            self.assertFalse(cmd_schema["additionalProperties"])
+
+    def test_combined_schema_is_valid(self):
+        jsonschema.Draft202012Validator.check_schema(schema)
+
+    def test_every_command_is_registered_and_applies(self):
+        self.assertEqual(set(commands), set(command_schemas))
+        self.assertEqual(set(commands), set(result_schemas))
+        for op, cmd in commands.items():
+            self.assertEqual(cmd.op, op)
+            self.assertIsNot(type(cmd).apply, Command.apply)
+
+    def test_tool_definitions_drop_op_and_carry_output_schema(self):
+        tools = {t["name"]: t for t in tool_definitions()}
+        self.assertEqual(set(tools), set(command_schemas))
+        for op, tool in tools.items():
+            self.assertNotIn("op", tool["inputSchema"]["properties"])
+            self.assertNotIn("op", tool["inputSchema"]["required"])
+            self.assertEqual(tool["outputSchema"], result_schemas[op])
+
+    def test_result_schemas_are_valid_and_closed(self):
+        self.assertEqual(set(result_schemas), set(command_schemas))
+        for res_schema in result_schemas.values():
+            jsonschema.Draft202012Validator.check_schema(res_schema)
+            self.assertFalse(res_schema["additionalProperties"])
+            self.assertEqual(set(res_schema["required"]),
+                             set(res_schema["properties"]))
+
+
+class JsonConformanceTC(unittest.TestCase):
+    """A few pure-JSON cases pin what the schema accepts and rejects."""
+
+    def test_valid_command_passes(self):
+        command = {"op": "save_image", "window_id": 1, "path": "out.png"}
+        self.assertIs(validate_command(command), command)
+        jsonschema.validate(command, schema,
+                            cls=jsonschema.Draft202012Validator)
+
+    def test_wrong_type_is_rejected(self):
+        with self.assertRaises(CommandError):
+            validate_command({"op": "activate_window", "window_id": "1"})
+        with self.assertRaises(CommandError):
+            validate_command({"op": "save_image", "window_id": 1, "path": 2})
+
+    def test_missing_required_is_rejected(self):
+        with self.assertRaises(CommandError):
+            validate_command({"op": "save_image", "window_id": 1})
+
+    def test_unknown_op_and_extra_key_are_rejected(self):
+        with self.assertRaises(CommandError):
+            validate_command({"op": "minimize_window", "window_id": 1})
+        with self.assertRaises(CommandError):
+            validate_command({"op": "new_canvas", "extra": 1})
+
+    def test_script_validation(self):
+        script = [{"op": "new_canvas"},
+                  {"op": "activate_window", "window_id": 1}]
+        self.assertIs(validate_script(script), script)
+        with self.assertRaises(CommandError):
+            validate_script([{"op": "new_canvas"}, {"op": "fly"}])
+        with self.assertRaises(CommandError):
+            validate_script({"op": "new_canvas"})
+
+
+class ExecutorTC(unittest.TestCase):
+    """Application runs validated commands against a fake window manager."""
+
+    def setUp(self):
+        self.manager = FakeWindowManager()
+        self.ex = Executor(self.manager)
+
+    def test_new_canvas_opens_and_activates(self):
+        res = self.ex.run({"op": "new_canvas"})
+        self.assertTrue(res.ok)
+        self.assertEqual(res.value["window_id"], 1)
+        windows = self.ex.run({"op": "list_windows"}).value["windows"]
+        self.assertEqual(len(windows), 1)
+        self.assertTrue(windows[0]["active"])
+        self.assertEqual(windows[0]["title"], "2D canvas")
+
+    def test_list_windows_reflects_the_active_one(self):
+        self.ex.run({"op": "new_canvas"})
+        self.ex.run({"op": "new_canvas"})
+        windows = self.ex.run({"op": "list_windows"}).value["windows"]
+        active = [w["id"] for w in windows if w["active"]]
+        self.assertEqual(active, [2])
+
+    def test_activate_window_switches_the_active_one(self):
+        self.ex.run({"op": "new_canvas"})
+        self.ex.run({"op": "new_canvas"})
+        self.assertTrue(
+            self.ex.run({"op": "activate_window", "window_id": 1}).ok)
+        windows = self.ex.run({"op": "list_windows"}).value["windows"]
+        active = [w["id"] for w in windows if w["active"]]
+        self.assertEqual(active, [1])
+
+    def test_close_window_removes_it(self):
+        self.ex.run({"op": "new_canvas"})
+        self.ex.run({"op": "new_canvas"})
+        self.assertTrue(
+            self.ex.run({"op": "close_window", "window_id": 1}).ok)
+        ids = [w["id"]
+               for w in self.ex.run({"op": "list_windows"}).value["windows"]]
+        self.assertEqual(ids, [2])
+
+    def test_save_image_routes_to_the_manager(self):
+        self.ex.run({"op": "new_canvas"})
+        res = self.ex.run(
+            {"op": "save_image", "window_id": 1, "path": "canvas.png"})
+        self.assertTrue(res.ok)
+        self.assertEqual(self.manager.saved, [(1, "canvas.png")])
+
+    def test_save_image_reports_a_failed_write(self):
+        class FailingManager(FakeWindowManager):
+            def save_image(self, window_id, path):
+                super().save_image(window_id, path)
+                return False
+
+        manager = FailingManager()
+        ex = Executor(manager)
+        ex.run({"op": "new_canvas"})
+        res = ex.run({"op": "save_image", "window_id": 1, "path": "x.png"})
+        self.assertFalse(res.ok)
+        self.assertIn("x.png", res.error)
+
+    def test_by_id_commands_fail_cleanly_on_a_missing_window(self):
+        for op in ("activate_window", "close_window"):
+            with self.subTest(op=op):
+                res = self.ex.run({"op": op, "window_id": 99})
+                self.assertFalse(res.ok)
+                self.assertIn("99", res.error)
+        res = self.ex.run(
+            {"op": "save_image", "window_id": 99, "path": "x.png"})
+        self.assertFalse(res.ok)
+        self.assertEqual(self.manager.saved, [])
+
+    def test_results_match_declared_schemas(self):
+        self.ex.run({"op": "new_canvas"})
+        script = [
+            {"op": "new_canvas"},
+            {"op": "list_windows"},
+            {"op": "activate_window", "window_id": 1},
+            {"op": "save_image", "window_id": 1, "path": "a.png"},
+            {"op": "close_window", "window_id": 1},
+        ]
+        for command in script:
+            with self.subTest(op=command["op"]):
+                res = self.ex.run(command)
+                self.assertTrue(res.ok, res.error)
+                jsonschema.validate(
+                    res.value, result_schemas[command["op"]],
+                    cls=jsonschema.Draft202012Validator)
+
+    def test_run_script_walks_the_vocabulary(self):
+        results = self.ex.run_script([
+            {"op": "new_canvas"},
+            {"op": "new_canvas"},
+            {"op": "activate_window", "window_id": 1},
+            {"op": "save_image", "window_id": 2, "path": "b.png"},
+            {"op": "close_window", "window_id": 2},
+            {"op": "list_windows"},
+        ])
+        self.assertTrue(all(r.ok for r in results),
+                        [r.error for r in results])
+        ids = [w["id"] for w in results[-1].value["windows"]]
+        self.assertEqual(ids, [1])
+
+    def test_the_module_doubles_as_a_command_set(self):
+        # The module delegates its command API to the set, so a bare
+        # CommandProcessor drives it like the draw module.
+        proc = CommandProcessor(self.manager, window)
+        self.assertTrue(proc.run({"op": "new_canvas"}).ok)
+        self.assertEqual(len(self.manager.list_windows()), 1)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
The Agent Draw family lets an AI backend edit what lives in the World. This adds the family that manages the canvas windows around it: open a canvas, list the open ones, activate, close, and save an image.

Agent Window drives a duck-typed window manager, the surface the GUI WindowController will later bind to the pilot's RManager and QMdiArea (tests bind an in-memory fake). The vocabulary is new_canvas, list_windows, activate_window, close_window, and save_image. Commands that take a window id fail as a clean result when the id is unknown rather than leaking a KeyError from the manager or the Qt layer.

The family mirrors solvcon.agent.draw exactly: one Command subclass per op, a private CommandSet that derives the JSON Schema, validators, and MCP-style tool definitions, and an Executor that binds the set to a target. The re-export boilerplate that lets a module double as its own command set had been copied verbatim into every front-end package; it now lives once in _command.install_command_api, and the draw package is migrated onto the shared helper in this PR.

Wiring the family into AgentSession alongside Draw needs a multi-family dispatcher and stays a follow-up. The Agent View family, which drives the 2D pan/zoom transform (ViewTransform2dFp64), builds on the same install_command_api helper and lands in its own PR stacked on this one.

The command set is covered by tests/test_agent_window_command.py, which exercises schema derivation, JSON conformance, and each command end to end against an in-memory fake manager.

Related to #966.
