### PR TITLE
Check small_vector size for equality test

### DIFF
--- a/cpp/solvcon/buffer/small_vector.hpp
+++ b/cpp/solvcon/buffer/small_vector.hpp
@@ -446,7 +446,8 @@ small_vector<T, N>::quick_select(iterator first, iterator last, size_t k)
 template <typename T>
 bool operator==(small_vector<T> const & lhs, small_vector<T> const & rhs)
 {
-    return std::equal(lhs.begin(), lhs.end(), rhs.begin());
+    return lhs.size() == rhs.size() &&
+           std::equal(lhs.begin(), lhs.end(), rhs.begin());
 }
 
 static_assert(sizeof(small_vector<size_t>) == 40, "small_vector<size_t> should use 40 bytes");

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -252,6 +252,17 @@ TEST(small_vector, select_kth_random)
     }
 }
 
+TEST(small_vector, equality_requires_same_size)
+{
+    solvcon::small_vector<int> prefix{1, 2};
+    solvcon::small_vector<int> equal{1, 2};
+    solvcon::small_vector<int> longer{1, 2, 3};
+
+    EXPECT_TRUE(prefix == equal);
+    EXPECT_FALSE(prefix == longer);
+    EXPECT_FALSE(longer == prefix);
+}
+
 TEST(TakeAlongAxisSimd, basic_int32)
 {
     using namespace solvcon;


### PR DESCRIPTION
`small_vector::operator==` compares the lhs element range with `rhs.begin()` without first checking the two sizes. A shorter lhs that matches the rhs prefix may therefore compare equal, while a longer lhs may read past the rhs range.

This change requires equal sizes before comparing corresponding elements. Regression coverage includes unequal `small_vector` sizes in both directions and the `SimpleArray` shape-validation case that exposed the bug.

Related to #1177.