### PR TITLE
Remove unnecessary ghost metadata changes from array assignment

### DIFF
--- a/cpp/solvcon/buffer/pymod/array_common.hpp
+++ b/cpp/solvcon/buffer/pymod/array_common.hpp
@@ -165,21 +165,7 @@ public:
     static void broadcast_array_using_ellipsis(SimpleArray<T> & arr_out, pybind11::array const & arr_in)
     {
         auto slices = make_default_slices(arr_out);
-
-        TypeBroadcast<T>::check_shape(arr_out, slices, arr_in);
-
-        const ssize_t nghost = arr_out.nghost();
-        if (0 != nghost)
-        {
-            arr_out.set_nghost(0);
-        }
-
-        TypeBroadcast<T>::broadcast(arr_out, slices, arr_in);
-
-        if (0 != nghost)
-        {
-            arr_out.set_nghost(nghost);
-        }
+        broadcast_array_using_slice(arr_out, slices, arr_in);
     }
 
     // FIXME: NOLINTNEXTLINE(readability-function-cognitive-complexity)
@@ -458,19 +444,7 @@ private:
                                             pybind11::array const & arr_in)
     {
         TypeBroadcast<T>::check_shape(arr_out, slices, arr_in);
-
-        const ssize_t nghost = arr_out.nghost();
-        if (0 != nghost)
-        {
-            arr_out.set_nghost(0);
-        }
-
         TypeBroadcast<T>::broadcast(arr_out, slices, arr_in);
-
-        if (0 != nghost)
-        {
-            arr_out.set_nghost(nghost);
-        }
     }
 }; /* end class ArrayPropertyHelper */
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -999,6 +999,21 @@ class SimpleArrayBasicTC(unittest.TestCase):
                     self.assertEqual(v, sarr[i, j, k])
                     v += 1
 
+    def test_SimpleArray_broadcast_error_preserves_nghost(self):
+        sarr = solvcon.SimpleArrayFloat64(shape=(2, 2), value=0)
+        rhs = np.ones((2, 2), dtype='complex128')
+
+        for key in (Ellipsis, np.s_[:, :]):
+            with self.subTest(key=key):
+                sarr.nghost = 1
+                with self.assertRaisesRegex(
+                        RuntimeError,
+                        r"^Cannot convert between complex and "
+                        r"non-complex types$"
+                ):
+                    sarr[key] = rhs
+                self.assertEqual(1, sarr.nghost)
+
     def test_SimpleArray_broadcast_slice_basic(self):
         ndarr_input = np.arange(
             1 * 2 * 3 * 4 * 5, dtype='float64').reshape((1, 2, 3, 4, 5))


### PR DESCRIPTION
Array assignment resets `SimpleArray::nghost` around broadcasting, although broadcasting computes destination addresses from `logical_data()` and does not depend on `body()`. This unnecessary metadata change can become permanent when assignment raises an exception.

Remove the `nghost` mutation from the shared slice-assignment path and route ellipsis assignment through the same path.

Related to #1148.