### PR TITLE
Guard the shortcut standard-key table behind the Qt import

### DIFF
--- a/tests/test_pilot_shortcut.py
+++ b/tests/test_pilot_shortcut.py
@@ -14,6 +14,7 @@ try:
     from PySide6 import QtCore, QtGui
 except ImportError:
     pilot = None
+    QtGui = None
 
 GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
 
@@ -28,12 +29,13 @@ _PANEL_CHORDS = (
     ("panel.painter", ["Ctrl+Shift+P"]),
 )
 
-_STANDARD_IDS = {
-    "edit.undo": QtGui.QKeySequence.StandardKey.Undo,
-    "edit.redo": QtGui.QKeySequence.StandardKey.Redo,
-    "file.exit": QtGui.QKeySequence.StandardKey.Quit,
-    "canvas.blank_2d": QtGui.QKeySequence.StandardKey.New,
-}
+if QtGui is not None:
+    _STANDARD_IDS = {
+        "edit.undo": QtGui.QKeySequence.StandardKey.Undo,
+        "edit.redo": QtGui.QKeySequence.StandardKey.Redo,
+        "file.exit": QtGui.QKeySequence.StandardKey.Quit,
+        "canvas.blank_2d": QtGui.QKeySequence.StandardKey.New,
+    }
 
 
 def _live_sequences(action):


### PR DESCRIPTION
The nightly CI run failed to collect tests/test_pilot_shortcut.py with "NameError: name 'QtGui' is not defined". The module-level _STANDARD_IDS table evaluated QtGui.QKeySequence.StandardKey at import time, but QtGui is only bound inside the try block that imports the pilot GUI. On a build without pilot the import fails and QtGui is left unbound, so collection raised before the @skipIf(not HAS_PILOT) guard on the test classes could take effect.

This binds QtGui to None on the failed import and builds _STANDARD_IDS only when QtGui is present. The table is read solely inside a HAS_PILOT-gated test, so leaving it undefined on the no-pilot path is safe. Verified with the pilot suite passing under QT_QPA_PLATFORM=offscreen and by simulating the import failure to confirm the module now collects cleanly.

Related to #1143.
