### PR TITLE
Make the 2D canvas follow the application theme

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/common/render_misc.hpp
     # theme/
     ${CMAKE_CURRENT_SOURCE_DIR}/theme/theme.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/theme/theme_qt.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/theme/RThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/theme/RMacThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/theme/RWindowsThemeBackend.hpp

--- a/cpp/solvcon/pilot/app/RManager.cpp
+++ b/cpp/solvcon/pilot/app/RManager.cpp
@@ -159,6 +159,16 @@ R2DWidget * RManager::add2DWidget()
     if (m_mdiArea)
     {
         viewer = new R2DWidget(/*parent*/ m_mdiArea);
+        // The canvas fills its own pixels, so it cannot inherit a theme switch
+        // from the application palette the way an ordinary widget does. Hand it
+        // the colors now and again on every switch, with the canvas itself as
+        // the connection context so the link dies with it.
+        auto applyCanvasPalette = [this, viewer](ThemeVariant)
+        {
+            viewer->setCanvasPalette(m_themeManager->canvas2dPalette());
+        };
+        applyCanvasPalette(m_themeManager->currentVariant());
+        QObject::connect(m_themeManager, &RThemeManager::themeChanged, viewer, applyCanvasPalette);
         viewer->setWindowTitle("2D canvas");
         viewer->show();
         auto * subwin = this->addSubWindow(viewer);

--- a/cpp/solvcon/pilot/canvas/DrawTool.cpp
+++ b/cpp/solvcon/pilot/canvas/DrawTool.cpp
@@ -22,9 +22,10 @@ namespace solvcon
 void DrawToolBase::paint_preview(
     QPainter & painter,
     ViewTransform2dFp64 const & view,
+    QColor const & color,
     std::span<DrawPoint const> points) const
 {
-    QPen pen(QColor(240, 200, 120));
+    QPen pen(color);
     pen.setCosmetic(true);
     pen.setWidthF(1.5);
     pen.setStyle(Qt::DashLine);

--- a/cpp/solvcon/pilot/canvas/DrawTool.hpp
+++ b/cpp/solvcon/pilot/canvas/DrawTool.hpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+class QColor;
 class QPainter;
 
 namespace solvcon
@@ -56,9 +57,14 @@ public:
     /// Wether this tool draws a shape or just navigates the view.
     virtual bool can_draw_shape() const = 0;
 
-    /// Paint the rubber-band preview of the gesture `points`. Sets the
-    /// shared preview pen, then defers to `paint_outline`.
-    void paint_preview(QPainter & painter, ViewTransform2dFp64 const & view, std::span<DrawPoint const> points) const;
+    /**
+     * Paint the rubber-band preview of the gesture `points` in `color`. Sets
+     * the shared preview pen, then defers to `paint_outline`.
+     */
+    void paint_preview(QPainter & painter,
+                       ViewTransform2dFp64 const & view,
+                       QColor const & color,
+                       std::span<DrawPoint const> points) const;
 
     /// Commit the shape described by the gesture `points` into `world`.
     virtual void commit(WorldFp64 & world, std::span<DrawPoint const> points) const = 0;

--- a/cpp/solvcon/pilot/canvas/R2DWidget.cpp
+++ b/cpp/solvcon/pilot/canvas/R2DWidget.cpp
@@ -8,6 +8,8 @@
 #include <array>
 #include <cmath>
 
+#include <solvcon/pilot/theme/theme_qt.hpp>
+
 #include <QColor>
 #include <QImage>
 #include <QMouseEvent>
@@ -46,8 +48,6 @@ constexpr double PICK_TOLERANCE_PX = 5.0;
 constexpr double ROTATE_HANDLE_GAP_PX = 16.0;
 constexpr double ROTATE_HANDLE_RADIUS_PX = 5.0;
 constexpr double ROTATE_HANDLE_HIT_PX = 9.0;
-
-QColor const SELECTION(120, 200, 255);
 
 double clamp_zoom(double zoom)
 {
@@ -154,7 +154,8 @@ void R2DWidget::paintEvent(QPaintEvent * /*event*/)
 {
     QPainter painter(this);
     constexpr bool full_canvas = true;
-    RWorldRenderer2d(m_world.get(), m_view, m_overlay).paint_canvas(painter, width(), height(), full_canvas);
+    RWorldRenderer2d(m_world.get(), m_view, m_palette, m_overlay)
+        .paint_canvas(painter, width(), height(), full_canvas);
 
     // Rubber-band preview of the shape currently being dragged, if any.
     paintDrawPreview(painter);
@@ -173,7 +174,7 @@ QImage R2DWidget::renderImage(Overlay2dOptions const & overlay) const
     image.setDevicePixelRatio(dpr);
     QPainter painter(&image);
     constexpr bool full_canvas = true;
-    RWorldRenderer2d(m_world.get(), m_view, overlay)
+    RWorldRenderer2d(m_world.get(), m_view, m_palette, overlay)
         .paint_canvas(painter, width(), height(), full_canvas);
     return image;
 }
@@ -200,7 +201,7 @@ bool R2DWidget::saveSvg(std::string const & filename, Overlay2dOptions const & o
         return false;
     }
     constexpr bool full_canvas = true;
-    RWorldRenderer2d(m_world.get(), m_view, overlay)
+    RWorldRenderer2d(m_world.get(), m_view, m_palette, overlay)
         .paint_canvas(painter, width(), height(), full_canvas);
     painter.end();
     return true;
@@ -218,7 +219,7 @@ void R2DWidget::paintDrawPreview(QPainter & painter) const
         return;
     }
     std::array<DrawPoint, 2> const points{{{m_draw_start_x, m_draw_start_y}, {m_draw_current_x, m_draw_current_y}}};
-    m_tool->paint_preview(painter, m_view, points);
+    m_tool->paint_preview(painter, m_view, qcolor(m_palette.draw_preview), points);
 }
 
 void R2DWidget::paintSelection(QPainter & painter) const
@@ -240,7 +241,8 @@ void R2DWidget::paintSelection(QPainter & painter) const
     }
 
     // Draw the box and the rotate handle knob.
-    QPen pen(SELECTION);
+    QColor const selection = qcolor(m_palette.selection);
+    QPen pen(selection);
     pen.setCosmetic(true);
     pen.setWidthF(1.5);
     pen.setStyle(Qt::DashLine);
@@ -253,7 +255,7 @@ void R2DWidget::paintSelection(QPainter & painter) const
     pen.setStyle(Qt::SolidLine);
     painter.setPen(pen);
     painter.drawLine(box.front(), handle);
-    painter.setBrush(SELECTION);
+    painter.setBrush(selection);
     painter.drawEllipse(handle, ROTATE_HANDLE_RADIUS_PX, ROTATE_HANDLE_RADIUS_PX);
 }
 

--- a/cpp/solvcon/pilot/canvas/R2DWidget.hpp
+++ b/cpp/solvcon/pilot/canvas/R2DWidget.hpp
@@ -17,6 +17,7 @@
 #include <solvcon/buffer/small_vector.hpp>
 #include <solvcon/pilot/canvas/DrawTool.hpp>
 #include <solvcon/pilot/canvas/RWorldRenderer2d.hpp>
+#include <solvcon/pilot/theme/theme.hpp>
 #include <solvcon/universe/ViewTransform2d.hpp>
 #include <solvcon/universe/World.hpp>
 
@@ -93,6 +94,19 @@ public:
 
     /// Get the world currently being painted.
     std::shared_ptr<WorldFp64> const & world() const { return m_world; }
+
+    Canvas2dPalette const & canvasPalette() const { return m_palette; }
+
+    /**
+     * Repaint the canvas with a new set of colors. The widget fills every
+     * pixel itself, so it cannot pick a theme switch up from the application
+     * palette; whoever owns the theme hands the new table down here instead.
+     */
+    void setCanvasPalette(Canvas2dPalette const & palette)
+    {
+        m_palette = palette;
+        update();
+    }
 
     Overlay2dOptions const & overlayOptions() const { return m_overlay; }
 
@@ -187,6 +201,14 @@ private:
 
     ViewTransform2dFp64 m_view;
     std::shared_ptr<WorldFp64> m_world;
+
+    /**
+     * The colors every paint reads from. Seeded dark so a canvas built
+     * without a theme owner still draws; RManager replaces it as the widget
+     * is created and again on each theme change.
+     */
+    Canvas2dPalette m_palette = darkCanvas2dPalette();
+
     Overlay2dOptions m_overlay;
     bool m_view_modified = false;
     QPointF m_last_mouse_pos;

--- a/cpp/solvcon/pilot/canvas/RWorldRenderer2d.cpp
+++ b/cpp/solvcon/pilot/canvas/RWorldRenderer2d.cpp
@@ -12,6 +12,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <solvcon/pilot/theme/theme_qt.hpp>
+
 #include <QColor>
 #include <QFontMetricsF>
 #include <QPainter>
@@ -27,15 +29,6 @@ namespace solvcon
 
 namespace
 {
-
-QColor const BACKGROUND(32, 32, 36);
-QColor const MINOR_GRID(64, 64, 70);
-QColor const AXIS(200, 200, 80);
-QColor const ORIGIN(220, 80, 80);
-QColor const GEOMETRY(120, 180, 240);
-QColor const OVERLAY_TEXT(225, 225, 230);
-QColor const OVERLAY_BBOX(150, 200, 150);
-QColor const OVERLAY_HIGHLIGHT(240, 180, 60);
 
 constexpr double BASE_GRID_SPACING_PX = 64.0;
 constexpr double MIN_GRID_SPACING_PX = 16.0;
@@ -123,7 +116,12 @@ private:
     double m_first;
 }; /* end class GridLineRange */
 
-void paint_chrome(QPainter & painter, ViewTransform2dFp64 const & view, int width, int height)
+void paint_chrome(
+    QPainter & painter,
+    ViewTransform2dFp64 const & view,
+    Canvas2dPalette const & palette,
+    int width,
+    int height)
 {
     double const widget_w = static_cast<double>(width);
     double const widget_h = static_cast<double>(height);
@@ -131,7 +129,7 @@ void paint_chrome(QPainter & painter, ViewTransform2dFp64 const & view, int widt
     double const spacing_px = view.zoom() * grid_spacing_world(view);
 
     // Draw minor grid lines in screen space directly.
-    QPen minor_pen(MINOR_GRID);
+    QPen minor_pen(qcolor(palette.minor_grid));
     minor_pen.setCosmetic(true);
     minor_pen.setWidth(1);
     painter.setPen(minor_pen);
@@ -146,7 +144,7 @@ void paint_chrome(QPainter & painter, ViewTransform2dFp64 const & view, int widt
     }
 
     // Draw the world axes through the origin, if visible.
-    QPen axis_pen(AXIS);
+    QPen axis_pen(qcolor(palette.axis));
     axis_pen.setCosmetic(true);
     axis_pen.setWidth(1);
     painter.setPen(axis_pen);
@@ -203,13 +201,13 @@ public:
     {
     }
 
-    void paint()
+    void paint(QColor const & overlay_text_color)
     {
         if (!(m_spacing_px > 0.0) || !std::isfinite(m_spacing_world))
         {
             return;
         }
-        m_painter.setPen(OVERLAY_TEXT);
+        m_painter.setPen(overlay_text_color);
         paint_x_row();
         paint_y_column();
         paint_axis_letters();
@@ -628,7 +626,7 @@ void RWorldRenderer2d::paint(QPainter & painter) const
     }
 
     // Segments and flattened curves share one cosmetic stroke pen.
-    QPen geom_pen(GEOMETRY);
+    QPen geom_pen(qcolor(m_palette.geometry));
     geom_pen.setCosmetic(true);
     geom_pen.setWidthF(GEOMETRY_LINE_WIDTH_PX);
     painter.setPen(geom_pen);
@@ -660,7 +658,7 @@ void RWorldRenderer2d::paint(QPainter & painter) const
     std::shared_ptr<PointPadFp64> const & points = m_world->points();
     if (points->size() > 0)
     {
-        QPen point_pen(GEOMETRY);
+        QPen point_pen(qcolor(m_palette.geometry));
         point_pen.setCosmetic(true);
         point_pen.setWidth(GEOMETRY_POINT_WIDTH_PX);
         point_pen.setCapStyle(Qt::RoundCap);
@@ -684,11 +682,14 @@ void RWorldRenderer2d::paint_shape_annotations(
     std::vector<int32_t> const ids = m_world->query_visible(
         std::min(left, right), std::min(top, bottom), std::max(left, right), std::max(top, bottom));
 
-    QPen bbox_pen(OVERLAY_BBOX);
+    QColor const label_text_color = qcolor(m_palette.overlay_text);
+    QColor const label_highlight_color = qcolor(m_palette.overlay_highlight);
+
+    QPen bbox_pen(qcolor(m_palette.overlay_bbox));
     bbox_pen.setCosmetic(true);
     bbox_pen.setWidthF(1.0);
     bbox_pen.setStyle(Qt::DashLine);
-    QPen highlight_pen(OVERLAY_HIGHLIGHT);
+    QPen highlight_pen(label_highlight_color);
     highlight_pen.setCosmetic(true);
     highlight_pen.setWidthF(2.0);
     highlight_pen.setStyle(Qt::DashLine);
@@ -781,7 +782,7 @@ void RWorldRenderer2d::paint_shape_annotations(
         QRectF const placed(tl.x(), tl.y(), block_w, block_h);
         obstacles.add(placed);
 
-        painter.setPen(highlighted ? OVERLAY_HIGHLIGHT : OVERLAY_TEXT);
+        painter.setPen(highlighted ? label_highlight_color : label_text_color);
         painter.drawText(placed, Qt::AlignLeft | Qt::AlignTop, rows.join(QChar('\n')));
     }
 }
@@ -795,7 +796,7 @@ void RWorldRenderer2d::paint_overlay(QPainter & painter, int width, int height) 
     if (m_overlay.coordinate_labels)
     {
         CoordinateLabelPainter labels(painter, m_view, width, height);
-        labels.paint();
+        labels.paint(qcolor(m_palette.overlay_text));
         coord_labels = labels.placed();
     }
     if (m_world && m_overlay.shape_annotations())
@@ -807,11 +808,11 @@ void RWorldRenderer2d::paint_overlay(QPainter & painter, int width, int height) 
 void RWorldRenderer2d::paint_canvas(QPainter & painter, int width, int height, bool full_canvas) const
 {
     painter.setRenderHint(QPainter::Antialiasing, true);
-    painter.fillRect(0, 0, width, height, BACKGROUND);
+    painter.fillRect(0, 0, width, height, qcolor(m_palette.background));
 
     if (full_canvas)
     {
-        paint_chrome(painter, m_view, width, height);
+        paint_chrome(painter, m_view, m_palette, width, height);
     }
 
     paint(painter);
@@ -819,7 +820,7 @@ void RWorldRenderer2d::paint_canvas(QPainter & painter, int width, int height, b
     if (full_canvas)
     {
         // Origin dot (cosmetic, fixed pixel size regardless of zoom).
-        QPen origin_pen(ORIGIN);
+        QPen origin_pen(qcolor(m_palette.origin));
         origin_pen.setCosmetic(true);
         origin_pen.setWidth(6);
         origin_pen.setCapStyle(Qt::RoundCap);

--- a/cpp/solvcon/pilot/canvas/RWorldRenderer2d.hpp
+++ b/cpp/solvcon/pilot/canvas/RWorldRenderer2d.hpp
@@ -14,6 +14,7 @@
 
 #include <solvcon/pilot/common/common_detail.hpp> // Must be the first include.
 
+#include <solvcon/pilot/theme/theme.hpp>
 #include <solvcon/universe/ViewTransform2d.hpp>
 #include <solvcon/universe/World.hpp>
 
@@ -57,16 +58,22 @@ struct Overlay2dOptions
  * screen space, mapping math-convention world coordinates through a 2D view
  * transform. paint() draws geometry only; paint_canvas() adds the backdrop
  * and optional grid/axes/origin chrome, then the optional annotation overlay.
- * m_world is non-owning and may be null.
+ * Every color it paints with comes from the palette the caller hands in, so
+ * the canvas follows the theme. m_world is non-owning and may be null.
  *
  * @ingroup group_domain
  */
 class RWorldRenderer2d
 {
 public:
-    RWorldRenderer2d(WorldFp64 const * world, ViewTransform2dFp64 const & view, Overlay2dOptions const & overlay = {})
+    RWorldRenderer2d(
+        WorldFp64 const * world,
+        ViewTransform2dFp64 const & view,
+        Canvas2dPalette const & palette,
+        Overlay2dOptions const & overlay = {})
         : m_world(world)
         , m_view(view)
+        , m_palette(palette)
         , m_overlay(overlay)
     {
     }
@@ -89,6 +96,7 @@ private:
 
     WorldFp64 const * m_world;
     ViewTransform2dFp64 const & m_view;
+    Canvas2dPalette m_palette;
     Overlay2dOptions m_overlay;
 }; /* end class RWorldRenderer2d */
 

--- a/cpp/solvcon/pilot/console/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/console/RPythonConsoleDockWidget.cpp
@@ -6,6 +6,7 @@
 #include <solvcon/pilot/console/RPythonConsoleDockWidget.hpp>
 
 #include <solvcon/pilot/console/RPythonSyntaxRules.hpp>
+#include <solvcon/pilot/theme/theme_qt.hpp>
 
 #include <QAbstractItemView>
 #include <QApplication>
@@ -383,8 +384,7 @@ RPythonConsoleDockWidget::RPythonConsoleDockWidget(const QString & title, QWidge
 void RPythonConsoleDockWidget::applyTheme(SyntaxColors const & colors)
 {
     m_highlighter->applyColors(colors);
-    m_command_edit->setBracketMatchColor(
-        QColor(colors.bracket_match.r, colors.bracket_match.g, colors.bracket_match.b));
+    m_command_edit->setBracketMatchColor(qcolor(colors.bracket_match));
 }
 
 QString RPythonConsoleDockWidget::command() const

--- a/cpp/solvcon/pilot/console/RPythonSyntaxHighlighter.cpp
+++ b/cpp/solvcon/pilot/console/RPythonSyntaxHighlighter.cpp
@@ -6,8 +6,8 @@
 #include <solvcon/pilot/console/RPythonSyntaxHighlighter.hpp>
 
 #include <solvcon/pilot/console/RPythonSyntaxRules.hpp>
+#include <solvcon/pilot/theme/theme_qt.hpp>
 
-#include <QColor>
 #include <QTextBlock>
 
 namespace solvcon
@@ -25,14 +25,11 @@ RPythonSyntaxHighlighter::RPythonSyntaxHighlighter(QTextDocument * parent)
 
 void RPythonSyntaxHighlighter::applyColors(SyntaxColors const & colors)
 {
-    auto qc = [](ThemeColor c)
-    { return QColor(c.r, c.g, c.b); };
-
-    m_keyword_format.setForeground(qc(colors.keyword));
-    m_builtin_format.setForeground(qc(colors.builtin));
-    m_string_format.setForeground(qc(colors.string));
-    m_comment_format.setForeground(qc(colors.comment));
-    m_number_format.setForeground(qc(colors.number));
+    m_keyword_format.setForeground(qcolor(colors.keyword));
+    m_builtin_format.setForeground(qcolor(colors.builtin));
+    m_string_format.setForeground(qcolor(colors.string));
+    m_comment_format.setForeground(qcolor(colors.comment));
+    m_number_format.setForeground(qcolor(colors.number));
     rehighlight();
 }
 

--- a/cpp/solvcon/pilot/console/RPythonTerminalDockWidget.cpp
+++ b/cpp/solvcon/pilot/console/RPythonTerminalDockWidget.cpp
@@ -6,12 +6,12 @@
 #include <solvcon/pilot/console/RPythonTerminalDockWidget.hpp>
 
 #include <solvcon/pilot/console/RPythonSyntaxRules.hpp>
+#include <solvcon/pilot/theme/theme_qt.hpp>
 
 #include <algorithm>
 
 #include <QAbstractItemView>
 #include <QApplication>
-#include <QColor>
 #include <QFont>
 #include <QKeyEvent>
 #include <QMimeData>
@@ -487,9 +487,8 @@ void RPythonTerminalDockWidget::writeToHistory(std::string const & data)
 void RPythonTerminalDockWidget::applyTheme(SyntaxColors const & colors)
 {
     m_highlighter->applyColors(colors);
-    m_edit->setBracketMatchColor(
-        QColor(colors.bracket_match.r, colors.bracket_match.g, colors.bracket_match.b));
-    m_edit->setErrorColor(QColor(colors.error.r, colors.error.g, colors.error.b));
+    m_edit->setBracketMatchColor(qcolor(colors.bracket_match));
+    m_edit->setErrorColor(qcolor(colors.error));
 }
 
 void RPythonTerminalDockWidget::executeCommand()

--- a/cpp/solvcon/pilot/theme/RThemeManager.cpp
+++ b/cpp/solvcon/pilot/theme/RThemeManager.cpp
@@ -5,6 +5,8 @@
 
 #include <solvcon/pilot/theme/RThemeManager.hpp> // Must be the first include.
 
+#include <solvcon/pilot/theme/theme_qt.hpp>
+
 #include <QApplication>
 #include <QColor>
 #include <QGuiApplication>
@@ -145,6 +147,14 @@ ThemeCapabilities RThemeManager::capabilities() const
     return m_backend->capabilities();
 }
 
+Canvas2dPalette const & RThemeManager::canvas2dPalette() const
+{
+    // The canvas keeps its curated tables under either look: the system look
+    // hands over the platform's widget colors, which say nothing about how a
+    // drawing surface should read.
+    return canvas2dPaletteFor(m_backend->platform(), currentVariant());
+}
+
 std::string RThemeManager::modeId() const
 {
     return themeModeId(m_mode);
@@ -192,46 +202,43 @@ void RThemeManager::syncOsColorScheme()
 
 QPalette RThemeManager::buildPalette(ThemePalette const & spec, ThemeVariant variant) const
 {
-    auto color = [](ThemeColor c)
-    { return QColor(c.r, c.g, c.b); };
-
     // A native accent, when the backend reads one, overrides the curated
     // highlight so the pilot picks up the user's chosen system color.
-    QColor highlight = color(spec.highlight);
+    QColor highlight = qcolor(spec.highlight);
     if (std::optional<ThemeColor> const accent = m_backend->accentColor(variant))
     {
-        highlight = color(*accent);
+        highlight = qcolor(*accent);
     }
 
     QPalette pal;
-    pal.setColor(QPalette::Window, color(spec.window));
-    pal.setColor(QPalette::WindowText, color(spec.window_text));
-    pal.setColor(QPalette::Base, color(spec.base));
-    pal.setColor(QPalette::AlternateBase, color(spec.alternate_base));
-    pal.setColor(QPalette::Text, color(spec.text));
-    pal.setColor(QPalette::Button, color(spec.button));
-    pal.setColor(QPalette::ButtonText, color(spec.button_text));
-    pal.setColor(QPalette::BrightText, color(spec.bright_text));
+    pal.setColor(QPalette::Window, qcolor(spec.window));
+    pal.setColor(QPalette::WindowText, qcolor(spec.window_text));
+    pal.setColor(QPalette::Base, qcolor(spec.base));
+    pal.setColor(QPalette::AlternateBase, qcolor(spec.alternate_base));
+    pal.setColor(QPalette::Text, qcolor(spec.text));
+    pal.setColor(QPalette::Button, qcolor(spec.button));
+    pal.setColor(QPalette::ButtonText, qcolor(spec.button_text));
+    pal.setColor(QPalette::BrightText, qcolor(spec.bright_text));
     pal.setColor(QPalette::Highlight, highlight);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
     // The dedicated Accent role (Qt 6.6+) lets widgets that want the platform
     // accent, distinct from a selection highlight, pick it up from the palette.
     pal.setColor(QPalette::Accent, highlight);
 #endif
-    pal.setColor(QPalette::HighlightedText, color(spec.highlighted_text));
-    pal.setColor(QPalette::ToolTipBase, color(spec.tool_tip_base));
-    pal.setColor(QPalette::ToolTipText, color(spec.tool_tip_text));
-    pal.setColor(QPalette::PlaceholderText, color(spec.placeholder_text));
-    pal.setColor(QPalette::Link, color(spec.link));
-    pal.setColor(QPalette::LinkVisited, color(spec.link_visited));
+    pal.setColor(QPalette::HighlightedText, qcolor(spec.highlighted_text));
+    pal.setColor(QPalette::ToolTipBase, qcolor(spec.tool_tip_base));
+    pal.setColor(QPalette::ToolTipText, qcolor(spec.tool_tip_text));
+    pal.setColor(QPalette::PlaceholderText, qcolor(spec.placeholder_text));
+    pal.setColor(QPalette::Link, qcolor(spec.link));
+    pal.setColor(QPalette::LinkVisited, qcolor(spec.link_visited));
 
     // The disabled group keeps greyed-out controls legible instead of letting
     // the style derive a washed-out shade from the enabled colors.
-    pal.setColor(QPalette::Disabled, QPalette::Text, color(spec.disabled_text));
-    pal.setColor(QPalette::Disabled, QPalette::WindowText, color(spec.disabled_window_text));
-    pal.setColor(QPalette::Disabled, QPalette::ButtonText, color(spec.disabled_button_text));
-    pal.setColor(QPalette::Disabled, QPalette::HighlightedText, color(spec.disabled_text));
-    pal.setColor(QPalette::Disabled, QPalette::Highlight, color(spec.disabled_highlight));
+    pal.setColor(QPalette::Disabled, QPalette::Text, qcolor(spec.disabled_text));
+    pal.setColor(QPalette::Disabled, QPalette::WindowText, qcolor(spec.disabled_window_text));
+    pal.setColor(QPalette::Disabled, QPalette::ButtonText, qcolor(spec.disabled_button_text));
+    pal.setColor(QPalette::Disabled, QPalette::HighlightedText, qcolor(spec.disabled_text));
+    pal.setColor(QPalette::Disabled, QPalette::Highlight, qcolor(spec.disabled_highlight));
     return pal;
 }
 

--- a/cpp/solvcon/pilot/theme/RThemeManager.hpp
+++ b/cpp/solvcon/pilot/theme/RThemeManager.hpp
@@ -108,6 +108,12 @@ public:
     /// switch behind the application palette.
     QColor windowColor() const { return m_window_color; }
 
+    /**
+     * The 2D canvas colors the current variant resolves to, for a canvas that
+     * fills its own pixels and so cannot pick the theme up from the palette.
+     */
+    Canvas2dPalette const & canvas2dPalette() const;
+
 signals:
 
     /// Emitted after a palette is applied, carrying the resolved variant.

--- a/cpp/solvcon/pilot/theme/theme.cpp
+++ b/cpp/solvcon/pilot/theme/theme.cpp
@@ -210,6 +210,45 @@ static SyntaxColors makeDarkSyntaxColors()
     return c;
 }
 
+// The canvas tables invert around the drawing surface: a white sheet with dark
+// chrome under the light variant, a near-black sheet with lifted chrome under
+// the dark one. The background, the geometry stroke, and the shared selection
+// accent are the design's own values; the rest are tuned to sit a readable
+// distance off whichever surface they land on. Grid lines stay the quietest
+// mark on the canvas and the origin the loudest, in both variants.
+
+static Canvas2dPalette makeLightCanvas2dPalette()
+{
+    Canvas2dPalette c;
+    c.background = {0xff, 0xff, 0xff};
+    c.minor_grid = {0xc9, 0xc9, 0xc9};
+    c.axis = {0x96, 0x8c, 0x28};
+    c.origin = {0xc8, 0x32, 0x32};
+    c.geometry = {0x3d, 0x86, 0xc6};
+    c.selection = {0x0d, 0x99, 0xff};
+    c.draw_preview = {0xa8, 0x8a, 0x2a};
+    c.overlay_text = {0x1c, 0x1e, 0x21};
+    c.overlay_bbox = {0x3c, 0x78, 0x3c};
+    c.overlay_highlight = {0xb0, 0x6e, 0x10};
+    return c;
+}
+
+static Canvas2dPalette makeDarkCanvas2dPalette()
+{
+    Canvas2dPalette c;
+    c.background = {0x1a, 0x1a, 0x1a};
+    c.minor_grid = {0x40, 0x40, 0x46};
+    c.axis = {0xc8, 0xc8, 0x50};
+    c.origin = {0xdc, 0x50, 0x50};
+    c.geometry = {0x5a, 0xa9, 0xe6};
+    c.selection = {0x0d, 0x99, 0xff};
+    c.draw_preview = {0xf0, 0xc8, 0x78};
+    c.overlay_text = {0xe1, 0xe1, 0xe6};
+    c.overlay_bbox = {0x96, 0xc8, 0x96};
+    c.overlay_highlight = {0xf0, 0xb4, 0x3c};
+    return c;
+}
+
 // The capability records state what each platform's theme can honor. macOS and
 // Windows own their title bar and pin a variant through the native color-scheme
 // hint, so both flags are set; Linux carries a pinned variant with the curated
@@ -318,6 +357,26 @@ SyntaxColors const & syntaxColorsFor(PlatformId platform, ThemeVariant variant)
 {
     (void)platform;
     return variant == ThemeVariant::Dark ? darkSyntaxColors() : lightSyntaxColors();
+}
+
+Canvas2dPalette const & lightCanvas2dPalette()
+{
+    static Canvas2dPalette const palette = makeLightCanvas2dPalette();
+    return palette;
+}
+
+Canvas2dPalette const & darkCanvas2dPalette()
+{
+    static Canvas2dPalette const palette = makeDarkCanvas2dPalette();
+    return palette;
+}
+
+Canvas2dPalette const & canvas2dPaletteFor(PlatformId platform, ThemeVariant variant)
+{
+    // A drawing surface is the pilot's own, not the platform's, so no room
+    // tunes it; the variant alone picks the table.
+    (void)platform;
+    return variant == ThemeVariant::Dark ? darkCanvas2dPalette() : lightCanvas2dPalette();
 }
 
 ThemeCapabilities const & themeCapabilitiesFor(PlatformId platform)

--- a/cpp/solvcon/pilot/theme/theme.hpp
+++ b/cpp/solvcon/pilot/theme/theme.hpp
@@ -140,6 +140,30 @@ struct SyntaxColors
 }; /* end struct SyntaxColors */
 
 /**
+ * @brief The colors the 2D canvas paints its own surface with.
+ *
+ * The canvas fills every pixel itself rather than letting the style paint a
+ * widget, so none of these are QPalette roles and they sit apart from
+ * ThemePalette. Like the syntax colors they come in a light and a dark table,
+ * which is what lets the canvas follow the theme instead of staying dark under
+ * a light window. selection is the same accent in both variants, so a selected
+ * shape reads as selected at a glance either way.
+ */
+struct Canvas2dPalette
+{
+    ThemeColor background;
+    ThemeColor minor_grid;
+    ThemeColor axis;
+    ThemeColor origin;
+    ThemeColor geometry;
+    ThemeColor selection;
+    ThemeColor draw_preview;
+    ThemeColor overlay_text;
+    ThemeColor overlay_bbox;
+    ThemeColor overlay_highlight;
+}; /* end struct Canvas2dPalette */
+
+/**
  * @brief What a platform's theme is able to honor.
  *
  * A plain record of yes-or-no facts, kept in the Qt-free core so it is data a
@@ -182,6 +206,15 @@ SyntaxColors const & darkSyntaxColors();
 
 /// The syntax colors a platform draws a resolved variant with.
 SyntaxColors const & syntaxColorsFor(PlatformId platform, ThemeVariant variant);
+
+/// The canvas colors for a white drawing surface.
+Canvas2dPalette const & lightCanvas2dPalette();
+
+/// The canvas colors for a near-black drawing surface.
+Canvas2dPalette const & darkCanvas2dPalette();
+
+/// The canvas colors a platform draws a resolved variant with.
+Canvas2dPalette const & canvas2dPaletteFor(PlatformId platform, ThemeVariant variant);
 
 /// The capability record for a platform.
 ThemeCapabilities const & themeCapabilitiesFor(PlatformId platform);

--- a/cpp/solvcon/pilot/theme/theme_qt.hpp
+++ b/cpp/solvcon/pilot/theme/theme_qt.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * The one bridge from the Qt-free theme foundation into Qt's own color type.
+ *
+ * theme.hpp deliberately mentions no Qt so the color tables compile into the
+ * no-GUI test target, which leaves every Qt consumer needing the same three
+ * field copies. They belong here, once, rather than as a private lambda in
+ * each adapter.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/theme/theme.hpp>
+
+#include <QColor>
+
+namespace solvcon
+{
+
+/// The Qt color for one theme color.
+inline QColor qcolor(ThemeColor c) { return QColor(c.r, c.g, c.b); }
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -157,6 +157,27 @@ static pybind11::object pick_to_py(RDomainWidget::PickResult const & r)
     return d;
 }
 
+/// Convert a canvas palette to a Python dict of (r, g, b) tuples.
+static pybind11::dict canvas_palette_to_py(Canvas2dPalette const & p)
+{
+    namespace py = pybind11;
+    auto rgb = [](ThemeColor c)
+    { return py::make_tuple(c.r, c.g, c.b); };
+
+    py::dict d;
+    d["background"] = rgb(p.background);
+    d["minor_grid"] = rgb(p.minor_grid);
+    d["axis"] = rgb(p.axis);
+    d["origin"] = rgb(p.origin);
+    d["geometry"] = rgb(p.geometry);
+    d["selection"] = rgb(p.selection);
+    d["draw_preview"] = rgb(p.draw_preview);
+    d["overlay_text"] = rgb(p.overlay_text);
+    d["overlay_bbox"] = rgb(p.overlay_bbox);
+    d["overlay_highlight"] = rgb(p.overlay_highlight);
+    return d;
+}
+
 /// Convert a resolved shortcut to a Python dict of its portable fields.
 static pybind11::dict resolved_shortcut_to_py(ResolvedShortcut const & r)
 {
@@ -645,6 +666,14 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapR2DWidget
                 &wrapped_type::overlayOptions,
                 &wrapped_type::setOverlayOptions,
                 py::return_value_policy::copy)
+            .def_property_readonly(
+                "canvasPalette",
+                [](wrapped_type & self)
+                {
+                    return canvas_palette_to_py(self.canvasPalette());
+                },
+                "The colors this canvas paints with, as name -> (r, g, b). "
+                "Follows the application theme.")
             .def("setDrawTool", &wrapped_type::setDrawTool, py::arg("name"))
             .def_property_readonly("drawTool", &wrapped_type::drawTool)
             .def_property_readonly("selectedShape", &wrapped_type::selectedShape)

--- a/gtests/test_nopython_pilot_theme.cpp
+++ b/gtests/test_nopython_pilot_theme.cpp
@@ -5,12 +5,16 @@
 
 #include <solvcon/pilot/theme/theme.hpp>
 
+#include <cstdlib>
 #include <string>
 
 #include <gtest/gtest.h>
 
+using solvcon::canvas2dPaletteFor;
+using solvcon::darkCanvas2dPalette;
 using solvcon::darkSyntaxColors;
 using solvcon::darkThemePalette;
+using solvcon::lightCanvas2dPalette;
 using solvcon::lightSyntaxColors;
 using solvcon::lightThemePalette;
 using solvcon::linuxDesktopHasNativeTheme;
@@ -29,6 +33,23 @@ using solvcon::themeModeId;
 using solvcon::themeModeLabel;
 using solvcon::themePaletteFor;
 using solvcon::ThemeVariant;
+
+namespace
+{
+
+/// Rough perceived lightness, enough to order two canvas colors apart.
+int lightness(solvcon::ThemeColor c)
+{
+    return (2 * static_cast<int>(c.r) + 5 * static_cast<int>(c.g) + static_cast<int>(c.b)) / 8;
+}
+
+/// How far a mark sits from the surface it is painted on.
+int contrast(solvcon::ThemeColor mark, solvcon::ThemeColor surface)
+{
+    return std::abs(lightness(mark) - lightness(surface));
+}
+
+} /* end namespace */
 
 TEST(PilotThemeResolve, ForcedModesIgnoreTheOs)
 {
@@ -177,6 +198,87 @@ TEST(PilotThemeSyntax, DarkTokensAreBrighterAndSelectByVariant)
     {
         EXPECT_EQ(syntaxColorsFor(platform, ThemeVariant::Light).keyword.b, light.keyword.b);
         EXPECT_EQ(syntaxColorsFor(platform, ThemeVariant::Dark).keyword.b, dark.keyword.b);
+    }
+}
+
+TEST(PilotCanvas2dPalette, TablesInvertAndSelectByVariant)
+{
+    auto const & light = lightCanvas2dPalette();
+    auto const & dark = darkCanvas2dPalette();
+
+    // A light canvas is a bright sheet carrying dark marks; a dark canvas is
+    // the other way round. Ordering the grid against its own background, not
+    // against the other table, is what catches the two being swapped.
+    EXPECT_GT(lightness(light.background), lightness(dark.background));
+    EXPECT_LT(lightness(light.minor_grid), lightness(light.background));
+    EXPECT_GT(lightness(dark.minor_grid), lightness(dark.background));
+
+    // The selection accent is deliberately the one color both variants share,
+    // so a selected shape reads as selected at a glance under either theme;
+    // the marks around it do change, or the canvas would not follow the theme.
+    EXPECT_EQ(light.selection.b, dark.selection.b);
+    EXPECT_NE(light.geometry.r, dark.geometry.r);
+    EXPECT_NE(light.overlay_text.r, dark.overlay_text.r);
+
+    // No platform tunes the drawing surface, so the variant alone picks the
+    // table wherever the pilot runs.
+    for (PlatformId platform : {PlatformId::Linux, PlatformId::Mac, PlatformId::Windows})
+    {
+        EXPECT_EQ(canvas2dPaletteFor(platform, ThemeVariant::Light).background.r, light.background.r);
+        EXPECT_EQ(canvas2dPaletteFor(platform, ThemeVariant::Dark).background.r, dark.background.r);
+    }
+}
+
+TEST(PilotCanvas2dPalette, EveryMarkStandsOffItsOwnBackground)
+{
+    // A mark drawn too near the surface under it disappears, which is exactly
+    // what a canvas that ignored the theme did. Hold every mark a readable
+    // distance off the background of its own variant, and keep the grid the
+    // quietest of them since it is the rhythm the axes are a landmark over.
+    constexpr int MIN_CONTRAST = 24;
+
+    for (auto const & p : {lightCanvas2dPalette(), darkCanvas2dPalette()})
+    {
+        EXPECT_GE(contrast(p.minor_grid, p.background), MIN_CONTRAST);
+        EXPECT_GE(contrast(p.axis, p.background), MIN_CONTRAST);
+        EXPECT_GE(contrast(p.origin, p.background), MIN_CONTRAST);
+        EXPECT_GE(contrast(p.geometry, p.background), MIN_CONTRAST);
+        EXPECT_GE(contrast(p.selection, p.background), MIN_CONTRAST);
+        EXPECT_GE(contrast(p.draw_preview, p.background), MIN_CONTRAST);
+        EXPECT_GE(contrast(p.overlay_text, p.background), MIN_CONTRAST);
+        EXPECT_GE(contrast(p.overlay_bbox, p.background), MIN_CONTRAST);
+        EXPECT_GE(contrast(p.overlay_highlight, p.background), MIN_CONTRAST);
+        EXPECT_GT(contrast(p.axis, p.background), contrast(p.minor_grid, p.background));
+    }
+}
+
+TEST(PilotCanvas2dPalette, OnAPlainFrameOnlyGeometryIsBlueAndTheOriginRed)
+{
+    // The Python pixel tests locate geometry and the origin marker by color
+    // dominance rather than by literal values, which only works while no other
+    // mark on a plain frame answers to either rule. That is a property of these
+    // tables, so it is held here instead of argued in a comment over there. A
+    // plain frame is the backdrop, grid, axes, origin, and geometry: the
+    // selection accent and the overlay marks are drawn only when asked for, and
+    // both would answer.
+    auto blue_dominant = [](solvcon::ThemeColor c)
+    { return c.b >= 120 && c.b > c.r + 30 && c.b > c.g; };
+    auto red_dominant = [](solvcon::ThemeColor c)
+    { return c.r >= 150 && c.r > c.g + 40 && c.r > c.b + 40; };
+
+    for (auto const & p : {lightCanvas2dPalette(), darkCanvas2dPalette()})
+    {
+        EXPECT_TRUE(blue_dominant(p.geometry));
+        EXPECT_TRUE(red_dominant(p.origin));
+
+        for (solvcon::ThemeColor c : {p.background, p.minor_grid, p.axis, p.origin})
+        {
+            EXPECT_FALSE(blue_dominant(c));
+        }
+        for (solvcon::ThemeColor c : {p.background, p.minor_grid, p.axis, p.geometry})
+        {
+            EXPECT_FALSE(red_dominant(c));
+        }
     }
 }
 

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -27,12 +27,13 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
 
 _PNG_MAGIC = b'\x89PNG\r\n\x1a\n'
 
-# The pixel helpers below classify colors that RWorldRenderer2d paints (see
-# RWorldRenderer2d.cpp). GEOMETRY (120, 180, 240) is the only strongly-blue
-# color: the backdrop, grid, axes, and origin marker all have blue <= 80, so
-# a blue-dominant pixel must be geometry. ORIGIN (220, 80, 80) is the only
-# red-dominant color, since the yellow axes have equal red and green, which
-# lets the origin marker be located on its own.
+# The pixel helpers below classify colors that RWorldRenderer2d paints. Which
+# ones those are depends on the theme (Canvas2dPalette in theme.cpp), so the
+# masks key on dominance rather than on literal values: on a plain frame the
+# geometry stroke is the only blue-dominant mark and the origin marker the only
+# red-dominant one. Both canvas tables are held to that rule by the gtest
+# PilotCanvas2dPalette.OnAPlainFrameOnlyGeometryIsBlueAndTheOriginRed, so these
+# thresholds read the same under light and dark.
 
 
 def _clipboard_can_hold_pixmap(clipboard):
@@ -669,8 +670,8 @@ def _grab_foreground(widget, overlay=None):
         else:
             assert widget.saveImage(path, overlay)
         rgb = _load_rgba(path)[:, :, :3].astype('int16')
-    # The canvas backdrop is RGB(32, 32, 36); anything far from it is drawn.
-    background = np.array([32, 32, 36], dtype='int16')
+    # Anything far from the themed backdrop was drawn on top of it.
+    background = np.array(widget.canvasPalette["background"], dtype='int16')
     return int((np.abs(rgb - background).max(axis=2) > 60).sum())
 
 
@@ -990,6 +991,55 @@ class R2DWidgetExportOverlayTC(unittest.TestCase):
         if not labeled and not plain:
             self.skipTest("offscreen render reads back blank on this backend")
         self.assertGreater(labeled, plain)
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "theme switching needs a real window surface")
+class R2DWidgetThemeTC(unittest.TestCase):
+    """The painted frame follows the theme, not just the palette the widget
+    reports. Whether a canvas is themed can only be settled on the pixels.
+    """
+
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.widget = self.mgr.add2DWidget()
+
+    def tearDown(self):
+        # The manager is a shared singleton, so restore the default mode to
+        # keep the tests independent of the order they run in.
+        self.mgr.set_theme("system")
+
+    def _dominant_color(self):
+        """The most common color in an offscreen render of an empty canvas.
+
+        On a world with no geometry the backdrop covers nearly every pixel,
+        with only the grid, the axes, and the origin marker over it, so the
+        winner is the backdrop the renderer filled with. Reading the most
+        common color rather than a fixed pixel keeps the test off the grid
+        lines, whose spacing shifts with the view.
+        """
+        self.widget.updateWorld(solvcon.WorldFp64())
+        self.widget.resetView()
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "theme.png")
+            self.assertTrue(
+                self.widget.saveImage(path, pilot.Overlay2dOptions()))
+            pixels = _load_rgba(path)[:, :, :3].astype('uint32')
+        # Pack each pixel into one integer first: np.unique over a 1-D array
+        # is a plain sort, while over rows (axis=0) it takes a much slower
+        # void-dtype lexsort.
+        packed = ((pixels[:, :, 0] << 16)
+                  | (pixels[:, :, 1] << 8) | pixels[:, :, 2]).ravel()
+        values, counts = np.unique(packed, return_counts=True)
+        winner = int(values[counts.argmax()])
+        return (winner >> 16, (winner >> 8) & 0xff, winner & 0xff)
+
+    def test_the_rendered_backdrop_is_the_themed_one(self):
+        for mode in ("light", "dark"):
+            with self.subTest(mode=mode):
+                self.mgr.set_theme(mode)
+                self.assertEqual(self._dominant_color(),
+                                 self.widget.canvasPalette["background"])
 
 
 @unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,

--- a/tests/test_pilot_theme.py
+++ b/tests/test_pilot_theme.py
@@ -12,7 +12,7 @@ try:
     from solvcon.pilot.base import _gui
     from PySide6 import QtWidgets
     from PySide6.QtCore import QSettings, QStandardPaths
-    from PySide6.QtGui import QPalette
+    from PySide6.QtGui import QColor, QPalette
     # Redirect QSettings to a throwaway location so the theme's persistence
     # does not touch the developer's real configuration during the tests.
     QStandardPaths.setTestModeEnabled(True)
@@ -215,6 +215,55 @@ class ThemePolishTC(unittest.TestCase):
         settings = QSettings("solvcon", "pilot")
         self.assertEqual(settings.value("theme/mode"), "dark")
         self.assertEqual(settings.value("theme/look"), "system")
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class ThemeCanvasTC(unittest.TestCase):
+    """The 2D canvas fills every pixel itself instead of letting the style
+    paint a widget, so it follows the theme only because the manager hands it
+    the canvas colors on creation and again on each switch.
+    """
+
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.app = QtWidgets.QApplication.instance()
+
+    def tearDown(self):
+        # The manager is a shared singleton, so restore the default mode to
+        # keep the tests independent of the order they run in.
+        self.mgr.set_theme("system")
+
+    @staticmethod
+    def _backdrop_lightness(canvas):
+        return QColor(*canvas.canvasPalette["background"]).lightness()
+
+    def test_an_open_canvas_follows_a_later_switch(self):
+        # The canvas is opened first and the theme changed after, the path
+        # that used to leave a dark canvas sitting in a light window.
+        canvas = self.mgr.add2DWidget()
+        self.mgr.set_theme("dark")
+        self.assertLess(self._backdrop_lightness(canvas), 100)
+        self.mgr.set_theme("light")
+        self.assertGreater(self._backdrop_lightness(canvas), 150)
+
+    def test_a_new_canvas_starts_on_the_current_theme(self):
+        # A canvas opened after the switch must not wait for the next one.
+        self.mgr.set_theme("dark")
+        dark = self._backdrop_lightness(self.mgr.add2DWidget())
+        self.mgr.set_theme("light")
+        light = self._backdrop_lightness(self.mgr.add2DWidget())
+        self.assertLess(dark, light)
+
+    def test_the_canvas_is_a_sheet_rather_than_more_chrome(self):
+        # Under the light theme the drawing surface is brighter than the
+        # window around it, so the canvas reads as paper on a desk instead of
+        # merging into the panels.
+        self.mgr.set_theme("light")
+        canvas = self.mgr.add2DWidget()
+        self.assertGreater(
+            self._backdrop_lightness(canvas),
+            self.app.palette().color(QPalette.Window).lightness())
 
 
 @unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,


### PR DESCRIPTION
The pilot 2D canvas painted from color constants compiled into RWorldRenderer2d and R2DWidget, so it stayed dark under the light theme while every other widget switched. A canvas fills every pixel itself and cannot inherit a QPalette, so the colors have to be handed to it.

This adds Canvas2dPalette beside ThemePalette in the Qt-free theme foundation, with a light and a dark table, and exposes the resolved one from RThemeManager. The renderer, the widget, and the rubber-band preview now read every color from it, and RManager hands the table to each canvas as the canvas is created and again on every theme change. theme_qt.hpp carries the one ThemeColor to QColor conversion the Qt consumers share.

R2DWidget.canvasPalette is exposed to Python as a name to (r, g, b) mapping, which is what the new tests in test_pilot_2d.py and test_pilot_theme.py check the canvas against. A gtest covers the two tables directly in the no-GUI target.

Related to #1062.
