### PR TITLE
Follow up the canvas theme and Painter naming reviews

### DIFF
--- a/cpp/solvcon/pilot/app/RManager.cpp
+++ b/cpp/solvcon/pilot/app/RManager.cpp
@@ -159,16 +159,7 @@ R2DWidget * RManager::add2DWidget()
     if (m_mdiArea)
     {
         viewer = new R2DWidget(/*parent*/ m_mdiArea);
-        // The canvas fills its own pixels, so it cannot inherit a theme switch
-        // from the application palette the way an ordinary widget does. Hand it
-        // the colors now and again on every switch, with the canvas itself as
-        // the connection context so the link dies with it.
-        auto applyCanvasPalette = [this, viewer](ThemeVariant)
-        {
-            viewer->setCanvasPalette(m_themeManager->canvas2dPalette());
-        };
-        applyCanvasPalette(m_themeManager->currentVariant());
-        QObject::connect(m_themeManager, &RThemeManager::themeChanged, viewer, applyCanvasPalette);
+        viewer->followTheme(m_themeManager);
         viewer->setWindowTitle("2D canvas");
         viewer->show();
         auto * subwin = this->addSubWindow(viewer);

--- a/cpp/solvcon/pilot/canvas/R2DWidget.cpp
+++ b/cpp/solvcon/pilot/canvas/R2DWidget.cpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <cmath>
 
+#include <solvcon/pilot/theme/RThemeManager.hpp>
 #include <solvcon/pilot/theme/theme_qt.hpp>
 
 #include <QColor>
@@ -142,6 +143,21 @@ void R2DWidget::updateWorld(std::shared_ptr<WorldFp64> const & world)
     m_overlay.highlight_id = -1;
     m_drag = EditDrag::None;
     update();
+}
+
+void R2DWidget::followTheme(RThemeManager * manager)
+{
+    if (manager == nullptr)
+    {
+        return;
+    }
+
+    auto apply = [this, manager](ThemeVariant)
+    {
+        setCanvasPalette(manager->canvas2dPalette());
+    };
+    apply(manager->currentVariant());
+    connect(manager, &RThemeManager::themeChanged, this, apply);
 }
 
 void R2DWidget::centerViewOnOrigin()

--- a/cpp/solvcon/pilot/canvas/R2DWidget.hpp
+++ b/cpp/solvcon/pilot/canvas/R2DWidget.hpp
@@ -38,6 +38,8 @@ class QWheelEvent;
 namespace solvcon
 {
 
+class RThemeManager;
+
 /**
  * Strictly-2D drawing widget for the pilot. Paints the geometry of a
  * `World<double>` by mapping it to screen space through a 2D view
@@ -107,6 +109,14 @@ public:
         m_palette = palette;
         update();
     }
+
+    /**
+     * Take the colors from the theme manager now and again on every switch.
+     * The canvas fills its own pixels, so it cannot inherit a theme switch
+     * from the application palette the way an ordinary widget does. The
+     * canvas itself is the connection context, so the link dies with it.
+     */
+    void followTheme(RThemeManager * manager);
 
     Overlay2dOptions const & overlayOptions() const { return m_overlay; }
 

--- a/solvcon/pilot/canvas/_painter_gui.py
+++ b/solvcon/pilot/canvas/_painter_gui.py
@@ -2,7 +2,7 @@
 # BSD 3-Clause License, see COPYING
 
 """
-Painter toolbox for the 2D canvas: the tool rail and the inspector.
+Painter toolbox for the 2D canvas: the draw tool selector and the inspector.
 """
 
 from PySide6 import QtCore, QtGui, QtWidgets
@@ -38,7 +38,8 @@ def _shade(widget, ratio):
 
     Blending toward the text is what makes a shade follow the theme: it steps
     darker under a light palette and lighter under a dark one, which is how the
-    design separates the rail from the inspector and the checked tab from both.
+    design separates the selector from the inspector and the checked tab from
+    both.
     """
     palette = widget.palette()
     return _blend(palette.color(QtGui.QPalette.Window),
@@ -70,7 +71,7 @@ class _PaletteStyled(QtWidgets.QWidget):
         raise NotImplementedError
 
 
-class _ToolRail(_PaletteStyled):
+class _DrawToolSelector(_PaletteStyled):
     """The tool column: flat entries on a shade of the inspector panel.
 
     The shade is painted rather than written into the widget's palette, because
@@ -81,26 +82,26 @@ class _ToolRail(_PaletteStyled):
     icons and the 9px labels arrive with the tool box itself.
     """
 
-    # How far the rail shade sits from the inspector panel color, and how far
-    # a hovered entry sits from the rail.
+    # How far the column shade sits from the inspector panel color, and how
+    # far a hovered entry sits from the column.
     _SHADE_MIX = 0.06
     _HOVER_MIX = 0.12
 
-    # Rail and entry geometry from the design, in device-independent pixels.
+    # Column and entry geometry from the design, in device-independent pixels.
     _WIDTH = 64
     _ENTRY_WIDTH = 52
     _RADIUS = 7
     _GAP = 2
     _PAD_Y = 8
 
-    def __init__(self, tool_actions, rail_labels, parent=None):
+    def __init__(self, tool_actions, short_labels, parent=None):
         """
-        :param tool_actions: The draw tools as ``{tool id: QAction}`` in rail
-            order; each becomes one entry's default action.
+        :param tool_actions: The draw tools as ``{tool id: QAction}`` in
+            column order; each becomes one entry's default action.
         :type tool_actions: dict
-        :param rail_labels: Short rail text per tool id, for the tools whose
-            menu label does not fit the narrow rail.
-        :type rail_labels: dict
+        :param short_labels: Short entry text per tool id, for the tools whose
+            menu label does not fit the narrow column.
+        :type short_labels: dict
         """
         super().__init__(parent)
         self.buttons = {}
@@ -113,9 +114,9 @@ class _ToolRail(_PaletteStyled):
             # The default action drives the button and reflects its checked
             # state, so a menu radio and a button stay one selection.
             button.setDefaultAction(action)
-            # The action's menu text is too wide for the rail, so the button
-            # shows the short rail name and keeps the menu text as its tip.
-            button.setText(rail_labels.get(tool, action.text()))
+            # The action's menu text is too wide for the column, so the button
+            # shows the short name and keeps the menu text as its tip.
+            button.setText(short_labels.get(tool, action.text()))
             button.setFixedWidth(self._ENTRY_WIDTH)
             button.setCursor(QtCore.Qt.PointingHandCursor)
             layout.addWidget(button, 0, QtCore.Qt.AlignHCenter)
@@ -222,12 +223,12 @@ class _SegmentedTabs(_PaletteStyled):
 
 
 class PainterPanel(QtWidgets.QWidget):
-    """The Painter dock body: the tool rail left of the inspector.
+    """The Painter dock body: the draw tool selector left of the inspector.
 
-    The rail holds one button per draw tool, each a view of the shared
+    The selector holds one button per draw tool, each a view of the shared
     ``draw.tool`` action the Canvas menu also shows. The inspector stacks the
     Design, Layers, and Canvas pages under a segmented tab row that selects
-    among them. The frame is at its designed widths; the rail icons and the
+    among them. The frame is at its designed widths; the tool icons and the
     page contents arrive with the later steps of the redesign, so every page
     is a greyed-out placeholder naming what it will hold.
     """
@@ -244,17 +245,17 @@ class PainterPanel(QtWidgets.QWidget):
         ("Canvas", "View, grid, axes, background, and units"),
     )
 
-    def __init__(self, tool_actions, rail_labels=None, parent=None):
+    def __init__(self, tool_actions, short_labels=None, parent=None):
         """
-        :param tool_actions: The draw tools as ``{tool id: QAction}`` in rail
-            order; each becomes one rail button's default action.
+        :param tool_actions: The draw tools as ``{tool id: QAction}`` in
+            selector order; each becomes one button's default action.
         :type tool_actions: dict
-        :param rail_labels: Short rail text per tool id, for the tools whose
-            menu label does not fit the narrow rail.
-        :type rail_labels: dict or None
+        :param short_labels: Short button text per tool id, for the tools
+            whose menu label does not fit the narrow selector.
+        :type short_labels: dict or None
         """
         super().__init__(parent)
-        self._rail = _ToolRail(tool_actions, rail_labels or {}, self)
+        self._tools = _DrawToolSelector(tool_actions, short_labels or {}, self)
         self._stack = QtWidgets.QStackedWidget()
         self._tabs = _SegmentedTabs([name for name, _text in self.PAGES])
         self._tabs.selected.connect(self.show_page)
@@ -262,14 +263,14 @@ class PainterPanel(QtWidgets.QWidget):
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
-        layout.addWidget(self._rail)
+        layout.addWidget(self._tools)
         layout.addWidget(_rule(QtWidgets.QFrame.VLine))
         layout.addWidget(self._inspector, 1)
 
     @property
     def tool_buttons(self):
-        """The rail buttons as ``{tool id: QToolButton}``."""
-        return self._rail.buttons
+        """The selector buttons as ``{tool id: QToolButton}``."""
+        return self._tools.buttons
 
     @property
     def tabs(self):
@@ -320,7 +321,7 @@ class Painter(_gui_common.PilotFeature):
     to the focused 2D canvas, not bound to any one canvas.
 
     The dock body is a :class:`PainterPanel`; this feature owns the dock, the
-    menu toggle, and the draw-tool actions the panel's rail shows.
+    menu toggle, and the draw-tool actions the panel's selector shows.
     """
 
     # Button label for a tool id. The ids, their order, and the default
@@ -335,9 +336,9 @@ class Painter(_gui_common.PilotFeature):
         "circle": "Circle",
     }
 
-    # Rail text for a tool whose menu label overflows the 64px rail. The
-    # names are the design's; a tool with no entry keeps its menu label.
-    RAIL_LABELS = {
+    # Button text for a tool whose menu label overflows the 64px selector.
+    # The names are the design's; a tool with no entry keeps its menu label.
+    SHORT_LABELS = {
         "pan": "Pan",
         "triangle": "Tri",
         "rectangle": "Rect",
@@ -366,7 +367,7 @@ class Painter(_gui_common.PilotFeature):
 
     def _build_tool_actions(self):
         """One exclusive checkable action per draw tool, the single source of
-        truth shared by the Canvas/Draw tool radio items and the rail
+        truth shared by the Canvas/Draw tool radio items and the selector
         buttons. Each action routes its own trigger to the manager.
 
         Idempotent: the tools are declared once on the model, so a second
@@ -406,7 +407,7 @@ class Painter(_gui_common.PilotFeature):
             self._dock.hide()
 
     def _ensure_dock(self):
-        """Create the dock once, its rail buttons views of the tool actions."""
+        """Create the dock once, its tool buttons views of the tool actions."""
         if self._dock is not None:
             return
         # A standalone Painter (used in tests) reaches the dock without
@@ -416,7 +417,7 @@ class Painter(_gui_common.PilotFeature):
         dock.setAllowedAreas(
             QtCore.Qt.LeftDockWidgetArea | QtCore.Qt.RightDockWidgetArea)
 
-        self._panel = PainterPanel(self._tool_actions, self.RAIL_LABELS, dock)
+        self._panel = PainterPanel(self._tool_actions, self.SHORT_LABELS, dock)
         dock.setWidget(self._panel)
         self._mainWindow.addDockWidget(QtCore.Qt.RightDockWidgetArea, dock)
         # Keep the menu check in sync when the dock is closed by its button.

--- a/tests/test_pilot_draw_tool.py
+++ b/tests/test_pilot_draw_tool.py
@@ -78,7 +78,7 @@ class DrawToolTC(unittest.TestCase):
         action.setChecked(False)
         self.assertTrue(self.painter._dock.isHidden())
 
-    def test_rail_holds_one_button_per_registered_tool(self):
+    def test_selector_holds_one_button_per_registered_tool(self):
         panel = self._panel()
         self.assertEqual(set(panel.tool_buttons), set(draw_tool_names()))
 
@@ -100,27 +100,27 @@ class DrawToolTC(unittest.TestCase):
         # The panel outlives the test, so leave it on the default page.
         panel.show_page("Design")
 
-    def test_rail_shade_follows_the_theme(self):
-        # The rail paints its own shade of the panel colour. Reading it back
-        # from a grab is what catches a shade captured once and never
+    def test_selector_shade_follows_the_theme(self):
+        # The selector paints its own shade of the panel colour. Reading it
+        # back from a grab is what catches a shade captured once and never
         # refreshed, which is how a set-on-palette-change colour behaves.
-        rail = self._panel()._rail
+        tools = self._panel()._tools
         try:
             self.mgr.set_theme("light")
-            light = rail.grab().toImage().pixelColor(2, 2).lightness()
+            light = tools.grab().toImage().pixelColor(2, 2).lightness()
             self.mgr.set_theme("dark")
-            dark = rail.grab().toImage().pixelColor(2, 2).lightness()
+            dark = tools.grab().toImage().pixelColor(2, 2).lightness()
         finally:
             self.mgr.set_theme("system")
         self.assertGreater(light, dark)
 
     def test_widening_the_panel_grows_the_inspector(self):
-        # The rail keeps its designed width and the inspector takes the rest,
-        # so a dock wider than the design leaves no bands beside the panel.
+        # The selector keeps its designed width and the inspector takes the
+        # rest, so a dock wider than the design leaves no bands beside it.
         panel = self._panel()
         panel.resize(500, 400)
         panel.layout().activate()
-        self.assertEqual(panel._rail.width(), 64)
+        self.assertEqual(panel._tools.width(), 64)
         self.assertGreater(panel._inspector.width(), 264)
 
     def test_tab_row_restyles_with_the_theme(self):


### PR DESCRIPTION
Two review comments from the canvas theme (#1193) and Painter frame (#1197) pull requests. Both were left after the branches merged, so they are addressed here instead.

RManager::add2DWidget() used to set up the canvas theme connection itself: it had to know that a canvas fills its own pixels and therefore cannot pick a theme switch up from the application palette the way an ordinary widget does. That knowledge belongs to the canvas rather than to whoever happens to create one, and a second creation site would have had to repeat it to get a canvas that follows the theme. R2DWidget::followTheme() now owns it, taking the current colors and connecting to themeChanged with the widget as the connection context, exactly as the old lambda did. The manager is left with one call. The console, the terminal, and the MDI backdrop still wire their own theme handlers in RManager; only the canvas moves here.

The Painter panel's _ToolRail named where the widget sits in the mockup rather than what it is, and "tool" reads as ambiguous in a file full of QToolButton. It is the exclusive selector for the active draw tool, so it becomes _DrawToolSelector, and the vocabulary around it follows: rail_labels becomes short_labels, RAIL_LABELS becomes SHORT_LABELS, and the comments say "selector" for the widget and "column" where the sentence is about its shape. No behavior changes; the existing tests are renamed to match and keep their assertions.

Related to #1175, and to the review comments on #1193 and #1197.
