### PR TITLE
Reuse the shared shape formatter in linalg

### DIFF
--- a/cpp/solvcon/linalg/EigenSystem.hpp
+++ b/cpp/solvcon/linalg/EigenSystem.hpp
@@ -95,8 +95,6 @@ public:
 
 private:
 
-    static std::string format_shape(array_type const & arr);
-
     array_type const & m_matrix;
     array_type m_colmajor;
     real_array_type m_wr;
@@ -125,7 +123,7 @@ EigenSystem<T>::EigenSystem(array_type const & matrix, bool do_vl, bool do_vr, c
     {
         throw std::invalid_argument(std::format(
             "EigenSystem: matrix must be a square 2D SimpleArray, but got shape {}",
-            format_shape(matrix)));
+            detail::format_shape(matrix.shape())));
     }
 
     // Result buffers stay uninitialized: *GEEV never reads them on entry and
@@ -284,22 +282,6 @@ EigenSystem<T>::array_type const & EigenSystem<T>::vr(bool suppress_exception) c
             "(do_vr=false)");
     }
     return m_vr;
-}
-
-template <typename T>
-std::string EigenSystem<T>::format_shape(array_type const & arr)
-{
-    std::string result = "(";
-    for (size_t i = 0; i < arr.ndim(); ++i)
-    {
-        if (i > 0)
-        {
-            result += ", ";
-        }
-        result += std::to_string(arr.shape(i));
-    }
-    result += ")";
-    return result;
 }
 
 /**

--- a/cpp/solvcon/linalg/factorization.hpp
+++ b/cpp/solvcon/linalg/factorization.hpp
@@ -54,31 +54,15 @@ Llt<T>::array_type Llt<T>::forward_substitution(array_type const & l, array_type
     if (l.ndim() != 2 || l.shape(0) != l.shape(1))
     {
         std::ostringstream oss;
-        oss << "Llt::forward_substitution: The first argument l must be a square 2D SimpleArray, but got shape (";
-        for (ssize_t i = 0; i < l.ndim(); ++i)
-        {
-            if (i > 0)
-            {
-                oss << ", ";
-            }
-            oss << l.shape(i);
-        }
-        oss << ")";
+        oss << "Llt::forward_substitution: The first argument l must be a square 2D SimpleArray, but got shape "
+            << detail::format_shape(l.shape());
         throw std::invalid_argument(oss.str());
     }
     if (b.ndim() != 2 || b.shape(0) != l.shape(0))
     {
         std::ostringstream oss;
-        oss << "Llt::forward_substitution: The second argument b must be a 2D SimpleArray with first dimension matching l, but got shape (";
-        for (ssize_t i = 0; i < b.ndim(); ++i)
-        {
-            if (i > 0)
-            {
-                oss << ", ";
-            }
-            oss << b.shape(i);
-        }
-        oss << ")";
+        oss << "Llt::forward_substitution: The second argument b must be a 2D SimpleArray with first dimension matching l, but got shape "
+            << detail::format_shape(b.shape());
         throw std::invalid_argument(oss.str());
     }
 
@@ -107,31 +91,15 @@ Llt<T>::array_type Llt<T>::backward_substitution(array_type const & l, array_typ
     if (l.ndim() != 2 || l.shape(0) != l.shape(1))
     {
         std::ostringstream oss;
-        oss << "Llt::backward_substitution: The first argument l must be a square 2D SimpleArray, but got shape (";
-        for (ssize_t i = 0; i < l.ndim(); ++i)
-        {
-            if (i > 0)
-            {
-                oss << ", ";
-            }
-            oss << l.shape(i);
-        }
-        oss << ")";
+        oss << "Llt::backward_substitution: The first argument l must be a square 2D SimpleArray, but got shape "
+            << detail::format_shape(l.shape());
         throw std::invalid_argument(oss.str());
     }
     if (y.ndim() != 2 || y.shape(0) != l.shape(0))
     {
         std::ostringstream oss;
-        oss << "Llt::backward_substitution: The second argument y must be a 2D SimpleArray with first dimension matching l, but got shape (";
-        for (ssize_t i = 0; i < y.ndim(); ++i)
-        {
-            if (i > 0)
-            {
-                oss << ", ";
-            }
-            oss << y.shape(i);
-        }
-        oss << ")";
+        oss << "Llt::backward_substitution: The second argument y must be a 2D SimpleArray with first dimension matching l, but got shape "
+            << detail::format_shape(y.shape());
         throw std::invalid_argument(oss.str());
     }
 
@@ -160,16 +128,8 @@ Llt<T>::array_type Llt<T>::factorize(array_type const & a)
     if (a.ndim() != 2 || a.shape(0) != a.shape(1))
     {
         std::ostringstream oss;
-        oss << "Llt::factorize: The first argument a must be a square 2D SimpleArray, but got shape (";
-        for (ssize_t i = 0; i < a.ndim(); ++i)
-        {
-            if (i > 0)
-            {
-                oss << ", ";
-            }
-            oss << a.shape(i);
-        }
-        oss << ")";
+        oss << "Llt::factorize: The first argument a must be a square 2D SimpleArray, but got shape "
+            << detail::format_shape(a.shape());
         throw std::invalid_argument(oss.str());
     }
 
@@ -211,16 +171,8 @@ Llt<T>::array_type Llt<T>::solve(array_type const & a, array_type const & b)
     if (a.ndim() != 2 || a.shape(0) != a.shape(1))
     {
         std::ostringstream oss;
-        oss << "Llt::solve: The first argument a must be a square 2D SimpleArray, but got shape (";
-        for (ssize_t i = 0; i < a.ndim(); ++i)
-        {
-            if (i > 0)
-            {
-                oss << ", ";
-            }
-            oss << a.shape(i);
-        }
-        oss << ")";
+        oss << "Llt::solve: The first argument a must be a square 2D SimpleArray, but got shape "
+            << detail::format_shape(a.shape());
         throw std::invalid_argument(oss.str());
     }
     if (a.shape(0) != b.shape(0))

--- a/cpp/solvcon/linalg/kalman_filter.hpp
+++ b/cpp/solvcon/linalg/kalman_filter.hpp
@@ -347,91 +347,43 @@ void KalmanFilter<T>::check_dimensions()
     if (m_f.ndim() != 2 || m_f.shape(0) != m_state_size || m_f.shape(1) != m_state_size)
     {
         std::ostringstream oss;
-        oss << "KalmanFilter::check_dimensions: The state transition SimpleArray f must be state_sizexstate_size, but got shape (";
-        for (ssize_t i = 0; i < m_f.ndim(); ++i)
-        {
-            if (i > 0)
-            {
-                oss << ", ";
-            }
-            oss << m_f.shape(i);
-        }
-        oss << ")";
+        oss << "KalmanFilter::check_dimensions: The state transition SimpleArray f must be state_sizexstate_size, but got shape "
+            << detail::format_shape(m_f.shape());
         throw std::invalid_argument(oss.str());
     }
     if (m_h.ndim() != 2 || m_h.shape(0) != m_measurement_size || m_h.shape(1) != m_state_size)
     {
         std::ostringstream oss;
-        oss << "KalmanFilter::check_dimensions: The measurement SimpleArray h must be measurement_sizexstate_size, but got shape (";
-        for (ssize_t i = 0; i < m_h.ndim(); ++i)
-        {
-            if (i > 0)
-            {
-                oss << ", ";
-            }
-            oss << m_h.shape(i);
-        }
-        oss << ")";
+        oss << "KalmanFilter::check_dimensions: The measurement SimpleArray h must be measurement_sizexstate_size, but got shape "
+            << detail::format_shape(m_h.shape());
         throw std::invalid_argument(oss.str());
     }
     if (m_q.ndim() != 2 || m_q.shape(0) != m_state_size || m_q.shape(1) != m_state_size)
     {
         std::ostringstream oss;
-        oss << "KalmanFilter::check_dimensions: The process noise covariance SimpleArray q must be state_sizexstate_size, but got shape (";
-        for (ssize_t i = 0; i < m_q.ndim(); ++i)
-        {
-            if (i > 0)
-            {
-                oss << ", ";
-            }
-            oss << m_q.shape(i);
-        }
-        oss << ")";
+        oss << "KalmanFilter::check_dimensions: The process noise covariance SimpleArray q must be state_sizexstate_size, but got shape "
+            << detail::format_shape(m_q.shape());
         throw std::invalid_argument(oss.str());
     }
     if (m_r.ndim() != 2 || m_r.shape(0) != m_measurement_size || m_r.shape(1) != m_measurement_size)
     {
         std::ostringstream oss;
-        oss << "KalmanFilter::check_dimensions: The measurement noise covariance SimpleArray r must be measurement_sizexmeasurement_size, but got shape (";
-        for (ssize_t i = 0; i < m_r.ndim(); ++i)
-        {
-            if (i > 0)
-            {
-                oss << ", ";
-            }
-            oss << m_r.shape(i);
-        }
-        oss << ")";
+        oss << "KalmanFilter::check_dimensions: The measurement noise covariance SimpleArray r must be measurement_sizexmeasurement_size, but got shape "
+            << detail::format_shape(m_r.shape());
         throw std::invalid_argument(oss.str());
     }
     if (m_p.ndim() != 2 || m_p.shape(0) != m_state_size || m_p.shape(1) != m_state_size)
     {
         std::ostringstream oss;
-        oss << "KalmanFilter::check_dimensions: The state covariance SimpleArray p must be state_sizexstate_size, but got shape (";
-        for (ssize_t i = 0; i < m_p.ndim(); ++i)
-        {
-            if (i > 0)
-            {
-                oss << ", ";
-            }
-            oss << m_p.shape(i);
-        }
-        oss << ")";
+        oss << "KalmanFilter::check_dimensions: The state covariance SimpleArray p must be state_sizexstate_size, but got shape "
+            << detail::format_shape(m_p.shape());
         throw std::invalid_argument(oss.str());
     }
     if (m_x.ndim() != 1 || m_x.shape(0) != m_state_size)
     {
         std::ostringstream oss;
-        oss << "KalmanFilter::check_dimensions: The state SimpleArray x must be 1D of length state_size, but got shape (";
-        for (ssize_t i = 0; i < m_x.ndim(); ++i)
-        {
-            if (i > 0)
-            {
-                oss << ", ";
-            }
-            oss << m_x.shape(i);
-        }
-        oss << ")";
+        oss << "KalmanFilter::check_dimensions: The state SimpleArray x must be 1D of length state_size, but got shape "
+            << detail::format_shape(m_x.shape());
         throw std::invalid_argument(oss.str());
     }
 
@@ -446,16 +398,8 @@ void KalmanFilter<T>::check_dimensions()
         if (m_b.shape(0) != m_state_size || m_b.shape(1) != m_control_size)
         {
             std::ostringstream oss;
-            oss << "KalmanFilter::check_dimensions: The control SimpleArray b must be state_sizexcontrol_size, but got shape (";
-            for (ssize_t i = 0; i < m_b.ndim(); ++i)
-            {
-                if (i > 0)
-                {
-                    oss << ", ";
-                }
-                oss << m_b.shape(i);
-            }
-            oss << ")";
+            oss << "KalmanFilter::check_dimensions: The control SimpleArray b must be state_sizexcontrol_size, but got shape "
+                << detail::format_shape(m_b.shape());
             throw std::invalid_argument(oss.str());
         }
     }
@@ -464,16 +408,8 @@ void KalmanFilter<T>::check_dimensions()
         if (m_b.ndim() != 2 || m_b.shape(1) != 0)
         {
             std::ostringstream oss;
-            oss << "KalmanFilter::check_dimensions: The control SimpleArray b must be state_sizex0 when control_size = 0, but got shape (";
-            for (ssize_t i = 0; i < m_b.ndim(); ++i)
-            {
-                if (i > 0)
-                {
-                    oss << ", ";
-                }
-                oss << m_b.shape(i);
-            }
-            oss << ")";
+            oss << "KalmanFilter::check_dimensions: The control SimpleArray b must be state_sizex0 when control_size = 0, but got shape "
+                << detail::format_shape(m_b.shape());
             throw std::invalid_argument(oss.str());
         }
     }
@@ -507,16 +443,8 @@ void KalmanFilter<T>::check_measurement(array_type const & z)
     if (z.ndim() != 1 || z.shape(0) != m_measurement_size)
     {
         std::ostringstream oss;
-        oss << "KalmanFilter::check_measurement: The measurement SimpleArray z must be 1D of length measurement_size (" << m_measurement_size << "), but got shape (";
-        for (ssize_t i = 0; i < z.ndim(); ++i)
-        {
-            if (i > 0)
-            {
-                oss << ", ";
-            }
-            oss << z.shape(i);
-        }
-        oss << ")";
+        oss << "KalmanFilter::check_measurement: The measurement SimpleArray z must be 1D of length measurement_size ("
+            << m_measurement_size << "), but got shape " << detail::format_shape(z.shape());
         throw std::invalid_argument(oss.str());
     }
 }
@@ -533,16 +461,8 @@ void KalmanFilter<T>::check_control(array_type const & u)
     if (u.ndim() != 1 || u.shape(0) != m_control_size)
     {
         std::ostringstream oss;
-        oss << "KalmanFilter::check_control: The control SimpleArray u must be 1D of length control_size (" << m_control_size << "), but got shape (";
-        for (ssize_t i = 0; i < u.ndim(); ++i)
-        {
-            if (i > 0)
-            {
-                oss << ", ";
-            }
-            oss << u.shape(i);
-        }
-        oss << ")";
+        oss << "KalmanFilter::check_control: The control SimpleArray u must be 1D of length control_size ("
+            << m_control_size << "), but got shape " << detail::format_shape(u.shape());
         throw std::invalid_argument(oss.str());
     }
 }

--- a/cpp/solvcon/linalg/lu_factorization.hpp
+++ b/cpp/solvcon/linalg/lu_factorization.hpp
@@ -134,8 +134,6 @@ public:
 
 private:
 
-    static std::string format_shape(array_type const & arr);
-
     // Validate that a is square and 2D; return its shape for member init.
     static small_vector<ssize_t> validate_shape(array_type const & a);
 
@@ -161,29 +159,13 @@ private:
 }; /* end class LuFactorization */
 
 template <typename T>
-std::string LuFactorization<T>::format_shape(array_type const & arr)
-{
-    std::string result = "(";
-    for (size_t i = 0; i < arr.ndim(); ++i)
-    {
-        if (i > 0)
-        {
-            result += ", ";
-        }
-        result += std::to_string(arr.shape(i));
-    }
-    result += ")";
-    return result;
-}
-
-template <typename T>
 small_vector<ssize_t> LuFactorization<T>::validate_shape(array_type const & a)
 {
     if (a.ndim() != 2 || a.shape(0) != a.shape(1))
     {
         throw std::invalid_argument(std::format(
             "LuFactorization: a must be a square 2D SimpleArray, but got shape {}",
-            format_shape(a)));
+            detail::format_shape(a.shape())));
     }
     return a.shape();
 }


### PR DESCRIPTION
Several linalg classes independently format `SimpleArray` shapes for diagnostic messages, and the LLT and Kalman paths repeat the same formatting loop at each validation site.

Reuse the existing shared shape formatter in `Llt`, `LuFactorization`, `KalmanFilter`, and `EigenSystem`. This removes the duplicated helpers and loops without adding another inheritance layer or changing the messages or public API.

Related to #893.