### PR TITLE
Add a text label drawing primitive to World

### DIFF
--- a/cpp/solvcon/pilot/RWorldRenderer2d.cpp
+++ b/cpp/solvcon/pilot/RWorldRenderer2d.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <QColor>
+#include <QFont>
 #include <QFontMetricsF>
 #include <QPainter>
 #include <QPainterPath>
@@ -669,6 +670,34 @@ void RWorldRenderer2d::paint(QPainter & painter) const
         {
             painter.drawPoint(map(points->x(i), points->y(i)));
         }
+    }
+
+    // Text labels, drawn upright with the anchor at the baseline left. The
+    // world-space height maps to a screen pixel font size through the zoom, so
+    // a label scales with the rest of the geometry.
+    std::vector<WorldText> const texts = m_world->collect_live_texts();
+    if (!texts.empty())
+    {
+        painter.setPen(GEOMETRY);
+        // Restore the painter font afterward so a label's pixel size does not
+        // leak into the overlay text drawn later in the same paint pass.
+        QFont const original_font = painter.font();
+        QFont font = original_font;
+        for (WorldText const & t : texts)
+        {
+            // Clamp before the cast so an extreme zoom * height cannot overflow
+            // int into a negative pixel size that Qt would reject.
+            long const px_l = std::min<long>(std::lround(m_view.zoom() * t.height), 16384);
+            int const px = static_cast<int>(px_l);
+            if (px < 1)
+            {
+                continue; // too small to render at this zoom
+            }
+            font.setPixelSize(px);
+            painter.setFont(font);
+            painter.drawText(map(t.x, t.y), QString::fromStdString(t.text));
+        }
+        painter.setFont(original_font);
     }
 }
 

--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <limits>
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace solvcon
@@ -58,6 +59,7 @@ enum class ShapeType : uint8_t
     CIRCLE = 8, ///< Specialization of ELLIPSE with equal radii.
     POLYLINE = 9, ///< Open chain of straight segments.
     POLYGON = 10, ///< Closed chain of straight segments.
+    TEXT = 11, ///< A text label anchored in world space.
 }; /* end of enum class ShapeType */
 
 inline std::string shape_type_name(ShapeType st)
@@ -75,6 +77,7 @@ inline std::string shape_type_name(ShapeType st)
     case ShapeType::CIRCLE: return "circle";
     case ShapeType::POLYLINE: return "polyline";
     case ShapeType::POLYGON: return "polygon";
+    case ShapeType::TEXT: return "text";
     default: return "unknown";
     }
 }
@@ -147,14 +150,19 @@ public:
     curve_list_type const & curves() const { return m_curves; }
     curve_list_type & curves() { return m_curves; }
 
+    std::string const & text() const { return m_text; }
+    std::string & text() { return m_text; }
+
     // The shape type serializes to its lower-case name (e.g. "triangle") so
     // the rendered JSON stays human-readable; this is an output-only view.
+    // "text" is empty for every shape but a text label.
     MM_DECL_SERIALIZABLE(
         register_member("id", m_id);
         register_member("type", shape_type_name(m_type));
         register_member("bbox", m_bbox);
         register_member("segments", m_segments);
-        register_member("curves", m_curves);)
+        register_member("curves", m_curves);
+        register_member("text", m_text);)
 
 private:
 
@@ -163,6 +171,7 @@ private:
     coords_type m_bbox; ///< Bounding box as [min_x, min_y, max_x, max_y].
     segment_list_type m_segments; ///< Each segment as [x0, y0, x1, y1].
     curve_list_type m_curves; ///< Each curve as four [x, y] points.
+    std::string m_text; ///< Label content; empty unless the shape is TEXT.
 
 }; /* end class WorldShapeState */
 
@@ -222,9 +231,25 @@ private:
 }; /* end class WorldState */
 
 /**
- * Lightweight record mapping a shape ID to the segment and curve ranges
- * it owns in the world's pads. A shape may own segments only
- * (triangle, line, rectangle), curves only (ellipse, circle), or both.
+ * A text label anchored in world space. The anchor (x, y) is the left end of
+ * the baseline; height is the label's world-space cap height. Glyphs are
+ * drawn upright and never rotate, so only the anchor moves under a rotate.
+ *
+ * @ingroup group_geometry
+ */
+struct WorldText
+{
+    std::string text;
+    double x; ///< Baseline-left anchor x in world coordinates.
+    double y; ///< Baseline-left anchor y in world coordinates.
+    double height; ///< Cap height in world units.
+}; /* end struct WorldText */
+
+/**
+ * Lightweight record mapping a shape ID to the segment, curve, and text
+ * ranges it owns in the world's pads. A shape may own segments only
+ * (triangle, line, rectangle), curves only (ellipse, circle), both, or a
+ * single text item (text label).
  *
  * @ingroup group_geometry
  */
@@ -237,6 +262,8 @@ struct ShapeRecord
     size_t segment_count; ///< Number of segments this shape occupies.
     size_t curve_offset; ///< First index in CurvePad.
     size_t curve_count; ///< Number of cubic Beziers this shape occupies.
+    size_t text_offset; ///< First index in the text store.
+    size_t text_count; ///< Number of text items (0 or 1).
 
     /// OBB corner x's in world coordinates, ordered TL, TR, BR, BL.
     bbox_array_type obb_x;
@@ -434,7 +461,14 @@ public:
     int32_t add_polygon(std::vector<std::array<T, 2>> const & vertices);
 
     /**
-     * Translate all segments and curves belonging to a shape by (dx, dy).
+     * Add a text label with its baseline-left anchor at (x, y) and the given
+     * world-space height. Glyphs are drawn upright.
+     */
+    int32_t add_text(std::string text, T x, T y, T height);
+
+    /**
+     * Translate all segments, curves, and text belonging to a shape by
+     * (dx, dy).
      */
     void translate_shape(int32_t shape_id, value_type dx, value_type dy);
 
@@ -573,6 +607,12 @@ public:
     std::shared_ptr<curve_pad_type> collect_live_curves() const;
 
     /**
+     * Collect the text labels of every live TEXT shape, at their current
+     * anchors, for a renderer to draw.
+     */
+    std::vector<WorldText> collect_live_texts() const;
+
+    /**
      * Remove all geometry entities (points, segments, curves, shapes)
      * from the world. Rebuilds pads from scratch to reclaim memory.
      */
@@ -609,6 +649,14 @@ private:
     }
 
     bbox_type compute_shape_bbox(ShapeRecord const & rec) const;
+
+    /**
+     * Reset a shape's OBB to the corners of its axis-aligned bounding box,
+     * ordered TL, TR, BR, BL. Used at creation, and to keep an upright text
+     * label's box axis-aligned after a rotate that would otherwise tilt it
+     * away from the glyphs.
+     */
+    void seed_obb_from_bbox(ShapeRecord & rec) const;
 
     /**
      * Minimum distance from world point (px, py) to a shape's drawn geometry:
@@ -661,15 +709,31 @@ private:
 
     /**
      * Register a new shape owning [segment_offset, segment_offset +
-     * segment_count) in the segment pad and [curve_offset, curve_offset +
-     * curve_count) in the curve pad. Pushes into the registry and R-tree.
-     * Either range may be empty.
+     * segment_count) in the segment pad, [curve_offset, curve_offset +
+     * curve_count) in the curve pad, and [text_offset, text_offset +
+     * text_count) in the text store. Pushes into the registry and R-tree.
+     * Any range may be empty.
      */
     int32_t register_shape(ShapeType type,
                            size_t segment_offset,
                            size_t segment_count,
                            size_t curve_offset = 0,
-                           size_t curve_count = 0);
+                           size_t curve_count = 0,
+                           size_t text_offset = 0,
+                           size_t text_count = 0);
+
+    /**
+     * Approximate glyph advance as a fraction of the text height, so a text
+     * label gets a plausible bounding box without font metrics.
+     */
+    static constexpr double TEXT_ADVANCE_RATIO = 0.6;
+
+    /**
+     * Fraction of the text height that glyphs descend below the baseline
+     * (tails of g, y, p). Padding the box downward by this keeps a label's
+     * rendered pixels inside its bounds for picking and viewport queries.
+     */
+    static constexpr double TEXT_DESCENDER_RATIO = 0.25;
 
     /**
      * Check if shape_id is valid and not DEAD.
@@ -696,6 +760,10 @@ private:
     SimpleCollector<size_t> m_bare_segment_indices; ///< Indices of segments not owned by any shape.
 
     std::shared_ptr<curve_pad_type> m_curves;
+
+    // TODO: Replace std::vector with a text-aware pad, alongside the
+    // m_shape_registry SoA follow-up below.
+    std::vector<WorldText> m_texts; ///< Text labels, one per TEXT shape.
 
     // TODO: Replace std::vector with a custom SoA container and BoundBoxPad
     // auxiliary class. Consider moving the registry into the R-tree.
@@ -763,19 +831,25 @@ int32_t World<T>::register_shape(ShapeType type,
                                  size_t segment_offset,
                                  size_t segment_count,
                                  size_t curve_offset,
-                                 size_t curve_count)
+                                 size_t curve_count,
+                                 size_t text_offset,
+                                 size_t text_count)
 {
     auto shape_id = static_cast<int32_t>(m_shape_registry.size());
-    m_shape_registry.push_back(ShapeRecord{type, segment_offset, segment_count, curve_offset, curve_count}); // NOLINT(modernize-use-designated-initializers)
+    m_shape_registry.push_back(ShapeRecord{// NOLINT(modernize-use-designated-initializers)
+                                           type,
+                                           segment_offset,
+                                           segment_count,
+                                           curve_offset,
+                                           curve_count,
+                                           text_offset,
+                                           text_count});
     ++m_nshape;
-    bbox_type const bb = compute_shape_bbox(m_shape_registry[shape_id]);
 
     // Seed the oriented bounding box to the axis-aligned bbox corners.
     // TODO: store the OBB directly in ShapeRecord at construction.
-    ShapeRecord & seeded = m_shape_registry[shape_id];
-    seeded.obb_x = ShapeRecord::bbox_array_type{bb.min_x(), bb.max_x(), bb.max_x(), bb.min_x()};
-    seeded.obb_y = ShapeRecord::bbox_array_type{bb.max_y(), bb.max_y(), bb.min_y(), bb.min_y()};
-    m_rtree->insert(ShapeEntry<T>{shape_id, bb});
+    seed_obb_from_bbox(m_shape_registry[shape_id]);
+    m_rtree->insert(ShapeEntry<T>{shape_id, compute_shape_bbox(m_shape_registry[shape_id])});
 
     // Record the creation so undo removes the shape and redo brings it back
     // with the same type.
@@ -929,6 +1003,21 @@ int32_t World<T>::add_polygon(std::vector<std::array<T, 2>> const & vertices)
 }
 
 template <typename T>
+int32_t World<T>::add_text(std::string text, T x, T y, T height)
+{
+    if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(height) || height <= T(0))
+    {
+        throw std::invalid_argument("World: add_text needs a finite anchor and a positive height");
+    }
+    size_t const offset = m_texts.size();
+    m_texts.push_back(WorldText{std::move(text),
+                                static_cast<double>(x),
+                                static_cast<double>(y),
+                                static_cast<double>(height)});
+    return register_shape(ShapeType::TEXT, /*seg_off*/ 0, /*seg_cnt*/ 0, /*curve_off*/ 0, /*curve_cnt*/ 0, offset, 1);
+}
+
+template <typename T>
 void World<T>::apply_translate(int32_t shape_id, value_type dx, value_type dy)
 {
     ShapeRecord & rec = m_shape_registry[static_cast<size_t>(shape_id)];
@@ -953,6 +1042,12 @@ void World<T>::apply_translate(int32_t shape_id, value_type dx, value_type dy)
         m_curves->y2(idx) += dy;
         m_curves->x3(idx) += dx;
         m_curves->y3(idx) += dy;
+    }
+    for (uint32_t i = 0; i < rec.text_count; ++i)
+    {
+        WorldText & t = m_texts[rec.text_offset + i];
+        t.x += dx;
+        t.y += dy;
     }
     // The oriented bounding box rides along with the shape.
     for (uint32_t i = 0; i < 4; ++i)
@@ -1013,17 +1108,36 @@ void World<T>::apply_rotate(int32_t shape_id, value_type angle, value_type cx, v
         rotate(m_curves->x2(idx), m_curves->y2(idx));
         rotate(m_curves->x3(idx), m_curves->y3(idx));
     }
-
-    // Rotate the oriented bounding box about the same pivot so it stays
-    // fixed relative to the shape. Done in `double` to match its storage.
-    auto const dcos = static_cast<double>(cos_a);
-    auto const dsin = static_cast<double>(sin_a);
-    for (uint32_t i = 0; i < 4; ++i)
+    // Text anchors move with the shape, but glyphs are never re-oriented.
+    for (uint32_t i = 0; i < rec.text_count; ++i)
     {
-        double const ox = rec.obb_x[i] - cx;
-        double const oy = rec.obb_y[i] - cy;
-        rec.obb_x[i] = cx + dcos * ox - dsin * oy;
-        rec.obb_y[i] = cy + dsin * ox + dcos * oy;
+        WorldText & t = m_texts[rec.text_offset + i];
+        T tx = static_cast<T>(t.x);
+        T ty = static_cast<T>(t.y);
+        rotate(tx, ty);
+        t.x = static_cast<double>(tx);
+        t.y = static_cast<double>(ty);
+    }
+
+    if (rec.text_count > 0)
+    {
+        // Glyphs stay upright, so the box is always axis-aligned; a rotated
+        // OBB would tilt away from the text it is meant to frame.
+        seed_obb_from_bbox(rec);
+    }
+    else
+    {
+        // Rotate the oriented bounding box about the same pivot so it stays
+        // fixed relative to the shape. Done in `double` to match its storage.
+        auto const dcos = static_cast<double>(cos_a);
+        auto const dsin = static_cast<double>(sin_a);
+        for (uint32_t i = 0; i < 4; ++i)
+        {
+            double const ox = rec.obb_x[i] - cx;
+            double const oy = rec.obb_y[i] - cy;
+            rec.obb_x[i] = cx + dcos * ox - dsin * oy;
+            rec.obb_y[i] = cy + dsin * ox + dcos * oy;
+        }
     }
     // Reinsert with updated bounding box.
     m_rtree->insert(ShapeEntry<T>{shape_id, compute_shape_bbox(rec)});
@@ -1359,11 +1473,30 @@ std::shared_ptr<typename World<T>::curve_pad_type> World<T>::collect_live_curves
 }
 
 template <typename T>
+std::vector<WorldText> World<T>::collect_live_texts() const
+{
+    std::vector<WorldText> result;
+    for (auto const & rec : m_shape_registry)
+    {
+        if (rec.type == ShapeType::DEAD)
+        {
+            continue;
+        }
+        for (uint32_t i = 0; i < rec.text_count; ++i)
+        {
+            result.push_back(m_texts[rec.text_offset + i]);
+        }
+    }
+    return result;
+}
+
+template <typename T>
 void World<T>::clear()
 {
     m_points = point_pad_type::construct(/* ndim */ 3);
     m_segments = segment_pad_type::construct(/* ndim */ 3);
     m_curves = curve_pad_type::construct(/* ndim */ 3);
+    m_texts.clear();
     m_bare_segment_indices.clear();
     m_shape_registry.clear();
     m_nshape = 0;
@@ -1372,6 +1505,14 @@ void World<T>::clear()
     m_redo_stack.clear();
     m_in_operation = false;
     m_has_open = false;
+}
+
+template <typename T>
+void World<T>::seed_obb_from_bbox(ShapeRecord & rec) const
+{
+    bbox_type const bb = compute_shape_bbox(rec);
+    rec.obb_x = ShapeRecord::bbox_array_type{bb.min_x(), bb.max_x(), bb.max_x(), bb.min_x()};
+    rec.obb_y = ShapeRecord::bbox_array_type{bb.max_y(), bb.max_y(), bb.min_y(), bb.min_y()};
 }
 
 template <typename T>
@@ -1398,6 +1539,21 @@ typename World<T>::bbox_type World<T>::compute_shape_bbox(ShapeRecord const & re
         mn_y = std::min({mn_y, m_curves->y0(idx), m_curves->y1(idx), m_curves->y2(idx), m_curves->y3(idx)});
         mx_x = std::max({mx_x, m_curves->x0(idx), m_curves->x1(idx), m_curves->x2(idx), m_curves->x3(idx)});
         mx_y = std::max({mx_y, m_curves->y0(idx), m_curves->y1(idx), m_curves->y2(idx), m_curves->y3(idx)});
+    }
+    // A text label has no pad geometry; box it from the anchor and an
+    // approximate advance, since the world has no font metrics.
+    for (uint32_t i = 0; i < rec.text_count; ++i)
+    {
+        WorldText const & t = m_texts[rec.text_offset + i];
+        auto const glyphs = static_cast<double>(std::max<size_t>(t.text.size(), 1));
+        T const x0 = static_cast<T>(t.x);
+        T const y0 = static_cast<T>(t.y - TEXT_DESCENDER_RATIO * t.height);
+        T const x1 = static_cast<T>(t.x + TEXT_ADVANCE_RATIO * t.height * glyphs);
+        T const y1 = static_cast<T>(t.y + t.height);
+        mn_x = std::min({mn_x, x0, x1});
+        mn_y = std::min({mn_y, y0, y1});
+        mx_x = std::max({mx_x, x0, x1});
+        mx_y = std::max({mx_y, y0, y1});
     }
     return bbox_type(mn_x, mn_y, T(0), mx_x, mx_y, T(0));
 }
@@ -1453,6 +1609,10 @@ std::string World<T>::describe_state(DescribeLevel level) const
         for (uint32_t i = 0; i < rec.curve_count; ++i)
         {
             shape.curves().push_back(curve_coords(rec.curve_offset + i));
+        }
+        if (rec.text_count > 0)
+        {
+            shape.text() = m_texts[rec.text_offset].text;
         }
         state.shapes().push_back(std::move(shape));
     }

--- a/cpp/solvcon/universe/pymod/wrap_World.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_World.cpp
@@ -382,6 +382,16 @@ WrapWorld<T> & WrapWorld<T>::wrap_shape()
                 return self.add_polygon(vertices);
             },
             py::arg("vertices"))
+        .def(
+            "add_text",
+            [](wrapped_type & self, std::string const & text, value_type x, value_type y, value_type height)
+            {
+                return self.add_text(text, x, y, height);
+            },
+            py::arg("text"),
+            py::arg("x"),
+            py::arg("y"),
+            py::arg("height"))
         //
         ;
 

--- a/solvcon/agent/draw/command.py
+++ b/solvcon/agent/draw/command.py
@@ -79,8 +79,11 @@ SHAPE = {"type": "object",
                       "description": "Lower-case shape type name."},
              "bbox": _BBOX,
              "segments": _SEG_LIST,
-             "curves": _CURVE_LIST},
-         "required": ["id", "type", "bbox", "segments", "curves"],
+             "curves": _CURVE_LIST,
+             "text": {**STRING,
+                      "description": "Label content; empty unless a text "
+                      "shape."}},
+         "required": ["id", "type", "bbox", "segments", "curves", "text"],
          "additionalProperties": False}
 
 # Mirrors WorldState in cpp/solvcon/universe/World.hpp.
@@ -324,6 +327,23 @@ class AddPolygon(_cmd.Command):
     def apply(self, world, args, ctx):
         verts = [[p[0], p[1]] for p in args["vertices"]]
         return {"shape_id": world.add_polygon(verts)}
+
+
+@_command_set.register
+class AddText(_cmd.Command):
+    op = "add_text"
+    category = "create"
+    summary = ("Add an upright text label with its baseline-left anchor at "
+               "(x, y) and the given world-space height.")
+    arguments = {"text": {**STRING, "description": "Label content."},
+                 "x": _num("Baseline-left anchor x."),
+                 "y": _num("Baseline-left anchor y (+Y up)."),
+                 "height": _pos("Cap height in world units; positive.")}
+    returns = {"shape_id": _int("Id of the new shape.")}
+
+    def apply(self, world, args, ctx):
+        return {"shape_id": world.add_text(
+            args["text"], args["x"], args["y"], args["height"])}
 
 
 @_command_set.register

--- a/tests/test_agent_draw_command.py
+++ b/tests/test_agent_draw_command.py
@@ -81,7 +81,7 @@ class DrawVocabularyGoThroughTC(unittest.TestCase):
 
 
 class DrawPrimitiveCommandsTC(unittest.TestCase):
-    """The polyline and polygon commands end to end."""
+    """The polyline, polygon, and text commands end to end."""
 
     def setUp(self):
         self.world = solvcon.WorldFp64()
@@ -108,6 +108,17 @@ class DrawPrimitiveCommandsTC(unittest.TestCase):
             {"op": "add_polygon", "vertices": [[0, 0], [1, 1]]})
         self.assertFalse(short.ok)
         self.assertEqual(self.proc.run({"op": "nshape"}).value["nshape"], 0)
+
+    def test_text_round_trips_through_describe_state(self):
+        made = self.proc.run(
+            {"op": "add_text", "text": "SOLVCON",
+             "x": -5.0, "y": -5.0, "height": 2.0})
+        self.assertTrue(made.ok)
+        shape = self.proc.run(
+            {"op": "get_shape",
+             "shape_id": made.value["shape_id"]}).value["shape"]
+        self.assertEqual(shape["type"], "text")
+        self.assertEqual(shape["text"], "SOLVCON")
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -314,6 +314,28 @@ class R2DWidgetWorldTC(unittest.TestCase):
                           max(0, int(x_lo) - 2):int(x_hi) + 3]
         self.assertEqual(int(region.sum()), 0, "removed shape was painted")
 
+    def test_text_label_renders_glyph_pixels(self):
+        """A text label paints geometry-colored glyphs, so "draw solvcon"
+        yields legible text instead of nothing. The glyphs land inside the
+        label's screen bounding box (anchor rightward, cap height upward).
+        """
+        world = solvcon.WorldFp64()
+        world.add_text("SOLVCON", -40.0, -10.0, 20.0)
+
+        geometry, to_pixel = self._render_world(world, 200.0, 150.0, 2.0)
+        self.assertGreater(int(geometry.sum()), 0, "text did not render")
+
+        # The label spans from its anchor to about a 0.6-per-glyph advance and
+        # its cap height; the two opposite corners bound the screen region.
+        px0, py0 = to_pixel(-40.0, -10.0)
+        px1, py1 = to_pixel(44.0, 10.0)
+        x_lo, x_hi = sorted((px0, px1))
+        y_lo, y_hi = sorted((py0, py1))
+        region = geometry[max(0, int(y_lo)):int(y_hi) + 1,
+                          max(0, int(x_lo)):int(x_hi) + 1]
+        self.assertGreater(int(region.sum()), 0,
+                           "no glyph pixels inside the label box")
+
     def test_circle_renders_as_hollow_loop_on_locus(self):
         """A circle renders as a closed, hollow ring on its locus.
 

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -333,7 +333,7 @@ class WorldShapeTC(unittest.TestCase):
 
 
 class WorldPrimitivesTC(unittest.TestCase):
-    """Polyline and polygon primitives."""
+    """Polyline, polygon, and text primitives."""
 
     def setUp(self):
         self.w = solvcon.WorldFp64()
@@ -358,6 +358,36 @@ class WorldPrimitivesTC(unittest.TestCase):
     def test_polygon_needs_three_vertices(self):
         with self.assertRaises(ValueError):
             self.w.add_polygon([[0, 0], [1, 1]])
+
+    def test_text_anchor_and_height(self):
+        sid = self.w.add_text("SOLVCON", -5, -5, 2.0)
+        self.assertEqual(self.w.shape_type_of(sid), "text")
+        # No segments or curves; the label is boxed from its anchor, up by the
+        # height and down by a descender allowance (0.25 * height).
+        self.assertEqual(self.w.nsegment, 0)
+        bbox = self.w.shape_bbox(sid)
+        self.assertAlmostEqual(bbox[0], -5.0)
+        self.assertAlmostEqual(bbox[1], -5.5)  # anchor y - descender
+        self.assertAlmostEqual(bbox[3], -3.0)  # anchor y + height
+
+    def test_text_needs_positive_finite_height(self):
+        # The direct binding guards like add_polyline/add_polygon; a zero or
+        # non-finite height would render nothing and collapse the pick box.
+        with self.assertRaises(ValueError):
+            self.w.add_text("x", 0.0, 0.0, 0.0)
+        with self.assertRaises(ValueError):
+            self.w.add_text("x", 0.0, 0.0, float("nan"))
+
+    def test_text_obb_stays_axis_aligned_after_rotate(self):
+        # Glyphs never rotate, so a text label's oriented box must remain
+        # axis-aligned; otherwise the selection box would tilt off the text.
+        sid = self.w.add_text("hi", 0.0, 0.0, 2.0)
+        self.w.rotate_shape(sid, math.pi / 3, 0.0, 0.0)
+        obb = self.w.shape_obb(sid)  # TL, TR, BR, BL as x, y pairs
+        self.assertAlmostEqual(obb[1], obb[3])  # TL.y == TR.y
+        self.assertAlmostEqual(obb[5], obb[7])  # BR.y == BL.y
+        self.assertAlmostEqual(obb[0], obb[6])  # TL.x == BL.x
+        self.assertAlmostEqual(obb[2], obb[4])  # TR.x == BR.x
 
 
 class WorldUndoRedoTC(unittest.TestCase):


### PR DESCRIPTION
This is step 2 of the three-step Agent Draw primitive series from issue #1136 (polygon/polyline in #1140, then text, then arc and scale). Stacked on #1140, now rebased onto master so this diff is only the text slice.

A text label is a first-class shape: a string with a baseline-left anchor and a world-space cap height, stored in the world and drawn upright by the 2D renderer at a font size that tracks the zoom. This lets the agent render wordmarks and labels ("draw solvcon") correctly by construction instead of hand-drawing letters.

The label participates in the shape registry: it reports through describe_state (a new "text" field), translates and scales with its figure, and stays selectable. Glyphs never rotate, so a rotate moves only the anchor and the box is kept axis-aligned to match. The bounding box is approximated from an advance-per-glyph and a descender allowance, since the world holds no font metrics.

Binds add_text, adds the Agent Draw command, and covers the anchor/height box, the upright-rotate invariant, the describe_state round-trip, and a rendered-glyph pixel check.

Related to #1136.