### PR TITLE
Give each master CI run its own concurrency group

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -8,10 +8,14 @@ on:
     - cron: '34 17 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # A push to master must never cancel an earlier master run, so every
-  # merge keeps its own CI result. Superseded pull request and branch
-  # runs still cancel.
+  # Key each master push on its commit SHA so every merge lands in its own
+  # concurrency group. Sharing one group serializes master runs, and with
+  # cancel-in-progress disabled GitHub still cancels a pending run when the
+  # next merge queues behind the one in progress, so a later merge would
+  # drop an earlier merge's result. A unique group per SHA keeps every
+  # master run independent. Pull requests key on the PR number and other
+  # branches on the ref, so their superseded runs still cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.sha) || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,10 +8,14 @@ on:
     - cron: '34 17 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # A push to master must never cancel an earlier master run, so every
-  # merge keeps its own CI result. Superseded pull request and branch
-  # runs still cancel.
+  # Key each master push on its commit SHA so every merge lands in its own
+  # concurrency group. Sharing one group serializes master runs, and with
+  # cancel-in-progress disabled GitHub still cancels a pending run when the
+  # next merge queues behind the one in progress, so a later merge would
+  # drop an earlier merge's result. A unique group per SHA keeps every
+  # master run independent. Pull requests key on the PR number and other
+  # branches on the ref, so their superseded runs still cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.sha) || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -8,10 +8,14 @@ on:
     - cron: '34 17 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # A push to master must never cancel an earlier master run, so every
-  # merge keeps its own CI result. Superseded pull request and branch
-  # runs still cancel.
+  # Key each master push on its commit SHA so every merge lands in its own
+  # concurrency group. Sharing one group serializes master runs, and with
+  # cancel-in-progress disabled GitHub still cancels a pending run when the
+  # next merge queues behind the one in progress, so a later merge would
+  # drop an earlier merge's result. A unique group per SHA keeps every
+  # master run independent. Pull requests key on the PR number and other
+  # branches on the ref, so their superseded runs still cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.sha) || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:


### PR DESCRIPTION
This is an additional fix for master CI cancallation because PR #1092 was not a complete fix.

The lint, devbuild, and nouse_install workflows shared the concurrency group refs/heads/master across every push to master, relying on cancel-in-progress being false there to preserve each merge's result. That is not enough. With cancel-in-progress disabled GitHub serialises runs in a group and, when a new run queues behind the one in progress, cancels whatever run was previously pending. A merge that lands while an earlier master run is still going therefore drops that earlier run.

Key master pushes on the commit SHA so each merge lands in its own group and never queues behind or cancels another master run. Pull requests still key on the PR number and other branches on the ref, so their superseded runs cancel as before.