### PR TITLE
Add polygon and polyline drawing primitives to World

### DIFF
--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -22,6 +22,7 @@
 #include <solvcon/universe/rtree.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <limits>
 #include <optional>
@@ -55,6 +56,8 @@ enum class ShapeType : uint8_t
     SQUARE = 6, ///< Specialization of RECTANGLE with equal side lengths.
     ELLIPSE = 7,
     CIRCLE = 8, ///< Specialization of ELLIPSE with equal radii.
+    POLYLINE = 9, ///< Open chain of straight segments.
+    POLYGON = 10, ///< Closed chain of straight segments.
 }; /* end of enum class ShapeType */
 
 inline std::string shape_type_name(ShapeType st)
@@ -70,6 +73,8 @@ inline std::string shape_type_name(ShapeType st)
     case ShapeType::SQUARE: return "square";
     case ShapeType::ELLIPSE: return "ellipse";
     case ShapeType::CIRCLE: return "circle";
+    case ShapeType::POLYLINE: return "polyline";
+    case ShapeType::POLYGON: return "polygon";
     default: return "unknown";
     }
 }
@@ -415,6 +420,18 @@ public:
      * Add a cubic Bezier from a bezier_type struct.
      */
     int32_t add_bezier_shape(bezier_type const & bezier);
+
+    /**
+     * Add an open chain of straight segments through the given vertices.
+     * Needs at least two vertices; consecutive vertices form one segment each.
+     */
+    int32_t add_polyline(std::vector<std::array<T, 2>> const & vertices);
+
+    /**
+     * Add a closed chain of straight segments through the given vertices, with
+     * a final segment back to the first. Needs at least three vertices.
+     */
+    int32_t add_polygon(std::vector<std::array<T, 2>> const & vertices);
 
     /**
      * Translate all segments and curves belonging to a shape by (dx, dy).
@@ -874,6 +891,41 @@ int32_t World<T>::add_bezier_shape(bezier_type const & bezier)
     size_t const offset = m_curves->size();
     m_curves->append(bezier);
     return register_shape(ShapeType::BEZIER, /*seg_off*/ 0, /*seg_cnt*/ 0, offset, 1);
+}
+
+template <typename T>
+int32_t World<T>::add_polyline(std::vector<std::array<T, 2>> const & vertices)
+{
+    if (vertices.size() < 2)
+    {
+        throw std::invalid_argument("World: add_polyline needs at least 2 vertices");
+    }
+    size_t const offset = m_segments->size();
+    for (size_t i = 0; i + 1 < vertices.size(); ++i)
+    {
+        m_segments->append(
+            point_type(vertices[i][0], vertices[i][1], 0),
+            point_type(vertices[i + 1][0], vertices[i + 1][1], 0));
+    }
+    return register_shape(ShapeType::POLYLINE, offset, vertices.size() - 1);
+}
+
+template <typename T>
+int32_t World<T>::add_polygon(std::vector<std::array<T, 2>> const & vertices)
+{
+    if (vertices.size() < 3)
+    {
+        throw std::invalid_argument("World: add_polygon needs at least 3 vertices");
+    }
+    size_t const offset = m_segments->size();
+    for (size_t i = 0; i < vertices.size(); ++i)
+    {
+        size_t const j = (i + 1) % vertices.size();
+        m_segments->append(
+            point_type(vertices[i][0], vertices[i][1], 0),
+            point_type(vertices[j][0], vertices[j][1], 0));
+    }
+    return register_shape(ShapeType::POLYGON, offset, vertices.size());
 }
 
 template <typename T>

--- a/cpp/solvcon/universe/pymod/wrap_World.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_World.cpp
@@ -368,6 +368,20 @@ WrapWorld<T> & WrapWorld<T>::wrap_shape()
                 return self.add_bezier_shape(bezier);
             },
             py::arg("b"))
+        .def(
+            "add_polyline",
+            [](wrapped_type & self, std::vector<std::array<value_type, 2>> const & vertices)
+            {
+                return self.add_polyline(vertices);
+            },
+            py::arg("vertices"))
+        .def(
+            "add_polygon",
+            [](wrapped_type & self, std::vector<std::array<value_type, 2>> const & vertices)
+            {
+                return self.add_polygon(vertices);
+            },
+            py::arg("vertices"))
         //
         ;
 

--- a/solvcon/agent/draw/command.py
+++ b/solvcon/agent/draw/command.py
@@ -290,6 +290,42 @@ class AddBezierShape(_cmd.Command):
             _world_point(args["p2"]), _world_point(args["p3"]))}
 
 
+def _vertices(description, min_items):
+    return {"type": "array",
+            "items": {"type": "array", "items": {"type": "number"},
+                      "minItems": 2, "maxItems": 2},
+            "minItems": min_items, "description": description}
+
+
+@_command_set.register
+class AddPolyline(_cmd.Command):
+    op = "add_polyline"
+    category = "create"
+    summary = "Add an open polyline through a list of [x, y] vertices."
+    arguments = {"vertices": _vertices(
+        "Vertices as [x, y] pairs; at least two.", 2)}
+    returns = {"shape_id": _int("Id of the new shape.")}
+
+    def apply(self, world, args, ctx):
+        verts = [[p[0], p[1]] for p in args["vertices"]]
+        return {"shape_id": world.add_polyline(verts)}
+
+
+@_command_set.register
+class AddPolygon(_cmd.Command):
+    op = "add_polygon"
+    category = "create"
+    summary = "Add a closed polygon through a list of [x, y] vertices."
+    arguments = {"vertices": _vertices(
+        "Vertices as [x, y] pairs; at least three. The last connects "
+        "back to the first.", 3)}
+    returns = {"shape_id": _int("Id of the new shape.")}
+
+    def apply(self, world, args, ctx):
+        verts = [[p[0], p[1]] for p in args["vertices"]]
+        return {"shape_id": world.add_polygon(verts)}
+
+
 @_command_set.register
 class GetShape(_cmd.Command):
     op = "get_shape"

--- a/tests/test_agent_draw_command.py
+++ b/tests/test_agent_draw_command.py
@@ -80,4 +80,34 @@ class DrawVocabularyGoThroughTC(unittest.TestCase):
         self.assertEqual(self.proc.log, ["hello"])
 
 
+class DrawPrimitiveCommandsTC(unittest.TestCase):
+    """The polyline and polygon commands end to end."""
+
+    def setUp(self):
+        self.world = solvcon.WorldFp64()
+        self.proc = CommandProcessor(self.world, draw)
+
+    def test_polyline_and_polygon_create_shapes(self):
+        line = self.proc.run(
+            {"op": "add_polyline", "vertices": [[0, 0], [1, 0], [1, 1]]})
+        self.assertTrue(line.ok)
+        self.assertEqual(
+            self.proc.run({"op": "shape_type_of",
+                           "shape_id": line.value["shape_id"]}).value,
+            {"type": "polyline"})
+        poly = self.proc.run(
+            {"op": "add_polygon", "vertices": [[0, 0], [2, 0], [2, 2]]})
+        self.assertTrue(poly.ok)
+        self.assertEqual(
+            self.proc.run({"op": "shape_type_of",
+                           "shape_id": poly.value["shape_id"]}).value,
+            {"type": "polygon"})
+
+    def test_polygon_too_short_is_a_schema_failure(self):
+        short = self.proc.run(
+            {"op": "add_polygon", "vertices": [[0, 0], [1, 1]]})
+        self.assertFalse(short.ok)
+        self.assertEqual(self.proc.run({"op": "nshape"}).value["nshape"], 0)
+
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -332,6 +332,34 @@ class WorldShapeTC(unittest.TestCase):
         self.assertEqual(self.w.nsegment, 0)
 
 
+class WorldPrimitivesTC(unittest.TestCase):
+    """Polyline and polygon primitives."""
+
+    def setUp(self):
+        self.w = solvcon.WorldFp64()
+
+    def test_polyline_is_open(self):
+        sid = self.w.add_polyline([[0, 0], [1, 0], [1, 1]])
+        # An open chain of n vertices owns n-1 segments.
+        self.assertEqual(self.w.shape_type_of(sid), "polyline")
+        self.assertEqual(self.w.nsegment, 2)
+
+    def test_polygon_is_closed(self):
+        sid = self.w.add_polygon([[0, 0], [2, 0], [2, 2]])
+        # A closed chain of n vertices owns n segments; the last returns home.
+        self.assertEqual(self.w.shape_type_of(sid), "polygon")
+        self.assertEqual(self.w.nsegment, 3)
+        self.assertEqual(self.w.shape_bbox(sid), [0, 0, 2, 2])
+
+    def test_polyline_needs_two_vertices(self):
+        with self.assertRaises(ValueError):
+            self.w.add_polyline([[0, 0]])
+
+    def test_polygon_needs_three_vertices(self):
+        with self.assertRaises(ValueError):
+            self.w.add_polygon([[0, 0], [1, 1]])
+
+
 class WorldUndoRedoTC(unittest.TestCase):
     """Undo and redo of shape creation."""
 


### PR DESCRIPTION
This is step 1 of a three-step series that grows the Agent Draw primitive set from issue #1136 (polygon/polyline, then text, then arc and scale). Each step is a separate sub-500-LOC PR against master; the next opens after this one lands.

A polyline is an open chain of straight segments through a vertex list; a polygon is the closed chain, with a final segment back to the first vertex. Both are segment-backed shapes, so they translate, rotate, remove, and undo through the existing shape machinery, and they let the agent draw true silhouettes instead of stitching rectangles.

Binds add_polyline/add_polygon on World, adds the matching Agent Draw commands, and covers the open/closed segment counts and the minimum-vertex validation.

Related to #1136.