### PR TITLE
Add the agent observation layer and artifact store

### DIFF
--- a/solvcon/agent/__init__.py
+++ b/solvcon/agent/__init__.py
@@ -13,6 +13,8 @@ command family such as :mod:`solvcon.agent.draw` builds on the framework here.
 """
 
 from . import _command  # noqa: F401
+from . import _artifact  # noqa: F401
+from . import _observe  # noqa: F401
 from . import _core  # noqa: F401
 from . import _backend  # noqa: F401
 from . import _backends_impl  # noqa: F401
@@ -26,6 +28,21 @@ list_of_command = [
     'CommandProcessor',
     'CommandDispatcher',
     'CRUD_CATEGORIES',
+]
+
+# _artifact.py
+list_of_artifact = [
+    'ArtifactStore',
+    'ArtifactError',
+]
+
+# _observe.py
+list_of_observe = [
+    'format_scene',
+    'format_result',
+    'format_results',
+    'offload_blobs',
+    'has_blob',
 ]
 
 # _core.py
@@ -58,8 +75,8 @@ list_of_backends_impl = [
 Agent = None
 
 __all__ = (  # noqa: F822
-    list_of_command + list_of_core + list_of_backend
-    + list_of_backends_impl + ['Agent']
+    list_of_command + list_of_artifact + list_of_observe + list_of_core
+    + list_of_backend + list_of_backends_impl + ['Agent']
 )
 
 
@@ -69,6 +86,8 @@ def _load(module, symbol_list):
 
 
 _load(_command, list_of_command)
+_load(_artifact, list_of_artifact)
+_load(_observe, list_of_observe)
 _load(_core, list_of_core)
 _load(_backend, list_of_backend)
 _load(_backends_impl, list_of_backends_impl)

--- a/solvcon/agent/_artifact.py
+++ b/solvcon/agent/_artifact.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Per-session artifact store for the Agent.
+
+Some command results are binary or oversized: ``render_png`` returns an inline
+base64 PNG today.  Keeping those bytes in the prompt, transcript, and JSONL
+would bloat every step and defeat prefix caching.  The store writes such bytes
+to a file under a private session directory (never the Git worktree), hands
+back the path, and caps the total bytes a session may write so a runaway render
+cannot fill the disk.  The directory is removed on :meth:`ArtifactStore.close`;
+a finalizer removes it too if ``close`` is never reached.
+"""
+
+import os
+import shutil
+import tempfile
+import weakref
+
+
+class ArtifactError(RuntimeError):
+    """An artifact could not be stored (over quota, or the store is closed)."""
+
+
+def _rmtree(root):
+    shutil.rmtree(root, ignore_errors=True)
+
+
+def _safe_suffix(suffix):
+    """A harness-controlled extension reduced to dot-joined ASCII word parts,
+    so a media-type string can never inject a path separator or traversal."""
+    kept = "".join(ch for ch in suffix if ch.isalnum() or ch == ".")
+    parts = [part for part in kept.split(".") if part]
+    return "." + ".".join(parts) if parts else ""
+
+
+class ArtifactStore:
+    """A private directory holding one session's binary artifacts.
+
+    ``quota`` caps the total bytes written across the session; a request
+    that would exceed it raises :class:`ArtifactError` and writes nothing.
+    Names are harness-generated (``artifact-0001.png``), so a model-supplied
+    string never reaches the filesystem.
+    """
+
+    DEFAULT_QUOTA = 64 * 1024 * 1024  # 64 MiB across the whole session
+
+    def __init__(self, quota=DEFAULT_QUOTA, root=None):
+        self._root = tempfile.mkdtemp(prefix="solvcon-agent-", dir=root)
+        self._quota = quota
+        self._used = 0
+        self._count = 0
+        self._finalize = weakref.finalize(self, _rmtree, self._root)
+
+    @property
+    def root(self):
+        """The session directory, or ``None`` once closed."""
+        return self._root
+
+    @property
+    def used(self):
+        """Bytes written so far this session."""
+        return self._used
+
+    def store(self, data, suffix=""):
+        """Write ``data`` under a fresh safe name and return its absolute path.
+
+        Raises :class:`ArtifactError` when the store is closed or the write
+        would push the session past its quota."""
+        if self._root is None:
+            raise ArtifactError("artifact store is closed")
+        if self._used + len(data) > self._quota:
+            raise ArtifactError(
+                "artifact quota exceeded: %d + %d > %d bytes"
+                % (self._used, len(data), self._quota))
+        self._count += 1
+        name = "artifact-%04d%s" % (self._count, _safe_suffix(suffix))
+        path = os.path.join(self._root, name)
+        with open(path, "wb") as fobj:
+            fobj.write(data)
+        self._used += len(data)
+        return path
+
+    def close(self):
+        """Remove the session directory; safe to call more than once."""
+        if self._root is not None:
+            self._finalize()
+            self._root = None
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/agent/_backend.py
+++ b/solvcon/agent/_backend.py
@@ -108,8 +108,10 @@ class AgentBackend(abc.ABC):
         shared instruction rides separately as the system prompt
         (:attr:`_INSTRUCTIONS`), so it stays a stable prefix a backend can hand
         the model as a real system message rather than folding it into the
-        user turn."""
-        tools = json.dumps(tool_surface or [], indent=2)
+        user turn.  The tool dump is compact and key-sorted so the prefix stays
+        byte-stable for a prompt cache and does not vary run to run."""
+        tools = json.dumps(tool_surface or [], sort_keys=True,
+                           separators=(",", ":"))
         return (
             "Available operations (tool definitions):\n%s\n\n"
             "Current scene:\n%s\n\nUser request:\n%s"

--- a/solvcon/agent/_core.py
+++ b/solvcon/agent/_core.py
@@ -13,6 +13,8 @@ applied command into a transcript a caller can render.  No Qt is imported.
 import json
 import dataclasses
 
+from . import _observe
+
 
 @dataclasses.dataclass
 class TranscriptTurn:
@@ -61,11 +63,28 @@ class AgentSession:
         self._runner_injected = runner is not None
         self.allow_destructive = allow_destructive
         self._transcript = []
+        self._artifacts = None
 
     @property
     def transcript(self):
         """The recorded turns, oldest first (a copy)."""
         return list(self._transcript)
+
+    @property
+    def artifacts(self):
+        """The session artifact store, built on first use so a session that
+        never renders never creates a temp directory."""
+        if self._artifacts is None:
+            from ._artifact import ArtifactStore
+            self._artifacts = ArtifactStore()
+        return self._artifacts
+
+    def close(self):
+        """Release session resources: remove the artifact store directory.
+        Safe to call more than once."""
+        if self._artifacts is not None:
+            self._artifacts.close()
+            self._artifacts = None
 
     @property
     def runner(self):
@@ -107,9 +126,9 @@ class AgentSession:
         return set(by_category.get("delete", ()))
 
     def scene_context(self, level="basic"):
-        """A short text summary of the world for the model: the shape count
-        and distinct types from ``world.describe_state(...)`` (JSON), or a
-        plain count when it cannot be described."""
+        """A bounded scene snapshot for the model from
+        ``world.describe_state(...)`` (JSON), formatted per the composition
+        rules, or a plain count when the world cannot be described."""
         world = self.world
         if world is None:
             return "no active world"
@@ -117,10 +136,7 @@ class AgentSession:
             state = json.loads(world.describe_state(level=level))
         except Exception:
             return "world with %s shapes" % getattr(world, "nshape", "?")
-        shapes = state.get("shapes", [])
-        types = sorted({s["type"] for s in shapes if "type" in s})
-        kinds = ", ".join(types) if types else "none"
-        return "world with %d shapes (types: %s)" % (len(shapes), kinds)
+        return _observe.format_scene(state)
 
     @staticmethod
     def _op_of(command):
@@ -170,6 +186,21 @@ class AgentSession:
                 results.append(_OutcomeStub(
                     self._op_of(command),
                     error="%s: %s" % (type(exc).__name__, exc)))
+        return self._offload_results(results)
+
+    def _offload_results(self, results):
+        """Move any base64 blob in a result value into the artifact store,
+        leaving a path reference so the transcript and prompt never carry the
+        bytes.  A blob that cannot be stored (quota, bad base64, a filesystem
+        error) leaves an ``error`` in its reference rather than a path; the
+        command outcome is unchanged, since storing the artifact is the
+        harness's job, not the command's.  Builds no store until a blob
+        actually appears."""
+        for result in results:
+            value = getattr(result, "value", None)
+            if value is None or not _observe.has_blob(value):
+                continue
+            result.value = _observe.offload_blobs(value, self.artifacts)
         return results
 
     def _record_agent(self, text, commands=(), results=()):

--- a/solvcon/agent/_observe.py
+++ b/solvcon/agent/_observe.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Observation and scene formatting for the Agent (composition rules of #966).
+
+The model reads two kinds of text about the world each step.  The *scene* is a
+bounded snapshot: a header naming the shape count and types, a capped listing
+of shapes, and an explicit tail pointing at the read commands when more remain.
+An *observation* is one line per command result, with consecutive identical
+errors collapsed so a repeated failure does not flood the model.  Both stay
+compact and deterministic so small models keep focus and a byte-stable prefix
+serves prompt caches.
+
+Binary or oversized result values (``render_png``'s base64) are routed through
+the session :class:`~solvcon.agent._artifact.ArtifactStore` by
+:func:`offload_blobs`, so what the prompt and transcript keep is a path
+reference, never the bytes.
+"""
+
+import json
+import base64
+
+from ._artifact import ArtifactError
+
+# Extension used when naming a stored artifact, keyed by media type.
+_MIME_SUFFIX = {"image/png": ".png", "image/jpeg": ".jpg"}
+
+# Shapes listed in a scene before the remainder collapses into a tail.
+SCENE_SHAPE_CAP = 20
+
+# Longest a serialized result value may be before the observation truncates it.
+_DETAIL_CAP = 200
+
+
+def _looks_like_blob(node):
+    """A base64 blob: a mapping with string ``data`` and ``mime_type``."""
+    return (isinstance(node, dict)
+            and isinstance(node.get("data"), str)
+            and isinstance(node.get("mime_type"), str))
+
+
+def has_blob(value):
+    """Whether ``value`` holds any base64 blob, so a caller can skip building
+    the artifact store when there is nothing to offload."""
+    if _looks_like_blob(value):
+        return True
+    if isinstance(value, dict):
+        return any(has_blob(item) for item in value.values())
+    if isinstance(value, list):
+        return any(has_blob(item) for item in value)
+    return False
+
+
+def _offload_one(node, store):
+    ref = {key: val for key, val in node.items() if key != "data"}
+    try:
+        raw = base64.b64decode(node["data"], validate=True)
+    except (ValueError, TypeError) as exc:
+        ref["error"] = "invalid base64: %s" % exc
+        return ref
+    try:
+        ref["path"] = store.store(raw, _MIME_SUFFIX.get(node["mime_type"], ""))
+    except (ArtifactError, OSError) as exc:
+        # Quota, a full disk, or a vanished scratch dir are storage problems,
+        # not command failures: annotate the reference so the observation shows
+        # the drop, but never abort the turn or lose the bytes silently.
+        ref["error"] = str(exc)
+    return ref
+
+
+def offload_blobs(value, store):
+    """A copy of ``value`` with every base64 blob replaced by an artifact
+    reference.
+
+    Recurses into mappings and lists.  Each blob's ``data`` is decoded, written
+    to ``store``, and replaced by a ``path``.  A blob that fails to decode,
+    exceeds the quota, or cannot be written keeps no bytes and carries an
+    ``error`` in its reference instead, degrading the result honestly rather
+    than faking a path.  Storing the artifact is the harness's job, so the
+    command outcome the runner reported is left untouched.
+    """
+    def walk(node):
+        if _looks_like_blob(node):
+            return _offload_one(node, store)
+        if isinstance(node, dict):
+            return {key: walk(val) for key, val in node.items()}
+        if isinstance(node, list):
+            return [walk(item) for item in node]
+        return node
+
+    return walk(value)
+
+
+def _bounded(text):
+    """Collapse whitespace to a single line and cap the length, so one result
+    can never spill across lines or flood the prompt."""
+    flat = " ".join(text.split())
+    return flat[:_DETAIL_CAP] + "..." if len(flat) > _DETAIL_CAP else flat
+
+
+def _result_detail(value):
+    if value is None:
+        return ""
+    if value == {} or value == []:
+        return "empty"
+    return _bounded(json.dumps(value, sort_keys=True, separators=(",", ":")))
+
+
+def format_result(result):
+    """One observation line for a single command result: ``op: ok`` with a
+    compact value tail, or ``op: error: <reason>`` on failure."""
+    op = getattr(result, "op", None) or "?"
+    if not getattr(result, "ok", False):
+        reason = getattr(result, "error", None) or "failed"
+        return "%s: error: %s" % (op, _bounded(str(reason)))
+    detail = _result_detail(getattr(result, "value", None))
+    return "%s: ok (%s)" % (op, detail) if detail else "%s: ok" % op
+
+
+def format_results(results):
+    """The observation for a command batch: one line per result, with
+    consecutive identical error lines collapsed.  An empty batch reads
+    explicitly as such."""
+    if not results:
+        return "no commands run"
+    lines = []
+    previous = None
+    repeat = 0
+    for result in results:
+        line = format_result(result)
+        if not getattr(result, "ok", False) and line == previous:
+            repeat += 1
+            continue
+        if repeat:
+            lines.append("... and %d more identical errors" % repeat)
+            repeat = 0
+        lines.append(line)
+        previous = line
+    if repeat:
+        lines.append("... and %d more identical errors" % repeat)
+    return "\n".join(lines)
+
+
+def _fmt_num(value):
+    return "%g" % value if isinstance(value, (int, float)) else str(value)
+
+
+def _shape_line(shape):
+    if not isinstance(shape, dict):
+        return str(shape)
+    head = "#%s %s" % (shape.get("id", "?"), shape.get("type", "?"))
+    bbox = shape.get("bbox")
+    if isinstance(bbox, list) and len(bbox) == 4:
+        return "%s bbox=[%s]" % (head, ", ".join(_fmt_num(v) for v in bbox))
+    return head
+
+
+def format_scene(state, cap=SCENE_SHAPE_CAP):
+    """A bounded scene snapshot for the prompt.
+
+    ``state`` is the parsed ``describe_state`` mapping.  The header names the
+    shape count and distinct types; up to ``cap`` shapes are listed one per
+    line, and any remainder collapses into an explicit tail directing the model
+    to the read commands.
+    """
+    shapes = state.get("shapes", []) if isinstance(state, dict) else []
+    types = sorted({s["type"] for s in shapes
+                    if isinstance(s, dict) and "type" in s})
+    header = "world with %d shapes (types: %s)" % (
+        len(shapes), ", ".join(types) if types else "none")
+    lines = [header]
+    lines.extend("  " + _shape_line(shape) for shape in shapes[:cap])
+    extra = len(shapes) - cap
+    if extra > 0:
+        lines.append(
+            "  ... %d more shapes, use read commands (describe_state)" % extra)
+    return "\n".join(lines)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_core.py
+++ b/tests/test_agent_core.py
@@ -5,6 +5,7 @@
 """Tests for the headless AgentSession core (GUI-free), with fake
 orchestration and in-tree Agent Draw integration."""
 
+import os
 import json
 import unittest
 
@@ -205,6 +206,81 @@ class SceneContextTC(unittest.TestCase):
         self.assertIn("2 shapes", context)
         self.assertIn("circle", context)
         self.assertIn("rectangle", context)
+
+    def test_lists_shapes_below_the_header(self):
+        session = agent.AgentSession(world=_FakeWorld(["circle"]))
+        lines = session.scene_context().splitlines()
+        self.assertEqual(lines[1], "  #0 circle")
+
+    def test_describe_state_failure_falls_back_to_a_plain_count(self):
+        class _BadWorld:
+            nshape = 3
+
+            def describe_state(self, level="basic"):
+                raise RuntimeError("no describe")
+
+        self.assertEqual(agent.AgentSession(world=_BadWorld()).scene_context(),
+                         "world with 3 shapes")
+
+
+class ArtifactOffloadTC(unittest.TestCase):
+    """The session moves render_png's base64 out of the result value and into
+    its artifact store, so the transcript never carries the bytes."""
+
+    @staticmethod
+    def _renderer(world, view, width, height, antialiasing):
+        return b"PNGBYTES"
+
+    def test_render_png_value_becomes_a_path_reference(self):
+        world = solvcon.WorldFp64()
+        session = agent.AgentSession(world=world, renderer=self._renderer)
+        self.addCleanup(session.close)
+        result = session.apply_commands(
+            [{"op": "render_png", "width": 8, "height": 8}])[0]
+        self.assertTrue(result.ok, result.error)
+        image = result.value["image"]
+        self.assertNotIn("data", image)
+        self.assertEqual(os.path.dirname(image["path"]),
+                         session.artifacts.root)
+        with open(image["path"], "rb") as fobj:
+            self.assertEqual(fobj.read(), b"PNGBYTES")
+        # The recorded turn holds the reference, not the base64 bytes.
+        turn_value = session.transcript[0].results[0].value
+        self.assertEqual(turn_value["image"], image)
+
+    def test_unstorable_render_annotates_the_reference(self):
+        # A blob that cannot be stored (here, an exhausted quota) is a harness
+        # storage problem, not a command failure: the render still reports ok,
+        # but its reference carries the error in place of data or a path.
+        world = solvcon.WorldFp64()
+        session = agent.AgentSession(world=world, renderer=self._renderer)
+        session._artifacts = agent.ArtifactStore(quota=1)
+        self.addCleanup(session.close)
+        result = session.apply_commands(
+            [{"op": "render_png", "width": 8, "height": 8}])[0]
+        self.assertTrue(result.ok)
+        image = result.value["image"]
+        self.assertNotIn("data", image)
+        self.assertNotIn("path", image)
+        self.assertIn("quota", image["error"])
+
+    def test_no_render_builds_no_store(self):
+        world = solvcon.WorldFp64()
+        session = agent.AgentSession(world=world)
+        self.addCleanup(session.close)
+        session.apply_commands(
+            [{"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0}])
+        self.assertIsNone(session._artifacts)
+
+    def test_close_removes_the_store_directory(self):
+        world = solvcon.WorldFp64()
+        session = agent.AgentSession(world=world, renderer=self._renderer)
+        session.apply_commands(
+            [{"op": "render_png", "width": 8, "height": 8}])
+        root = session.artifacts.root
+        session.close()
+        self.assertFalse(os.path.exists(root))
+        self.assertIsNone(session._artifacts)
 
 
 class AgentDrawIntegrationTC(unittest.TestCase):

--- a/tests/test_agent_observe.py
+++ b/tests/test_agent_observe.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Tests for the Agent observation layer and artifact store (GUI-free): the
+artifact store's quota and cleanup, scene and result formatting, and the
+base64 offloading that keeps bytes out of the transcript."""
+
+import os
+import base64
+import unittest
+
+from solvcon import agent
+from solvcon.agent import _observe, _artifact
+
+
+class _Result:
+    """Minimal command-result stand-in for the observation formatters."""
+
+    def __init__(self, op, ok=True, value=None, error=None):
+        self.op = op
+        self.ok = ok
+        self.value = value
+        self.error = error
+
+
+class ArtifactStoreTC(unittest.TestCase):
+    def setUp(self):
+        self.store = _artifact.ArtifactStore()
+        self.addCleanup(self.store.close)
+
+    def test_store_writes_bytes_and_returns_a_safe_path(self):
+        path = self.store.store(b"PNGBYTES", ".png")
+        self.assertEqual(os.path.dirname(path), self.store.root)
+        self.assertEqual(os.path.basename(path), "artifact-0001.png")
+        with open(path, "rb") as fobj:
+            self.assertEqual(fobj.read(), b"PNGBYTES")
+        self.assertEqual(self.store.used, len(b"PNGBYTES"))
+
+    def test_names_are_sequential_and_harness_generated(self):
+        first = os.path.basename(self.store.store(b"a", ".png"))
+        second = os.path.basename(self.store.store(b"bb", ".png"))
+        self.assertEqual([first, second],
+                         ["artifact-0001.png", "artifact-0002.png"])
+
+    def test_suffix_is_sanitized_to_an_extension(self):
+        path = self.store.store(b"x", "../../evil.png")
+        self.assertEqual(os.path.basename(path), "artifact-0001.evil.png")
+        self.assertEqual(os.path.dirname(path), self.store.root)
+
+    def test_quota_is_enforced_and_writes_nothing(self):
+        store = _artifact.ArtifactStore(quota=4)
+        self.addCleanup(store.close)
+        store.store(b"abcd")
+        with self.assertRaises(_artifact.ArtifactError):
+            store.store(b"e")
+        self.assertEqual(store.used, 4)
+        self.assertEqual(len(os.listdir(store.root)), 1)
+
+    def test_close_removes_the_directory_and_is_idempotent(self):
+        store = _artifact.ArtifactStore()
+        root = store.root
+        store.store(b"x", ".png")
+        store.close()
+        self.assertFalse(os.path.exists(root))
+        self.assertIsNone(store.root)
+        store.close()
+
+    def test_store_after_close_raises(self):
+        store = _artifact.ArtifactStore()
+        store.close()
+        with self.assertRaises(_artifact.ArtifactError):
+            store.store(b"x")
+
+
+def _blob(data=b"PNGBYTES", mime="image/png", **extra):
+    node = {"data": base64.b64encode(data).decode("ascii"), "mime_type": mime}
+    node.update(extra)
+    return node
+
+
+class OffloadBlobsTC(unittest.TestCase):
+    def setUp(self):
+        self.store = _artifact.ArtifactStore()
+        self.addCleanup(self.store.close)
+
+    def test_blob_is_replaced_by_a_path_reference(self):
+        value = {"image": _blob(width=32, height=24)}
+        ref = _observe.offload_blobs(value, self.store)["image"]
+        self.assertNotIn("data", ref)
+        self.assertEqual(os.path.dirname(ref["path"]), self.store.root)
+        self.assertEqual(os.path.basename(ref["path"]), "artifact-0001.png")
+        self.assertEqual(ref["mime_type"], "image/png")
+        self.assertEqual((ref["width"], ref["height"]), (32, 24))
+        with open(ref["path"], "rb") as fobj:
+            self.assertEqual(fobj.read(), b"PNGBYTES")
+
+    def test_value_without_a_blob_is_returned_unchanged(self):
+        value = {"shape_id": 3, "tags": ["a", "b"]}
+        self.assertFalse(_observe.has_blob(value))
+        self.assertEqual(_observe.offload_blobs(value, self.store), value)
+        self.assertEqual(self.store.used, 0)
+
+    def test_invalid_base64_annotates_the_reference_with_an_error(self):
+        value = {"image": {"data": "not base64!!", "mime_type": "image/png"}}
+        ref = _observe.offload_blobs(value, self.store)["image"]
+        self.assertNotIn("data", ref)
+        self.assertNotIn("path", ref)
+        self.assertIn("invalid base64", ref["error"])
+
+    def test_over_quota_blob_keeps_no_bytes_and_annotates_the_error(self):
+        store = _artifact.ArtifactStore(quota=1)
+        self.addCleanup(store.close)
+        ref = _observe.offload_blobs({"image": _blob(b"PNGBYTES")},
+                                     store)["image"]
+        self.assertNotIn("path", ref)
+        self.assertIn("quota", ref["error"])
+        self.assertEqual(store.used, 0)
+
+    def test_filesystem_error_is_annotated_not_raised(self):
+        # A full or vanished scratch dir raises OSError from store(); it must
+        # become a reference annotation, not abort a turn.
+        class _FullDisk:
+            def store(self, data, suffix=""):
+                raise OSError("No space left on device")
+
+        ref = _observe.offload_blobs({"image": _blob(b"PNGBYTES")},
+                                     _FullDisk())["image"]
+        self.assertNotIn("path", ref)
+        self.assertEqual(ref["error"], "No space left on device")
+
+
+class FormatResultTC(unittest.TestCase):
+    def test_ok_without_a_value(self):
+        self.assertEqual(_observe.format_result(_Result("clear")),
+                         "clear: ok")
+
+    def test_ok_with_a_compact_value(self):
+        line = _observe.format_result(_Result("add_circle",
+                                              value={"shape_id": 7}))
+        self.assertEqual(line, 'add_circle: ok ({"shape_id":7})')
+
+    def test_empty_value_reads_explicitly(self):
+        line = _observe.format_result(
+            _Result("query_visible", value={}))
+        self.assertEqual(line, "query_visible: ok (empty)")
+
+    def test_error_line(self):
+        line = _observe.format_result(
+            _Result("add_circle", ok=False, error="bad radius"))
+        self.assertEqual(line, "add_circle: error: bad radius")
+
+    def test_multiline_error_is_flattened_to_one_line(self):
+        line = _observe.format_result(
+            _Result("add_circle", ok=False,
+                    error="Traceback:\n  File x\n  bad radius"))
+        self.assertEqual(line,
+                         "add_circle: error: Traceback: File x bad radius")
+
+    def test_long_error_is_truncated(self):
+        line = _observe.format_result(
+            _Result("add_circle", ok=False, error="x" * 500))
+        self.assertTrue(line.endswith("..."))
+        self.assertLessEqual(len(line), 40 + _observe._DETAIL_CAP)
+
+    def test_large_value_is_truncated(self):
+        line = _observe.format_result(
+            _Result("describe_state", value={"blob": "x" * 500}))
+        self.assertIn("...", line)
+        self.assertLessEqual(len(line), 60 + _observe._DETAIL_CAP)
+
+
+class FormatResultsTC(unittest.TestCase):
+    def test_empty_batch_is_explicit(self):
+        self.assertEqual(_observe.format_results([]), "no commands run")
+
+    def test_one_line_per_result(self):
+        text = _observe.format_results(
+            [_Result("add_circle", value={"shape_id": 1}),
+             _Result("add_circle", value={"shape_id": 2})])
+        self.assertEqual(len(text.splitlines()), 2)
+
+    def test_consecutive_identical_errors_collapse(self):
+        results = [_Result("add_circle", ok=False, error="bad")] * 4
+        text = _observe.format_results(results)
+        self.assertEqual(
+            text,
+            "add_circle: error: bad\n... and 3 more identical errors")
+
+    def test_distinct_errors_are_kept(self):
+        text = _observe.format_results(
+            [_Result("a", ok=False, error="x"),
+             _Result("b", ok=False, error="y")])
+        self.assertEqual(text.splitlines(),
+                         ["a: error: x", "b: error: y"])
+
+    def test_identical_ok_lines_are_not_collapsed(self):
+        text = _observe.format_results(
+            [_Result("add_circle", value={"shape_id": 1}),
+             _Result("add_circle", value={"shape_id": 1})])
+        self.assertEqual(len(text.splitlines()), 2)
+
+
+class FormatSceneTC(unittest.TestCase):
+    def test_empty_world(self):
+        self.assertEqual(_observe.format_scene({"shapes": []}),
+                         "world with 0 shapes (types: none)")
+
+    def test_header_names_count_and_types(self):
+        state = {"shapes": [{"id": 0, "type": "circle"},
+                            {"id": 1, "type": "rectangle"}]}
+        header = _observe.format_scene(state).splitlines()[0]
+        self.assertEqual(header,
+                         "world with 2 shapes (types: circle, rectangle)")
+
+    def test_shapes_are_listed_with_bbox(self):
+        state = {"shapes": [{"id": 5, "type": "circle",
+                             "bbox": [-1.0, -1.0, 1.0, 1.0]}]}
+        lines = _observe.format_scene(state).splitlines()
+        self.assertEqual(lines[1], "  #5 circle bbox=[-1, -1, 1, 1]")
+
+    def test_scene_is_capped_with_a_read_command_tail(self):
+        state = {"shapes": [{"id": i, "type": "circle"} for i in range(25)]}
+        lines = _observe.format_scene(state, cap=20).splitlines()
+        # Header plus 20 shapes plus one tail line.
+        self.assertEqual(len(lines), 22)
+        self.assertIn("5 more shapes", lines[-1])
+        self.assertIn("describe_state", lines[-1])
+
+
+class ExportsTC(unittest.TestCase):
+    def test_new_symbols_are_exported(self):
+        for name in ("ArtifactStore", "ArtifactError", "format_scene",
+                     "format_result", "format_results", "offload_blobs",
+                     "has_blob"):
+            self.assertTrue(hasattr(agent, name), name)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
This adds the agent's observation layer. It turns the world scene and command results into compact, bounded text for the model, and it routes large binary results (render_png's base64 PNG) into a per-session artifact store so the prompt and transcript keep a small file reference instead of the raw bytes. The tool list sent to the backend is now compact and key-sorted so the prompt prefix stays stable across runs.

This is groundwork for the agent loop. The step that feeds observations back to the model arrives in a later PR.

Related to #966.
