### PR TITLE
Add SVG export for the pilot 2D canvas

### DIFF
--- a/cpp/solvcon/CMakeLists.txt
+++ b/cpp/solvcon/CMakeLists.txt
@@ -30,6 +30,8 @@ if (BUILD_QT)
     find_package(Qt6 QUIET OPTIONAL_COMPONENTS GuiPrivate)
     # ShaderTools provides qt6_add_shaders() and the qsb tool.
     find_package(Qt6 REQUIRED COMPONENTS ShaderTools)
+    # Svg provides QSvgGenerator, used by R2DWidget::saveSvg.
+    find_package(Qt6 REQUIRED COMPONENTS Svg)
 endif () # BUILD_QT
 
 add_subdirectory(buffer)
@@ -120,6 +122,7 @@ if (BUILD_QT)
         Qt::Widgets
         Qt::Core
         Qt::Gui
+        Qt::Svg
     )
 
     # <rhi/qrhi.h> lives in the QtGui private headers. Prefer the GuiPrivate

--- a/cpp/solvcon/pilot/canvas/R2DWidget.cpp
+++ b/cpp/solvcon/pilot/canvas/R2DWidget.cpp
@@ -16,6 +16,8 @@
 #include <QPen>
 #include <QPolygonF>
 #include <QResizeEvent>
+#include <QString>
+#include <QSvgGenerator>
 #include <QWheelEvent>
 
 namespace solvcon
@@ -174,6 +176,34 @@ QImage R2DWidget::renderImage(Overlay2dOptions const & overlay) const
     RWorldRenderer2d(m_world.get(), m_view, overlay)
         .paint_canvas(painter, width(), height(), full_canvas);
     return image;
+}
+
+bool R2DWidget::saveSvg(std::string const & filename, Overlay2dOptions const & overlay) const
+{
+    // SVG is resolution-independent: no devicePixelRatioF scaling here,
+    // unlike renderImage's raster output.
+    QSvgGenerator generator;
+    generator.setFileName(QString::fromStdString(filename));
+    generator.setSize(size());
+    // Without an explicit viewBox, renderers map the unitless drawing
+    // coordinates onto the physical size using the CSS 96-DPI convention,
+    // which does not match the DPI QSvgGenerator itself used to compute
+    // that physical size; the content then renders shrunk into a corner
+    // of the canvas, padded with blank space. An identity viewBox pins
+    // pixel coordinates 1:1 to the canvas regardless of DPI.
+    generator.setViewBox(QRect(QPoint(0, 0), size()));
+    generator.setTitle(QStringLiteral("solvcon 2D canvas"));
+
+    QPainter painter;
+    if (!painter.begin(&generator))
+    {
+        return false;
+    }
+    constexpr bool full_canvas = true;
+    RWorldRenderer2d(m_world.get(), m_view, overlay)
+        .paint_canvas(painter, width(), height(), full_canvas);
+    painter.end();
+    return true;
 }
 
 void R2DWidget::paintDrawPreview(QPainter & painter) const

--- a/cpp/solvcon/pilot/canvas/R2DWidget.hpp
+++ b/cpp/solvcon/pilot/canvas/R2DWidget.hpp
@@ -110,6 +110,16 @@ public:
      */
     QImage renderImage(Overlay2dOptions const & overlay) const;
 
+    /**
+     * Write the widget's current geometry, chrome, and given overlay to
+     * filename as SVG, sized to the widget's current logical width and
+     * height (no device-pixel scaling: SVG is resolution-independent).
+     * Returns whether the file was opened for writing successfully. Like
+     * renderImage, the selection box and any in-progress rubber band stay
+     * out of the exported frame.
+     */
+    bool saveSvg(std::string const & filename, Overlay2dOptions const & overlay) const;
+
     /// Hook for subsequent stages; current implementation triggers a repaint.
     void requestRepaint() { update(); }
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -685,6 +685,18 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapR2DWidget
                 "succeeded. With no overlay, saves the on-screen frame; with "
                 "an Overlay2dOptions, renders that annotation set offscreen "
                 "instead, independent of what the widget currently shows.")
+            .def(
+                "saveSvg",
+                [](wrapped_type & self, std::string const & filename, std::optional<Overlay2dOptions> const & overlay)
+                {
+                    return self.saveSvg(filename, overlay.value_or(self.overlayOptions()));
+                },
+                py::arg("filename"),
+                py::arg("overlay") = py::none(),
+                "Save the canvas to filename as SVG and return whether the "
+                "write succeeded. With no overlay, uses the canvas's "
+                "current on-screen overlay; with an Overlay2dOptions, "
+                "renders that annotation set instead.")
             //
             ;
     }

--- a/solvcon/pilot/canvas/_canvas_gui.py
+++ b/solvcon/pilot/canvas/_canvas_gui.py
@@ -21,13 +21,16 @@ __all__ = [
 
 _PNG_FILTER = "PNG image (*.png)"
 _JPG_FILTER = "JPEG image (*.jpg *.jpeg)"
-_ALLOWED_EXTS = (".png", ".jpg", ".jpeg")
+_SVG_FILTER = "SVG image (*.svg)"
+_ALLOWED_EXTS = (".png", ".jpg", ".jpeg", ".svg")
 
 
 def resolve_save_path(path, name_filter):
-    """Force ``path`` to a png/jpg extension from the chosen name filter.
+    """Force ``path`` to a png/jpg/svg extension from the chosen name
+    filter.
 
-    Returns the resolved path, or ``None`` when the result is not png/jpg.
+    Returns the resolved path, or ``None`` when the result is not
+    png/jpg/svg.
     """
     if not path:
         return None
@@ -40,6 +43,9 @@ def resolve_save_path(path, name_filter):
     elif "jpg" in filt or "jpeg" in filt:
         if ext not in (".jpg", ".jpeg"):
             path = root + ".jpg"
+    elif "svg" in filt:
+        if ext != ".svg":
+            path = root + ".svg"
     elif ext not in _ALLOWED_EXTS:
         return None
     return path
@@ -47,7 +53,8 @@ def resolve_save_path(path, name_filter):
 
 class Save2DCanvasDialog(_gui_common.PilotFeature):
     """
-    File-menu action that saves the focused 2D canvas via ``saveImage``.
+    File-menu action that saves the focused 2D canvas via ``saveImage`` or,
+    for a chosen ``.svg`` path, ``saveSvg``.
 
     The save dialog carries an "Include labels" switch with a normal/advanced
     selector and an independent "Include coordinates" switch, so the exported
@@ -72,7 +79,7 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
         self._diag.setOption(QtWidgets.QFileDialog.DontUseNativeDialog, True)
         self._diag.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
         self._diag.setFileMode(QtWidgets.QFileDialog.AnyFile)
-        self._diag.setNameFilters([_PNG_FILTER, _JPG_FILTER])
+        self._diag.setNameFilters([_PNG_FILTER, _JPG_FILTER, _SVG_FILTER])
         self._diag.setDefaultSuffix("png")
         self._diag.setWindowTitle("Save 2D canvas")
         self._diag.filterSelected.connect(self._on_filter_selected)
@@ -111,7 +118,7 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
         self.add_action(
             "File",
             text="Save 2D canvas",
-            tip="Save the focused 2D canvas as a PNG or JPEG image",
+            tip="Save the focused 2D canvas as a PNG, JPEG, or SVG image",
             func=self.run,
             id="file.save_2d_canvas",
             weight=30,
@@ -146,6 +153,8 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
         filt = (name_filter or "").lower()
         if "jpg" in filt or "jpeg" in filt:
             self._diag.setDefaultSuffix("jpg")
+        elif "svg" in filt:
+            self._diag.setDefaultSuffix("svg")
         else:
             self._diag.setDefaultSuffix("png")
 
@@ -157,7 +166,7 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
         path = resolve_save_path(selected[0], self._diag.selectedNameFilter())
         if path is None:
             self._pycon.writeToHistory(
-                "Save 2D canvas: only png or jpg is allowed\n")
+                "Save 2D canvas: only png, jpg, or svg is allowed\n")
             return
         self._save_current(path)
 
@@ -181,7 +190,11 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
             return False
         # _export_overlay reads the dialog's label controls; build it first.
         self._ensure_dialog()
-        ok = widget.saveImage(path, self._export_overlay(widget))
+        overlay = self._export_overlay(widget)
+        if path.lower().endswith(".svg"):
+            ok = widget.saveSvg(path, overlay)
+        else:
+            ok = widget.saveImage(path, overlay)
         if ok:
             self._pycon.writeToHistory(f"Save 2D canvas: wrote {path}\n")
         else:

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -8,6 +8,7 @@ Tests for R2DWidget and its on-screen screenshot APIs.
 import os
 import tempfile
 import unittest
+from xml.etree import ElementTree
 
 import numpy as np
 
@@ -434,6 +435,41 @@ class R2DWidgetScreenshotTC(unittest.TestCase):
         width, height = _png_size(data)
         self.assertGreater(width, 0)
         self.assertGreater(height, 0)
+
+    def test_save_svg_writes_svg_file(self):
+        """saveSvg writes a well-formed, non-empty SVG of the widget."""
+        self.widget.updateWorld(_build_world())
+        self.widget.resetView()
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "widget.svg")
+            self.assertTrue(self.widget.saveSvg(path))
+            with open(path, 'rb') as stream:
+                data = stream.read()
+        self.assertGreater(len(data), 0)
+        root = ElementTree.fromstring(data)
+        self.assertTrue(root.tag.endswith("svg"))
+
+    def test_save_svg_honors_explicit_overlay(self):
+        """saveSvg bakes the given overlay regardless of what the widget
+        currently shows on screen, matching saveImage's export contract."""
+        self.widget.updateWorld(_build_world())
+        self.widget.resetView()
+        self.widget.overlay = pilot.Overlay2dOptions()
+        with tempfile.TemporaryDirectory() as folder:
+            labeled_path = os.path.join(folder, "labeled.svg")
+            self.assertTrue(
+                self.widget.saveSvg(labeled_path, _all_on_overlay()))
+            with open(labeled_path, 'rb') as stream:
+                labeled_data = stream.read()
+            plain_path = os.path.join(folder, "plain.svg")
+            self.widget.overlay = _all_on_overlay()
+            self.assertTrue(
+                self.widget.saveSvg(plain_path, pilot.Overlay2dOptions()))
+            with open(plain_path, 'rb') as stream:
+                plain_data = stream.read()
+        self.widget.overlay = pilot.Overlay2dOptions()
+        self.assertGreater(
+            labeled_data.count(b'<text'), plain_data.count(b'<text'))
 
     def test_current_2d_widget_exposes_screenshot_api(self):
         """currentR2DWidget returns the active 2D widget, API intact."""

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -548,6 +548,17 @@ class Save2DCanvasDialogTC(unittest.TestCase):
         self.assertIsNone(resolve_save_path("/tmp/a.bmp", ""))
         self.assertIsNone(resolve_save_path("", _PNG_FILTER))
 
+    def test_resolve_save_path_forces_svg(self):
+        from solvcon.pilot.canvas._canvas_gui import (
+            resolve_save_path, _SVG_FILTER)
+        self.assertEqual(
+            resolve_save_path("/tmp/a", _SVG_FILTER), "/tmp/a.svg")
+        self.assertEqual(
+            resolve_save_path("/tmp/a.png", _SVG_FILTER), "/tmp/a.svg")
+        self.assertEqual(
+            resolve_save_path("/tmp/a.svg", _SVG_FILTER), "/tmp/a.svg")
+        self.assertEqual(resolve_save_path("/tmp/a.svg", ""), "/tmp/a.svg")
+
     def test_menu_action_is_registered(self):
         from solvcon.pilot.base import _gui
         mgr = _gui.controller.build()
@@ -588,6 +599,17 @@ class Save2DCanvasDialogTC(unittest.TestCase):
         feature._ensure_dialog()
         self.assertIs(feature._diag, built)
 
+    def test_dialog_offers_svg_filter_and_sets_suffix(self):
+        """The SVG filter is offered, and selecting it sets the default
+        suffix to svg, matching the existing png/jpg behavior."""
+        from solvcon.pilot.canvas import _canvas_gui
+        mgr = pilot.RManager.instance.setUp()
+        feature = _canvas_gui.Save2DCanvasDialog(mgr=mgr)
+        feature._ensure_dialog()
+        self.assertIn(_canvas_gui._SVG_FILTER, feature._diag.nameFilters())
+        feature._on_filter_selected(_canvas_gui._SVG_FILTER)
+        self.assertEqual(feature._diag.defaultSuffix(), "svg")
+
     def test_save_current_reports_write_result(self):
         """Menu save path returns saveImage's bool and only writes on
         success."""
@@ -607,6 +629,25 @@ class Save2DCanvasDialogTC(unittest.TestCase):
             self.assertFalse(feature._save_current(bad))
             self.assertFalse(os.path.isfile(bad))
         self.assertEqual(data[:8], _PNG_MAGIC)
+
+    def test_save_current_dispatches_to_save_svg(self):
+        """The menu save path writes SVG (not PNG) when the resolved path
+        ends in .svg."""
+        from solvcon.pilot.canvas import _canvas_gui
+        mgr = pilot.RManager.instance.setUp()
+        widget = mgr.add2DWidget()
+        widget.updateWorld(_build_world())
+        widget.resetView()
+        feature = _canvas_gui.Save2DCanvasDialog(mgr=mgr)
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "out.svg")
+            self.assertTrue(feature._save_current(path))
+            self.assertTrue(os.path.isfile(path))
+            with open(path, 'rb') as stream:
+                data = stream.read()
+        self.assertNotEqual(data[:8], _PNG_MAGIC)
+        root = ElementTree.fromstring(data)
+        self.assertTrue(root.tag.endswith("svg"))
 
 
 def _grab_foreground(widget, overlay=None):


### PR DESCRIPTION
The pilot 2D canvas can currently only be exported as a raster PNG or JPEG. This adds a vector SVG export option alongside them, useful for anyone who wants to include a canvas snapshot in a document or diagram without losing resolution when scaled.

R2DWidget gains a saveSvg method that renders through the same paint_canvas path the existing PNG/JPEG export uses, but into a QSvgGenerator instead of a QImage, and is exposed to Python through the existing pybind11 binding pattern. Getting QSvgGenerator to produce a correctly scaled file took one extra step beyond setting the output size: without an explicit viewBox, viewers map the drawing coordinates onto the physical canvas size using the CSS convention of 96 DPI, which does not match the DPI QSvgGenerator itself used internally, so content (including the background fill) rendered shrunk into the canvas's top-left corner with blank space around it. Setting an identity viewBox fixes this by pinning pixel coordinates 1:1 to the canvas regardless of DPI.

On the Python side, the "Save 2D canvas" dialog now offers an SVG filter alongside PNG and JPEG, and dispatches to saveSvg when the resolved path ends in .svg.

Related to https://github.com/solvcon/solvcon/issues/1050.
