### PR TITLE
Add information for installing latex and clang-tidy/format

### DIFF
--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -42,8 +42,9 @@
 #       Print the system prerequisite commands (apt or brew) and exit.  The
 #       script never runs the package manager; copy, review, and run them
 #       yourself.  --print-apt is a backward-compatible alias.  The output
-#       ends with the C++ lint tools `make lint` needs but no build section
-#       installs: clang-format and clang-tidy, both from LLVM 22.
+#       ends with the two toolchains no build section installs: LaTeX, which
+#       the documentation needs to render its figures, then clang-format and
+#       clang-tidy for `make lint`, both from LLVM 22.
 #
 # Overridable variables (search below for defaults):
 #   Platform:
@@ -534,10 +535,31 @@ sudo ln -sf "$(brew --prefix llvm@22)/bin/clang-tidy" \
 EOF
 }
 
+scdv_brew_latex_cmd() {
+  # Print the brew command for the LaTeX toolchain the documentation needs.
+  # Even the plain HTML build needs it: the pstake extension renders
+  # ".. pstake::" PSTricks figures via latex -> dvips -> ImageMagick convert
+  # (Ghostscript is the fallback and convert's EPS delegate).  macOS ships no
+  # TeX at all, so the cask is the whole toolchain.  mactex-no-gui is the full
+  # distribution without the GUI front ends, which already carries the pst-*
+  # styles and the dvips/EPS helper binaries.  The download is several
+  # gigabytes.
+  #
+  # Gotcha: the cask puts the binaries in /Library/TeX/texbin and reaches PATH
+  # only through /etc/paths.d, so a shell started before the install finds no
+  # latex until `eval "$(/usr/libexec/path_helper)"` or a new terminal.
+  cat <<'EOF'
+brew install --cask mactex-no-gui
+brew install ghostscript imagemagick
+EOF
+}
+
 plat_print_deps() {
-  # macOS prints the brew base set (the QT and LaTeX toolchains need no extra
-  # brew packages), then the lint toolchain.
+  # macOS prints the brew base set (the QT toolchain needs no extra brew
+  # packages), then the LaTeX and lint toolchains.
   scdv_brew_base_cmd
+  echo
+  scdv_brew_latex_cmd
   echo
   scdv_brew_clang_lint_cmd
 }

--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -41,7 +41,9 @@
 #   ./build-scdv.sh --print-deps
 #       Print the system prerequisite commands (apt or brew) and exit.  The
 #       script never runs the package manager; copy, review, and run them
-#       yourself.  --print-apt is a backward-compatible alias.
+#       yourself.  --print-apt is a backward-compatible alias.  The output
+#       ends with the C++ lint tools `make lint` needs but no build section
+#       installs: clang-format and clang-tidy, both from LLVM 22.
 #
 # Overridable variables (search below for defaults):
 #   Platform:
@@ -208,13 +210,37 @@ sudo apt install -y \
 EOF
 }
 
+scdv_apt_clang_lint_cmd() {
+  # Print the apt command for the C++ lint tools: clang-format for
+  # `make cformat` and clang-tidy for `make USE_CLANG_TIDY=ON` and
+  # `make pilot_clang_tidy_diff`.  Both come from the one LLVM 22 in
+  # apt.llvm.org; noble's own are too old for C++23.  This is separate from
+  # the llvm-22-dev of the QT set, which is libclang for shiboken and ships
+  # neither tool.  The Makefile and CMake look the tools up by their bare
+  # names, hence the symlinks; CMake then resolves clang-tidy-diff.py
+  # relative to the symlink's real path, so /usr/lib/llvm-22/share/clang is
+  # still found.
+  cat <<'EOF'
+wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+  | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" \
+  | sudo tee /etc/apt/sources.list.d/llvm.list
+sudo apt-get -qqy update
+sudo apt install -y clang-format-22 clang-tidy-22
+sudo ln -fs "$(which clang-format-22)" /usr/local/bin/clang-format
+sudo ln -fs "$(which clang-tidy-22)" /usr/local/bin/clang-tidy
+EOF
+}
+
 plat_print_deps() {
-  # Ubuntu prints the apt base/QT/LaTeX sets.
+  # Ubuntu prints the apt base/QT/LaTeX sets, then the lint toolchain.
   scdv_apt_base_cmd
   echo
   scdv_apt_qt_cmd
   echo
   scdv_apt_latex_cmd
+  echo
+  scdv_apt_clang_lint_cmd
 }
 
 plat_python_env() {
@@ -487,10 +513,33 @@ brew install \
 EOF
 }
 
+scdv_brew_clang_lint_cmd() {
+  # Print the brew command for the C++ lint tools: clang-format for
+  # `make cformat` and clang-tidy for `make USE_CLANG_TIDY=ON` and
+  # `make pilot_clang_tidy_diff`.  Both come from the one keg-only brew
+  # llvm@22.  Apple's CLT ships no clang-tidy, and the libclang fetched for
+  # shiboken is lib/ and include/ only (see fetch_libclang), so neither tool
+  # is available otherwise.  Symlink the two tools instead of putting the keg
+  # bin on PATH: that bin also holds clang and clang++, which would shadow the
+  # Apple toolchain the rest of the build uses.  The Makefile and CMake look
+  # the tools up by their bare names, and CMake resolves clang-tidy-diff.py
+  # relative to the symlink's real path, so the keg's share/clang is still
+  # found.
+  cat <<'EOF'
+brew install llvm@22
+sudo ln -sf "$(brew --prefix llvm@22)/bin/clang-format" \
+  /usr/local/bin/clang-format
+sudo ln -sf "$(brew --prefix llvm@22)/bin/clang-tidy" \
+  /usr/local/bin/clang-tidy
+EOF
+}
+
 plat_print_deps() {
   # macOS prints the brew base set (the QT and LaTeX toolchains need no extra
-  # brew packages).
+  # brew packages), then the lint toolchain.
   scdv_brew_base_cmd
+  echo
+  scdv_brew_clang_lint_cmd
 }
 
 plat_python_env() {

--- a/doc/source/start/build_dep.md
+++ b/doc/source/start/build_dep.md
@@ -39,6 +39,14 @@ it to put the freshly built Python and Qt on your `PATH`, and run
 source ${HOME}/var/scdv/<platform>-py<pyver>-qt<qtver>/activate
 ```
 
+No build section installs the C++ lint tools `make lint` needs, so
+`--print-deps` ends with them. Both `clang-format` and `clang-tidy` come from
+the same LLVM 22 (`clang-format-22` and `clang-tidy-22` from apt.llvm.org on
+Ubuntu, `llvm@22` from Homebrew on macOS), symlinked under their bare names
+because that is how the `Makefile` and CMake look them up. Note that LLVM 22
+means `clang-format` is newer than the `CLANG_FORMAT_CI_VERSION` the `Makefile`
+pins, so `make cformat` prints a version-drift warning.
+
 Once the dependencies are in place, build solvcon as described in
 {doc}`build_solvcon`.
 

--- a/doc/source/start/build_dep.md
+++ b/doc/source/start/build_dep.md
@@ -39,13 +39,27 @@ it to put the freshly built Python and Qt on your `PATH`, and run
 source ${HOME}/var/scdv/<platform>-py<pyver>-qt<qtver>/activate
 ```
 
-No build section installs the C++ lint tools `make lint` needs, so
-`--print-deps` ends with them. Both `clang-format` and `clang-tidy` come from
-the same LLVM 22 (`clang-format-22` and `clang-tidy-22` from apt.llvm.org on
-Ubuntu, `llvm@22` from Homebrew on macOS), symlinked under their bare names
-because that is how the `Makefile` and CMake look them up. Note that LLVM 22
-means `clang-format` is newer than the `CLANG_FORMAT_CI_VERSION` the `Makefile`
-pins, so `make cformat` prints a version-drift warning.
+Two toolchains sit outside the build sections, so `--print-deps` ends with
+them. The first is LaTeX. Building the documentation needs it even for plain
+HTML, because the `pstake` extension renders the PSTricks figures through
+`latex`, `dvips`, and ImageMagick, with Ghostscript behind the EPS step. On
+Ubuntu that is the `texlive-*` set led by `texlive-pstricks`, plus
+`ghostscript` and `imagemagick`; note that Ubuntu's ImageMagick disables the
+EPS and PS coders in `policy.xml`, so either allow them or drop `imagemagick`
+and let the Ghostscript fallback do the work. On macOS there is no system TeX
+at all, so it is the `mactex-no-gui` cask (a several-gigabyte download) plus
+`ghostscript` and `imagemagick`. The cask installs into `/Library/TeX/texbin`
+and reaches `PATH` through `/etc/paths.d`, so run
+`eval "$(/usr/libexec/path_helper)"` or open a new terminal before building
+the documentation.
+
+The second is the C++ lint tools `make lint` needs. Both `clang-format` and
+`clang-tidy` come from the same LLVM 22 (`clang-format-22` and `clang-tidy-22`
+from apt.llvm.org on Ubuntu, `llvm@22` from Homebrew on macOS), symlinked under
+their bare names because that is how the `Makefile` and CMake look them up.
+Note that LLVM 22 means `clang-format` is newer than the
+`CLANG_FORMAT_CI_VERSION` the `Makefile` pins, so `make cformat` prints a
+version-drift warning.
 
 Once the dependencies are in place, build solvcon as described in
 {doc}`build_solvcon`.


### PR DESCRIPTION
In `build-scdv.sh` script, add information (and prints) for how to install latex for building the pstake/pstricks schematics for the document, and clang-tidy and clang-format for linting.