### PR TITLE
Balance timed wrapper profiling on exceptions

### DIFF
--- a/cpp/solvcon/python/common.hpp
+++ b/cpp/solvcon/python/common.hpp
@@ -85,6 +85,37 @@ private:
 
 }; /* end class WrapperProfilerStatus */
 
+class WrapperProfilerGuard
+{
+
+public:
+
+    WrapperProfilerGuard()
+        : m_enabled(WrapperProfilerStatus::me().enabled())
+    {
+    }
+
+    WrapperProfilerGuard(WrapperProfilerGuard const &) = delete;
+    WrapperProfilerGuard(WrapperProfilerGuard &&) = delete;
+    WrapperProfilerGuard & operator=(WrapperProfilerGuard const &) = delete;
+    WrapperProfilerGuard & operator=(WrapperProfilerGuard &&) = delete;
+
+    // FIXME: Remove the suppression after CallProfiler::end_caller() becomes noexcept.
+    // NOLINTNEXTLINE(bugprone-exception-escape)
+    ~WrapperProfilerGuard()
+    {
+        if (m_enabled)
+        {
+            CallProfiler::instance().end_caller();
+        }
+    }
+
+private:
+
+    bool m_enabled;
+
+}; /* end class WrapperProfilerGuard */
+
 struct mmtag
 {
 }; /* end struct mmtag */
@@ -107,14 +138,6 @@ struct process_attribute<solvcon::python::mmtag>
         if (solvcon::python::WrapperProfilerStatus::me().enabled())
         {
             solvcon::CallProfiler::instance().start_caller(get_name(call), nullptr);
-        }
-    }
-
-    static void postcall(function_call &, handle &)
-    {
-        if (solvcon::python::WrapperProfilerStatus::me().enabled())
-        {
-            solvcon::CallProfiler::instance().end_caller();
         }
     }
 
@@ -281,11 +304,13 @@ public:
         return *static_cast<std::add_pointer_t<wrapper_type>>(this);          \
     }
 
+// ref: https://pybind11.readthedocs.io/en/stable/advanced/functions.html#call-guard
 #define DECL_MM_PYBIND_CLASS_METHOD_TIMED(METHOD)                             \
     template <class... Args> /* NOLINTNEXTLINE(bugprone-macro-parentheses) */ \
     wrapper_type & METHOD##_timed(Args &&... args)                            \
     {                                                                         \
-        m_cls.METHOD(std::forward<Args>(args)..., mmtag());                   \
+        using guard_type = pybind11::call_guard<WrapperProfilerGuard>;        \
+        m_cls.METHOD(std::forward<Args>(args)..., mmtag(), guard_type());     \
         return *static_cast<std::add_pointer_t<wrapper_type>>(this);          \
     }
 

--- a/tests/test_callprofiler.py
+++ b/tests/test_callprofiler.py
@@ -306,4 +306,19 @@ class CallProfilerTC(unittest.TestCase):
         self.assertEqual(2, clone_result["count"])
         self.assertGreater(clone_result["total_time"], 0)
 
+    def test_wrapper_exception_keeps_profiler_balanced(self):
+        solvcon.wrapper_profiler_status.enable()
+        solvcon.call_profiler.reset()
+
+        with self.assertRaisesRegex(
+                ValueError, "size 1 must be a multiple of alignment 16"):
+            solvcon.ConcreteBuffer(1, alignment=16)
+
+        solvcon.ConcreteBuffer(16, alignment=16)
+        result = solvcon.call_profiler.result()
+        constructor = result["children"][0]
+        self.assertNotIn("current_node", constructor)
+        self.assertEqual(constructor["count"], 2)
+        self.assertEqual(constructor["children"], [])
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Timed pybind11 wrappers enter `CallProfiler` from the pre-call hook and leave it from the post-call hook. When the wrapped C++ call throws, pybind11 skips the post-call hook, so the failed frame remains current and the next call is nested below it.

```python
solvcon.wrapper_profiler_status.enable()
solvcon.call_profiler.reset()

try:
    solvcon.ConcreteBuffer(1, alignment=16)
except ValueError:
    pass

solvcon.ConcreteBuffer(16, alignment=16)
result = solvcon.call_profiler.result()
result["children"][0]["children"]  # contained the next constructor before this change
```

This change moves frame cleanup into a pybind11 call guard. Its destructor retires the frame after a successful call and during exception unwinding, while the existing pre-call hook still supplies the wrapper name.

The regression test runs a throwing constructor followed by a successful one and checks that both samples remain in one completed top-level node without a nested constructor.

Related to #1187.
