### PR TITLE
Preserve logical element order in SimpleArray reshape

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -2027,20 +2027,62 @@ public:
         }
     }
 
+    /**
+     * Reshape to a new shape, preserving the logical element order.
+     *
+     * Returns a zero-copy view when the source is C-contiguous and its
+     * buffer holds exactly the logical elements; otherwise copies them in
+     * C order into a new dense buffer, matching numpy's reshape(order='C').
+     * Rejects an array with ghost cells, whose ghost/body split has no
+     * well-defined element mapping.
+     *
+     * @param shape The new shape; its element count must match the source.
+     * @return A view when zero-copy is possible, otherwise a copy.
+     */
     template <typename U>
     SimpleArray<U> reshape(shape_type const & shape) const
     {
-        return SimpleArray<U>(shape, m_buffer, logical_data_offset());
+        if (has_ghost())
+        {
+            throw std::runtime_error(
+                std::format("SimpleArray: cannot reshape an array with {} ghost cells", m_nghost));
+        }
+        validate_shape(shape);
+
+        // numpy reshape keeps the type; we allow a cross-type reshape but only to a type of the same item size,
+        // so the element count is what must match either way.
+        if constexpr (!std::is_same_v<U, value_type>)
+        {
+            if (sizeof(U) != ITEMSIZE)
+            {
+                throw std::runtime_error(
+                    std::format("SimpleArray: cannot reshape to a different item size {} vs {}", sizeof(U), ITEMSIZE));
+            }
+        }
+        check_reshape_size(shape);
+
+        // Reuse the buffer only when its logical region holds exactly the
+        // logical element and is C-contiguous; otherwise the buffer order
+        // differs from the logical order, so copy in C order instead.
+        const size_t offset = logical_data_offset();
+        const bool exact_buffer = m_buffer && m_buffer->nbytes() - offset == size() * ITEMSIZE;
+        if (is_c_contiguous() && exact_buffer)
+        {
+            return SimpleArray<U>(shape, m_buffer, offset);
+        }
+        SimpleArray row_major(m_shape);
+        copy_logical_into(row_major);
+        return SimpleArray<U>(shape, row_major.m_buffer);
     }
 
     SimpleArray reshape(shape_type const & shape) const
     {
-        return SimpleArray(shape, m_buffer, logical_data_offset());
+        return reshape<value_type>(shape);
     }
 
     SimpleArray reshape() const
     {
-        return SimpleArray(m_shape, m_buffer, logical_data_offset());
+        return reshape(m_shape);
     }
 
     void swap(SimpleArray & other) noexcept
@@ -2366,6 +2408,21 @@ private:
             return 0;
         }
         return shape[0] * stride[0];
+    }
+
+    /// Reject a target shape whose element count differs from the source.
+    void check_reshape_size(shape_type const & shape) const
+    {
+        ssize_t target = 1;
+        for (ssize_t const dim : shape)
+        {
+            target *= dim;
+        }
+        if (static_cast<size_t>(target) != size())
+        {
+            throw std::runtime_error(
+                std::format("SimpleArray: cannot reshape size {} into size {}", size(), target));
+        }
     }
 
     /// Contiguous data buffer for the array.

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -76,6 +76,42 @@ TEST(SimpleArray, abs)
     EXPECT_EQ(brr.sum(), 10.0);
 }
 
+TEST(SimpleArray, reshape_cross_type_preserves_logical_order)
+{
+    using namespace solvcon;
+
+    SimpleArray<int64_t> array(small_vector<ssize_t>{2, 3}, 0);
+    int64_t v = 0;
+    for (auto & it : array)
+    {
+        it = v++;
+    }
+
+    array.transpose(false);
+    auto result = array.reshape<uint64_t>(small_vector<ssize_t>{6});
+
+    const uint64_t expected[6] = {0, 3, 1, 4, 2, 5};
+    for (ssize_t i = 0; i < 6; ++i)
+    {
+        EXPECT_EQ(result(i), expected[i]);
+    }
+}
+
+TEST(SimpleArray, reshape_rejects_mismatched_size)
+{
+    using namespace solvcon;
+
+    SimpleArray<uint64_t> array(small_vector<ssize_t>{3}, 0);
+
+    // A cross-type reshape to a different item size has no well-defined
+    // element mapping and is rejected.
+    EXPECT_THROW(array.reshape<uint32_t>(small_vector<ssize_t>{6}), std::runtime_error);
+
+    // A same-type reshape must keep the element count.
+    EXPECT_THROW(array.reshape(small_vector<ssize_t>{5}), std::runtime_error);
+    EXPECT_THROW(array.reshape(small_vector<ssize_t>{}), std::runtime_error);
+}
+
 TEST(SimpleArray, iterator)
 {
     using namespace solvcon;

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -263,8 +263,7 @@ class SimpleArrayBasicTC(unittest.TestCase):
 
         with self.assertRaisesRegex(
                 RuntimeError,
-                "SimpleArray: shape byte count 184 differs from available "
-                "buffer byte count 192 at data offset 0"
+                "SimpleArray: cannot reshape size 24 into size 23"
         ):
             sarr.reshape(23)
 
@@ -282,6 +281,87 @@ class SimpleArrayBasicTC(unittest.TestCase):
         self.assertEqual((1, 24), sarr.reshape((1, 24)).shape)
         self.assertEqual((12, 2), sarr.reshape((12, 2)).shape)
         self.assertEqual((2, 2, 2, 3), sarr.reshape((2, 2, 2, 3)).shape)
+
+    def test_SimpleArray_reshape_transposed(self):
+        ndarr = np.arange(6, dtype="float64").reshape((2, 3))
+        view = ndarr.T
+        sarr = solvcon.SimpleArrayFloat64(array=view)
+
+        expected = view.reshape((6,))
+        actual = sarr.reshape((6,)).ndarray
+        np.testing.assert_array_equal(actual, expected)
+
+    def test_SimpleArray_reshape_fortran(self):
+        ndarr = np.asfortranarray(
+            np.arange(6, dtype="float64").reshape((2, 3)))
+        sarr = solvcon.SimpleArrayFloat64(array=ndarr)
+
+        np.testing.assert_array_equal(
+            sarr.reshape((6,)).ndarray, ndarr.reshape((6,)))
+        np.testing.assert_array_equal(
+            sarr.reshape((3, 2)).ndarray, ndarr.reshape((3, 2)))
+
+    def test_SimpleArray_reshape_strided(self):
+        ndarr = np.arange(12, dtype="float64").reshape((3, 4))
+        view = ndarr[:, ::2]
+        sarr = solvcon.SimpleArrayFloat64(array=view)
+
+        np.testing.assert_array_equal(
+            sarr.reshape((6,)).ndarray, view.reshape((6,)))
+
+    def test_SimpleArray_reshape_contiguous_slice(self):
+        ndarr = np.arange(12, dtype="float64").reshape((3, 4))
+        view = ndarr[:2]
+        sarr = solvcon.SimpleArrayFloat64(array=view)
+
+        np.testing.assert_array_equal(
+            sarr.reshape((8,)).ndarray, view.reshape((8,)))
+
+    def test_SimpleArray_reshape_reversed_view(self):
+        ndarr = np.arange(6, dtype="float64").reshape((2, 3))
+        view = ndarr[::-1]
+        sarr = solvcon.SimpleArrayFloat64(array=view)
+
+        np.testing.assert_array_equal(
+            sarr.reshape((6,)).ndarray, view.reshape((6,)))
+
+    def test_SimpleArray_reshape_contiguous_is_view(self):
+        ndarr = np.arange(6, dtype="float64").reshape((2, 3))
+        sarr = solvcon.SimpleArrayFloat64(array=ndarr)
+
+        reshaped = sarr.reshape((6,))
+        reshaped[0] = 100.0
+        self.assertEqual(100.0, ndarr[0, 0])
+
+    def test_SimpleArray_reshape_copy_is_independent(self):
+        ndarr = np.arange(6, dtype="float64").reshape((2, 3))
+        view = ndarr.T
+        sarr = solvcon.SimpleArrayFloat64(array=view)
+
+        reshaped = sarr.reshape((6,))
+        reshaped[0] = 100.0
+        self.assertEqual(0.0, ndarr[0, 0])
+
+    def test_SimpleArray_reshape_ghost_raises(self):
+        sarr = solvcon.SimpleArrayFloat64((6,))
+        sarr.nghost = 2
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "SimpleArray: cannot reshape an array with 2 ghost cells"
+        ):
+            sarr.reshape((3, 2))
+
+    def test_SimpleArray_reshape_zero_size(self):
+        sarr = solvcon.SimpleArrayFloat64((0,))
+
+        np.testing.assert_array_equal(
+            sarr.reshape((0, 3)).ndarray, np.empty((0, 3), dtype="float64"))
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "SimpleArray: cannot reshape size 0 into size 1"
+        ):
+            sarr.reshape(())
 
     def test_SimpleArray_negative_shape_raises(self):
         with self.assertRaisesRegex(


### PR DESCRIPTION
SimpleArray::reshape() recomputed C-contiguous strides over the shared buffer and discarded the source layout, so reshaping a non-C-contiguous array (transposed, F-contiguous, or strided) silently returned the raw buffer order rather than the logical element order.

reshape() now returns a zero-copy view only when the source is C-contiguous and its buffer holds exactly the logical elements; otherwise it copies the elements in C order into a new dense buffer, matching numpy's reshape(order='C'). An array with ghost cells is rejected because reshaping across the ghost/body split of the first axis has no well-defined element mapping.

Related to #1126.
