### PR TITLE
Collect linalg bindings in a local macro

### DIFF
--- a/cpp/solvcon/linalg/pymod/wrap_factorization.cpp
+++ b/cpp/solvcon/linalg/pymod/wrap_factorization.cpp
@@ -12,74 +12,17 @@ namespace python
 {
 
 template <typename T>
-void def_llt_factorization(pybind11::module & mod)
+auto lu_det_for_python(SimpleArray<T> const & a)
 {
-    mod.def(
-        "llt_factorization", [](SimpleArray<T> const & a)
-        { return llt_factorization(a); },
-        pybind11::arg("a"));
-}
-
-template <typename T>
-void def_llt_solve(pybind11::module & mod)
-{
-    mod.def(
-        "llt_solve", [](SimpleArray<T> const & a, SimpleArray<T> const & b)
-        { return llt_solve(a, b); },
-        pybind11::arg("a"),
-        pybind11::arg("b"));
-}
-
-template <typename T>
-void def_lu_factorization(pybind11::module & mod)
-{
-    mod.def(
-        "lu_factorization", [](SimpleArray<T> const & a)
-        {
-            auto [lu, piv] = lu_factorization(a);
-            return pybind11::make_tuple(lu, piv); },
-        pybind11::arg("a"));
-}
-
-// Python binding for lu_solve().  Solves Ax = b for general matrices.
-template <typename T>
-void def_lu_solve(pybind11::module & mod)
-{
-    mod.def(
-        "lu_solve", [](SimpleArray<T> const & a, SimpleArray<T> const & b)
-        { return lu_solve(a, b); },
-        pybind11::arg("a"),
-        pybind11::arg("b"));
-}
-
-// Python binding for lu_inv().  Computes A^(-1) for general matrices.
-template <typename T>
-void def_lu_inv(pybind11::module & mod)
-{
-    mod.def(
-        "lu_inv", [](SimpleArray<T> const & a)
-        { return lu_inv(a); },
-        pybind11::arg("a"));
-}
-
-// Python binding for lu_det().  Computes det(A) for general matrices.
-template <typename T>
-void def_lu_det(pybind11::module & mod)
-{
-    mod.def(
-        "lu_det", [](SimpleArray<T> const & a)
-        {
-            // Complex<T> has no pybind11 caster; convert to std::complex
-            // (which pybind11 maps to a Python complex) for complex T.
-            if constexpr (is_complex_v<T>)
-            {
-                return lu_det(a).to_std_complex();
-            }
-            else
-            {
-                return lu_det(a);
-            } },
-        pybind11::arg("a"));
+    if constexpr (is_complex_v<T>)
+    {
+        // Complex<T> has no pybind11 caster.
+        return lu_det(a).to_std_complex();
+    }
+    else
+    {
+        return lu_det(a);
+    }
 }
 
 // Attach .solve() and .inv() methods to an already-registered SimpleArray
@@ -104,53 +47,58 @@ void add_simple_array_lu_methods(pybind11::module & mod, char const * pyname)
         "Compute matrix inverse");
     cls.attr("det") = py::cpp_function(
         [](SimpleArray<T> const & self)
-        {
-            // Complex<T> has no pybind11 caster; convert to std::complex
-            // (which pybind11 maps to a Python complex) for complex T.
-            if constexpr (is_complex_v<T>)
-            {
-                return lu_det(self).to_std_complex();
-            }
-            else
-            {
-                return lu_det(self);
-            }
-        },
+        { return lu_det_for_python(self); },
         py::is_method(cls),
         "Compute matrix determinant");
 }
 
 void wrap_factorization(pybind11::module & mod)
 {
-    def_llt_factorization<float>(mod);
-    def_llt_factorization<double>(mod);
-    def_llt_factorization<Complex<float>>(mod);
-    def_llt_factorization<Complex<double>>(mod);
+    // clang-format off
+#define MM_DECL_LADEF(T)                                                     \
+    mod.def(                                                                 \
+        "llt_factorization",                                                 \
+        [](SimpleArray<T> const & a)                                         \
+        { return llt_factorization(a); },                                    \
+        pybind11::arg("a"));                                                 \
+    mod.def(                                                                 \
+        "llt_solve",                                                         \
+        [](SimpleArray<T> const & a, SimpleArray<T> const & b)               \
+        { return llt_solve(a, b); },                                         \
+        pybind11::arg("a"),                                                  \
+        pybind11::arg("b"));                                                 \
+    mod.def(                                                                 \
+        "lu_factorization",                                                  \
+        [](SimpleArray<T> const & a)                                         \
+        {                                                                    \
+            auto [lu, piv] = lu_factorization(a);                            \
+            return pybind11::make_tuple(lu, piv);                            \
+        },                                                                   \
+        pybind11::arg("a"));                                                 \
+    mod.def(                                                                 \
+        "lu_solve",                                                          \
+        [](SimpleArray<T> const & a, SimpleArray<T> const & b)               \
+        { return lu_solve(a, b); },                                          \
+        pybind11::arg("a"),                                                  \
+        pybind11::arg("b"));                                                 \
+    mod.def(                                                                 \
+        "lu_inv",                                                            \
+        [](SimpleArray<T> const & a)                                         \
+        { return lu_inv(a); },                                               \
+        pybind11::arg("a"));                                                 \
+    mod.def(                                                                 \
+        "lu_det",                                                            \
+        [](SimpleArray<T> const & a)                                         \
+        { return lu_det_for_python(a); },                                    \
+        pybind11::arg("a"));
+    // clang-format on
 
-    def_llt_solve<float>(mod);
-    def_llt_solve<double>(mod);
-    def_llt_solve<Complex<float>>(mod);
-    def_llt_solve<Complex<double>>(mod);
+    MM_DECL_LADEF(float)
+    MM_DECL_LADEF(double)
+    MM_DECL_LADEF(Complex<float>)
+    MM_DECL_LADEF(Complex<double>)
 
-    def_lu_factorization<float>(mod);
-    def_lu_factorization<double>(mod);
-    def_lu_factorization<Complex<float>>(mod);
-    def_lu_factorization<Complex<double>>(mod);
-
-    def_lu_solve<float>(mod);
-    def_lu_solve<double>(mod);
-    def_lu_solve<Complex<float>>(mod);
-    def_lu_solve<Complex<double>>(mod);
-
-    def_lu_inv<float>(mod);
-    def_lu_inv<double>(mod);
-    def_lu_inv<Complex<float>>(mod);
-    def_lu_inv<Complex<double>>(mod);
-
-    def_lu_det<float>(mod);
-    def_lu_det<double>(mod);
-    def_lu_det<Complex<float>>(mod);
-    def_lu_det<Complex<double>>(mod);
+#undef MM_DECL_LADEF
 
     // Integer arrays are deliberately excluded: LU decomposition involves
     // division, which would silently truncate under integer arithmetic.


### PR DESCRIPTION
The factorization Python module repeats the same `mod.def` bindings for each supported element type, which spreads one API definition across several template helpers and registration blocks.

Collect the LLT and LU bindings in one function-local, type-parameterized macro, expand it for the four supported types, and immediately `#undef` it. Keep determinant result conversion in a template helper so real and complex types retain their existing Python return values.

Related to #892.
