### PR TITLE
Let the AI agent control pilot windows and the 2D view

### DIFF
--- a/solvcon/agent/_backend.py
+++ b/solvcon/agent/_backend.py
@@ -32,8 +32,9 @@ class AgentBackend(abc.ABC):
     """Interface every AI backend implements: a stable :attr:`name`, an
     :meth:`available` check, and :meth:`send`.  The tiny surface lets a caller
     drive any backend from a background thread.  Every backend also shares one
-    system instruction and one prompt layout through :meth:`_compose_prompt`,
-    so a CLI and an HTTP backend never drift apart in what they ask the model.
+    system instruction (:attr:`_INSTRUCTIONS`, sent as a real system prompt)
+    and one user-payload layout (:meth:`_compose_user`), so a CLI and an HTTP
+    backend never drift apart in what they ask the model.
     """
 
     # TODO: solvcon is an application platform for geometry-based computation:
@@ -42,11 +43,45 @@ class AgentBackend(abc.ABC):
     # drawing canvas alone; reframe that as one capability among the platform's
     # rather than the agent's whole scope.  Related to #966.
     _INSTRUCTIONS = (
-        "You drive a 2D drawing canvas. Translate the user's request into a "
-        "JSON array of drawing commands. Each command is an object with an "
-        "\"op\" key naming the operation and the operation's arguments as "
-        "sibling keys. Reply with only the JSON array, no prose and no code "
-        "fences. Use an empty array when no drawing is needed."
+        "You drive a 2D drawing canvas along with its windows and view. "
+        "Turn the user's request into a JSON array of commands chosen from "
+        "the operations below: draw on the canvas, open or arrange canvas "
+        "windows, and pan or zoom the view. Reply with only that array.\n"
+        "\n"
+        "Coordinate frame (canvas drawing). The canvas uses world "
+        "coordinates with the origin (0, 0) at the center and +Y pointing "
+        "up, so a larger y is higher on screen. The origin is always in "
+        "view; keep the whole subject centered on it and within about x in "
+        "[-180, 180] and y in [-130, 130] so nothing is clipped, letting it "
+        "span a couple hundred units to fill the canvas. Do not draw into a "
+        "small first-quadrant box such as x in [0, 100]: this is centered "
+        "world space, not screen or SVG pixels where (0, 0) is a corner and "
+        "y grows downward.\n"
+        "\n"
+        "Plan first. When drawing, break the subject into parts and choose "
+        "each part's size and position in world units before emitting "
+        "commands, so the parts line up and stay in frame. You may record "
+        "the plan as a leading \"log\" command.\n"
+        "\n"
+        "Compose cleanly. Keep repeated elements (wheels, petals, letters) "
+        "consistent in size and spacing, and add shapes back to front so "
+        "nearer parts are drawn last.\n"
+        "\n"
+        "Output contract. Each command is an object with an \"op\" key "
+        "naming the operation and the operation's arguments as sibling "
+        "keys. Reply with only the JSON array, no prose and no code fences. "
+        "Use an empty array when the request needs no action.\n"
+        "\n"
+        "Example, for \"draw a simple house\":\n"
+        "[\n"
+        "  {\"op\": \"log\", \"message\": \"body, roof, door\"},\n"
+        "  {\"op\": \"add_rectangle\", \"x_min\": -100, \"y_min\": -110, "
+        "\"x_max\": 100, \"y_max\": 40},\n"
+        "  {\"op\": \"add_triangle\", \"x0\": -125, \"y0\": 40, "
+        "\"x1\": 125, \"y1\": 40, \"x2\": 0, \"y2\": 125},\n"
+        "  {\"op\": \"add_rectangle\", \"x_min\": -25, \"y_min\": -110, "
+        "\"x_max\": 25, \"y_max\": -20}\n"
+        "]"
     )
 
     @property
@@ -68,15 +103,17 @@ class AgentBackend(abc.ABC):
         """
 
     @classmethod
-    def _compose_prompt(cls, prompt, scene_context, tool_surface):
-        """Fold the shared instruction, tool surface, scene, and user request
-        into one prompt string, so every backend sends the same thing whether
-        it is a CLI argument or an HTTP message body."""
+    def _compose_user(cls, prompt, scene_context, tool_surface):
+        """The user-role payload: the tool surface, scene, and request.  The
+        shared instruction rides separately as the system prompt
+        (:attr:`_INSTRUCTIONS`), so it stays a stable prefix a backend can hand
+        the model as a real system message rather than folding it into the
+        user turn."""
         tools = json.dumps(tool_surface or [], indent=2)
         return (
-            "%s\n\nAvailable operations (tool definitions):\n%s\n\n"
+            "Available operations (tool definitions):\n%s\n\n"
             "Current scene:\n%s\n\nUser request:\n%s"
-            % (cls._INSTRUCTIONS, tools, scene_context, prompt))
+            % (tools, scene_context, prompt))
 
 
 _REGISTRY = []

--- a/solvcon/agent/_backends_impl.py
+++ b/solvcon/agent/_backends_impl.py
@@ -157,8 +157,10 @@ class SubprocessBackend(_backend.AgentBackend):
         return self.executable() is not None
 
     @abc.abstractmethod
-    def _build_argv(self, exe, prompt):
-        """The argv that runs ``exe`` on the composed ``prompt``."""
+    def _build_argv(self, exe, user_prompt, system_prompt):
+        """The argv that runs ``exe`` on the ``user_prompt``, passing
+        ``system_prompt`` through whatever system-prompt channel the CLI
+        offers."""
 
     def _parse_output(self, stdout):
         """Extract the assistant text from CLI ``stdout``.  The default treats
@@ -170,9 +172,10 @@ class SubprocessBackend(_backend.AgentBackend):
         if exe is None:
             return _backend.BackendResponse(
                 error="%s not found on PATH" % self.command)
-        composed = self._compose_prompt(prompt, scene_context, tool_surface)
+        user_prompt = self._compose_user(prompt, scene_context, tool_surface)
+        argv = self._build_argv(exe, user_prompt, self._INSTRUCTIONS)
         try:
-            code, out, err = self._communicate(self._build_argv(exe, composed))
+            code, out, err = self._communicate(argv)
         except subprocess.TimeoutExpired:
             return _backend.BackendResponse(
                 error="%s timed out" % self.command)
@@ -234,10 +237,11 @@ class ClaudeCliBackend(SubprocessBackend):
 
     command = "claude"
 
-    def _build_argv(self, exe, prompt):
+    def _build_argv(self, exe, user_prompt, system_prompt):
         # TODO: provide more permission and config to the CLI sandbox later.
         return [
-            exe, "-p", prompt, "--output-format", "json",
+            exe, "-p", user_prompt, "--output-format", "json",
+            "--append-system-prompt", system_prompt,
             "--tools", "",
             "--permission-mode", "dontAsk",  # no interactive prompts
             "--setting-sources", "",  # no config files
@@ -315,11 +319,14 @@ class OpenAIHttpBackend(_backend.AgentBackend):
         if not self.available():
             return _backend.BackendResponse(
                 error="openai http backend needs base_url and model")
-        composed = self._compose_prompt(prompt, scene_context, tool_surface)
+        user_prompt = self._compose_user(prompt, scene_context, tool_surface)
         body = {
             "model": self._model,
             "stream": False,
-            "messages": [{"role": "user", "content": composed}],
+            "messages": [
+                {"role": "system", "content": self._INSTRUCTIONS},
+                {"role": "user", "content": user_prompt},
+            ],
         }
         try:
             status, raw = self._post_chat(body)

--- a/solvcon/agent/_command.py
+++ b/solvcon/agent/_command.py
@@ -301,6 +301,15 @@ class CommandProcessor:
     def log(self):
         return list(self._log)
 
+    def tool_definitions(self):
+        """The tool definitions of the one family this processor runs."""
+        return self.command_set.tool_definitions()
+
+    def commands_by_category(self):
+        """The ops of the one family this processor runs, grouped by
+        category."""
+        return self.command_set.commands_by_category()
+
     def run(self, command):
         """Validate and apply one command, returning its ``CommandResult``."""
         op = command.get("op", "?") if isinstance(command, dict) else "?"
@@ -358,6 +367,15 @@ class CommandDispatcher:
         for executor in self.executors:
             tools.extend(executor.command_set.tool_definitions())
         return tools
+
+    def commands_by_category(self):
+        """Merge every member family's ops, grouped by category."""
+        merged = {}
+        for executor in self.executors:
+            grouped = executor.command_set.commands_by_category()
+            for category, ops in grouped.items():
+                merged.setdefault(category, []).extend(ops)
+        return merged
 
     def _route(self, command):
         if not isinstance(command, dict):

--- a/solvcon/agent/_core.py
+++ b/solvcon/agent/_core.py
@@ -43,20 +43,6 @@ def _make_executor(world, renderer=None):
     return draw.Executor(world, renderer)
 
 
-def tool_surface(allow_destructive=False):
-    """The command tools allowed for a backend."""
-    from . import draw
-    tools = draw.tool_definitions()
-    if allow_destructive:
-        return tools
-    return [tool for tool in tools if tool["category"] != "delete"]
-
-
-def _destructive_ops():
-    from . import draw
-    return set(draw.commands_by_category()["delete"])
-
-
 class AgentSession:
     """Bind a ``World``, a backend, and a runner; record a transcript.
 
@@ -96,9 +82,29 @@ class AgentSession:
         if not self._runner_injected:
             self._runner = None
 
+    def _command_provider(self):
+        """What answers ``tool_definitions`` and ``commands_by_category``: the
+        bound runner if it carries that surface, else Agent Draw.  Reads
+        ``self._runner`` directly to avoid forcing a lazy build."""
+        runner = self._runner
+        if runner is not None and hasattr(runner, "tool_definitions"):
+            return runner
+        from . import draw
+        return draw
+
     def tool_surface(self):
-        """The command tool definitions to hand the backend."""
-        return tool_surface(allow_destructive=self.allow_destructive)
+        """The command tool definitions to hand the backend, with delete ops
+        dropped unless this session allows them."""
+        tools = self._command_provider().tool_definitions()
+        if self.allow_destructive:
+            return tools
+        return [tool for tool in tools if tool["category"] != "delete"]
+
+    def _gated_ops(self):
+        """Op names blocked while destructive commands are disabled: the
+        delete category across the provider's families."""
+        by_category = self._command_provider().commands_by_category()
+        return set(by_category.get("delete", ()))
 
     def scene_context(self, level="basic"):
         """A short text summary of the world for the model: the shape count
@@ -136,7 +142,7 @@ class AgentSession:
         """
         if not commands:
             return []
-        blocked = set() if self.allow_destructive else _destructive_ops()
+        blocked = set() if self.allow_destructive else self._gated_ops()
         allowed = [command for command in commands
                    if self._op_of(command) not in blocked]
         if not allowed:

--- a/solvcon/pilot/agent/_agent_control.py
+++ b/solvcon/pilot/agent/_agent_control.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Real Agent Draw, Window, and View targets, bound to the live pilot.
+
+The Agent command families in :mod:`solvcon.agent` are Qt-free and
+duck-typed: the draw commands mutate a ``World``, the window commands drive a
+window-manager surface, the view commands drive a ``ViewTransform2dFp64``.
+This module supplies the pilot-backed targets those families run against so an
+agent can draw on, open, list, activate, close, and save real canvas windows
+and steer the active canvas's view.  All three resolve the *active* canvas per
+command, so one batch that opens a canvas and then draws on it lands on the
+same window; :func:`build_control_dispatcher` wires them into one dispatcher.
+"""
+
+from ... import core
+from ...agent import _command as _cmd
+from ...agent import draw
+from ...agent.window import Executor as WindowExecutor
+from ...agent.window import view as _view
+
+__all__ = [
+    'PilotWindowManager',
+    'LiveDrawExecutor',
+    'LiveViewExecutor',
+    'build_control_dispatcher',
+    'pilot_scene_context',
+]
+
+
+class PilotWindowManager:
+    """Adapt the pilot ``RManager`` and its ``QMdiArea`` to the Agent Window
+    manager surface.
+
+    Presents the surface the window command family calls: ``new_canvas``,
+    ``list_windows``, ``activate_window``, ``close_window``, and
+    ``save_image``.  Each open sub-window carries a stable integer id keyed on
+    the MDI sub-window, whose identity Qt keeps stable across calls; ids for
+    windows that have closed are dropped.  ``save_image`` briefly activates the
+    target window so it can be grabbed through the current canvas, then
+    restores the previously active one.
+    """
+
+    def __init__(self, mgr):
+        self._mgr = mgr
+        self._ids = {}  # sub-window -> stable id
+        self._next_id = 1
+
+    def _area(self):
+        return self._mgr.mdiArea
+
+    def _open_subwindows(self):
+        return [s for s in self._area().subWindowList() if s.isVisible()]
+
+    def _id_of(self, subwin):
+        window_id = self._ids.get(subwin)
+        if window_id is None:
+            window_id = self._next_id
+            self._next_id += 1
+            self._ids[subwin] = window_id
+        return window_id
+
+    def _subwindow_of(self, window_id):
+        for subwin in self._open_subwindows():
+            if self._ids.get(subwin) == window_id:
+                return subwin
+        return None
+
+    def new_canvas(self):
+        # A raw canvas has no world and an un-centered view; give it both, so
+        # an agent-opened window matches the blank canvas the Canvas feature
+        # builds and the agent draws on it without a separate bind step.
+        widget = self._mgr.add2DWidget()
+        widget.updateWorld(core.WorldFp64())
+        widget.resetView()
+        # add2DWidget activates the window it opens, so it is the active one.
+        return self._id_of(self._area().activeSubWindow())
+
+    def list_windows(self):
+        active = self._area().activeSubWindow()
+        subwins = self._open_subwindows()
+        live = set(subwins)
+        self._ids = {s: i for s, i in self._ids.items() if s in live}
+        return [{"id": self._id_of(s),
+                 "title": s.windowTitle() or "window",
+                 "active": s is active}
+                for s in subwins]
+
+    def activate_window(self, window_id):
+        subwin = self._subwindow_of(window_id)
+        if subwin.isMinimized():
+            subwin.showNormal()
+        self._area().setActiveSubWindow(subwin)
+
+    def close_window(self, window_id):
+        self._subwindow_of(window_id).close()
+
+    def save_image(self, window_id, path):
+        subwin = self._subwindow_of(window_id)
+        area = self._area()
+        previous = area.activeSubWindow()
+        area.setActiveSubWindow(subwin)
+        try:
+            widget = self._mgr.currentR2DWidget()
+            # Only a 2D canvas can be grabbed; report anything else as a
+            # failed write rather than a bogus success.
+            if widget is None:
+                return False
+            return widget.saveImage(path)
+        finally:
+            if previous is not None and previous is not subwin:
+                area.setActiveSubWindow(previous)
+
+
+class _ActiveCanvasExecutor:
+    """Mixin for a command executor bound to the *active* 2D canvas.
+
+    Combined with a family ``Executor``, it resolves the active canvas per
+    command and fails cleanly when there is none, seeds the command's target
+    from that canvas through :meth:`_seed_target`, and calls
+    :meth:`_on_change` after any command that mutates the canvas (every
+    non-``read`` op).  Subclasses supply only those two hooks.
+    """
+
+    def __init__(self, mgr, *args, **kw):
+        super().__init__(*args, **kw)
+        self._mgr = mgr
+
+    def _apply(self, op, command):
+        widget = self._mgr.currentR2DWidget()
+        if widget is None:
+            return _cmd.CommandResult(op, False, error="no active 2D canvas")
+        try:
+            self.target = self._seed_target(widget)
+        except _cmd.CommandError as exc:
+            return _cmd.CommandResult(op, False, error=str(exc))
+        result = super()._apply(op, command)
+        if result.ok and self.command_set.commands[op].category != "read":
+            self._on_change(widget)
+        return result
+
+    def _seed_target(self, widget):
+        """The per-command target read from ``widget``; may raise
+        ``CommandError`` to fail the command cleanly."""
+        raise NotImplementedError
+
+    def _on_change(self, widget):
+        """React to a mutating command, e.g. write back and repaint."""
+
+
+class LiveDrawExecutor(_ActiveCanvasExecutor, draw.Executor):
+    """Bind the Agent Draw commands to the active 2D canvas's world.
+
+    The world is resolved per command, so a batch that opens a canvas then
+    draws on it targets the window it just opened; the canvas is repainted
+    after any command that changes it.  A canvas with no world yet fails
+    cleanly.
+    """
+
+    def __init__(self, mgr, renderer=None, validate_results=False,
+                 reraise=False):
+        super().__init__(mgr, None, renderer,
+                         validate_results=validate_results, reraise=reraise)
+
+    def _seed_target(self, widget):
+        world = widget.world
+        if world is None:
+            raise _cmd.CommandError("active canvas has no world")
+        return world
+
+    def _on_change(self, widget):
+        widget.requestRepaint()
+
+
+class LiveViewExecutor(_ActiveCanvasExecutor, _view.Executor):
+    """Bind the Agent View commands to the active 2D canvas.
+
+    ``R2DWidget.viewTransform`` hands back a detached copy, so each command
+    runs against a fresh copy seeded from the active canvas; a command that
+    changes the view is written back with ``setViewTransform`` and the canvas
+    is repainted, while read commands touch neither.
+    """
+
+    def __init__(self, mgr, validate_results=False, reraise=False):
+        super().__init__(mgr, None, validate_results=validate_results,
+                         reraise=reraise)
+
+    def _seed_target(self, widget):
+        return widget.viewTransform
+
+    def _on_change(self, widget):
+        widget.setViewTransform(self.target)
+        widget.requestRepaint()
+
+
+def build_control_dispatcher(mgr, renderer=None):
+    """Assemble the draw, window, and view command families into one
+    dispatcher bound to the live pilot.  Every family resolves the active
+    canvas or the MDI area itself, so the caller needs no per-turn rebinding.
+    """
+    return _cmd.CommandDispatcher([
+        LiveDrawExecutor(mgr, renderer),
+        WindowExecutor(PilotWindowManager(mgr)),
+        LiveViewExecutor(mgr)])
+
+
+def pilot_scene_context(dispatcher, base):
+    """Append a snapshot of the open windows and the active view to ``base``.
+
+    A one-shot backend never sees a command's result, so window ids stay
+    invisible unless the scene carries them; this lists every open window with
+    its id and the active view so the model can target ``activate_window``,
+    ``close_window``, or ``save_image`` without guessing.  The read commands
+    route through ``dispatcher`` so the ids match what the executors assign.
+    """
+    lines = [base]
+    windows = dispatcher.run({"op": "list_windows"}).value["windows"]
+    if windows:
+        lines.append("windows: " + ", ".join(
+            "#%d %r%s" % (w["id"], w["title"],
+                          " (active)" if w["active"] else "")
+            for w in windows))
+    else:
+        lines.append("windows: none open")
+    view = dispatcher.run({"op": "get_view"})
+    if view.ok:
+        transform = view.value["view"]
+        lines.append("view: pan (%g, %g), zoom %g" % (
+            transform["pan_x"], transform["pan_y"], transform["zoom"]))
+    return "\n".join(lines)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/agent/_agent_gui.py
+++ b/solvcon/pilot/agent/_agent_gui.py
@@ -19,6 +19,7 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QDockWidget,
                                QPushButton)
 
 from ...agent import AgentSession, available_backends
+from . import _agent_control
 from ..base import _gui_common
 
 __all__ = [  # noqa: F822
@@ -82,7 +83,8 @@ class AgentConsoleWidget(QWidget):
         self._status.setVisible(False)
 
         self._input = QLineEdit()
-        self._input.setPlaceholderText("Ask the agent to draw...")
+        self._input.setPlaceholderText(
+            "Ask the agent to draw, arrange windows, or aim the view...")
         self._send = QPushButton("Send")
 
         selector = QHBoxLayout()
@@ -158,7 +160,9 @@ class AgentPanel(_gui_common.PilotFeature):
 
     It holds one :class:`~solvcon.agent.AgentSession` reused across prompts
     (the "current session"), rebinding it to the active world and the selected
-    backend on each turn.
+    backend on each turn.  The session runs a dispatcher over the Agent Draw,
+    Agent Window, and Agent View families, so a prompt can draw on the canvas,
+    open or arrange windows, and aim the view through one tool surface.
     """
 
     def __init__(self, *args, **kw):
@@ -166,7 +170,8 @@ class AgentPanel(_gui_common.PilotFeature):
         self._action = None
         self._dock = None
         self._panel = None
-        self._session = AgentSession()
+        self._session = AgentSession(
+            runner=_agent_control.build_control_dispatcher(self._mgr))
         self._worker = None
         self._active_widget = None
         # Make sure the worker thread is joined before the main thread exits.
@@ -224,6 +229,8 @@ class AgentPanel(_gui_common.PilotFeature):
         widget = self._mgr.currentR2DWidget()
         session = self._session
         session.backend = self._panel.selected_backend()
+        # The draw, window, and view executors resolve the active canvas on
+        # their own; bind_world only keeps scene_context pointed at it.
         session.bind_world(None if widget is None else widget.world)
         self._panel.append_message("user", prompt)
         self._panel.clear_input()
@@ -234,8 +241,10 @@ class AgentPanel(_gui_common.PilotFeature):
         self._active_widget = widget
         self._panel.set_busy(True)
         self._panel.start_working()
+        scene = _agent_control.pilot_scene_context(
+            session.runner, session.scene_context())
         self._worker = AgentBackendWorker(
-            session.backend, prompt, session.scene_context(),
+            session.backend, prompt, scene,
             session.tool_surface(), parent=self._panel)
         self._worker.succeeded.connect(self._on_backend_succeeded)
         self._worker.failed.connect(self._on_backend_failed)

--- a/tests/test_agent_backends_impl.py
+++ b/tests/test_agent_backends_impl.py
@@ -102,7 +102,7 @@ class SubprocessBackendDiscoveryTC(unittest.TestCase):
         # A subclass that names no executable is never available even though
         # which() would answer for a real name.
         class Nameless(agent.SubprocessBackend):
-            def _build_argv(self, exe, prompt):
+            def _build_argv(self, exe, user_prompt, system_prompt):
                 return [exe]
 
         with mock.patch(_WHICH, lambda name: "/usr/bin/" + str(name)):
@@ -189,6 +189,11 @@ class ClaudeCliSendTC(unittest.TestCase):
         self.assertIn("hello", prompt)
         self.assertIn("one shape", prompt)
         self.assertIn("add_circle", prompt)  # tool surface folded in
+        # The instruction rides as a real system prompt, not the user turn.
+        self.assertIn("--append-system-prompt", argv)
+        system = argv[argv.index("--append-system-prompt") + 1]
+        self.assertIn("drive a 2D drawing canvas", system)
+        self.assertNotIn("drive a 2D drawing canvas", prompt)
 
 
 class RegistrationTC(unittest.TestCase):
@@ -244,11 +249,16 @@ class OpenAIHttpBackendTC(unittest.TestCase):
         self.assertEqual(body["model"], "qwen2.5vl:7b")
         self.assertIs(body["stream"], False)
         messages = body["messages"]
-        self.assertEqual(len(messages), 1)
-        self.assertEqual(messages[0]["role"], "user")
-        self.assertIn("hello", messages[0]["content"])
-        self.assertIn("one shape", messages[0]["content"])
-        self.assertIn("add_circle", messages[0]["content"])
+        self.assertEqual(len(messages), 2)
+        # The instruction rides as a real system prompt, first; the user turn
+        # carries only the tools, scene, and request.
+        self.assertEqual(messages[0]["role"], "system")
+        self.assertIn("drive a 2D drawing canvas", messages[0]["content"])
+        self.assertEqual(messages[1]["role"], "user")
+        self.assertIn("hello", messages[1]["content"])
+        self.assertIn("one shape", messages[1]["content"])
+        self.assertIn("add_circle", messages[1]["content"])
+        self.assertNotIn("drive a 2D drawing canvas", messages[1]["content"])
 
     def test_send_http_error_status_is_error(self):
         self.backend._post_chat = lambda body: (500, b"boom")

--- a/tests/test_pilot_agent_control.py
+++ b/tests/test_pilot_agent_control.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""The Agent Window and Agent View real-target suite: the command families
+driving live pilot windows and the active canvas view through the pilot
+RManager, its QMdiArea, and the R2DWidget. Skipped where no GUI is available;
+run with ``make run_pilot_pytest HEADLESS=1``."""
+
+import os
+import tempfile
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot, agent
+    from solvcon.pilot.agent import _agent_gui
+    from solvcon.pilot.agent._agent_control import (
+        PilotWindowManager, LiveViewExecutor, build_control_dispatcher,
+        pilot_scene_context)
+    from solvcon.agent import window
+    from PySide6 import QtWidgets
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class _PilotTC(unittest.TestCase):
+    """Shared setup: a shown main window with an empty MDI area, so every
+    freshly added sub-window reports visible and earlier tests' windows do
+    not linger in the list."""
+
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.area = self.mgr.mdiArea
+        self.mgr.show()
+        self.area.closeAllSubWindows()
+        QtWidgets.QApplication.processEvents()
+
+    def tearDown(self):
+        self.area.closeAllSubWindows()
+        QtWidgets.QApplication.processEvents()
+
+
+class PilotWindowManagerTC(_PilotTC):
+    """The window command family runs against the live RManager/QMdiArea."""
+
+    def setUp(self):
+        super().setUp()
+        self.wm = PilotWindowManager(self.mgr)
+        self.ex = window.Executor(self.wm)
+
+    def test_new_canvas_opens_a_real_canvas_and_lists_it(self):
+        res = self.ex.run({"op": "new_canvas"})
+        self.assertTrue(res.ok, res.error)
+        window_id = res.value["window_id"]
+        windows = self.ex.run({"op": "list_windows"}).value["windows"]
+        self.assertEqual(len(windows), 1)
+        self.assertEqual(windows[0]["id"], window_id)
+        self.assertTrue(windows[0]["active"])
+        self.assertTrue(windows[0]["title"].endswith("2D canvas"))
+        self.assertIsNotNone(self.mgr.currentR2DWidget())
+
+    def test_list_reflects_the_newest_active_canvas(self):
+        first = self.ex.run({"op": "new_canvas"}).value["window_id"]
+        second = self.ex.run({"op": "new_canvas"}).value["window_id"]
+        windows = self.ex.run({"op": "list_windows"}).value["windows"]
+        self.assertEqual({w["id"] for w in windows}, {first, second})
+        active = [w["id"] for w in windows if w["active"]]
+        self.assertEqual(active, [second])
+
+    def test_activate_window_switches_the_active_one(self):
+        first = self.ex.run({"op": "new_canvas"}).value["window_id"]
+        self.ex.run({"op": "new_canvas"})
+        self.assertTrue(
+            self.ex.run({"op": "activate_window", "window_id": first}).ok)
+        windows = self.ex.run({"op": "list_windows"}).value["windows"]
+        self.assertEqual([w["id"] for w in windows if w["active"]], [first])
+
+    def test_close_window_removes_it(self):
+        first = self.ex.run({"op": "new_canvas"}).value["window_id"]
+        second = self.ex.run({"op": "new_canvas"}).value["window_id"]
+        self.assertTrue(
+            self.ex.run({"op": "close_window", "window_id": first}).ok)
+        QtWidgets.QApplication.processEvents()
+        ids = [w["id"]
+               for w in self.ex.run({"op": "list_windows"}).value["windows"]]
+        self.assertEqual(ids, [second])
+
+    def test_save_image_writes_a_real_file(self):
+        window_id = self.ex.run({"op": "new_canvas"}).value["window_id"]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "canvas.png")
+            res = self.ex.run(
+                {"op": "save_image", "window_id": window_id, "path": path})
+            self.assertTrue(res.ok, res.error)
+            self.assertTrue(os.path.exists(path))
+            self.assertGreater(os.path.getsize(path), 0)
+
+    def test_by_id_commands_fail_cleanly_on_a_missing_window(self):
+        self.ex.run({"op": "new_canvas"})
+        for op in ("activate_window", "close_window"):
+            with self.subTest(op=op):
+                res = self.ex.run({"op": op, "window_id": 999})
+                self.assertFalse(res.ok)
+                self.assertIn("999", res.error)
+        res = self.ex.run(
+            {"op": "save_image", "window_id": 999, "path": "x.png"})
+        self.assertFalse(res.ok)
+
+
+class LiveViewExecutorTC(_PilotTC):
+    """The view command family steers the active canvas's live transform."""
+
+    def setUp(self):
+        super().setUp()
+        self.ex = LiveViewExecutor(self.mgr)
+
+    def test_set_view_writes_through_to_the_canvas(self):
+        self.mgr.add2DWidget()
+        res = self.ex.run(
+            {"op": "set_view", "pan_x": 10.0, "pan_y": 20.0, "zoom": 4.0})
+        self.assertTrue(res.ok, res.error)
+        transform = self.mgr.currentR2DWidget().viewTransform
+        self.assertEqual(transform.pan_x, 10.0)
+        self.assertEqual(transform.pan_y, 20.0)
+        self.assertEqual(transform.zoom, 4.0)
+        self.assertEqual(self.ex.run({"op": "get_view"}).value["view"],
+                         {"pan_x": 10.0, "pan_y": 20.0, "zoom": 4.0})
+
+    def test_pan_then_reset_returns_to_identity(self):
+        self.mgr.add2DWidget()
+        self.ex.run({"op": "set_view", "pan_x": 0, "pan_y": 0, "zoom": 1})
+        self.assertTrue(self.ex.run(
+            {"op": "pan", "dx_screen": 100.0, "dy_screen": 50.0}).ok)
+        transform = self.mgr.currentR2DWidget().viewTransform
+        self.assertEqual((transform.pan_x, transform.pan_y), (100.0, 50.0))
+        self.assertTrue(self.ex.run({"op": "reset_view"}).ok)
+        self.assertEqual(self.ex.run({"op": "get_view"}).value["view"],
+                         {"pan_x": 0.0, "pan_y": 0.0, "zoom": 1.0})
+
+    def test_commands_fail_cleanly_without_an_active_canvas(self):
+        res = self.ex.run({"op": "get_view"})
+        self.assertFalse(res.ok)
+        self.assertIn("no active 2D canvas", res.error)
+
+
+class DispatcherIntegrationTC(_PilotTC):
+    """One dispatcher lets a session drive windows, the view, and the world."""
+
+    def test_dispatcher_drives_windows_view_and_world(self):
+        dispatcher = build_control_dispatcher(self.mgr)
+        self.assertTrue(dispatcher.run({"op": "new_canvas"}).ok)
+        self.assertTrue(dispatcher.run(
+            {"op": "set_view", "pan_x": 5.0, "pan_y": 6.0, "zoom": 2.0}).ok)
+        self.assertTrue(dispatcher.run(
+            {"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0}).ok)
+        widget = self.mgr.currentR2DWidget()
+        self.assertEqual(widget.viewTransform.zoom, 2.0)
+        self.assertEqual(widget.world.nshape, 1)
+
+    def test_open_then_draw_lands_on_the_new_canvas(self):
+        # The batch opens a canvas and draws on it in one go: the draw target
+        # must follow the window the batch just opened, not the world (if any)
+        # that was active when the batch began.
+        dispatcher = build_control_dispatcher(self.mgr)
+        results = dispatcher.run_script([
+            {"op": "new_canvas"},
+            {"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0}])
+        self.assertTrue(all(r.ok for r in results), [r.error for r in results])
+        self.assertEqual(self.mgr.currentR2DWidget().world.nshape, 1)
+
+    def test_draw_fails_cleanly_without_a_canvas(self):
+        dispatcher = build_control_dispatcher(self.mgr)
+        res = dispatcher.run(
+            {"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0})
+        self.assertFalse(res.ok)
+        self.assertIn("no active 2D canvas", res.error)
+
+    def test_scene_context_lists_windows_and_the_active_view(self):
+        dispatcher = build_control_dispatcher(self.mgr)
+        dispatcher.run({"op": "new_canvas"})
+        scene = pilot_scene_context(dispatcher, "world with 0 shapes")
+        self.assertIn("world with 0 shapes", scene)
+        self.assertIn("2D canvas", scene)
+        self.assertIn("(active)", scene)
+        self.assertIn("view:", scene)
+
+    def test_scene_context_notes_when_no_window_is_open(self):
+        dispatcher = build_control_dispatcher(self.mgr)
+        scene = pilot_scene_context(dispatcher, "base")
+        self.assertIn("windows: none open", scene)
+
+    def test_session_tool_surface_unions_the_families(self):
+        dispatcher = build_control_dispatcher(self.mgr)
+        session = agent.AgentSession(runner=dispatcher)
+        names = {tool["name"] for tool in session.tool_surface()}
+        self.assertLessEqual(
+            {"add_circle", "new_canvas", "list_windows", "get_view",
+             "set_view"}, names)
+        # Delete ops stay hidden by default, across every family.
+        self.assertNotIn("close_window", names)
+        self.assertNotIn("clear", names)
+        self.assertNotIn("remove_shape", names)
+
+    def test_opt_in_exposes_the_delete_ops_of_every_family(self):
+        dispatcher = build_control_dispatcher(self.mgr)
+        session = agent.AgentSession(runner=dispatcher, allow_destructive=True)
+        names = {tool["name"] for tool in session.tool_surface()}
+        self.assertLessEqual(
+            {"close_window", "clear", "remove_shape"}, names)
+
+
+class AgentPanelControlTC(_PilotTC):
+    """The console panel wires the composite dispatcher into its session."""
+
+    def test_panel_session_exposes_window_and_view_tools(self):
+        feature = _agent_gui.AgentPanel(mgr=self.mgr)
+        names = {tool["name"] for tool in feature._session.tool_surface()}
+        self.assertLessEqual(
+            {"add_circle", "new_canvas", "list_windows", "get_view",
+             "set_view"}, names)
+        self.assertNotIn("close_window", names)
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
This wires the Agent's Window and View command families to the live pilot so an AI backend can open, list, activate, close, and save canvas windows and pan, zoom, and reset the active 2D view, alongside the existing drawing commands. A dispatcher composes the three families and each one resolves the active canvas per command, so a single request can open a canvas and immediately draw on it. The session's tool surface and destructive-command gating now span every family it routes.

The backend instruction is also sent as a real system prompt rather than folded into the user turn, and it now describes the canvas coordinate frame (origin-centered, +Y up) with a worked example so drawings land centered and in view.

Related to #966.
