### PR TITLE
Apply some fixes on the AI instructions for common AI mistakes

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -187,12 +187,40 @@ cross-reference; flag any drift between the two.
   closed/fix/fixes/fixed/resolve/resolves/resolved followed by `#nnn`).
   Rewrite the offending line to "Related to #xxx" or "For issue #xxx"
   and re-confirm with the user before retrying.
+- **Hard-wrapped prose.** The 79-char source limit does NOT apply to a
+  PR body; each paragraph must be one unbroken line. This is easy to
+  violate by reflex after editing wrapped source all session, so treat
+  it as a mechanical gate, not a preference. After writing `$body_file`
+  in step 4, but **before** `gh pr create`, scan for a paragraph split
+  across lines -- any two consecutive non-blank prose lines:
+
+  ```bash
+  awk '
+    /^```/            { fence = !fence; prev = 0; next }
+    fence             { next }
+    /^[[:space:]]*$/  { prev = 0; next }
+    /^[[:space:]]*([-*+>|]|[0-9]+\.)/ { prev = 0; next }
+    { if (prev) { print "hard-wrap at line " NR ": " $0; hit = 1 }
+      prev = 1 }
+    END { exit hit }
+  ' "$body_file"
+  ```
+
+  A non-zero exit means a paragraph was wrapped. Rejoin it into a single
+  line (fenced code blocks, list items, and table rows are exempt and
+  the check skips them) and re-run before creating the PR. Apply the
+  same one-line-per-paragraph rule to the draft shown in step 3, not
+  only to `$body_file`.
 - **Branch protection.** Never push directly to `master`/`main`, never
   `--no-verify`. If `gh pr create` fails, surface the error and stop --
   do not work around it.
 - **No fabricated context.** Do not invent benchmark numbers, test
   results, or verification claims. Only include what the user has stated
   or what is visible in the diff/commits.
+- **Diff accuracy.** Before presenting the draft, re-read
+  `git diff origin/master...HEAD` and confirm every claim in the subject
+  and body corresponds to a hunk in the diff. Drop claims about behavior
+  that already exists upstream or that the diff does not change.
 - **Trailers.** Do not append `Co-Authored-By:` or "Generated with Claude
   Code" trailers to the PR body. Commits in this project are
   human-authored by convention.

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -21,4 +21,6 @@ Based on the agent type, do one of the following:
 
 Implement `<description>` in the worktree. Follow normal project rules. Stop when done; do not auto-commit, open a PR, or remove the worktree unless asked.
 
+Run every command from the worktree, never from the original checkout. Before the first build, test, edit, or git command (and after anything that may reset the shell's directory), confirm the working directory with `git rev-parse --show-toplevel` and expect the worktree path. If it points at the main checkout, change into the worktree before continuing.
+
 <!-- vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,19 @@ When opening a pull request, reference the related issue (e.g., "Related to
 "fixes #725". We do not let PR and commit log comments to mandate the
 management.
 
+Before pushing to a PR branch, run the tests and `make lint`, and invoke the
+matching style-review skill for the changed files. Report the actual results;
+never declare the branch clean without having run the checks.
+
+Write the PR subject and body against the real diff. Keep the body short and
+accurate; never describe changes the diff does not contain. When editing an
+existing PR (e.g. `gh pr edit`), change only what was asked and preserve the
+current title, including any prefix such as a series label.
+
+Keep every PR reviewable. When a change grows beyond roughly 500 changed
+lines, split it into stacked PRs, and present the split plan (branches and
+per-branch line counts) for confirmation before creating the branches.
+
 ## Writing Style for Prose
 
 This applies to every passage you write for humans: code comments, commit
@@ -235,7 +248,11 @@ messages, PR and issue descriptions and comments, and documentation.
   issue or pull request, write one line per paragraph and let it wrap on its
   own. Manual line breaks mid-paragraph render as ragged text on GitHub. This
   no-wrap rule is for GitHub prose only; source files keep their linting
-  line-width limits.
+  line-width limits. The source-file line limit is the opposite habit, so
+  check this deliberately: before you present or post any GitHub prose, verify
+  each paragraph is a single unbroken line. Two consecutive non-blank prose
+  lines mean a paragraph was wrapped; rejoin it. The `create-pr` skill has a
+  mechanical guardrail for this.
 
 ## Development Workflow
 

--- a/contrib/prompt/general-rule.md
+++ b/contrib/prompt/general-rule.md
@@ -67,4 +67,12 @@ in your verdict.
 "Completed" is wrong if anything was skipped silently. "Tests pass" is wrong if
 any were skipped. Default to surfacing uncertainty, not hiding it.
 
+## Rule 13 -- Verify against ground truth
+A claim is a hypothesis until checked against the actual codebase, the live
+system, or rendered output. Do not act on another agent's report, a stale
+summary, or a single suspicious tool reading (e.g. version-skewed CLI output);
+re-check with a direct command first. Before declaring a task blocked or
+impossible, try at least two different approaches and report exactly what was
+tried and the errors seen.
+
 <!-- vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: -->


### PR DESCRIPTION
Apply some fixes on the AI instructions for common AI mistakes:

- Verify claims against ground truth (the codebase, the live system, or rendered output) before acting, and try at least two approaches before declaring a task blocked (general-rule.md Rule 13).
- Before pushing a PR branch, run the tests, make lint, and the matching style-review skill; write the subject and body against the real diff; preserve an existing PR title when editing; and split a change past roughly 500 lines into stacked PRs (CLAUDE.md PR guidelines).
- Run worktree tasks from the worktree directory by confirming the working directory before the first command, so builds and git operations do not land in the main checkout (worktree skill).
- Guard against hard-wrapped GitHub prose with a mechanical check in the create-pr skill and an explicit pre-output check in CLAUDE.md.

[skip-ci]
