### PR TITLE
Keep profiler probes consistent during cancellation and reset

### DIFF
--- a/cpp/solvcon/profiling/RadixTree.cpp
+++ b/cpp/solvcon/profiling/RadixTree.cpp
@@ -5,11 +5,21 @@
 
 #include <solvcon/profiling/RadixTree.hpp>
 
+#include <stdexcept>
+
 namespace solvcon
 {
 
 void CallProfiler::reset()
 {
+    for (auto & cancel_callback : m_cancel_callbacks)
+    {
+        if (cancel_callback)
+        {
+            cancel_callback();
+        }
+    }
+
     while (!m_radix_tree.is_root())
     {
         CallerProfile & profile = m_radix_tree.get_current_node()->data();
@@ -40,8 +50,7 @@ void CallProfiler::end_caller()
     CallerProfile & call_profile = m_radix_tree.get_current_node()->data();
     call_profile.stop_stopwatch(); // Update profiling information to the pending time and count
     m_pending_nodes.insert(m_radix_tree.get_current_node());
-    m_radix_tree.move_current_to_parent(); // Pop the caller from the call stack
-    m_cancel_callbacks.pop_back();
+    pop_caller();
 
     if (m_radix_tree.get_current_node() == m_radix_tree.get_root()) // If the root function ends, update all pending nodes and stable items
     {
@@ -49,6 +58,22 @@ void CallProfiler::end_caller()
         m_radix_tree.update_stable_items();
     }
 }
+
+void CallProfiler::discard_caller(RadixTreeNode<CallerProfile> const * frame_node)
+{
+    if (frame_node != m_radix_tree.get_current_node())
+    {
+        throw std::runtime_error("CallProfilerProbe::cancel: only the most recent active probe can be canceled");
+    }
+    pop_caller();
+}
+
+void CallProfiler::pop_caller()
+{
+    m_radix_tree.move_current_to_parent();
+    m_cancel_callbacks.pop_back();
+}
+
 // NOLINTNEXTLINE(misc-no-recursion)
 void CallProfiler::print_profiling_result(const RadixTreeNode<CallerProfile> & node, const int depth, std::ostream & outstream) const
 {

--- a/cpp/solvcon/profiling/RadixTree.hpp
+++ b/cpp/solvcon/profiling/RadixTree.hpp
@@ -280,6 +280,9 @@ public:
     /// Called when a function ends
     void end_caller();
 
+    /// Discard the most recent caller without recording it
+    void discard_caller(RadixTreeNode<CallerProfile> const * frame_node);
+
     /// Print the profiling information
     void print_profiling_result(std::ostream & outstream) const
     {
@@ -290,18 +293,12 @@ public:
     void reset();
 
     /// Cancel the profiling from all probes
-    void cancel()
-    {
-        for (auto & cancel_callback : m_cancel_callbacks)
-        {
-            cancel_callback();
-        }
-        reset();
-    }
+    void cancel() { reset(); }
 
     const RadixTree<CallerProfile> & radix_tree() const { return m_radix_tree; }
 
 private:
+    void pop_caller();
     void print_profiling_result(const RadixTreeNode<CallerProfile> & node, int depth, std::ostream & outstream) const;
     static void print_statistics(const RadixTreeNode<CallerProfile> & node, std::ostream & outstream);
 
@@ -335,9 +332,10 @@ public:
     {
         auto cancel_callback = [&]()
         {
-            cancel();
+            m_cancel = true;
         };
         m_profiler.start_caller(m_caller_name, cancel_callback);
+        m_frame_node = m_profiler.radix_tree().get_current_node();
     }
 
     CallProfilerProbe(CallProfilerProbe const &) = delete;
@@ -356,11 +354,16 @@ public:
 
     void cancel()
     {
-        m_cancel = true;
+        if (!m_cancel)
+        {
+            m_profiler.discard_caller(m_frame_node);
+            m_cancel = true;
+        }
     }
 
 private:
     const char * m_caller_name;
+    RadixTreeNode<CallerProfile> const * m_frame_node = nullptr;
     bool m_cancel = false;
     CallProfiler & m_profiler;
 }; /* end class CallProfilerProbe */

--- a/gtests/test_nopython_callprofiler.cpp
+++ b/gtests/test_nopython_callprofiler.cpp
@@ -232,6 +232,18 @@ TEST_F(CallProfilerTest, retire_cancel_callbacks)
     EXPECT_EQ(cancel_callback_count(), 0);
 }
 
+TEST_F(CallProfilerTest, reset_with_empty_cancel_callback)
+{
+    pProfiler->reset();
+    pProfiler->start_caller("wrapper", nullptr);
+
+    EXPECT_EQ(cancel_callback_count(), 1);
+    EXPECT_FALSE(radix_tree().is_root());
+    EXPECT_NO_THROW(pProfiler->reset());
+    EXPECT_EQ(cancel_callback_count(), 0);
+    EXPECT_TRUE(radix_tree().is_root());
+}
+
 } /* end namespace detail */
 } /* end namespace solvcon */
 

--- a/tests/test_callprofiler.py
+++ b/tests/test_callprofiler.py
@@ -324,4 +324,50 @@ class CallProfilerTC(unittest.TestCase):
         self.assertEqual(constructor["count"], 2)
         self.assertEqual(constructor["children"], [])
 
+    def test_probe_cancel_is_lifo(self):
+        solvcon.call_profiler.reset()
+        outer = solvcon.CallProfilerProbe("outer")
+        inner = solvcon.CallProfilerProbe("inner")
+
+        with self.assertRaisesRegex(
+                RuntimeError, "only the most recent active probe"):
+            outer.cancel()
+
+        inner.cancel()
+        outer.cancel()
+        del inner
+        del outer
+
+        later = solvcon.CallProfilerProbe("later")
+        del later
+
+        result = solvcon.call_profiler.result()
+        outer_result, later_result = result["children"]
+        inner_result, = outer_result["children"]
+        self.assertEqual(outer_result["name"], "outer")
+        self.assertEqual(outer_result["count"], 0)
+        self.assertNotIn("current_node", outer_result)
+        self.assertEqual(inner_result["name"], "inner")
+        self.assertEqual(inner_result["count"], 0)
+        self.assertNotIn("current_node", inner_result)
+        self.assertEqual(later_result["name"], "later")
+        self.assertEqual(later_result["count"], 1)
+
+    def test_reset_invalidates_active_probes(self):
+        solvcon.call_profiler.reset()
+        outer = solvcon.CallProfilerProbe("outer")
+        inner = solvcon.CallProfilerProbe("inner")
+
+        solvcon.call_profiler.reset()
+        del inner
+        del outer
+
+        later = solvcon.CallProfilerProbe("later")
+        del later
+
+        result = solvcon.call_profiler.result()
+        later_result, = result["children"]
+        self.assertEqual(later_result["name"], "later")
+        self.assertEqual(later_result["count"], 1)
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`CallProfilerProbe.cancel()` suppresses destructor cleanup but leaves its call-tree frame and callback active. A direct `CallProfiler.reset()` has the inverse lifecycle problem: it clears profiler state without invalidating live probes, so their destructors later operate on an empty stack.

This change records each probe's frame identity and only discards the most recent active frame. Reset now marks live probes canceled before clearing profiler state, skips empty callbacks used by wrapper frames, and provides the safe path used by profiler-wide cancellation.

Related to #1189.