### PR TITLE
Add direct BLAS routes for DOT, unbatched GEVM/GEMV, and BLAS-compatible GEMM

### DIFF
--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <format>
+#include <optional>
 #include <ranges>
 #include <stdexcept>
 #include <string>
@@ -72,6 +73,8 @@ public:
     ssize_t rhs_inner_stride() const noexcept { return m_strides.m_rhs_inner_stride; }
     ssize_t rhs_column_stride() const noexcept { return m_strides.m_rhs_column_stride; }
 
+    bool lhs_is_vector() const noexcept { return m_contraction.m_lhs_vector; }
+    bool rhs_is_vector() const noexcept { return m_contraction.m_rhs_vector; }
     bool has_batch_axes() const noexcept { return m_batch.m_domain.rank() != 0; }
     MappedOffsetCursor batch_cursor() const & { return MappedOffsetCursor(m_batch.m_domain, m_batch.m_mappings); }
     MappedOffsetCursor batch_cursor() const && = delete;
@@ -147,9 +150,9 @@ private:
  * evaluates one `(3,4) @ (4,6)` contraction at each offset. The results are
  * written into the allocated `(2,5,3,6)` output.
  *
- * @note This implementation provides generic signed-stride DOT, GEMV, GEVM,
- * and GEMM routes with broadcast batch shapes. Optimized routes are
- * follow-up work.
+ * @note This implementation provides generic signed-stride routes and direct
+ * BLAS routes for unit-stride DOT, positive-increment GEMV and GEVM, and
+ * C/F-compatible GEMM. Packing and batched-vector tuning are follow-up work.
  */
 template <typename Array>
 class MatmulExecutor
@@ -161,6 +164,8 @@ public:
 
 private:
     using value_type = typename Array::value_type;
+    using matrix_view_type = BlasMatrixView<value_type>;
+    using vector_view_type = BlasVectorView<value_type>;
 
     enum class MappingSlot : std::uint8_t
     {
@@ -169,6 +174,23 @@ private:
         Rhs,
     };
 
+    static constexpr ssize_t BLAS_DOT_MIN_LENGTH = 128;
+    static constexpr ssize_t BLAS_COMPACT_GEVM_MIN_ELEMENTS = 729;
+    static constexpr ssize_t BLAS_GEMV_MIN_DIMENSION = 32;
+    static constexpr ssize_t BLAS_GEMM_MIN_DIMENSION = 8;
+
+    void execute_at(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base);
+    bool try_execute_blas(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base);
+    bool try_dot(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
+    bool try_gevm(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
+    bool try_gemv(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
+    bool try_gemm(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
+    static std::optional<matrix_view_type> make_matrix_view(
+        value_type const * data,
+        ssize_t row_stride,
+        ssize_t column_stride,
+        ssize_t rows,
+        ssize_t columns);
     void execute_generic(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base);
 
     MatmulPlan const & m_plan;
@@ -412,17 +434,158 @@ void MatmulExecutor<Array>::execute()
 {
     if (!m_plan.has_batch_axes())
     {
-        execute_generic(0, 0, 0);
+        execute_at(0, 0, 0);
         return;
     }
 
     for (MappedOffsetCursor cursor = m_plan.batch_cursor(); cursor; cursor.advance())
     {
-        execute_generic(
+        execute_at(
             cursor.offset(MappingSlot::Output),
             cursor.offset(MappingSlot::Lhs),
             cursor.offset(MappingSlot::Rhs));
     }
+}
+
+template <typename Array>
+void MatmulExecutor<Array>::execute_at(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base)
+{
+    if (!try_execute_blas(output_base, lhs_base, rhs_base))
+    {
+        execute_generic(output_base, lhs_base, rhs_base);
+    }
+}
+
+template <typename Array>
+bool MatmulExecutor<Array>::try_execute_blas(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base)
+{
+#if (defined(__APPLE__) && defined(__arm64__)) || defined(MM_HAS_CBLAS)
+    if constexpr (can_matmul_blas_v<value_type>)
+    {
+        value_type * output = m_output_data + output_base;
+        value_type const * lhs_data = m_lhs_data + lhs_base;
+        value_type const * rhs_data = m_rhs_data + rhs_base;
+        if (m_plan.lhs_is_vector() && m_plan.rhs_is_vector())
+        {
+            return try_dot(output, lhs_data, rhs_data);
+        }
+        if (m_plan.lhs_is_vector())
+        {
+            return !m_plan.has_batch_axes() && try_gevm(output, lhs_data, rhs_data);
+        }
+        if (m_plan.rhs_is_vector())
+        {
+            return !m_plan.has_batch_axes() && try_gemv(output, lhs_data, rhs_data);
+        }
+        return try_gemm(output, lhs_data, rhs_data);
+    }
+#endif
+    return false;
+}
+
+template <typename Array>
+bool MatmulExecutor<Array>::try_dot(value_type * output, value_type const * lhs_data, value_type const * rhs_data)
+{
+    if (m_plan.inner_size() < BLAS_DOT_MIN_LENGTH)
+    {
+        return false;
+    }
+
+    ssize_t lhs_stride = m_plan.lhs_inner_stride();
+    ssize_t rhs_stride = m_plan.rhs_inner_stride();
+    if (lhs_stride == -1 && rhs_stride == -1)
+    {
+        lhs_data += (m_plan.inner_size() - 1) * lhs_stride;
+        rhs_data += (m_plan.inner_size() - 1) * rhs_stride;
+        lhs_stride = -lhs_stride;
+        rhs_stride = -rhs_stride;
+    }
+    if (lhs_stride != 1 || rhs_stride != 1)
+    {
+        return false;
+    }
+
+    vector_view_type const lhs{lhs_data, lhs_stride};
+    vector_view_type const rhs{rhs_data, rhs_stride};
+    output[0] = dot_blas(m_plan.inner_size(), lhs, rhs);
+    return true;
+}
+
+template <typename Array>
+bool MatmulExecutor<Array>::try_gevm(value_type * output, value_type const * lhs_data, value_type const * rhs_data)
+{
+    ssize_t const vector_stride = m_plan.lhs_inner_stride();
+    auto const matrix = make_matrix_view(
+        rhs_data, m_plan.rhs_inner_stride(), m_plan.rhs_column_stride(), m_plan.inner_size(), m_plan.columns());
+    if (vector_stride <= 0 || !matrix)
+    {
+        return false;
+    }
+    bool const is_compact = matrix->m_transpose == BlasTranspose::None &&
+                            matrix->m_leading_dimension == m_plan.columns();
+    bool const is_large_enough = is_compact
+                                     ? m_plan.inner_size() * m_plan.columns() >= BLAS_COMPACT_GEVM_MIN_ELEMENTS
+                                     : std::min(m_plan.inner_size(), m_plan.columns()) >= BLAS_GEMV_MIN_DIMENSION;
+    if (!is_large_enough)
+    {
+        return false;
+    }
+    vector_view_type const vector{lhs_data, vector_stride};
+    gemv_blas(m_plan.inner_size(), m_plan.columns(), *matrix, vector, output, BlasTranspose::Transpose);
+    return true;
+}
+
+template <typename Array>
+bool MatmulExecutor<Array>::try_gemv(value_type * output, value_type const * lhs_data, value_type const * rhs_data)
+{
+    auto const matrix = make_matrix_view(
+        lhs_data, m_plan.lhs_row_stride(), m_plan.lhs_inner_stride(), m_plan.rows(), m_plan.inner_size());
+    ssize_t const vector_stride = m_plan.rhs_inner_stride();
+    if (std::min(m_plan.rows(), m_plan.inner_size()) < BLAS_GEMV_MIN_DIMENSION || !matrix || vector_stride <= 0)
+    {
+        return false;
+    }
+    vector_view_type const vector{rhs_data, vector_stride};
+    gemv_blas(m_plan.rows(), m_plan.inner_size(), *matrix, vector, output, BlasTranspose::None);
+    return true;
+}
+
+template <typename Array>
+bool MatmulExecutor<Array>::try_gemm(value_type * output, value_type const * lhs_data, value_type const * rhs_data)
+{
+    if (std::min({m_plan.rows(), m_plan.columns(), m_plan.inner_size()}) < BLAS_GEMM_MIN_DIMENSION)
+    {
+        return false;
+    }
+    auto const lhs = make_matrix_view(
+        lhs_data, m_plan.lhs_row_stride(), m_plan.lhs_inner_stride(), m_plan.rows(), m_plan.inner_size());
+    auto const rhs = make_matrix_view(
+        rhs_data, m_plan.rhs_inner_stride(), m_plan.rhs_column_stride(), m_plan.inner_size(), m_plan.columns());
+    if (!lhs || !rhs)
+    {
+        return false;
+    }
+    gemm_blas(m_plan.rows(), m_plan.columns(), m_plan.inner_size(), *lhs, *rhs, output);
+    return true;
+}
+
+template <typename Array>
+std::optional<typename MatmulExecutor<Array>::matrix_view_type> MatmulExecutor<Array>::make_matrix_view(
+    value_type const * data,
+    ssize_t row_stride,
+    ssize_t column_stride,
+    ssize_t rows,
+    ssize_t columns)
+{
+    if (column_stride == 1 && row_stride >= columns)
+    {
+        return BlasMatrixView<value_type>{data, row_stride, BlasTranspose::None};
+    }
+    if (row_stride == 1 && column_stride >= rows)
+    {
+        return BlasMatrixView<value_type>{data, column_stride, BlasTranspose::Transpose};
+    }
+    return std::nullopt;
 }
 
 template <typename Array>

--- a/cpp/solvcon/math/blas_compat.cpp
+++ b/cpp/solvcon/math/blas_compat.cpp
@@ -60,6 +60,16 @@ static CBLAS_TRANSPOSE to_cblas_transpose(bool transpose_matrix)
     return transpose_matrix ? CblasTrans : CblasNoTrans;
 }
 
+static CBLAS_TRANSPOSE to_cblas_transpose(BlasTranspose transpose)
+{
+    return transpose == BlasTranspose::Transpose ? CblasTrans : CblasNoTrans;
+}
+
+static BlasTranspose compose_transposes(BlasTranspose storage, BlasTranspose requested)
+{
+    return storage == requested ? BlasTranspose::None : BlasTranspose::Transpose;
+}
+
 float dot_blas(ssize_t size, float const * lhs, float const * rhs)
 {
     blas_int_type const bsize = to_blas_int(size, "size");
@@ -305,6 +315,162 @@ void gemm_blas(ssize_t m,
                 as_std_complex_pointer(result),
                 bn);
 }
+
+namespace detail
+{
+
+float dot(ssize_t size, BlasVectorView<float> lhs, BlasVectorView<float> rhs)
+{
+    blas_int_type const bsize = to_blas_int(size, "size");
+    blas_int_type const bincx = to_blas_int(lhs.m_increment, "incx");
+    blas_int_type const bincy = to_blas_int(rhs.m_increment, "incy");
+    return cblas_sdot(bsize, lhs.m_data, bincx, rhs.m_data, bincy);
+}
+
+double dot(ssize_t size, BlasVectorView<double> lhs, BlasVectorView<double> rhs)
+{
+    blas_int_type const bsize = to_blas_int(size, "size");
+    blas_int_type const bincx = to_blas_int(lhs.m_increment, "incx");
+    blas_int_type const bincy = to_blas_int(rhs.m_increment, "incy");
+    return cblas_ddot(bsize, lhs.m_data, bincx, rhs.m_data, bincy);
+}
+
+Complex<float> dot(ssize_t size, BlasVectorView<Complex<float>> lhs, BlasVectorView<Complex<float>> rhs)
+{
+    blas_int_type const bsize = to_blas_int(size, "size");
+    blas_int_type const bincx = to_blas_int(lhs.m_increment, "incx");
+    blas_int_type const bincy = to_blas_int(rhs.m_increment, "incy");
+    std::complex<float> value;
+    cblas_cdotu_sub(
+        bsize, as_std_complex_pointer(lhs.m_data), bincx, as_std_complex_pointer(rhs.m_data), bincy, &value);
+    return value;
+}
+
+Complex<double> dot(ssize_t size, BlasVectorView<Complex<double>> lhs, BlasVectorView<Complex<double>> rhs)
+{
+    blas_int_type const bsize = to_blas_int(size, "size");
+    blas_int_type const bincx = to_blas_int(lhs.m_increment, "incx");
+    blas_int_type const bincy = to_blas_int(rhs.m_increment, "incy");
+    std::complex<double> value;
+    cblas_zdotu_sub(
+        bsize, as_std_complex_pointer(lhs.m_data), bincx, as_std_complex_pointer(rhs.m_data), bincy, &value);
+    return value;
+}
+
+void gemv(ssize_t m, ssize_t n, BlasMatrixView<float> matrix, BlasVectorView<float> vector, float * result, BlasTranspose requested_transpose)
+{
+    bool const transposed_storage = matrix.m_transpose == BlasTranspose::Transpose;
+    blas_int_type const bm = to_blas_int(transposed_storage ? n : m, "m");
+    blas_int_type const bn = to_blas_int(transposed_storage ? m : n, "n");
+    blas_int_type const blda = to_blas_int(matrix.m_leading_dimension, "lda");
+    blas_int_type const bincx = to_blas_int(vector.m_increment, "incx");
+    CBLAS_TRANSPOSE const bop = to_cblas_transpose(compose_transposes(matrix.m_transpose, requested_transpose));
+    cblas_sgemv(CblasRowMajor, bop, bm, bn, 1.0F, matrix.m_data, blda, vector.m_data, bincx, 0.0F, result, 1);
+}
+
+void gemv(ssize_t m, ssize_t n, BlasMatrixView<double> matrix, BlasVectorView<double> vector, double * result, BlasTranspose requested_transpose)
+{
+    bool const transposed_storage = matrix.m_transpose == BlasTranspose::Transpose;
+    blas_int_type const bm = to_blas_int(transposed_storage ? n : m, "m");
+    blas_int_type const bn = to_blas_int(transposed_storage ? m : n, "n");
+    blas_int_type const blda = to_blas_int(matrix.m_leading_dimension, "lda");
+    blas_int_type const bincx = to_blas_int(vector.m_increment, "incx");
+    CBLAS_TRANSPOSE const bop = to_cblas_transpose(compose_transposes(matrix.m_transpose, requested_transpose));
+    cblas_dgemv(CblasRowMajor, bop, bm, bn, 1.0, matrix.m_data, blda, vector.m_data, bincx, 0.0, result, 1);
+}
+
+void gemv(ssize_t m, ssize_t n, BlasMatrixView<Complex<float>> matrix, BlasVectorView<Complex<float>> vector, Complex<float> * result, BlasTranspose requested_transpose)
+{
+    bool const transposed_storage = matrix.m_transpose == BlasTranspose::Transpose;
+    blas_int_type const bm = to_blas_int(transposed_storage ? n : m, "m");
+    blas_int_type const bn = to_blas_int(transposed_storage ? m : n, "n");
+    blas_int_type const blda = to_blas_int(matrix.m_leading_dimension, "lda");
+    blas_int_type const bincx = to_blas_int(vector.m_increment, "incx");
+    CBLAS_TRANSPOSE const bop = to_cblas_transpose(compose_transposes(matrix.m_transpose, requested_transpose));
+    std::complex<float> const alpha{1.0F, 0.0F};
+    std::complex<float> const beta{0.0F, 0.0F};
+    auto const * matrix_data = as_std_complex_pointer(matrix.m_data);
+    auto const * vector_data = as_std_complex_pointer(vector.m_data);
+    auto * result_data = as_std_complex_pointer(result);
+    cblas_cgemv(CblasRowMajor, bop, bm, bn, &alpha, matrix_data, blda, vector_data, bincx, &beta, result_data, 1);
+}
+
+void gemv(ssize_t m, ssize_t n, BlasMatrixView<Complex<double>> matrix, BlasVectorView<Complex<double>> vector, Complex<double> * result, BlasTranspose requested_transpose)
+{
+    bool const transposed_storage = matrix.m_transpose == BlasTranspose::Transpose;
+    blas_int_type const bm = to_blas_int(transposed_storage ? n : m, "m");
+    blas_int_type const bn = to_blas_int(transposed_storage ? m : n, "n");
+    blas_int_type const blda = to_blas_int(matrix.m_leading_dimension, "lda");
+    blas_int_type const bincx = to_blas_int(vector.m_increment, "incx");
+    CBLAS_TRANSPOSE const bop = to_cblas_transpose(compose_transposes(matrix.m_transpose, requested_transpose));
+    std::complex<double> const alpha{1.0, 0.0};
+    std::complex<double> const beta{0.0, 0.0};
+    auto const * matrix_data = as_std_complex_pointer(matrix.m_data);
+    auto const * vector_data = as_std_complex_pointer(vector.m_data);
+    auto * result_data = as_std_complex_pointer(result);
+    cblas_zgemv(CblasRowMajor, bop, bm, bn, &alpha, matrix_data, blda, vector_data, bincx, &beta, result_data, 1);
+}
+
+void gemm(ssize_t m, ssize_t n, ssize_t k, BlasMatrixView<float> lhs, BlasMatrixView<float> rhs, float * result)
+{
+    blas_int_type const bm = to_blas_int(m, "m");
+    blas_int_type const bn = to_blas_int(n, "n");
+    blas_int_type const bk = to_blas_int(k, "k");
+    blas_int_type const blda = to_blas_int(lhs.m_leading_dimension, "lda");
+    blas_int_type const bldb = to_blas_int(rhs.m_leading_dimension, "ldb");
+    CBLAS_TRANSPOSE const opa = to_cblas_transpose(lhs.m_transpose);
+    CBLAS_TRANSPOSE const opb = to_cblas_transpose(rhs.m_transpose);
+    cblas_sgemm(CblasRowMajor, opa, opb, bm, bn, bk, 1.0F, lhs.m_data, blda, rhs.m_data, bldb, 0.0F, result, bn);
+}
+
+void gemm(ssize_t m, ssize_t n, ssize_t k, BlasMatrixView<double> lhs, BlasMatrixView<double> rhs, double * result)
+{
+    blas_int_type const bm = to_blas_int(m, "m");
+    blas_int_type const bn = to_blas_int(n, "n");
+    blas_int_type const bk = to_blas_int(k, "k");
+    blas_int_type const blda = to_blas_int(lhs.m_leading_dimension, "lda");
+    blas_int_type const bldb = to_blas_int(rhs.m_leading_dimension, "ldb");
+    CBLAS_TRANSPOSE const opa = to_cblas_transpose(lhs.m_transpose);
+    CBLAS_TRANSPOSE const opb = to_cblas_transpose(rhs.m_transpose);
+    cblas_dgemm(CblasRowMajor, opa, opb, bm, bn, bk, 1.0, lhs.m_data, blda, rhs.m_data, bldb, 0.0, result, bn);
+}
+
+void gemm(ssize_t m, ssize_t n, ssize_t k, BlasMatrixView<Complex<float>> lhs, BlasMatrixView<Complex<float>> rhs, Complex<float> * result)
+{
+    blas_int_type const bm = to_blas_int(m, "m");
+    blas_int_type const bn = to_blas_int(n, "n");
+    blas_int_type const bk = to_blas_int(k, "k");
+    blas_int_type const blda = to_blas_int(lhs.m_leading_dimension, "lda");
+    blas_int_type const bldb = to_blas_int(rhs.m_leading_dimension, "ldb");
+    CBLAS_TRANSPOSE const opa = to_cblas_transpose(lhs.m_transpose);
+    CBLAS_TRANSPOSE const opb = to_cblas_transpose(rhs.m_transpose);
+    std::complex<float> const alpha{1.0F, 0.0F};
+    std::complex<float> const beta{0.0F, 0.0F};
+    auto const * lhs_data = as_std_complex_pointer(lhs.m_data);
+    auto const * rhs_data = as_std_complex_pointer(rhs.m_data);
+    auto * result_data = as_std_complex_pointer(result);
+    cblas_cgemm(CblasRowMajor, opa, opb, bm, bn, bk, &alpha, lhs_data, blda, rhs_data, bldb, &beta, result_data, bn);
+}
+
+void gemm(ssize_t m, ssize_t n, ssize_t k, BlasMatrixView<Complex<double>> lhs, BlasMatrixView<Complex<double>> rhs, Complex<double> * result)
+{
+    blas_int_type const bm = to_blas_int(m, "m");
+    blas_int_type const bn = to_blas_int(n, "n");
+    blas_int_type const bk = to_blas_int(k, "k");
+    blas_int_type const blda = to_blas_int(lhs.m_leading_dimension, "lda");
+    blas_int_type const bldb = to_blas_int(rhs.m_leading_dimension, "ldb");
+    CBLAS_TRANSPOSE const opa = to_cblas_transpose(lhs.m_transpose);
+    CBLAS_TRANSPOSE const opb = to_cblas_transpose(rhs.m_transpose);
+    std::complex<double> const alpha{1.0, 0.0};
+    std::complex<double> const beta{0.0, 0.0};
+    auto const * lhs_data = as_std_complex_pointer(lhs.m_data);
+    auto const * rhs_data = as_std_complex_pointer(rhs.m_data);
+    auto * result_data = as_std_complex_pointer(result);
+    cblas_zgemm(CblasRowMajor, opa, opb, bm, bn, bk, &alpha, lhs_data, blda, rhs_data, bldb, &beta, result_data, bn);
+}
+
+} /* end namespace detail */
+
 #else
 [[noreturn]] static void throw_blas_unavailable()
 {

--- a/cpp/solvcon/math/blas_compat.hpp
+++ b/cpp/solvcon/math/blas_compat.hpp
@@ -8,8 +8,44 @@
 #include <solvcon/base.hpp>
 #include <solvcon/math/Complex.hpp>
 
+#include <cstdint>
+#include <stdexcept>
+
 namespace solvcon
 {
+
+/**
+ * @brief Select whether BLAS reads a matrix descriptor as stored or transposed.
+ */
+enum class BlasTranspose : std::uint8_t
+{
+    None,
+    Transpose,
+}; /* end enum class BlasTranspose */
+
+/**
+ * @brief Describe a non-owning BLAS vector with a positive element increment.
+ */
+template <typename T>
+struct BlasVectorView
+{
+    T const * m_data;
+    ssize_t m_increment;
+}; /* end struct BlasVectorView */
+
+/**
+ * @brief Describe a non-owning row-major BLAS matrix operand.
+ *
+ * A column-major logical matrix is represented by its row-major transposed
+ * storage and `BlasTranspose::Transpose`.
+ */
+template <typename T>
+struct BlasMatrixView
+{
+    T const * m_data;
+    ssize_t m_leading_dimension;
+    BlasTranspose m_transpose;
+}; /* end struct BlasMatrixView */
 
 float dot_blas(ssize_t size, float const * lhs, float const * rhs);
 double dot_blas(ssize_t size, double const * lhs, double const * rhs);
@@ -67,6 +103,56 @@ void gemm_blas(ssize_t m,
                Complex<double> const * lhs,
                Complex<double> const * rhs,
                Complex<double> * result);
+
+namespace detail
+{
+
+float dot(ssize_t size, BlasVectorView<float> lhs, BlasVectorView<float> rhs);
+double dot(ssize_t size, BlasVectorView<double> lhs, BlasVectorView<double> rhs);
+Complex<float> dot(ssize_t size, BlasVectorView<Complex<float>> lhs, BlasVectorView<Complex<float>> rhs);
+Complex<double> dot(ssize_t size, BlasVectorView<Complex<double>> lhs, BlasVectorView<Complex<double>> rhs);
+
+void gemv(ssize_t m, ssize_t n, BlasMatrixView<float> matrix, BlasVectorView<float> vector, float * result, BlasTranspose requested_transpose);
+void gemv(ssize_t m, ssize_t n, BlasMatrixView<double> matrix, BlasVectorView<double> vector, double * result, BlasTranspose requested_transpose);
+void gemv(ssize_t m, ssize_t n, BlasMatrixView<Complex<float>> matrix, BlasVectorView<Complex<float>> vector, Complex<float> * result, BlasTranspose requested_transpose);
+void gemv(ssize_t m, ssize_t n, BlasMatrixView<Complex<double>> matrix, BlasVectorView<Complex<double>> vector, Complex<double> * result, BlasTranspose requested_transpose);
+
+void gemm(ssize_t m, ssize_t n, ssize_t k, BlasMatrixView<float> lhs, BlasMatrixView<float> rhs, float * result);
+void gemm(ssize_t m, ssize_t n, ssize_t k, BlasMatrixView<double> lhs, BlasMatrixView<double> rhs, double * result);
+void gemm(ssize_t m, ssize_t n, ssize_t k, BlasMatrixView<Complex<float>> lhs, BlasMatrixView<Complex<float>> rhs, Complex<float> * result);
+void gemm(ssize_t m, ssize_t n, ssize_t k, BlasMatrixView<Complex<double>> lhs, BlasMatrixView<Complex<double>> rhs, Complex<double> * result);
+
+} /* end namespace detail */
+
+template <typename T>
+T dot_blas(ssize_t size, BlasVectorView<T> lhs, BlasVectorView<T> rhs)
+{
+#if (defined(__APPLE__) && defined(__arm64__)) || defined(MM_HAS_CBLAS)
+    return detail::dot(size, lhs, rhs);
+#else
+    throw std::runtime_error("solvcon BLAS wrapper: CBLAS backend is unavailable");
+#endif
+}
+
+template <typename T>
+void gemv_blas(ssize_t m, ssize_t n, BlasMatrixView<T> matrix, BlasVectorView<T> vector, T * result, BlasTranspose requested_transpose)
+{
+#if (defined(__APPLE__) && defined(__arm64__)) || defined(MM_HAS_CBLAS)
+    detail::gemv(m, n, matrix, vector, result, requested_transpose);
+#else
+    throw std::runtime_error("solvcon BLAS wrapper: CBLAS backend is unavailable");
+#endif
+}
+
+template <typename T>
+void gemm_blas(ssize_t m, ssize_t n, ssize_t k, BlasMatrixView<T> lhs, BlasMatrixView<T> rhs, T * result)
+{
+#if (defined(__APPLE__) && defined(__arm64__)) || defined(MM_HAS_CBLAS)
+    detail::gemm(m, n, k, lhs, rhs, result);
+#else
+    throw std::runtime_error("solvcon BLAS wrapper: CBLAS backend is unavailable");
+#endif
+}
 
 } /* end namespace solvcon */
 

--- a/profiling/profile_matrix_ops.py
+++ b/profiling/profile_matrix_ops.py
@@ -204,13 +204,12 @@ def iter_planned_cases(dtype):
         yield ("Batched GEMV", batch_matrix, vector, 15)
 
     for side in (*small_sides, 256):
-        samples = 5 if side == 256 else 15
         batch_lhs = make_data(dtype, (10, side, side))
         batch_rhs = make_data(dtype, (10, side, side))
         cross_lhs = make_data(dtype, (2, 1, side, side))
         cross_rhs = make_data(dtype, (1, 5, side, side))
-        yield ("Equal-batch GEMM", batch_lhs, batch_rhs, samples)
-        yield ("Cross-broadcast GEMM", cross_lhs, cross_rhs, samples)
+        yield ("Equal-batch GEMM", batch_lhs, batch_rhs, 15)
+        yield ("Cross-broadcast GEMM", cross_lhs, cross_rhs, 15)
 
 
 def profile_planned_suite(dtype, warmups, rounds):

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -89,10 +89,18 @@ class MatmulTestBase(sc.testing.TestBase):
     def make_matrix_stride_cases(cls, data, axis):
         f_contiguous = np.array(
             data, dtype=data.dtype.name, order='F', copy=True)
+        storage_shape = list(data.shape)
+        storage_shape[-1] += 2
+        storage = np.empty(storage_shape, dtype=data.dtype.name)
+        selection = [slice(None)] * data.ndim
+        selection[-1] = slice(0, data.shape[-1])
+        padded = storage[tuple(selection)]
+        padded[...] = data
 
         return (
             ('c_contiguous', data),
             ('f_contiguous', f_contiguous),
+            ('padded', padded),
             ('negative_stride',
              cls.make_strided_view(data, axis, -1)),
             ('step_two', cls.make_strided_view(data, axis, 2)),
@@ -126,7 +134,9 @@ class MatmulTestBase(sc.testing.TestBase):
         result = lhs.matmul_planned(rhs)
 
         self.assertEqual(list(result.shape), list(expected.shape))
-        np.testing.assert_array_almost_equal(result.ndarray, expected)
+        tol = 64 * np.finfo(result.ndarray.real.dtype).eps
+        np.testing.assert_allclose(
+            result.ndarray, expected, rtol=tol, atol=tol)
         return result
 
     def test_square(self):
@@ -242,8 +252,9 @@ class MatmulTestBase(sc.testing.TestBase):
             with self.subTest(
                     method=method, tile_name=tile_name,
                     tile_size=tile_size):
-                lhs = self.SimpleArray((2,), value=1)
-                rhs = self.SimpleArray((2,), value=1)
+                data = np.ones((2,), dtype=np.dtype(self.dtype).name)
+                lhs = self.SimpleArray(array=data)
+                rhs = self.SimpleArray(array=data)
                 tiles = {'tile_x': 1, 'tile_y': 1, 'tile_z': 1}
                 tiles[tile_name] = tile_size
                 message = (
@@ -364,21 +375,22 @@ class MatmulTestBase(sc.testing.TestBase):
                 self.assert_matmul_planned(a, b, expected)
 
     def test_matrix_strides(self):
-        """Matrix axes support C, F, negative, and step-two strides."""
+        """Matrix axes support generic and BLAS-compatible layouts."""
         dtype = np.dtype(self.dtype).name
+        for m, k, n in ((3, 4, 2), (16, 17, 18)):
+            lhs_data = np.arange(m * k, dtype=dtype).reshape(m, k)
+            rhs_data = np.arange(k * n, dtype=dtype).reshape(k, n)
+            lhs_cases = self.make_matrix_stride_cases(lhs_data, 1)
+            rhs_cases = self.make_matrix_stride_cases(rhs_data, 0)
+            cases = itertools.product(lhs_cases, rhs_cases)
+            for (lhs_case, case_lhs), (rhs_case, case_rhs) in cases:
+                lhs = self.SimpleArray(array=case_lhs)
+                rhs = self.SimpleArray(array=case_rhs)
+                expected = np.matmul(case_lhs, case_rhs)
 
-        lhs_cases = self.make_matrix_stride_cases(
-            np.arange(12, dtype=dtype).reshape(3, 4), 1)
-        rhs_cases = self.make_matrix_stride_cases(
-            np.arange(8, dtype=dtype).reshape(4, 2), 0)
-        cases = itertools.product(lhs_cases, rhs_cases)
-        for (lhs_case, lhs_data), (rhs_case, rhs_data) in cases:
-            lhs = self.SimpleArray(array=lhs_data)
-            rhs = self.SimpleArray(array=rhs_data)
-            expected = np.matmul(lhs_data, rhs_data)
-
-            with self.subTest(lhs=lhs_case, rhs=rhs_case):
-                self.assert_matmul_planned(lhs, rhs, expected)
+                with self.subTest(
+                        shape=(m, k, n), lhs=lhs_case, rhs=rhs_case):
+                    self.assert_matmul_planned(lhs, rhs, expected)
 
     def test_batch_strides(self):
         """Batch axes support negative and step-two strides."""
@@ -405,21 +417,24 @@ class MatmulTestBase(sc.testing.TestBase):
                     self.assert_matmul_planned(lhs, rhs, expected)
 
     def test_broadcast_batch_strides(self):
-        """Broadcasting supports zero and signed batch strides."""
+        """Broadcast batch strides across generic and direct BLAS routes."""
         dtype = np.dtype(self.dtype).name
-        lhs_data = np.arange(24, dtype=dtype).reshape(2, 1, 3, 4)
-        rhs_data = np.arange(40, dtype=dtype).reshape(1, 5, 4, 2)
-        cases = itertools.product(
-            self.make_batch_stride_cases(lhs_data),
-            self.make_batch_stride_cases(rhs_data),
-        )
-        for (lhs_case, case_lhs), (rhs_case, case_rhs) in cases:
-            lhs = self.SimpleArray(array=case_lhs)
-            rhs = self.SimpleArray(array=case_rhs)
-            expected = np.matmul(case_lhs, case_rhs)
+        for m, k, n in ((3, 4, 2), (17, 18, 19)):
+            lhs_data = np.arange(2 * m * k, dtype=dtype).reshape(2, 1, m, k)
+            rhs_data = np.arange(5 * k * n, dtype=dtype).reshape(1, 5, k, n)
+            cases = itertools.product(
+                self.make_batch_stride_cases(lhs_data),
+                self.make_batch_stride_cases(rhs_data),
+            )
+            for (lhs_case, case_lhs), (rhs_case, case_rhs) in cases:
+                lhs = self.SimpleArray(array=case_lhs)
+                rhs = self.SimpleArray(array=case_rhs)
+                expected = np.matmul(case_lhs, case_rhs)
 
-            with self.subTest(lhs=lhs_case, rhs=rhs_case):
-                self.assert_matmul_planned(lhs, rhs, expected)
+                with self.subTest(
+                        shape=(m, k, n),
+                        lhs=lhs_case, rhs=rhs_case):
+                    self.assert_matmul_planned(lhs, rhs, expected)
 
     def test_broadcast_matrix_strides(self):
         """Broadcasting preserves signed matrix strides."""
@@ -474,6 +489,30 @@ class MatmulTestBase(sc.testing.TestBase):
                         role=role, lhs=lhs_case, rhs=rhs_case):
                     self.assert_matmul_planned(lhs, rhs, expected)
 
+        lhs_matrix = np.arange(64 * 512, dtype=dtype).reshape(64, 512)
+        rhs_matrix = np.arange(512 * 64, dtype=dtype).reshape(512, 64)
+        lhs_vector = np.empty(1024, dtype=dtype)[::2]
+        rhs_vector = np.empty(1024, dtype=dtype)[::2]
+        lhs_vector[...] = lhs_matrix[0]
+        rhs_vector[...] = rhs_matrix[:, 0]
+        contiguous_rhs = np.ascontiguousarray(rhs_matrix[:, 0], dtype=dtype)
+        cases = (
+            (lhs_matrix[0], contiguous_rhs),
+            (lhs_matrix[0, ::-1], contiguous_rhs[::-1]),
+            (lhs_matrix[0], rhs_matrix),
+            (lhs_matrix, contiguous_rhs),
+            (lhs_vector, np.asfortranarray(rhs_matrix, dtype=dtype)),
+            (np.asfortranarray(lhs_matrix, dtype=dtype), rhs_vector),
+        )
+        for lhs_data, rhs_data in cases:
+            lhs = self.SimpleArray(array=lhs_data)
+            rhs = self.SimpleArray(array=rhs_data)
+            with self.subTest(lhs=lhs_data.strides,
+                              rhs=rhs_data.strides):
+                expected = np.atleast_1d(np.matmul(lhs_data, rhs_data))
+                self.assert_matmul_planned(
+                    lhs, rhs, expected)
+
     def test_batch_axes_align_right(self):
         """Leading batch axes align from the right like NumPy matmul."""
         dtype = np.dtype(self.dtype).name
@@ -497,8 +536,11 @@ class MatmulTestBase(sc.testing.TestBase):
 
     def test_broadcast_batch_mismatch(self):
         """Incompatible leading batch axes report both operand shapes."""
-        lhs = self.SimpleArray(shape=(2, 3, 4), value=0)
-        rhs = self.SimpleArray(shape=(3, 4, 2), value=0)
+        dtype = np.dtype(self.dtype).name
+        lhs = self.SimpleArray(
+            array=np.zeros((2, 3, 4), dtype=dtype))
+        rhs = self.SimpleArray(
+            array=np.zeros((3, 4, 2), dtype=dtype))
         with self.assertRaisesRegex(
             ValueError,
             r"SimpleArray::matmul_planned\(\): batch shape mismatch: "
@@ -524,8 +566,8 @@ class MatmulTestBase(sc.testing.TestBase):
             lhs_data = np.zeros(lhs_shape, dtype=dtype)
             rhs_data = np.zeros(rhs_shape, dtype=dtype)
             expected = np.atleast_1d(np.matmul(lhs_data, rhs_data))
-            lhs = self.SimpleArray(shape=lhs_shape, value=0)
-            rhs = self.SimpleArray(shape=rhs_shape, value=0)
+            lhs = self.SimpleArray(array=lhs_data)
+            rhs = self.SimpleArray(array=rhs_data)
 
             with self.subTest(lhs=lhs_shape, rhs=rhs_shape):
                 self.assert_matmul_planned(lhs, rhs, expected)
@@ -873,5 +915,17 @@ class MatmulFloat64TC(MatmulTestBase, unittest.TestCase):
     def setUp(self):
         self.dtype = np.float64
         self.SimpleArray = sc.SimpleArrayFloat64
+
+
+class MatmulComplex64TC(MatmulTestBase, unittest.TestCase):
+    def setUp(self):
+        self.dtype = np.complex64
+        self.SimpleArray = sc.SimpleArrayComplex64
+
+
+class MatmulComplex128TC(MatmulTestBase, unittest.TestCase):
+    def setUp(self):
+        self.dtype = np.complex128
+        self.SimpleArray = sc.SimpleArrayComplex128
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
## Motivation

Before this PR, `matmul_planned()` evaluated every contraction with generic C++ loops, even when the operand layout could be passed to CBLAS without copying. On the tested Apple M1 system, NumPy uses Accelerate for the same compatible workloads. As the contraction grows, the generic path can become hundreds of times slower than NumPy.

## Approach

`MatmulExecutor` sends sufficiently large DOT, unbatched vector products, and matrix-matrix products directly to CBLAS when their strides can be represented without copying. GEMM dispatch happens after batch offsets are resolved, so regular batch and batch-broadcast products use the same route. Smaller operations and unsupported layouts continue to use the generic signed-stride loops.

## Profiling

The plots compare full-call execution time among NumPy 2.5.1, the generic `matmul_planned()` implementation before this PR, and the automatic dispatch added by this PR. The vertical line marks the measured dispatch threshold; points to its left remain on the generic route as small-workload controls.

Above the thresholds, the after-PR route tracks NumPy across direct DOT, unbatched vector products, 2D GEMM, equal-batch GEMM, and cross-broadcast GEMM. At the largest plotted GEMM sizes, it is hundreds of times faster than the before-PR generic loops.

### float32 scaling by operation and layout

<img width="2400" height="900" alt="pr1209-dot-float32" src="https://github.com/user-attachments/assets/796d4eb8-31de-4010-8952-2105ffad9ebc" />

<img width="2400" height="900" alt="pr1209-matrix-vector-float32" src="https://github.com/user-attachments/assets/90f2ff6c-52b7-4bee-aa68-fb62ae8b6129" />

<img width="1400" height="900" alt="pr1209-gemm-2d-float32" src="https://github.com/user-attachments/assets/5dd898bf-8f23-494b-811a-3495d7aaa7a8" />

<img width="2400" height="900" alt="pr1209-gemm-batch-broadcast-float32" src="https://github.com/user-attachments/assets/32767497-aa32-4036-b366-19e6170b8d09" />

### float64 scaling by operation and layout

<img width="2400" height="900" alt="pr1209-dot-float64" src="https://github.com/user-attachments/assets/ff77fa2f-e2c6-42f4-b1ea-33ead18701fe" />

<img width="2400" height="900" alt="pr1209-matrix-vector-float64" src="https://github.com/user-attachments/assets/12672331-ff1f-4654-9d78-11f225fa2610" />

<img width="1400" height="900" alt="pr1209-gemm-2d-float64" src="https://github.com/user-attachments/assets/caca55e8-9634-4d3b-b354-86a16fe1c0ea" />

<img width="2400" height="900" alt="pr1209-gemm-batch-broadcast-float64" src="https://github.com/user-attachments/assets/d2f604c0-540f-4413-89d8-637475cc106f" />

<details>
<summary>Measurement details</summary>

- Environment: native Apple M1 arm64, macOS 26.5.1, Python 3.14.6, NumPy 2.5.1, and Accelerate. BLAS-related thread variables were set to `1` before importing NumPy.

- Baselines: the before-PR series uses the generic `matmul_planned()` implementation from the parent of this PR. The after-PR series uses the automatic dispatch introduced here. Both use the same workloads, seed, dependencies, and sampling procedure.

- Timing: input construction, conversion, correctness checks, and warmups were outside timing. Each timed call includes wrapper dispatch, computation, result allocation, and return.

- Sampling: seed `1209`, five rounds per case, two warmups, and 15 individually profiled calls per implementation per round. Plots use the untrimmed median of 75 calls. The four C-contiguous `S=256` batch GEMM cases were independently repeated five times; their ratio ranges were `0.951-1.031` and their medians were `0.995-1.008`.

- Thresholds: forced generic and CBLAS passes used identical inputs in generic, CBLAS, CBLAS, generic order. Calibrated timing chunks and 1,632 vector-matrix and matrix-vector layout and shape combinations selected `K >= 128` for DOT, `K * N >= 729` for compact C-layout vector-matrix products, a minimum matrix dimension of `32` for other vector products, and a minimum M/N/K dimension of `8` for GEMM.

</details>

<details>
<summary>After-PR raw profile output</summary>

[Download the complete after-PR profile output.](https://github.com/user-attachments/files/30631476/pr1209-profile-matrix-ops-2f5f055b.txt)

</details>

Related to #1172.