### PR TITLE
Group ShapeType enumerators by straight and curved edge family

### DIFF
--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -42,22 +42,20 @@ namespace solvcon
 enum class ShapeType : uint8_t
 {
     DEAD = 0, ///< Deleted or unused slot.
-
-    // 0D shapes
     POINT = 1,
 
-    // 1D shapes
+    // Rectilinear family (straight edges only).
     LINE = 2,
-    BEZIER = 3, ///< Single cubic Bezier curve.
+    POLYLINE = 3, ///< Open chain of straight segments.
+    POLYGON = 4, ///< Closed chain of straight segments.
+    TRIANGLE = 5,
+    RECTANGLE = 6,
+    SQUARE = 7, ///< Specialization of RECTANGLE with equal side lengths.
 
-    // 2D shapes
-    TRIANGLE = 4,
-    RECTANGLE = 5,
-    SQUARE = 6, ///< Specialization of RECTANGLE with equal side lengths.
-    ELLIPSE = 7,
-    CIRCLE = 8, ///< Specialization of ELLIPSE with equal radii.
-    POLYLINE = 9, ///< Open chain of straight segments.
-    POLYGON = 10, ///< Closed chain of straight segments.
+    // Curvilinear family (one or more curved edges).
+    BEZIER = 8, ///< Single cubic Bezier curve.
+    ELLIPSE = 9,
+    CIRCLE = 10, ///< Specialization of ELLIPSE with equal radii.
 }; /* end of enum class ShapeType */
 
 inline std::string shape_type_name(ShapeType st)
@@ -67,14 +65,14 @@ inline std::string shape_type_name(ShapeType st)
     case ShapeType::DEAD: return "DEAD";
     case ShapeType::POINT: return "point";
     case ShapeType::LINE: return "line";
-    case ShapeType::BEZIER: return "bezier";
+    case ShapeType::POLYLINE: return "polyline";
+    case ShapeType::POLYGON: return "polygon";
     case ShapeType::TRIANGLE: return "triangle";
     case ShapeType::RECTANGLE: return "rectangle";
     case ShapeType::SQUARE: return "square";
+    case ShapeType::BEZIER: return "bezier";
     case ShapeType::ELLIPSE: return "ellipse";
     case ShapeType::CIRCLE: return "circle";
-    case ShapeType::POLYLINE: return "polyline";
-    case ShapeType::POLYGON: return "polygon";
     default: return "unknown";
     }
 }


### PR DESCRIPTION
Follow-up to #1140, which added the polyline and polygon primitives. A review comment there (yungyuc on the ShapeType enum) asked to reference the coding system of other drawing systems and keep straight lines in one group and curvilinear shapes in another, for future development. This change does that: the enum now lists the rectilinear shapes (LINE, POLYLINE, POLYGON, TRIANGLE, RECTANGLE, SQUARE) ahead of the curvilinear ones (BEZIER, ELLIPSE, CIRCLE), and the shape_type_name switch is reordered to match.

The grouping and the dense, gap-free numbering follow what production drawing libraries actually do in their path-type enums. I surveyed four of them:

| Source | Enum | Straight members | Curved members | Numeric scheme |
|---|---|---|---|---|
| Skia `SkPathTypes.h` | `SkPathVerb` | `kMove`, `kLine` | `kQuad`, `kConic`, `kCubic` | Dense, sequential, no gaps; `kClose` last |
| Qt `qpainterpath.h` | `ElementType` | `LineToElement=1` | `CurveToElement=2` | `Move=0, Line=1, Curve=2, CurveData=3`, dense |
| matplotlib `path.py` | `Path` codes | `MOVETO=1`, `LINETO=2` | `CURVE3=3`, `CURVE4=4` | Dense (`CLOSEPOLY=79` is a legacy sentinel, not a family boundary) |
| W3C SVG DOM `SVGPathSeg` | IDL constants | `LINETO_ABS=4`, `LINETO_HORIZONTAL=12` | `CURVETO_CUBIC=6`, `ARC_ABS=10` | Dense, but straight and curved are interleaved, not cleanly partitioned |

The straight-before-curved ordering is well precedented; reserving numeric range blocks per family is not, so the values stay dense. New curved shapes append after CIRCLE and new straight shapes after SQUARE. Nothing depends on the numeric values beyond identity comparison and switch dispatch, and the Python binding exposes only the string name, so the renumbering is behavior-preserving. The build, cformat, and the universe shape tests all pass.

Related to #1136.
