### PR TITLE
Complete generic planned matmul operation

### DIFF
--- a/cpp/solvcon/buffer/loop.hpp
+++ b/cpp/solvcon/buffer/loop.hpp
@@ -32,10 +32,6 @@ namespace detail
  * For `(2,1,3,4) @ (1,5,4,6)`, a broadcast-capable MatmulPlan uses
  * `LoopDomain({2,5})` for the ten result-batch coordinates. M=3, N=6, and
  * K=4 remain matrix metadata rather than becoming axes of this domain.
- *
- * @note The current consumer is MatmulPlan with equal leading batch shapes.
- * Batch broadcasting and plans for other operation families are follow-up
- * work.
  */
 class LoopDomain
 {
@@ -68,9 +64,6 @@ private:
  * For `(2,1,3,4) @ (1,5,4,6)`, the domain is `(2,5)`. The output, lhs, and
  * rhs mappings are `{90,18}`, `{12,0}`, and `{0,24}`. The zero lhs stride
  * reuses it across axis 1, and the zero rhs stride reuses it across axis 0.
- *
- * @note The current MatmulPlan constructs mappings for equal batch shapes,
- * so it does not create zero broadcast strides yet.
  */
 class OperandMapping
 {
@@ -105,9 +98,7 @@ private:
  * output, lhs, and rhs offsets start at `(0,0,0)`. They advance to
  * `(18,0,24)` for coordinate `(0,1)` and `(90,12,0)` for coordinate `(1,0)`.
  *
- * @note The current consumer is MatmulExecutor with three equal-batch
- * mappings. The cursor borrows its domain and mappings, which must outlive
- * it. Broadcast and other operation executors are follow-up work.
+ * @note The cursor borrows its domain and mappings, which must outlive it.
  */
 class MappedOffsetCursor
 {

--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -39,17 +39,21 @@ inline constexpr bool can_matmul_blas_v = std::is_same_v<T, float> ||
  * the result shape, and records the signed-stride mappings used to locate
  * operands in the result batch domain. Broadcast batch axes are represented
  * by zero strides, so an executor can advance operand offsets without
- * reinterpreting ranks or broadcasting rules.
+ * reinterpreting operand dimensions or broadcasting rules.
  *
  * For `(2,1,3,4) @ (1,5,4,6)`, the plan records batch shape `(2,5)`, M=3,
  * N=6, K=4, output shape `(2,5,3,6)`, and zero-stride batch mappings for
  * the broadcast axes. It does not allocate the output or evaluate the ten
  * matrix pairs.
  *
- * @note This implementation plans matrix-matrix operands with equal ranks
- * and equal leading batch shapes. It records the batch domain and mappings,
- * M, N, K, the output shape, and signed matrix strides. Vector roles and
- * broadcast batch axes are follow-up work.
+ * For `(K,) @ (B,K,N)`, the plan keeps a synthetic M=1 for execution but
+ * omits that axis from the `(B,N)` output. Matrix-vector products similarly
+ * omit synthetic N=1, while vector-vector products retain SimpleArray's
+ * existing `(1,)` dot-result convention.
+ *
+ * @note This implementation plans vector and matrix operand roles with
+ * broadcast leading batch shapes. It records the batch domain and mappings,
+ * M, N, K, the output shape, and signed contraction strides.
  */
 class MatmulPlan
 {
@@ -78,18 +82,20 @@ private:
 
     struct Contraction
     {
+        bool m_lhs_vector;
+        bool m_rhs_vector;
         ssize_t m_rows;
         ssize_t m_columns;
         ssize_t m_inner_size;
     }; /* end struct Contraction */
 
-    struct MatrixStrides
+    struct ContractionStrides
     {
         ssize_t m_lhs_row_stride;
         ssize_t m_lhs_inner_stride;
         ssize_t m_rhs_inner_stride;
         ssize_t m_rhs_column_stride;
-    }; /* end struct MatrixStrides */
+    }; /* end struct ContractionStrides */
 
     struct BatchMappings
     {
@@ -97,13 +103,25 @@ private:
         mapping_type m_mappings;
     }; /* end struct BatchMappings */
 
-    MatmulPlan(shape_type output_shape, Contraction contraction, MatrixStrides strides, BatchMappings batch);
+    MatmulPlan(shape_type output_shape, Contraction contraction, ContractionStrides strides, BatchMappings batch);
 
     template <typename Array>
     static Contraction make_contraction(Array const & lhs, Array const & rhs);
 
     template <typename Array>
-    static BatchMappings make_batch_mappings(Array const & lhs, Array const & rhs, ssize_t output_matrix_size);
+    static ContractionStrides make_contraction_strides(
+        Array const & lhs,
+        Array const & rhs,
+        Contraction const & contraction);
+
+    template <typename Array>
+    static BatchMappings make_batch_mappings(Array const & lhs, Array const & rhs, ssize_t output_block_size);
+
+    template <typename Array>
+    static shape_type make_batch_shape(Array const & lhs, Array const & rhs);
+
+    template <typename Array>
+    static OperandMapping make_batch_mapping(Array const & operand, LoopDomain const & domain);
 
     static shape_type make_output_shape(BatchMappings const & batch, Contraction const & contraction);
 
@@ -112,7 +130,7 @@ private:
 
     shape_type m_output_shape;
     Contraction m_contraction;
-    MatrixStrides m_strides;
+    ContractionStrides m_strides;
     BatchMappings m_batch;
 }; /* end class MatmulPlan */
 
@@ -129,9 +147,9 @@ private:
  * evaluates one `(3,4) @ (4,6)` contraction at each offset. The results are
  * written into the allocated `(2,5,3,6)` output.
  *
- * @note This implementation provides the generic signed-stride
- * matrix-matrix route for equal batch shapes. Broadcast, optimized, and
- * vector routes are follow-up work.
+ * @note This implementation provides generic signed-stride DOT, GEMV, GEVM,
+ * and GEMM routes with broadcast batch shapes. Optimized routes are
+ * follow-up work.
  */
 template <typename Array>
 class MatmulExecutor
@@ -162,7 +180,7 @@ private:
 inline MatmulPlan::MatmulPlan(
     shape_type output_shape,
     Contraction contraction,
-    MatrixStrides strides,
+    ContractionStrides strides,
     BatchMappings batch)
     : m_output_shape(std::move(output_shape))
     , m_contraction(contraction)
@@ -175,14 +193,7 @@ template <typename Array>
 MatmulPlan MatmulPlan::make(Array const & lhs, Array const & rhs)
 {
     Contraction const contraction = make_contraction(lhs, rhs);
-    size_t const lhs_matrix_axis = lhs.ndim() - 2;
-    size_t const rhs_matrix_axis = rhs.ndim() - 2;
-    MatrixStrides const strides{
-        .m_lhs_row_stride = lhs.stride(lhs_matrix_axis),
-        .m_lhs_inner_stride = lhs.stride(lhs_matrix_axis + 1),
-        .m_rhs_inner_stride = rhs.stride(rhs_matrix_axis),
-        .m_rhs_column_stride = rhs.stride(rhs_matrix_axis + 1),
-    };
+    ContractionStrides const strides = make_contraction_strides(lhs, rhs, contraction);
     BatchMappings batch = make_batch_mappings(lhs, rhs, contraction.m_rows * contraction.m_columns);
     shape_type output_shape = make_output_shape(batch, contraction);
     return MatmulPlan{
@@ -196,15 +207,21 @@ MatmulPlan MatmulPlan::make(Array const & lhs, Array const & rhs)
 template <typename Array>
 MatmulPlan::Contraction MatmulPlan::make_contraction(Array const & lhs, Array const & rhs)
 {
-    if (lhs.ndim() < 2 || rhs.ndim() < 2)
+    if (lhs.ndim() == 0 || rhs.ndim() == 0)
     {
         throw std::invalid_argument(
-            "planned matrix-matrix matmul requires rank-2 or greater operands");
+            "planned matmul requires non-scalar operands");
     }
 
-    size_t const lhs_matrix_axis = lhs.ndim() - 2;
-    size_t const rhs_matrix_axis = rhs.ndim() - 2;
-    if (lhs.shape(lhs_matrix_axis + 1) != rhs.shape(rhs_matrix_axis))
+    bool const lhs_vector = lhs.ndim() == 1;
+    bool const rhs_vector = rhs.ndim() == 1;
+    size_t const lhs_inner_axis = lhs.ndim() - 1;
+    size_t rhs_inner_axis = rhs.ndim() - 1;
+    if (!rhs_vector)
+    {
+        --rhs_inner_axis;
+    }
+    if (lhs.shape(lhs_inner_axis) != rhs.shape(rhs_inner_axis))
     {
         throw std::invalid_argument(
             std::format("SimpleArray::matmul_planned(): shape mismatch: "
@@ -212,10 +229,50 @@ MatmulPlan::Contraction MatmulPlan::make_contraction(Array const & lhs, Array co
                         shape_string(lhs),
                         shape_string(rhs)));
     }
+
+    ssize_t rows = 1;
+    if (!lhs_vector)
+    {
+        rows = lhs.shape(lhs.ndim() - 2);
+    }
+    ssize_t columns = 1;
+    if (!rhs_vector)
+    {
+        columns = rhs.shape(rhs.ndim() - 1);
+    }
     return Contraction{
-        .m_rows = lhs.shape(lhs_matrix_axis),
-        .m_columns = rhs.shape(rhs_matrix_axis + 1),
-        .m_inner_size = lhs.shape(lhs_matrix_axis + 1),
+        .m_lhs_vector = lhs_vector,
+        .m_rhs_vector = rhs_vector,
+        .m_rows = rows,
+        .m_columns = columns,
+        .m_inner_size = lhs.shape(lhs_inner_axis),
+    };
+}
+
+template <typename Array>
+MatmulPlan::ContractionStrides MatmulPlan::make_contraction_strides(
+    Array const & lhs,
+    Array const & rhs,
+    Contraction const & contraction)
+{
+    ssize_t lhs_row_stride = 0;
+    if (!contraction.m_lhs_vector)
+    {
+        lhs_row_stride = lhs.stride(lhs.ndim() - 2);
+    }
+
+    size_t rhs_inner_axis = rhs.ndim() - 1;
+    ssize_t rhs_column_stride = 0;
+    if (!contraction.m_rhs_vector)
+    {
+        --rhs_inner_axis;
+        rhs_column_stride = rhs.stride(rhs.ndim() - 1);
+    }
+    return ContractionStrides{
+        .m_lhs_row_stride = lhs_row_stride,
+        .m_lhs_inner_stride = lhs.stride(lhs.ndim() - 1),
+        .m_rhs_inner_stride = rhs.stride(rhs_inner_axis),
+        .m_rhs_column_stride = rhs_column_stride,
     };
 }
 
@@ -223,35 +280,13 @@ template <typename Array>
 MatmulPlan::BatchMappings MatmulPlan::make_batch_mappings(
     Array const & lhs,
     Array const & rhs,
-    ssize_t output_matrix_size)
+    ssize_t output_block_size)
 {
-    if (lhs.ndim() != rhs.ndim())
-    {
-        throw std::invalid_argument(
-            std::format("SimpleArray::matmul_planned(): batch shape "
-                        "mismatch: this={} other={}",
-                        shape_string(lhs),
-                        shape_string(rhs)));
-    }
-
-    size_t const batch_rank = lhs.ndim() - 2;
-    shape_type batch_shape(lhs.shape().begin(), lhs.shape().begin() + batch_rank);
-    if (!std::equal(batch_shape.begin(), batch_shape.end(), rhs.shape().begin()))
-    {
-        throw std::invalid_argument(
-            std::format("SimpleArray::matmul_planned(): batch shape "
-                        "mismatch: this={} other={}",
-                        shape_string(lhs),
-                        shape_string(rhs)));
-    }
-
-    LoopDomain domain{std::move(batch_shape)};
-    batch_stride_type lhs_batch_strides(lhs.stride().begin(), lhs.stride().begin() + batch_rank);
-    batch_stride_type rhs_batch_strides(rhs.stride().begin(), rhs.stride().begin() + batch_rank);
+    LoopDomain domain{make_batch_shape(lhs, rhs)};
     mapping_type mappings{
-        OperandMapping::contiguous_blocks(domain, output_matrix_size),
-        OperandMapping(std::move(lhs_batch_strides)),
-        OperandMapping(std::move(rhs_batch_strides)),
+        OperandMapping::contiguous_blocks(domain, output_block_size),
+        make_batch_mapping(lhs, domain),
+        make_batch_mapping(rhs, domain),
     };
     return BatchMappings{
         .m_domain = std::move(domain),
@@ -259,15 +294,91 @@ MatmulPlan::BatchMappings MatmulPlan::make_batch_mappings(
     };
 }
 
+template <typename Array>
+MatmulPlan::shape_type MatmulPlan::make_batch_shape(Array const & lhs, Array const & rhs)
+{
+    size_t lhs_batch_axis_count = 0;
+    if (lhs.ndim() > 1)
+    {
+        lhs_batch_axis_count = lhs.ndim() - 2;
+    }
+    size_t rhs_batch_axis_count = 0;
+    if (rhs.ndim() > 1)
+    {
+        rhs_batch_axis_count = rhs.ndim() - 2;
+    }
+    size_t const batch_axis_count = std::max(lhs_batch_axis_count, rhs_batch_axis_count);
+    shape_type batch_shape(batch_axis_count, 1);
+    for (size_t offset = 0; offset < batch_axis_count; ++offset)
+    {
+        ssize_t const lhs_extent =
+            offset < lhs_batch_axis_count ? lhs.shape(lhs_batch_axis_count - offset - 1) : 1;
+        ssize_t const rhs_extent =
+            offset < rhs_batch_axis_count ? rhs.shape(rhs_batch_axis_count - offset - 1) : 1;
+        if (lhs_extent != rhs_extent && lhs_extent != 1 && rhs_extent != 1)
+        {
+            throw std::invalid_argument(
+                std::format("SimpleArray::matmul_planned(): batch shape "
+                            "mismatch: this={} other={}",
+                            shape_string(lhs),
+                            shape_string(rhs)));
+        }
+        batch_shape[batch_axis_count - offset - 1] = lhs_extent == 1 ? rhs_extent : lhs_extent;
+    }
+    return batch_shape;
+}
+
+template <typename Array>
+OperandMapping MatmulPlan::make_batch_mapping(Array const & operand, LoopDomain const & domain)
+{
+    size_t batch_axis_count = 0;
+    if (operand.ndim() > 1)
+    {
+        batch_axis_count = operand.ndim() - 2;
+    }
+    size_t const batch_axis_offset = domain.rank() - batch_axis_count;
+    batch_stride_type strides(domain.rank(), 0);
+    for (size_t axis = 0; axis < batch_axis_count; ++axis)
+    {
+        size_t const domain_axis = batch_axis_offset + axis;
+        if (operand.shape(axis) == domain.extent(domain_axis))
+        {
+            strides[domain_axis] = operand.stride(axis);
+        }
+    }
+    return OperandMapping(std::move(strides));
+}
+
 inline MatmulPlan::shape_type MatmulPlan::make_output_shape(
     BatchMappings const & batch,
     Contraction const & contraction)
 {
-    size_t const batch_rank = batch.m_domain.rank();
-    shape_type output_shape(batch_rank + 2);
+    size_t const batch_axis_count = batch.m_domain.rank();
+    if (contraction.m_lhs_vector && contraction.m_rhs_vector)
+    {
+        return shape_type{1};
+    }
+
+    size_t output_axis_count = batch_axis_count;
+    if (!contraction.m_lhs_vector)
+    {
+        ++output_axis_count;
+    }
+    if (!contraction.m_rhs_vector)
+    {
+        ++output_axis_count;
+    }
+    shape_type output_shape(output_axis_count);
     std::ranges::copy(batch.m_domain.shape(), output_shape.begin());
-    output_shape[batch_rank] = contraction.m_rows;
-    output_shape[batch_rank + 1] = contraction.m_columns;
+    size_t output_axis = batch_axis_count;
+    if (!contraction.m_lhs_vector)
+    {
+        output_shape[output_axis++] = contraction.m_rows;
+    }
+    if (!contraction.m_rhs_vector)
+    {
+        output_shape[output_axis] = contraction.m_columns;
+    }
     return output_shape;
 }
 

--- a/profiling/profile_matrix_ops.py
+++ b/profiling/profile_matrix_ops.py
@@ -2,6 +2,8 @@
 # BSD 3-Clause License, see COPYING
 
 import functools
+import itertools
+import statistics
 import numpy as np
 import solvcon
 
@@ -54,13 +56,21 @@ def make_data(dtype, shape):
     return np.random.rand(*shape).astype(dtype)
 
 
-def make_matrix_layout_cases(lhs, rhs):
-    return (
-        ("c_contiguous", lhs, rhs),
-        ("non_contiguous",
-         np.flip(lhs, axis=-1),
-         np.flip(rhs, axis=-2)),
+def iter_stride_cases(lhs, rhs):
+    rhs_inner_axis = -1 if rhs.ndim == 1 else -2
+    lhs_cases = (
+        ("c_contiguous", lhs),
+        ("negative_inner_stride", np.flip(lhs, axis=-1)),
     )
+    rhs_cases = (
+        ("c_contiguous", rhs),
+        ("negative_inner_stride", np.flip(rhs, axis=rhs_inner_axis)),
+    )
+    for lhs_case, rhs_case in itertools.product(lhs_cases, rhs_cases):
+        lhs_name, case_lhs = lhs_case
+        rhs_name, case_rhs = rhs_case
+        name = f"lhs_{lhs_name}_rhs_{rhs_name}"
+        yield name, case_lhs, case_rhs
 
 
 def element_strides(data):
@@ -72,20 +82,29 @@ def print_profile_row(*columns):
         "| {:20s} | {:15s} | {:15s} |", *(columns[0:3])))
 
 
-def profile_matmul_operation(dtype, shapes, it=10):
+def profile_one_call(func, *args):
+    solvcon.call_profiler.reset()
+    func(*args)
+    result = solvcon.call_profiler.result()["children"]
+    if len(result) != 1 or result[0]["count"] != 1:
+        raise RuntimeError("Expected exactly one profiled call")
+    return result[0]["total_time"]
+
+
+def profile_unbatched_gemm(dtype, sides, samples=10):
     tile_configs = (
         (16, 16, 16),
         (32, 32, 32),
         (64, 64, 64),
     )
-    for m in shapes:
-        lhs = make_data(dtype, (m, m))
-        rhs = make_data(dtype, (m, m))
-        for layout, case_lhs, case_rhs in make_matrix_layout_cases(lhs, rhs):
+    for side in sides:
+        lhs = make_data(dtype, (side, side))
+        rhs = make_data(dtype, (side, side))
+        for case_name, case_lhs, case_rhs in iter_stride_cases(lhs, rhs):
             lhs_sa = make_container(case_lhs)
             rhs_sa = make_container(case_rhs)
             solvcon.call_profiler.reset()
-            for _ in range(it):
+            for _ in range(samples):
                 profile_matmul_np(case_lhs, case_rhs)
                 profile_matmul_naive_sa(lhs_sa, rhs_sa)
                 profile_matmul_blas_sa(lhs_sa, rhs_sa)
@@ -94,13 +113,13 @@ def profile_matmul_operation(dtype, shapes, it=10):
                     profile_matmul_fast_sa(
                         lhs_sa, rhs_sa, tile_x, tile_y, tile_z)
 
-            res = solvcon.call_profiler.result()["children"]
-            out = {}
-            for r in res:
-                name = r["name"].replace("profile_matmul_", "")
-                out[name] = r["total_time"] / r["count"]
+            result = solvcon.call_profiler.result()["children"]
+            timings = {}
+            for item in result:
+                name = item["name"].replace("profile_matmul_", "")
+                timings[name] = item["total_time"] / item["count"]
 
-            print(f"## 2D x 2D layout: `{layout}` "
+            print(f"## 2D x 2D strides: `{case_name}` "
                   f"dtype: `{np.dtype(dtype)}`\n")
             print(f"- lhs shape: `{case_lhs.shape}`, element strides: "
                   f"`{element_strides(case_lhs)}`")
@@ -109,77 +128,106 @@ def profile_matmul_operation(dtype, shapes, it=10):
 
             print_profile_row("func", "per call (ms)", "cmp to np")
             print_profile_row("-" * 20, "-" * 15, "-" * 15)
-            npbase = out["np"]
-            keys = ["np", "naive_sa", "blas_sa", "planned_sa"]
-            keys += [
+            numpy_time = timings["np"]
+            methods = ["np", "naive_sa", "blas_sa", "planned_sa"]
+            methods += [
                 f"fast_sa_{tile_x}_{tile_y}_{tile_z}"
                 for tile_x, tile_y, tile_z in tile_configs
             ]
-            for key in keys:
-                value = out[key]
-                print_profile_row(
-                    f"{key:8s}", f"{value:.3E}",
-                    f"{value / npbase:.3f}")
-            print()
-
-
-def profile_batched_matmul_operation(
-        dtype, sides, batch, warmups, samples):
-    for side in sides:
-        lhs = make_data(dtype, (batch, side, side))
-        rhs = make_data(dtype, (batch, side, side))
-        for layout, case_lhs, case_rhs in make_matrix_layout_cases(lhs, rhs):
-            lhs_sa = make_container(case_lhs)
-            rhs_sa = make_container(case_rhs)
-            for _ in range(warmups):
-                np.matmul(case_lhs, case_rhs)
-                lhs_sa.matmul_planned(rhs_sa)
-
-            solvcon.call_profiler.reset()
-            for _ in range(samples):
-                profile_matmul_np(case_lhs, case_rhs)
-                profile_matmul_planned_sa(lhs_sa, rhs_sa)
-
-            result = solvcon.call_profiler.result()["children"]
-            timings = {}
-            for item in result:
-                name = item["name"].replace("profile_matmul_", "")
-                timings[name] = item["total_time"] / item["count"]
-
-            print(f"## Equal batch: `{layout}`, "
-                  f"dtype: `{np.dtype(dtype)}`")
-            print(f"- lhs shape: `{case_lhs.shape}`, element strides: "
-                  f"`{element_strides(case_lhs)}`")
-            print(f"- rhs shape: `{case_rhs.shape}`, element strides: "
-                  f"`{element_strides(case_rhs)}`\n")
-
-            print_profile_row("func", "per call (ms)", "cmp to np")
-            print_profile_row("-" * 20, "-" * 15, "-" * 15)
-            npbase = timings["np"]
-            for method in ("np", "planned_sa"):
+            for method in methods:
                 value = timings[method]
                 print_profile_row(
                     f"{method:8s}", f"{value:.3E}",
-                    f"{value / npbase:.3f}")
+                    f"{value / numpy_time:.3f}")
             print()
 
 
+def profile_planned_case(
+        title, dtype, case_name, lhs, rhs, warmups, samples, rounds):
+    lhs_sa = make_container(lhs)
+    rhs_sa = make_container(rhs)
+    timings = {"np": [], "planned_sa": []}
+    for _ in range(rounds):
+        for _ in range(warmups):
+            np.matmul(lhs, rhs)
+            lhs_sa.matmul_planned(rhs_sa)
+
+        for _ in range(samples):
+            timings["np"].append(profile_one_call(
+                profile_matmul_np, lhs, rhs))
+            timings["planned_sa"].append(profile_one_call(
+                profile_matmul_planned_sa, lhs_sa, rhs_sa))
+
+    methods = ("np", "planned_sa")
+    timings = {
+        method: statistics.median(timings[method])
+        for method in methods
+    }
+
+    print(f"## {title}: `{case_name}`, dtype: `{np.dtype(dtype)}`")
+    print(f"- lhs shape: `{lhs.shape}`, element strides: "
+          f"`{element_strides(lhs)}`")
+    print(f"- rhs shape: `{rhs.shape}`, element strides: "
+          f"`{element_strides(rhs)}`\n")
+
+    print_profile_row("func", "median (ms)", "cmp to np")
+    print_profile_row("-" * 20, "-" * 15, "-" * 15)
+    numpy_time = timings["np"]
+    for method in methods:
+        value = timings[method]
+        print_profile_row(
+            f"{method:8s}", f"{value:.3E}",
+            f"{value / numpy_time:.3f}")
+    print()
+
+
+def iter_planned_cases(dtype):
+    small_sides = (4, 9, 16, 27, 64, 81)
+    vector_sides = (*small_sides, 256, 1024)
+    dot_sizes = (*vector_sides, 16_384, 1_048_576)
+
+    for size in dot_sizes:
+        yield (
+            "DOT",
+            make_data(dtype, (size,)),
+            make_data(dtype, (size,)),
+            15,
+        )
+
+    for side in vector_sides:
+        vector = make_data(dtype, (side,))
+        matrix = make_data(dtype, (side, side))
+        batch_matrix = make_data(dtype, (2, 5, side, side))
+        yield ("GEVM", vector, matrix, 15)
+        yield ("GEMV", matrix, vector, 15)
+        yield ("Batched GEVM", vector, batch_matrix, 15)
+        yield ("Batched GEMV", batch_matrix, vector, 15)
+
+    for side in (*small_sides, 256):
+        samples = 5 if side == 256 else 15
+        batch_lhs = make_data(dtype, (10, side, side))
+        batch_rhs = make_data(dtype, (10, side, side))
+        cross_lhs = make_data(dtype, (2, 1, side, side))
+        cross_rhs = make_data(dtype, (1, 5, side, side))
+        yield ("Equal-batch GEMM", batch_lhs, batch_rhs, samples)
+        yield ("Cross-broadcast GEMM", cross_lhs, cross_rhs, samples)
+
+
+def profile_planned_suite(dtype, warmups, rounds):
+    for title, lhs, rhs, samples in iter_planned_cases(dtype):
+        for case_name, case_lhs, case_rhs in iter_stride_cases(lhs, rhs):
+            profile_planned_case(
+                title, dtype, case_name, case_lhs, case_rhs,
+                warmups, samples, rounds)
+
+
 def main():
-    shapes = [4, 16, 64, 256, 1024]
+    gemm_sides = (4, 9, 16, 27, 64, 81, 243, 256, 729, 1024)
+    for dtype in (np.float32, np.float64):
+        profile_unbatched_gemm(dtype, gemm_sides)
 
     for dtype in (np.float32, np.float64):
-        profile_matmul_operation(dtype, shapes)
-
-    shapes = [9, 27, 81, 243, 729]
-
-    for dtype in (np.float32, np.float64):
-        profile_matmul_operation(dtype, shapes)
-
-    batch_sides = (4, 9, 16, 27, 64, 81)
-
-    for dtype in (np.float32, np.float64):
-        profile_batched_matmul_operation(
-            dtype, batch_sides, batch=10, warmups=2, samples=15)
+        profile_planned_suite(dtype, warmups=2, rounds=5)
 
 
 if __name__ == "__main__":

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -58,35 +58,35 @@ class MatrixFloat64TC(MatrixTestBase, unittest.TestCase):
 
 
 class MatmulTestBase(sc.testing.TestBase):
-    """Tests for matrix-matrix multiplication"""
+    """Tests for SimpleArray matrix multiplication roles."""
 
     @staticmethod
-    def make_strided_layout(data, axis, step):
+    def make_strided_view(data, axis, step):
         storage_shape = list(data.shape)
         storage_shape[axis] *= abs(step)
         storage = np.empty(storage_shape, dtype=data.dtype.name)
         selection = [slice(None)] * data.ndim
         selection[axis] = slice(None, None, step)
-        layout = storage[tuple(selection)]
-        layout[...] = data
-        return layout
+        view = storage[tuple(selection)]
+        view[...] = data
+        return view
 
     @classmethod
-    def make_batch_layouts(cls, data):
-        layouts = [('c_contiguous', data)]
+    def make_batch_stride_cases(cls, data):
+        cases = [('c_contiguous', data)]
         for axis in range(data.ndim - 2):
-            layouts.append((
+            cases.append((
                 f'negative_batch_axis_{axis}',
-                cls.make_strided_layout(data, axis, -1),
+                cls.make_strided_view(data, axis, -1),
             ))
-            layouts.append((
+            cases.append((
                 f'step_two_batch_axis_{axis}',
-                cls.make_strided_layout(data, axis, 2),
+                cls.make_strided_view(data, axis, 2),
             ))
-        return tuple(layouts)
+        return tuple(cases)
 
     @classmethod
-    def make_matrix_layouts(cls, data, stride_axis):
+    def make_matrix_stride_cases(cls, data, axis):
         f_contiguous = np.array(
             data, dtype=data.dtype.name, order='F', copy=True)
 
@@ -94,8 +94,8 @@ class MatmulTestBase(sc.testing.TestBase):
             ('c_contiguous', data),
             ('f_contiguous', f_contiguous),
             ('negative_stride',
-             cls.make_strided_layout(data, stride_axis, -1)),
-            ('step_two', cls.make_strided_layout(data, stride_axis, 2)),
+             cls.make_strided_view(data, axis, -1)),
+            ('step_two', cls.make_strided_view(data, axis, 2)),
         )
 
     def assert_matmul(self, lhs, rhs, expected):
@@ -361,17 +361,18 @@ class MatmulTestBase(sc.testing.TestBase):
                 result = self.assert_matmul(a, b, expected)
                 self.assert_matmul_fast(a, b, expected, result)
                 self.assert_matmul_blas(a, b, expected, result)
+                self.assert_matmul_planned(a, b, expected)
 
-    def test_matrix_layout_combinations(self):
-        """Matrix multiplication supports signed-stride operand layouts."""
+    def test_matrix_strides(self):
+        """Matrix axes support C, F, negative, and step-two strides."""
         dtype = np.dtype(self.dtype).name
 
-        lhs_layouts = self.make_matrix_layouts(
+        lhs_cases = self.make_matrix_stride_cases(
             np.arange(12, dtype=dtype).reshape(3, 4), 1)
-        rhs_layouts = self.make_matrix_layouts(
+        rhs_cases = self.make_matrix_stride_cases(
             np.arange(8, dtype=dtype).reshape(4, 2), 0)
-        layouts = itertools.product(lhs_layouts, rhs_layouts)
-        for (lhs_case, lhs_data), (rhs_case, rhs_data) in layouts:
+        cases = itertools.product(lhs_cases, rhs_cases)
+        for (lhs_case, lhs_data), (rhs_case, rhs_data) in cases:
             lhs = self.SimpleArray(array=lhs_data)
             rhs = self.SimpleArray(array=rhs_data)
             expected = np.matmul(lhs_data, rhs_data)
@@ -379,8 +380,8 @@ class MatmulTestBase(sc.testing.TestBase):
             with self.subTest(lhs=lhs_case, rhs=rhs_case):
                 self.assert_matmul_planned(lhs, rhs, expected)
 
-    def test_equal_batch_layout_combinations(self):
-        """Equal matrix batches support runtime-rank strided traversal."""
+    def test_batch_strides(self):
+        """Batch axes support negative and step-two strides."""
         dtype = np.dtype(self.dtype).name
         shapes = (
             ((3, 3, 4), (3, 4, 2)),
@@ -391,10 +392,10 @@ class MatmulTestBase(sc.testing.TestBase):
                 np.prod(lhs_shape), dtype=dtype).reshape(lhs_shape)
             rhs_data = np.arange(
                 np.prod(rhs_shape), dtype=dtype).reshape(rhs_shape)
-            lhs_layouts = self.make_batch_layouts(lhs_data)
-            rhs_layouts = self.make_batch_layouts(rhs_data)
-            layouts = itertools.product(lhs_layouts, rhs_layouts)
-            for (lhs_case, case_lhs), (rhs_case, case_rhs) in layouts:
+            lhs_cases = self.make_batch_stride_cases(lhs_data)
+            rhs_cases = self.make_batch_stride_cases(rhs_data)
+            cases = itertools.product(lhs_cases, rhs_cases)
+            for (lhs_case, case_lhs), (rhs_case, case_rhs) in cases:
                 lhs = self.SimpleArray(array=case_lhs)
                 rhs = self.SimpleArray(array=case_rhs)
                 expected = np.matmul(case_lhs, case_rhs)
@@ -403,17 +404,126 @@ class MatmulTestBase(sc.testing.TestBase):
                         shape=lhs_shape, lhs=lhs_case, rhs=rhs_case):
                     self.assert_matmul_planned(lhs, rhs, expected)
 
-    def test_empty_matrix_dimensions(self):
-        """Matrix multiplication preserves empty output and inner axes."""
+    def test_broadcast_batch_strides(self):
+        """Broadcasting supports zero and signed batch strides."""
         dtype = np.dtype(self.dtype).name
-        shapes = (((0, 4), (4, 2)),
+        lhs_data = np.arange(24, dtype=dtype).reshape(2, 1, 3, 4)
+        rhs_data = np.arange(40, dtype=dtype).reshape(1, 5, 4, 2)
+        cases = itertools.product(
+            self.make_batch_stride_cases(lhs_data),
+            self.make_batch_stride_cases(rhs_data),
+        )
+        for (lhs_case, case_lhs), (rhs_case, case_rhs) in cases:
+            lhs = self.SimpleArray(array=case_lhs)
+            rhs = self.SimpleArray(array=case_rhs)
+            expected = np.matmul(case_lhs, case_rhs)
+
+            with self.subTest(lhs=lhs_case, rhs=rhs_case):
+                self.assert_matmul_planned(lhs, rhs, expected)
+
+    def test_broadcast_matrix_strides(self):
+        """Broadcasting preserves signed matrix strides."""
+        dtype = np.dtype(self.dtype).name
+        lhs_data = np.arange(24, dtype=dtype).reshape(2, 1, 3, 4)
+        rhs_data = np.arange(40, dtype=dtype).reshape(1, 5, 4, 2)
+        cases = itertools.product(
+            self.make_matrix_stride_cases(lhs_data, 3),
+            self.make_matrix_stride_cases(rhs_data, 2),
+        )
+        for (lhs_case, case_lhs), (rhs_case, case_rhs) in cases:
+            lhs = self.SimpleArray(array=case_lhs)
+            rhs = self.SimpleArray(array=case_rhs)
+            expected = np.matmul(case_lhs, case_rhs)
+
+            with self.subTest(lhs=lhs_case, rhs=rhs_case):
+                self.assert_matmul_planned(lhs, rhs, expected)
+
+    def test_vector_strides(self):
+        """Vector roles preserve signed vector, matrix, and batch strides."""
+        dtype = np.dtype(self.dtype).name
+        vector_data = np.arange(4, dtype=dtype)
+        vector_cases = (
+            ('contiguous', vector_data),
+            ('negative_stride',
+             self.make_strided_view(vector_data, 0, -1)),
+            ('step_two', self.make_strided_view(vector_data, 0, 2)),
+        )
+
+        gevm_data = np.arange(24, dtype=dtype).reshape(2, 1, 4, 3)
+        gevm_cases = (
+            self.make_matrix_stride_cases(gevm_data, 2) +
+            self.make_batch_stride_cases(gevm_data)[1:]
+        )
+        gemv_data = np.arange(24, dtype=dtype).reshape(2, 1, 3, 4)
+        gemv_cases = (
+            self.make_matrix_stride_cases(gemv_data, 3) +
+            self.make_batch_stride_cases(gemv_data)[1:]
+        )
+        role_cases = (
+            ('gevm', vector_cases, gevm_cases),
+            ('gemv', gemv_cases, vector_cases),
+        )
+        for role, lhs_cases, rhs_cases in role_cases:
+            cases = itertools.product(lhs_cases, rhs_cases)
+            for (lhs_case, lhs_data), (rhs_case, rhs_data) in cases:
+                lhs = self.SimpleArray(array=lhs_data)
+                rhs = self.SimpleArray(array=rhs_data)
+                expected = np.matmul(lhs_data, rhs_data)
+
+                with self.subTest(
+                        role=role, lhs=lhs_case, rhs=rhs_case):
+                    self.assert_matmul_planned(lhs, rhs, expected)
+
+    def test_batch_axes_align_right(self):
+        """Leading batch axes align from the right like NumPy matmul."""
+        dtype = np.dtype(self.dtype).name
+        shapes = (
+            ((3, 4), (2, 5, 4, 2)),
+            ((2, 5, 3, 4), (4, 2)),
+            ((1, 3, 4), (2, 5, 4, 2)),
+            ((2, 1, 3, 4), (5, 4, 2)),
+        )
+        for lhs_shape, rhs_shape in shapes:
+            lhs_data = np.arange(
+                np.prod(lhs_shape), dtype=dtype).reshape(lhs_shape)
+            rhs_data = np.arange(
+                np.prod(rhs_shape), dtype=dtype).reshape(rhs_shape)
+            lhs = self.SimpleArray(array=lhs_data)
+            rhs = self.SimpleArray(array=rhs_data)
+
+            with self.subTest(lhs=lhs_shape, rhs=rhs_shape):
+                self.assert_matmul_planned(
+                    lhs, rhs, np.matmul(lhs_data, rhs_data))
+
+    def test_broadcast_batch_mismatch(self):
+        """Incompatible leading batch axes report both operand shapes."""
+        lhs = self.SimpleArray(shape=(2, 3, 4), value=0)
+        rhs = self.SimpleArray(shape=(3, 4, 2), value=0)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"SimpleArray::matmul_planned\(\): batch shape mismatch: "
+            r"this=\(2,3,4\) other=\(3,4,2\)"
+        ):
+            lhs.matmul_planned(rhs)
+
+    def test_empty_dimensions(self):
+        """Matmul preserves empty output and inner axes."""
+        dtype = np.dtype(self.dtype).name
+        shapes = (((0,), (0,)),
+                  ((3, 0), (0,)),
+                  ((0,), (0, 2)),
+                  ((2, 3, 0), (0,)),
+                  ((0,), (2, 3, 0, 4)),
+                  ((0, 4), (4, 2)),
                   ((3, 0), (0, 2)),
                   ((3, 4), (4, 0)),
-                  ((0, 3, 4), (0, 4, 2)))
+                  ((0, 3, 4), (0, 4, 2)),
+                  ((0, 1, 3, 4), (1, 5, 4, 2)),
+                  ((1, 3, 4), (0, 4, 2)))
         for lhs_shape, rhs_shape in shapes:
             lhs_data = np.zeros(lhs_shape, dtype=dtype)
             rhs_data = np.zeros(rhs_shape, dtype=dtype)
-            expected = np.matmul(lhs_data, rhs_data)
+            expected = np.atleast_1d(np.matmul(lhs_data, rhs_data))
             lhs = self.SimpleArray(shape=lhs_shape, value=0)
             rhs = self.SimpleArray(shape=rhs_shape, value=0)
 
@@ -428,7 +538,7 @@ class MatmulTestBase(sc.testing.TestBase):
             'negative': np.arange(8, dtype=dtype)[::-1],
             'step_two': np.arange(16, dtype=dtype)[::2],
         }
-        methods = ('matmul', 'matmul_fast', 'matmul_blas')
+        methods = ('matmul', 'matmul_fast', 'matmul_blas', 'matmul_planned')
 
         cases = itertools.product(vectors, vectors, methods)
         for lhs_case, rhs_case, method in cases:


### PR DESCRIPTION
The parent #1181 traverses equal matrix batch shapes, but it neither broadcasts unequal leading axes nor accepts rank-1 operands. NumPy matmul needs both behaviors for `(2,1,M,K) @ (1,5,K,N)`, `(K,) @ (...,K,N)`, `(...,M,K) @ (K,)`, and `(K,) @ (K,)`.

This stacked change completes the generic planned roles. `MatmulPlan` aligns leading batch axes with zero strides and records whether each operand is a vector or matrix. Synthetic M=1 or N=1 lets one signed-stride executor evaluate DOT, GEVM, GEMV, and GEMM, while output-shape construction removes the synthetic axes and retains the existing `(1,)` dot-result convention. Operands are not expanded.

Differential tests cover rank alignment, empty domains, incompatible shapes, signed vector, batch, and contraction strides, and C-, F-, negative-, and step-two layouts. `profile_matrix_ops.py` measures broadcast batch matrix-matrix, DOT, single GEVM/GEMV, and batch GEVM/GEMV across all four independent LHS/RHS C-contiguous or negative-contraction-stride combinations.

## Profiling

The benchmark ran at `4e42c825` on an Apple M1 with Python 3.14.6, NumPy 2.5.1, and Accelerate. Each plotted point is the median of individual calls from five rounds. Each round uses two warmups and 15 measured calls per implementation.

At `S = 1024`, C-contiguous batch GEVM/GEMV planned-to-NumPy ratios are 14.044/7.102 for float32 and 6.412/3.929 for float64. The other three stride combinations range from 0.783 to 0.984; mixed or negative DOT at `S = 1048576` ranges from 0.999 to 1.000. NumPy remains faster for large C-contiguous inputs and side-256 broadcast batches.

### float32 scaling by operation and layout (NumPy 2.5.1)

![Float32 planned matmul scaling with explicit LHS, RHS, and output shape and element stride labels](https://github.com/user-attachments/assets/25bfb79a-6bf9-4b70-8ed5-39c39c41b5ff)

### float64 scaling by operation and layout (NumPy 2.5.1)

![Float64 planned matmul scaling with explicit LHS, RHS, and output shape and element stride labels](https://github.com/user-attachments/assets/21953d1f-cead-4bc3-9f4e-140c00696e73)

[Download the complete profile output.](https://github.com/user-attachments/files/30590397/pr1208-profile-matrix-ops-4e42c825.txt)

Matrix correctness passes all 58 tests and 498 subtests in `tests/test_matrix.py`.

Related to #1172.
