### PR TITLE
Add a solution panel for the 2D Euler oblique-shock solver

### DIFF
--- a/solvcon/pilot/_euler/__init__.py
+++ b/solvcon/pilot/_euler/__init__.py
@@ -4,21 +4,29 @@
 
 """
 Pilot features for the multi-dimensional Euler solver: the oblique-shock
-sample meshes.
+sample meshes and driver, the shared scalar-field rendering, and the
+interactive Euler solver panel.
 """
 
 from .. import _pilot_core as _pcore
 
 if _pcore.enable:
+    from . import _field_render  # noqa: F401
     from . import _oblique
+    from . import _solution_info
 
     ObliqueShockMesh = _oblique.ObliqueShockMesh
+    SolutionInfo = _solution_info.SolutionInfo
 else:
+    _field_render = None
     _oblique = None
+    _solution_info = None
     ObliqueShockMesh = None
+    SolutionInfo = None
 
 __all__ = [
     'ObliqueShockMesh',
+    'SolutionInfo',
 ]
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/_euler/_field_render.py
+++ b/solvcon/pilot/_euler/_field_render.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Turn a per-cell scalar field into the flat colored triangles that
+``RDomainWidget.updateColorField`` draws.
+
+The mesh cells are triangulated once with :func:`cell_triangulation`; each
+frame then maps the scalar field to vertex colors with :func:`field_colors`
+over that fixed triangulation.  Shared by the oblique-shock sample and the
+solution panel so both read a 2D field the same way.
+"""
+
+import numpy as np
+
+from ... import core
+
+
+def colormap(t):
+    """Map ``t`` in [0, 1] to a jet-like RGB array (``..., 3``) in [0, 1].
+
+    A four-stop blue-cyan-yellow-red ramp; the triangle-wave channels are the
+    standard compact "jet" approximation, enough to read a scalar field
+    without pulling in a plotting dependency.
+    """
+    t = np.clip(np.asarray(t, dtype='float64'), 0.0, 1.0)
+    r = np.clip(1.5 - np.abs(4.0 * t - 3.0), 0.0, 1.0)
+    g = np.clip(1.5 - np.abs(4.0 * t - 2.0), 0.0, 1.0)
+    b = np.clip(1.5 - np.abs(4.0 * t - 1.0), 0.0, 1.0)
+    return np.stack([r, g, b], axis=-1)
+
+
+def cell_triangulation(mh):
+    """Fan every cell into unshared triangles for a flat color field.
+
+    Each cell fans into ``nnd - 2`` triangles whose corners are emitted
+    unshared, so a cell can take one flat color.  Returns the triangles as a
+    ``TrianglePadFp32`` and the per-cell vertex count that :func:`field_colors`
+    repeats each cell's color over.
+    """
+    nodes = core.PointPadFp32(ndim=3)
+    for ind in range(mh.nnode):
+        nodes.append(mh.ndcrd[ind, 0], mh.ndcrd[ind, 1], 0.0)
+    fan = core.TrianglePadFp32(ndim=3)
+    counts = core.SimpleCollectorInt32(0)
+    for icl in range(mh.ncell):
+        nnd = int(mh.clnds[icl, 0])
+        apex = nodes.get_at(int(mh.clnds[icl, 1]))
+        for it in range(1, nnd - 1):
+            fan.append(apex,
+                       nodes.get_at(int(mh.clnds[icl, 1 + it])),
+                       nodes.get_at(int(mh.clnds[icl, 1 + it + 1])))
+        counts.push_back(3 * (nnd - 2))
+    return fan, counts.as_array().ndarray
+
+
+def field_colors(field, counts, vmin, vmax):
+    """Map each cell's scalar to a color and repeat it over the cell's
+    vertices, matching the layout of :func:`cell_triangulation`.
+    """
+    span = vmax - vmin
+    t = (field - vmin) / span if span > 0 else np.zeros_like(field)
+    return np.repeat(colormap(t), counts, axis=0).astype('float32')
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/_euler/_solution_info.py
+++ b/solvcon/pilot/_euler/_solution_info.py
@@ -1,0 +1,424 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Dock panel that runs the 2D Euler oblique-shock solver and draws a
+selected solution field as a flat color map.
+
+The panel mirrors the mesh information panel: a feature toggled from the
+View "Panels" submenu owns a control widget.  Here the controls set the free
+stream and mesh, open or close the domain viewer sub-window, start / pause /
+step the march, and pick which derived field (density, velocity, pressure,
+Mach, ...) the viewer colors.
+"""
+
+import numpy as np
+
+from PySide6.QtCore import Qt, QTimer, QObject, QEvent
+from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QFormLayout,
+                               QDockWidget, QComboBox, QDoubleSpinBox,
+                               QSpinBox, QPushButton, QTreeWidget,
+                               QTreeWidgetItem, QFrame)
+
+from ... import core
+from ...multidim.euler import oblique
+from . import _field_render
+from .. import _gui_common
+
+__all__ = [  # noqa: F822
+    'SolutionInfo',
+]
+
+
+class _SubWindowCloseFilter(QObject):
+    """Report a watched sub-window's close synchronously.
+
+    A ``QMdiSubWindow`` has no close signal, so this filter is the only way to
+    stop the march before Qt frees the viewer.
+    """
+
+    def __init__(self, on_close, parent):
+        super().__init__(parent)
+        self._on_close = on_close
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Type.Close:
+            self._on_close()
+        return False
+
+
+class SolutionPanel(QWidget):
+    """Widget with the solver controls and a live solution-field readout."""
+
+    #: Derived scalar fields the viewer can color, in display order.
+    FIELDS = ('density', 'velocity-x', 'velocity-y', 'speed',
+              'pressure', 'mach', 'energy')
+    #: Mesh flavors offered by :class:`~solvcon.multidim.euler.oblique`.
+    CELL_TYPES = ('quad', 'triangle', 'unstructured')
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        # Owner-supplied callbacks that drive the solver from the controls.
+        self.viewer_toggled = None
+        self.start_requested = None
+        self.pause_toggled = None
+        self.step_requested = None
+        self.field_changed = None
+        self._build_controls()
+        self._build_status()
+
+    def _build_controls(self):
+        """Lay out the free-stream / mesh inputs and the run buttons."""
+        self._gamma = self._spin(1.4, 1.01, 3.0, 0.01, 3)
+        self._density = self._spin(1.0, 1e-3, 1e6, 0.1, 3)
+        self._pressure = self._spin(1.0, 1e-3, 1e6, 0.1, 3)
+        self._mach = self._spin(2.0, 0.1, 20.0, 0.1, 3)
+        self._dt = self._spin(2e-3, 1e-6, 1.0, 1e-3, 6)
+        self._steps = QSpinBox()
+        self._steps.setRange(1, 1000)
+        self._steps.setValue(5)
+        self._cell_type = QComboBox()
+        self._cell_type.addItems(self.CELL_TYPES)
+        self._field = QComboBox()
+        self._field.addItems(self.FIELDS)
+        self._field.currentTextChanged.connect(self._on_field_changed)
+
+        form = QFormLayout()
+        form.addRow("gamma", self._gamma)
+        form.addRow("density", self._density)
+        form.addRow("pressure", self._pressure)
+        form.addRow("mach", self._mach)
+        form.addRow("dt", self._dt)
+        form.addRow("steps/frame", self._steps)
+        form.addRow("cell type", self._cell_type)
+        form.addRow("field", self._field)
+
+        # Opens and closes the one domain viewer the run buttons draw into.
+        self._viewer_btn = QPushButton("Open viewer")
+        self._viewer_btn.setCheckable(True)
+        self._viewer_btn.toggled.connect(self._on_viewer_toggled)
+
+        self._start = QPushButton("Start")
+        self._start.clicked.connect(self._on_start_clicked)
+        self._pause = QPushButton("Pause")
+        self._pause.setCheckable(True)
+        self._pause.toggled.connect(self._on_pause_toggled)
+        self._step = QPushButton("Step")
+        self._step.clicked.connect(self._on_step_clicked)
+        buttons = QHBoxLayout()
+        buttons.addWidget(self._start)
+        buttons.addWidget(self._pause)
+        buttons.addWidget(self._step)
+
+        self._layout = QVBoxLayout(self)
+        self._layout.setContentsMargins(4, 4, 4, 4)
+        self._layout.addLayout(form)
+        self._layout.addWidget(self._viewer_btn)
+        self._layout.addLayout(buttons)
+
+    def _build_status(self):
+        """Add the read-only step / value-range tree below the controls."""
+        self._tree = QTreeWidget()
+        self._tree.setColumnCount(1)
+        self._tree.setHeaderHidden(True)
+        self._tree.setFrameShape(QFrame.NoFrame)
+        self._layout.addWidget(self._tree)
+        self.set_status(None, None, None)
+
+    @staticmethod
+    def _spin(value, low, high, step, decimals):
+        box = QDoubleSpinBox()
+        box.setDecimals(decimals)
+        box.setRange(low, high)
+        box.setSingleStep(step)
+        box.setValue(value)
+        return box
+
+    def params(self):
+        """Collect the current control values for the solver driver."""
+        return dict(gamma=self._gamma.value(),
+                    density=self._density.value(),
+                    pressure=self._pressure.value(),
+                    mach=self._mach.value(),
+                    time_increment=self._dt.value(),
+                    cell_type=self._cell_type.currentText())
+
+    def field(self):
+        return self._field.currentText()
+
+    def steps_per_frame(self):
+        return self._steps.value()
+
+    def set_paused(self, paused):
+        """Reflect the run state in the Pause button without re-firing it."""
+        self._pause.blockSignals(True)
+        self._pause.setChecked(paused)
+        self._pause.setText("Resume" if paused else "Pause")
+        self._pause.blockSignals(False)
+
+    def set_viewer_open(self, open_):
+        """Reflect the viewer state in its button without re-firing it."""
+        self._viewer_btn.blockSignals(True)
+        self._viewer_btn.setChecked(open_)
+        self._viewer_btn.setText("Close viewer" if open_ else "Open viewer")
+        self._viewer_btn.blockSignals(False)
+
+    def set_status(self, step, vmin, vmax):
+        """Show the marched step count and the drawn field's value range."""
+        self._tree.clear()
+        if step is None:
+            QTreeWidgetItem(self._tree, ["not started"])
+            return
+        QTreeWidgetItem(self._tree, [f"step: {step}"])
+        QTreeWidgetItem(self._tree, [f"field: {self.field()}"])
+        QTreeWidgetItem(self._tree, [f"min: {vmin:.4g}"])
+        QTreeWidgetItem(self._tree, [f"max: {vmax:.4g}"])
+
+    @staticmethod
+    def compute_field(name, cons, gamma, ndim):
+        """Derive the named scalar field from the conserved variables.
+
+        ``cons`` is the order-0 solution ``[ncell, neq]`` over the body cells
+        -- density, the ``ndim`` momentum components, then total energy -- and
+        ``gamma`` the matching per-cell ratio of specific heats.  Pressure
+        follows the ideal-gas relation and Mach divides the speed by the local
+        speed of sound.
+        """
+        rho = cons[:, 0]
+        energy = cons[:, 1 + ndim]
+        if name == 'density':
+            return rho
+        if name == 'energy':
+            return energy
+        vel = cons[:, 1:1 + ndim] / rho[:, None]
+        if name == 'velocity-x':
+            return vel[:, 0]
+        if name == 'velocity-y':
+            return vel[:, 1]
+        speed2 = (vel ** 2).sum(axis=1)
+        if name == 'speed':
+            return np.sqrt(speed2)
+        pressure = (gamma - 1.0) * (energy - 0.5 * rho * speed2)
+        if name == 'pressure':
+            return pressure
+        if name == 'mach':
+            return np.sqrt(speed2) / np.sqrt(gamma * pressure / rho)
+        raise ValueError(f"unknown field '{name}'")
+
+    @classmethod
+    def solver_field(cls, svr, name):
+        """Return the named field over ``svr``'s body (non-ghost) cells."""
+        ng = svr.ngstcell
+        return cls.compute_field(name, svr.so0n.ndarray[ng:],
+                                 svr.gamma.ndarray[ng:], svr.ndim)
+
+    def _on_viewer_toggled(self, open_):
+        self._viewer_btn.setText("Close viewer" if open_ else "Open viewer")
+        if self.viewer_toggled is not None:
+            self.viewer_toggled(open_)
+
+    def _on_start_clicked(self):
+        if self.start_requested is not None:
+            self.start_requested()
+
+    def _on_pause_toggled(self, paused):
+        self._pause.setText("Resume" if paused else "Pause")
+        if self.pause_toggled is not None:
+            self.pause_toggled(paused)
+
+    def _on_step_clicked(self):
+        if self.step_requested is not None:
+            self.step_requested()
+
+    def _on_field_changed(self, name):
+        if self.field_changed is not None:
+            self.field_changed(name)
+
+
+class SolutionInfo(_gui_common.PilotFeature):
+    """Euler solver panel, toggled from the View "Panels" submenu.
+
+    The panel owns one domain viewer sub-window and one solver run.  The viewer
+    control opens and closes the sub-window; starting marches the driver into
+    it on a timer; closing it stops the march.
+    """
+
+    #: Stop the timer-driven march after this many steps.
+    MAX_STEPS = 2000
+    #: Qt timer interval in milliseconds.
+    INTERVAL_MS = 50
+
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        # Fired after a run sets the viewer mesh, so the inspector can refresh.
+        self.viewer_updated = None
+        self._action = None
+        self._dock = None
+        self._panel = None
+        self._session = None
+        self._viewer = None
+        self._subwin = None
+        self._close_filter = None
+        # Held for the panel's lifetime: a throwaway mdiArea wrapper is
+        # garbage-collected right after use, invalidating any sub-window handle
+        # taken through it.
+        self._mdi = None
+
+    def populate_menu(self):
+        self._action = self.add_action(
+            "View/Panels", "Euler solver", "Toggle the Euler solver panel",
+            None, id="panel.euler_solver", weight=20, checkable=True)
+        self._action.toggled.connect(self._on_toggled)
+
+    def _on_toggled(self, checked):
+        if checked:
+            self._ensure_panel()
+            self._dock.show()
+        elif self._dock is not None:
+            self._dock.hide()
+
+    def _ensure_panel(self):
+        if self._panel is not None:
+            return
+        self._panel = SolutionPanel()
+        self._panel.viewer_toggled = self._on_viewer
+        self._panel.start_requested = self._on_start
+        self._panel.pause_toggled = self._on_pause
+        self._panel.step_requested = self._on_step
+        self._panel.field_changed = self._on_field
+        self._dock = QDockWidget("euler solver")
+        self._dock.setWidget(self._panel)
+        self._mgr.mainWindow.addDockWidget(Qt.LeftDockWidgetArea, self._dock)
+        self._dock.visibilityChanged.connect(self._action.setChecked)
+
+    def _on_viewer(self, open_):
+        if open_:
+            self._open_viewer()
+        else:
+            self._close_viewer()
+
+    def _open_viewer(self):
+        """Open the domain viewer sub-window if it is not already open."""
+        if self._viewer is not None:
+            return
+        self._viewer = self._mgr.add3DWidget()
+        self._viewer.showAxis(True)
+        # Delete the sub-window on close and watch for that close, so a close
+        # from any source stops the march before Qt frees the viewer.
+        if self._mdi is None:
+            self._mdi = self._mgr.mdiArea
+        self._subwin = self._mdi.activeSubWindow()
+        if self._subwin is not None:
+            self._subwin.setAttribute(Qt.WA_DeleteOnClose, True)
+            self._close_filter = _SubWindowCloseFilter(
+                self._on_viewer_closed, self._subwin)
+            self._subwin.installEventFilter(self._close_filter)
+        self._panel.set_viewer_open(True)
+
+    def _close_viewer(self):
+        """Close the viewer sub-window; its close event stops the run."""
+        if self._subwin is not None:
+            self._subwin.close()
+        else:
+            self._on_viewer_closed()
+
+    def _on_viewer_closed(self):
+        # Reached from the sub-window's close event; stop the run and drop the
+        # viewer before Qt frees it.
+        self._stop_timer()
+        self._viewer = None
+        self._subwin = None
+        self._close_filter = None
+        self._panel.set_viewer_open(False)
+
+    def _viewer_alive(self):
+        """True while the viewer is open; the close filter clears it."""
+        return self._viewer is not None
+
+    def _on_start(self):
+        """(Re)build the driver from the controls and march into the viewer,
+        opening the viewer sub-window first if it was closed."""
+        self._stop_timer()
+        self._open_viewer()
+        params = self._panel.params()
+        shock = oblique.ObliqueShock()
+        shock.build_constant(gamma=params['gamma'],
+                             density=params['density'],
+                             pressure=params['pressure'],
+                             mach=params['mach'])
+        shock.build_numerical(cell_type=params['cell_type'],
+                              time_increment=params['time_increment'])
+        # Set the viewer mesh so the inspector can report it; reusing an open
+        # viewer raises no activation, so nudge the inspector directly.
+        if self._viewer is not None:
+            self._viewer.updateMesh(shock.mesh)
+            if self.viewer_updated is not None:
+                self.viewer_updated()
+        fan, counts = _field_render.cell_triangulation(shock.mesh)
+        # updateColorField wants an indexed vertex soup; the fan already is
+        # one, so pack its vertices once (the geometry is fixed for the run)
+        # and index them sequentially.
+        verts = fan.pack_array().ndarray.reshape(-1, 3)
+        indices = np.arange(verts.shape[0], dtype='uint32').reshape(-1, 3)
+        timer = QTimer()
+        timer.timeout.connect(self._advance)
+        self._session = dict(
+            shock=shock, timer=timer, counts=counts,
+            verts=core.SimpleArrayFloat32(array=verts),
+            indices=core.SimpleArrayUint32(array=indices), step=0)
+        self._panel.set_paused(False)
+        self._draw_frame()
+        timer.start(self.INTERVAL_MS)
+
+    def _on_pause(self, paused):
+        if self._session is None:
+            return
+        if paused:
+            self._session['timer'].stop()
+        elif self._viewer_alive():
+            self._session['timer'].start(self.INTERVAL_MS)
+
+    def _on_step(self):
+        if self._session is not None and self._viewer_alive():
+            self._march_frame()
+
+    def _on_field(self, _name):
+        if self._session is not None:
+            self._draw_frame()
+
+    def _advance(self):
+        if not self._viewer_alive():
+            self._stop_timer()
+            return
+        if self._session['step'] >= self.MAX_STEPS:
+            self._session['timer'].stop()
+            self._panel.set_paused(True)
+            return
+        self._march_frame()
+
+    def _march_frame(self):
+        session = self._session
+        steps = self._panel.steps_per_frame()
+        session['shock'].march(steps)
+        session['step'] += steps
+        self._draw_frame()
+
+    def _draw_frame(self):
+        if not self._viewer_alive():
+            return
+        session = self._session
+        field = SolutionPanel.solver_field(session['shock'].svr,
+                                           self._panel.field())
+        vmin, vmax = float(field.min()), float(field.max())
+        colors = _field_render.field_colors(field, session['counts'],
+                                            vmin, vmax)
+        self._viewer.updateColorField(
+            session['verts'], core.SimpleArrayFloat32(array=colors),
+            session['indices'])
+        self._panel.set_status(session['step'], vmin, vmax)
+
+    def _stop_timer(self):
+        if self._session is not None:
+            self._session['timer'].stop()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -17,6 +17,7 @@ if _pcore.enable:
     from . import _gui_common
     from . import _mesh
     from . import _tree_panel
+    from ._euler import _solution_info
     from ._euler import _oblique
     from . import _euler1d
     from . import _burgers1d
@@ -58,6 +59,7 @@ class _Controller(metaclass=_Singleton):
         self.gmsh_dialog = None
         self.svg_dialog = None
         self.tree_panel = None
+        self.solution_info = None
         self.sample_mesh = None
         self.mesh_style_status = None
         self.oblique_shock = None
@@ -106,6 +108,8 @@ class _Controller(metaclass=_Singleton):
         self.mesh_style_status = _mesh.MeshStyleStatus(mgr=self._rmgr)
         self.tree_panel = _tree_panel.TreePanel(
             mgr=self._rmgr, style_status=self.mesh_style_status)
+        self.solution_info = _solution_info.SolutionInfo(mgr=self._rmgr)
+        self.solution_info.viewer_updated = self.tree_panel.resync
         self.oblique_shock = _oblique.ObliqueShockMesh(mgr=self._rmgr)
         self.naca4airfoil = airfoil.Naca4Airfoil(mgr=self._rmgr)
         self.mesh_sample_dialog = _mesh.SampleMeshDialog(
@@ -153,6 +157,7 @@ class _Controller(metaclass=_Singleton):
         self.svg_dialog.populate_menu()
         self.save_2d_canvas.populate_menu()
         self.tree_panel.populate_menu()
+        self.solution_info.populate_menu()
         self.painter.populate_menu()
         self.mesh_sample_dialog.populate_menu()
         self.mesh_style_status.populate_menu()

--- a/solvcon/pilot/_tree_panel.py
+++ b/solvcon/pilot/_tree_panel.py
@@ -779,6 +779,15 @@ class TreePanel(_gui_common.PilotFeature):
         if self._dock is not None and self._action.isChecked():
             QTimer.singleShot(0, self._sync)
 
+    def resync(self):
+        """Refresh the shown tree for the active viewer.
+
+        A feature that rebuilds the active viewer's mesh in place raises no
+        activation, so it calls this to refresh the otherwise stale tree.
+        """
+        if self._stack is not None and self._action.isChecked():
+            self._sync()
+
     def _sync(self):
         """Select the tree that matches the active sub-window.
 

--- a/tests/test_pilot_bar.py
+++ b/tests/test_pilot_bar.py
@@ -47,7 +47,8 @@ class BarStructureTC(unittest.TestCase):
         panels = [a.text() for a in model.menu("View/Panels").actions()]
         self.assertEqual(
             list(dict.fromkeys(panels)),
-            ["Inspector", "Painter", "Console", "Terminal", "Agent Console"])
+            ["Inspector", "Euler solver", "Painter", "Console", "Terminal",
+             "Agent Console"])
 
         # The Console and Terminal toggles live with the other panel toggles;
         # the Window menu holds only the dynamic sub-window list.

--- a/tests/test_pilot_solution_info.py
+++ b/tests/test_pilot_solution_info.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import math
+import unittest
+
+import numpy as np
+
+import solvcon
+from solvcon.multidim.euler import oblique
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot import _gui
+    from solvcon.pilot._euler import _solution_info
+    from PySide6.QtWidgets import QApplication
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class ComputeFieldTC(unittest.TestCase):
+    """The derived-field math is independent of Qt, so it runs in CI."""
+
+    # A single cell at rho=1, u=(2, 0), p=1, gamma=1.4; the conserved row is
+    # [rho, rho*u, rho*v, E] with E = p/(gamma-1) + 0.5*rho*|u|^2.
+    GAMMA = 1.4
+    CONS = np.array([[1.0, 2.0, 0.0, 1.0 / 0.4 + 2.0]], dtype='float64')
+
+    def _field(self, name):
+        gamma = np.array([self.GAMMA], dtype='float64')
+        return _solution_info.SolutionPanel.compute_field(
+            name, self.CONS, gamma, ndim=2)[0]
+
+    def test_primitive_fields(self):
+        self.assertAlmostEqual(self._field('density'), 1.0)
+        self.assertAlmostEqual(self._field('velocity-x'), 2.0)
+        self.assertAlmostEqual(self._field('velocity-y'), 0.0)
+        self.assertAlmostEqual(self._field('speed'), 2.0)
+        self.assertAlmostEqual(self._field('energy'), 1.0 / 0.4 + 2.0)
+
+    def test_pressure_and_mach(self):
+        # Pressure inverts the energy relation; Mach divides the speed by the
+        # local speed of sound sqrt(gamma p / rho).
+        self.assertAlmostEqual(self._field('pressure'), 1.0)
+        self.assertAlmostEqual(self._field('mach'), 2.0 / math.sqrt(1.4))
+
+    def test_unknown_field_raises(self):
+        with self.assertRaises(ValueError):
+            self._field('nonesuch')
+
+    def test_solver_field_excludes_ghost(self):
+        # solver_field must slice off the ghost rows so the field spans only
+        # the body cells, matching the raw density column.
+        shock = oblique.ObliqueShock()
+        shock.build_constant()
+        shock.build_numerical(cell_type='quad', nx=8, ny=4)
+        shock.march(2)
+        svr = shock.svr
+        density = _solution_info.SolutionPanel.solver_field(svr, 'density')
+        self.assertEqual(density.shape[0], svr.ncell)
+        np.testing.assert_array_equal(
+            density, svr.so0n.ndarray[svr.ngstcell:, 0])
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class SolutionInfoTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+
+    def _feature(self):
+        feature = _solution_info.SolutionInfo(mgr=self.mgr)
+        feature.populate_menu()
+        feature._action.setChecked(True)  # builds the dock and panel
+        return feature
+
+    def test_panel_starts_paused_without_session(self):
+        feature = self._feature()
+        # Before Start there is no run, and the status tree says so.
+        self.assertIsNone(feature._session)
+        root = feature._panel._tree.topLevelItem(0)
+        self.assertIn("not started", root.text(0))
+
+    def test_start_builds_session_and_viewer(self):
+        feature = self._feature()
+        feature._panel._mach.setValue(2.5)
+        feature._on_start()
+        # Stop the timer so the heavy march does not run during the test.
+        feature._session['timer'].stop()
+        self.assertIsNotNone(feature._session)
+        self.assertEqual(feature._session['step'], 0)
+        self.assertIsNotNone(self.mgr.currentR3DWidget())
+        sections = [feature._panel._tree.topLevelItem(i).text(0)
+                    for i in range(feature._panel._tree.topLevelItemCount())]
+        self.assertTrue(any(s.startswith("step: 0") for s in sections))
+
+    def test_start_sets_viewer_mesh_for_inspector(self):
+        feature = self._feature()
+        feature._on_start()
+        feature._session['timer'].stop()
+        # The inspector reads the active viewer's mesh; the solver viewer must
+        # carry the run's mesh so the mesh panel is not empty during a run.
+        self.assertIsNotNone(self.mgr.currentR3DWidget().mesh)
+        QApplication.processEvents()
+
+    def test_start_notifies_viewer_updated(self):
+        feature = self._feature()
+        calls = []
+        feature.viewer_updated = lambda: calls.append(1)
+        # Opening the viewer first and then starting reuses it, which raises no
+        # sub-window activation, so start must notify the inspector itself.
+        feature._panel._viewer_btn.setChecked(True)
+        feature._on_start()
+        feature._session['timer'].stop()
+        self.assertEqual(len(calls), 1)
+        QApplication.processEvents()
+
+    def test_step_advances_one_frame(self):
+        feature = self._feature()
+        feature._on_start()
+        feature._session['timer'].stop()
+        feature._panel.set_paused(True)
+        feature._panel._steps.setValue(3)
+        feature._on_step()
+        self.assertEqual(feature._session['step'], 3)
+
+    def test_pause_toggle_controls_timer(self):
+        feature = self._feature()
+        feature._on_start()
+        feature._panel._pause.setChecked(True)
+        self.assertFalse(feature._session['timer'].isActive())
+        feature._panel._pause.setChecked(False)
+        self.assertTrue(feature._session['timer'].isActive())
+        feature._session['timer'].stop()
+
+    def test_field_change_redraws_without_marching(self):
+        feature = self._feature()
+        feature._on_start()
+        feature._session['timer'].stop()
+        feature._panel._pause.setChecked(True)
+        step = feature._session['step']
+        feature._panel._field.setCurrentText('pressure')
+        # Picking a field recolors the current frame; it must not march.
+        self.assertEqual(feature._session['step'], step)
+        root = feature._panel._tree.topLevelItem(1)
+        self.assertIn("pressure", root.text(0))
+
+    def test_viewer_button_opens_and_closes_subwindow(self):
+        feature = self._feature()
+        feature._panel._viewer_btn.setChecked(True)
+        self.assertIsNotNone(feature._viewer)
+        self.assertIsNotNone(self.mgr.currentR3DWidget())
+        feature._panel._viewer_btn.setChecked(False)
+        self.assertIsNone(feature._viewer)
+        QApplication.processEvents()
+
+    def test_closing_viewer_stops_run_without_drawing(self):
+        feature = self._feature()
+        feature._on_start()
+        # Closing the domain sub-window while marching must stop the timer,
+        # drop the viewer, and leave later frames as no-ops rather than
+        # drawing into the freed widget.
+        feature._close_viewer()
+        self.assertIsNone(feature._viewer)
+        self.assertFalse(feature._session['timer'].isActive())
+        self.assertFalse(feature._panel._viewer_btn.isChecked())
+        step = feature._session['step']
+        feature._advance()
+        feature._draw_frame()
+        self.assertEqual(feature._session['step'], step)
+        QApplication.processEvents()
+
+    def test_start_reopens_a_closed_viewer(self):
+        feature = self._feature()
+        feature._on_start()
+        feature._close_viewer()
+        feature._on_start()
+        feature._session['timer'].stop()
+        self.assertIsNotNone(feature._viewer)
+        self.assertTrue(feature._panel._viewer_btn.isChecked())
+        QApplication.processEvents()
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class SolutionInspectorTC(unittest.TestCase):
+    """The wired controller refreshes the inspector when a run sets the
+    mesh."""
+
+    def test_open_viewer_then_start_populates_inspector(self):
+        ctl = _gui.controller
+        ctl.build()
+        ctl.tree_panel._action.setChecked(True)
+        sol = ctl.solution_info
+        sol._action.setChecked(True)
+        # Open the viewer first, then start: the reused viewer raises no
+        # activation, so only the wired refresh keeps the inspector from
+        # standing on "No mesh loaded".
+        sol._panel._viewer_btn.setChecked(True)
+        QApplication.processEvents()
+        sol._on_start()
+        sol._session['timer'].stop()
+        QApplication.processEvents()
+        root = ctl.tree_panel._mesh_tree._tree.topLevelItem(0)
+        self.assertEqual(root.text(0), "StaticMesh (2D)")
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
(This PR stacked on the refactoring PR #1161.)

Add SolutionInfo, a dock panel toggled from the View "Panels" submenu (labeled "Euler solver") next to the inspector panel.  The panel owns one domain viewer sub-window and one solver run: an "Open viewer" / "Close viewer" control opens and closes the sub-window; Start, Pause, Resume, and Step drive the CESE march into that viewer; and a field selector chooses which derived field the viewer colors.

`SolutionPanel.compute_field` derives density, velocity, speed, pressure, Mach, and energy from the conserved variables, taking pressure from the ideal-gas relation and Mach from the local speed of sound.  A `_field_render` helper fans each cell into a TrianglePad of flat-colored triangles.

Closing the viewer sub-window mid-run would draw into the freed `QRhi` viewer and crash the pilot; a close-event filter stops the run first.  Starting also registers the run's mesh with the viewer and refreshes the inspector through `TreePanel.resync`, so the mesh panel reports the running mesh.

Tests cover the derived-field math without Qt (so they run in CI) and the panel controls, viewer lifecycle, and inspector refresh under the GUI.

For issue #404.