### PR TITLE
Fix const-correctness in shifted slice bounds

### DIFF
--- a/cpp/solvcon/buffer/pymod/array_common.hpp
+++ b/cpp/solvcon/buffer/pymod/array_common.hpp
@@ -351,8 +351,8 @@ private:
         pybind11::slice normalized_slice = slice_in;
         if (offset != 0)
         {
-            pybind11::object start = shift_slice_bound(slice_in.attr("start"), offset);
-            pybind11::object stop = shift_slice_bound(slice_in.attr("stop"), offset);
+            pybind11::object const start = shift_slice_bound(slice_in.attr("start"), offset);
+            pybind11::object const stop = shift_slice_bound(slice_in.attr("stop"), offset);
             normalized_slice = pybind11::slice(start, stop, slice_in.attr("step"));
         }
 


### PR DESCRIPTION
The [lint workflow fails on macOS and Ubuntu](https://github.com/solvcon/solvcon/actions/runs/29881085874) because clang-tidy reports the shifted `start` and `stop` slice bounds as mutable locals, and CI treats `misc-const-correctness` warnings as errors.

```
  2 warnings treated as errors
  gmake[4]: *** [cpp/solvcon/CMakeFiles/solvcon_primary.dir/build.make:251: cpp/solvcon/CMakeFiles/solvcon_primary.dir/buffer/pymod/wrap_SimpleArray_bool.cpp.o] Error 1
  gmake[4]: *** Waiting for unfinished jobs....
  /home/runner/work/solvcon/solvcon/cpp/solvcon/buffer/pymod/array_common.hpp:354:13: error: variable 'start' of type 'pybind11::object' can be declared 'const' [misc-const-correctness,-warnings-as-errors]
    354 |             pybind11::object start = shift_slice_bound(slice_in.attr("start"), offset);
        |             ^
        |                              const 
  /home/runner/work/solvcon/solvcon/cpp/solvcon/buffer/pymod/array_common.hpp:355:13: error: variable 'stop' of type 'pybind11::object' can be declared 'const' [misc-const-correctness,-warnings-as-errors]
    355 |             pybind11::object stop = shift_slice_bound(slice_in.attr("stop"), offset);
        |             ^
        |                              const 
  26817 warnings generated.
```

Declare both objects `const`. This does not change slice behavior and lets the pilot build pass with clang-tidy enabled.

Related to #1156.
