### PR TITLE
Accept zero-sized NumPy array layouts

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -2133,7 +2133,7 @@ private:
     static bool is_c_contiguous(shape_type const & shape,
                                 sshape_type const & stride)
     {
-        if (shape.empty())
+        if (std::ranges::contains(shape, 0))
         {
             return true;
         }
@@ -2152,7 +2152,7 @@ private:
     static bool is_f_contiguous(shape_type const & shape,
                                 sshape_type const & stride)
     {
-        if (shape.empty())
+        if (std::ranges::contains(shape, 0))
         {
             return true;
         }

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -290,13 +290,18 @@ class SimpleArrayBasicTC(unittest.TestCase):
         ):
             solvcon.SimpleArrayFloat64((-1, 2))
 
-    def test_SimpleArray_fortran_empty(self):
-        ndarr = np.empty((0, 0), order='F')
-        sarr = solvcon.SimpleArrayFloat64(array=ndarr)
+    def test_SimpleArray_from_zero_sized_ndarray(self):
+        for shape in ((0, 0), (3, 0), (0, 3), (2, 1, 0)):
+            for order in ('C', 'F'):
+                with self.subTest(shape=shape, order=order):
+                    ndarr = np.empty(shape, dtype='float64', order=order)
+                    sarr = solvcon.SimpleArrayFloat64(array=ndarr)
 
-        self.assertTrue(sarr.is_c_contiguous)
-        self.assertTrue(sarr.is_f_contiguous)
-        np.testing.assert_array_equal(ndarr, sarr.ndarray)
+                    self.assertEqual(shape, sarr.shape)
+                    self.assertEqual(tuple(0 for _ in shape), sarr.stride)
+                    self.assertTrue(sarr.is_c_contiguous)
+                    self.assertTrue(sarr.is_f_contiguous)
+                    np.testing.assert_array_equal(ndarr, sarr.ndarray)
 
     def test_SimpleArray_fortran_1x2(self):
         ndarr = np.asfortranarray([[1.0, 0.1]])


### PR DESCRIPTION
NumPy marks zero-sized arrays as both C- and F-contiguous even when their strides do not follow the recurrence used for non-empty arrays. SimpleArray preserved those flags but then rejected valid shapes such as `(3, 0)` and `(0, 3)`.

This change treats any shape with a zero-length axis as contiguous for order validation and adds constructor regressions for zero-sized shapes in different axis positions.

Related to #1178.