### PR TITLE
Add DataFrame.reorder_columns

### DIFF
--- a/solvcon/track/dataframe.py
+++ b/solvcon/track/dataframe.py
@@ -305,4 +305,43 @@ class DataFrame(object):
         """
         return self.sort(columns=columns, index_column=None, inplace=inplace)
 
+    def reorder_columns(self, columns=None, inplace=True):
+        """
+        Reorder the dataframe's columns
+
+        :param columns: full permutation of the existing column names
+        :type columns: List[str]
+        :param inplace: flag indicates whether to reorder inplace or
+                        out-of-place
+        :type inplace: bool
+        :return: reordered DataFrame (return self if inplace is set to
+                True)
+        """
+        if columns is None:
+            raise ValueError("DataFrame: provide columns to reorder")
+
+        if sorted(columns) != sorted(self._columns):
+            missing = sorted(set(self._columns) - set(columns))
+            unknown = sorted(set(columns) - set(self._columns))
+            if missing or unknown:
+                raise ValueError(
+                    "DataFrame: columns missing {}, unknown {}".format(
+                        missing, unknown))
+            raise ValueError("DataFrame: columns has duplicate names")
+
+        new_data = [self._data[self._columns.index(name)]
+                    for name in columns]
+
+        if inplace:
+            self._data = new_data
+            self._columns = list(columns)
+            return self
+        else:
+            ret = DataFrame()
+            ret._index_name = self._index_name
+            ret._index_data = self._index_data
+            ret._columns = list(columns)
+            ret._data = new_data
+            return ret
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/track/dataframe.py
+++ b/solvcon/track/dataframe.py
@@ -170,4 +170,43 @@ class DataFrame(object):
         """
         return self.sort(columns=columns, index_column=None, inplace=inplace)
 
+    def reorder_columns(self, columns=None, inplace=True):
+        """
+        Reorder the dataframe's columns
+
+        :param columns: full permutation of the existing column names
+        :type columns: List[str]
+        :param inplace: flag indicates whether to reorder inplace or
+                        out-of-place
+        :type inplace: bool
+        :return: reordered DataFrame (return self if inplace is set to
+                True)
+        """
+        if columns is None:
+            raise ValueError("DataFrame: provide columns to reorder")
+
+        if sorted(columns) != sorted(self._columns):
+            missing = sorted(set(self._columns) - set(columns))
+            unknown = sorted(set(columns) - set(self._columns))
+            if missing or unknown:
+                raise ValueError(
+                    "DataFrame: columns missing {}, unknown {}".format(
+                        missing, unknown))
+            raise ValueError("DataFrame: columns has duplicate names")
+
+        new_data = [self._data[self._columns.index(name)]
+                    for name in columns]
+
+        if inplace:
+            self._data = new_data
+            self._columns = list(columns)
+            return self
+        else:
+            ret = DataFrame()
+            ret._index_name = self._index_name
+            ret._index_data = self._index_data
+            ret._columns = list(columns)
+            ret._data = new_data
+            return ret
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_timeseries_dataframe.py
+++ b/tests/test_timeseries_dataframe.py
@@ -145,6 +145,81 @@ class TimeSeriesDataFrameTC(unittest.TestCase):
         nd_arr = np.genfromtxt(io.StringIO(self.dlc_data), delimiter=',')[1:]
         self.assertEqual(list(col_data), list(nd_arr[:, 1]))
 
+    def test_dataframe_reorder_columns_inplace(self):
+        tsdf = dataframe.DataFrame()
+        tsdf.read_from_text_file(io.StringIO(self.dlc_data))
+
+        col2 = list(tsdf['DELTA_VEL[2]'])
+        new_order = ['DELTA_VEL[3]', 'DELTA_VEL[1]', 'DELTA_VEL[2]']
+
+        ret = tsdf.reorder_columns(new_order)
+
+        self.assertIs(ret, tsdf)
+        self.assertEqual(tsdf.columns, new_order)
+        self.assertEqual(list(tsdf['DELTA_VEL[2]']), col2)
+
+    def test_dataframe_reorder_columns_out_of_place(self):
+        tsdf = dataframe.DataFrame()
+        tsdf.read_from_text_file(io.StringIO(self.dlc_data))
+
+        original_order = list(tsdf.columns)
+        new_order = ['DELTA_VEL[3]', 'DELTA_VEL[1]', 'DELTA_VEL[2]']
+
+        reordered = tsdf.reorder_columns(new_order, inplace=False)
+
+        self.assertIsNot(reordered, tsdf)
+        self.assertEqual(reordered.columns, new_order)
+        self.assertEqual(tsdf.columns, original_order)
+
+    def test_dataframe_reorder_columns_does_not_alias_input_list(self):
+        tsdf = dataframe.DataFrame()
+        tsdf.read_from_text_file(io.StringIO(self.dlc_data))
+
+        new_order = ['DELTA_VEL[3]', 'DELTA_VEL[1]', 'DELTA_VEL[2]']
+        tsdf.reorder_columns(new_order)
+        new_order.append('EXTRA')
+
+        self.assertEqual(
+            tsdf.columns, ['DELTA_VEL[3]', 'DELTA_VEL[1]', 'DELTA_VEL[2]']
+        )
+
+    def test_dataframe_reorder_columns_requires_permutation(self):
+        tsdf = dataframe.DataFrame()
+        tsdf.read_from_text_file(io.StringIO(self.dlc_data))
+
+        missing_pattern = re.escape(
+            "DataFrame: columns missing ['DELTA_VEL[3]'], unknown []"
+        )
+        with self.assertRaisesRegex(ValueError, missing_pattern):
+            tsdf.reorder_columns(['DELTA_VEL[1]', 'DELTA_VEL[2]'])
+
+        unknown_pattern = re.escape(
+            "DataFrame: columns missing [], unknown ['EXTRA']"
+        )
+        with self.assertRaisesRegex(ValueError, unknown_pattern):
+            tsdf.reorder_columns(
+                ['DELTA_VEL[1]', 'DELTA_VEL[2]', 'DELTA_VEL[3]', 'EXTRA']
+            )
+
+    def test_dataframe_reorder_columns_rejects_duplicates(self):
+        tsdf = dataframe.DataFrame()
+        tsdf.read_from_text_file(io.StringIO(self.dlc_data))
+
+        duplicate_pattern = re.escape("DataFrame: columns has duplicate names")
+        with self.assertRaisesRegex(ValueError, duplicate_pattern):
+            tsdf.reorder_columns(
+                ['DELTA_VEL[1]', 'DELTA_VEL[1]', 'DELTA_VEL[2]',
+                 'DELTA_VEL[3]']
+            )
+
+    def test_dataframe_reorder_columns_requires_columns(self):
+        tsdf = dataframe.DataFrame()
+        tsdf.read_from_text_file(io.StringIO(self.dlc_data))
+
+        empty_pattern = re.escape("DataFrame: provide columns to reorder")
+        with self.assertRaisesRegex(ValueError, empty_pattern):
+            tsdf.reorder_columns()
+
     def test_read_from_text_file_accepts_str_path(self):
         tsdf = dataframe.DataFrame()
         with tempfile.NamedTemporaryFile(

--- a/tests/test_timeseries_dataframe.py
+++ b/tests/test_timeseries_dataframe.py
@@ -159,6 +159,81 @@ class TimeSeriesDataFrameTC(unittest.TestCase):
         nd_arr = np.genfromtxt(io.StringIO(self.dlc_data), delimiter=',')[1:]
         self.assertEqual(list(col_data), list(nd_arr[:, 1]))
 
+    def test_dataframe_reorder_columns_inplace(self):
+        tsdf = dataframe.DataFrame()
+        tsdf.read_from_text_file(io.StringIO(self.dlc_data))
+
+        col2 = list(tsdf['DELTA_VEL[2]'])
+        new_order = ['DELTA_VEL[3]', 'DELTA_VEL[1]', 'DELTA_VEL[2]']
+
+        ret = tsdf.reorder_columns(new_order)
+
+        self.assertIs(ret, tsdf)
+        self.assertEqual(tsdf.columns, new_order)
+        self.assertEqual(list(tsdf['DELTA_VEL[2]']), col2)
+
+    def test_dataframe_reorder_columns_out_of_place(self):
+        tsdf = dataframe.DataFrame()
+        tsdf.read_from_text_file(io.StringIO(self.dlc_data))
+
+        original_order = list(tsdf.columns)
+        new_order = ['DELTA_VEL[3]', 'DELTA_VEL[1]', 'DELTA_VEL[2]']
+
+        reordered = tsdf.reorder_columns(new_order, inplace=False)
+
+        self.assertIsNot(reordered, tsdf)
+        self.assertEqual(reordered.columns, new_order)
+        self.assertEqual(tsdf.columns, original_order)
+
+    def test_dataframe_reorder_columns_does_not_alias_input_list(self):
+        tsdf = dataframe.DataFrame()
+        tsdf.read_from_text_file(io.StringIO(self.dlc_data))
+
+        new_order = ['DELTA_VEL[3]', 'DELTA_VEL[1]', 'DELTA_VEL[2]']
+        tsdf.reorder_columns(new_order)
+        new_order.append('EXTRA')
+
+        self.assertEqual(
+            tsdf.columns, ['DELTA_VEL[3]', 'DELTA_VEL[1]', 'DELTA_VEL[2]']
+        )
+
+    def test_dataframe_reorder_columns_requires_permutation(self):
+        tsdf = dataframe.DataFrame()
+        tsdf.read_from_text_file(io.StringIO(self.dlc_data))
+
+        missing_pattern = re.escape(
+            "DataFrame: columns missing ['DELTA_VEL[3]'], unknown []"
+        )
+        with self.assertRaisesRegex(ValueError, missing_pattern):
+            tsdf.reorder_columns(['DELTA_VEL[1]', 'DELTA_VEL[2]'])
+
+        unknown_pattern = re.escape(
+            "DataFrame: columns missing [], unknown ['EXTRA']"
+        )
+        with self.assertRaisesRegex(ValueError, unknown_pattern):
+            tsdf.reorder_columns(
+                ['DELTA_VEL[1]', 'DELTA_VEL[2]', 'DELTA_VEL[3]', 'EXTRA']
+            )
+
+    def test_dataframe_reorder_columns_rejects_duplicates(self):
+        tsdf = dataframe.DataFrame()
+        tsdf.read_from_text_file(io.StringIO(self.dlc_data))
+
+        duplicate_pattern = re.escape("DataFrame: columns has duplicate names")
+        with self.assertRaisesRegex(ValueError, duplicate_pattern):
+            tsdf.reorder_columns(
+                ['DELTA_VEL[1]', 'DELTA_VEL[1]', 'DELTA_VEL[2]',
+                 'DELTA_VEL[3]']
+            )
+
+    def test_dataframe_reorder_columns_requires_columns(self):
+        tsdf = dataframe.DataFrame()
+        tsdf.read_from_text_file(io.StringIO(self.dlc_data))
+
+        empty_pattern = re.escape("DataFrame: provide columns to reorder")
+        with self.assertRaisesRegex(ValueError, empty_pattern):
+            tsdf.reorder_columns()
+
     def test_read_from_text_file_accepts_str_path(self):
         tsdf = dataframe.DataFrame()
         with tempfile.NamedTemporaryFile(

--- a/tests/test_timeseries_dataframe.py
+++ b/tests/test_timeseries_dataframe.py
@@ -201,16 +201,18 @@ class TimeSeriesDataFrameTC(unittest.TestCase):
         tsdf = dataframe.DataFrame()
         tsdf.read_from_text_file(io.StringIO(self.dlc_data))
 
-        missing_pattern = re.escape(
-            "DataFrame: columns missing ['DELTA_VEL[3]'], unknown []"
-        )
-        with self.assertRaisesRegex(ValueError, missing_pattern):
+        with self.assertRaisesRegex(ValueError,
+                                    re.escape(
+                "DataFrame: columns missing ['DELTA_VEL[3]'], unknown []"
+                                        )
+                                    ):
             tsdf.reorder_columns(['DELTA_VEL[1]', 'DELTA_VEL[2]'])
 
-        unknown_pattern = re.escape(
-            "DataFrame: columns missing [], unknown ['EXTRA']"
-        )
-        with self.assertRaisesRegex(ValueError, unknown_pattern):
+        with self.assertRaisesRegex(ValueError,
+                                    re.escape(
+                "DataFrame: columns missing [], unknown ['EXTRA']"
+                                        )
+                                    ):
             tsdf.reorder_columns(
                 ['DELTA_VEL[1]', 'DELTA_VEL[2]', 'DELTA_VEL[3]', 'EXTRA']
             )
@@ -219,8 +221,11 @@ class TimeSeriesDataFrameTC(unittest.TestCase):
         tsdf = dataframe.DataFrame()
         tsdf.read_from_text_file(io.StringIO(self.dlc_data))
 
-        duplicate_pattern = re.escape("DataFrame: columns has duplicate names")
-        with self.assertRaisesRegex(ValueError, duplicate_pattern):
+        with self.assertRaisesRegex(ValueError,
+                                    re.escape(
+                "DataFrame: columns has duplicate names"
+                                        )
+                                    ):
             tsdf.reorder_columns(
                 ['DELTA_VEL[1]', 'DELTA_VEL[1]', 'DELTA_VEL[2]',
                  'DELTA_VEL[3]']
@@ -230,8 +235,11 @@ class TimeSeriesDataFrameTC(unittest.TestCase):
         tsdf = dataframe.DataFrame()
         tsdf.read_from_text_file(io.StringIO(self.dlc_data))
 
-        empty_pattern = re.escape("DataFrame: provide columns to reorder")
-        with self.assertRaisesRegex(ValueError, empty_pattern):
+        with self.assertRaisesRegex(ValueError,
+                                    re.escape(
+                "DataFrame: provide columns to reorder"
+                                        )
+                                    ):
             tsdf.reorder_columns()
 
     def test_read_from_text_file_accepts_str_path(self):


### PR DESCRIPTION
DataFrame already provides sort() and sort_by_index() to control row order, but has no way to change the order of its columns. This PR adds DataFrame.reorder_columns(columns, inplace=True), which takes a full permutation of the existing column names and rearranges the columns to match, supporting both in-place and out-of-place use the same way sort() does.

Related to #435.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
