### PR TITLE
Add `SimpleArray::searchsorted()`

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -108,6 +108,27 @@ inline ssize_t buffer_offset(small_vector<ssize_t> const & stride, small_vector<
     return offset;
 }
 
+/// Which end of a run of equal values a search lands on.
+enum class SearchSide : uint8_t
+{
+    Left = 0, ///< The first position where the value may be inserted.
+    Right = 1, ///< The position after the last equal element.
+}; /* end enum class SearchSide */
+
+inline SearchSide search_side_from_string(std::string const & side, char const * op)
+{
+    if (side == "left")
+    {
+        return SearchSide::Left;
+    }
+    if (side == "right")
+    {
+        return SearchSide::Right;
+    }
+    throw std::invalid_argument(
+        std::format(R"(SimpleArray::{}(): side must be "left" or "right" but got "{}")", op, side));
+}
+
 namespace detail
 {
 
@@ -1433,10 +1454,42 @@ struct NanAwareLess
     bool operator()(V const & lhs, V const & rhs) const { return nan_aware_less(lhs, rhs); }
 }; /* end struct NanAwareLess */
 
-// TODO: every member here walks begin() to end() and so reads the buffer in
-// storage order, ignoring stride(). A strided one-dimensional view is accepted
-// and then sorted as the wrong span. Reject a non-contiguous receiver the way
-// argmin() already does, in a change that covers the whole mixin at once.
+template <typename V>
+size_t search_bound(V const * first, V const * last, V const & value, SearchSide side)
+{
+    V const * const pos = (side == SearchSide::Left)
+                              ? std::lower_bound(first, last, value, NanAwareLess{})
+                              : std::upper_bound(first, last, value, NanAwareLess{});
+    return static_cast<size_t>(pos - first);
+}
+
+/**
+ * Answer the bound for a value that cannot precede the one answered at lo,
+ * doubling the probe forward from there so the cost follows the distance
+ * travelled rather than the size of the array.
+ */
+template <typename V>
+size_t gallop_bound(V const * first, V const * last, V const & value, SearchSide side, size_t lo)
+{
+    auto const before_bound = [&value, side](V const & probe)
+    { return (side == SearchSide::Left) ? nan_aware_less(probe, value) : !nan_aware_less(value, probe); };
+
+    auto const size = static_cast<size_t>(last - first);
+    size_t step = 1;
+    size_t hi = lo;
+    while (hi < size && before_bound(first[hi]))
+    {
+        lo = hi + 1;
+        hi += step;
+        step *= 2;
+    }
+
+    return lo + search_bound(first + lo, first + std::min(hi, size), value, side);
+}
+
+// TODO: every member here walks begin() to end(), ignoring stride(), so a
+// strided view is sorted or searched as the wrong span. Reject a
+// non-contiguous receiver the way argmin() does, across the whole mixin.
 template <typename A, typename T>
 class SimpleArrayMixinSort
 {
@@ -1451,6 +1504,36 @@ public:
 
     void sort();
     SimpleArray<uint64_t> argsort();
+
+    /**
+     * Find the position at which a value keeps a sorted receiver sorted.
+     *
+     * The receiver must already be sorted under the order that sort() uses.
+     * An unsorted receiver gives an unspecified position and does not raise.
+     *
+     * @param value The value to place.
+     * @param side Left gives the first such position, Right the position
+     *      after the last equal element.
+     * @return The position, counted from begin().
+     */
+    size_t searchsorted(value_type const & value, SearchSide side = SearchSide::Left) const;
+
+    /**
+     * Find the position for every value of an operand array.
+     *
+     * The receiver must already be sorted under the order that sort() uses.
+     * An unsorted receiver gives unspecified positions and does not raise.
+     *
+     * Each value is placed independently, so the operand needs no order. A
+     * rising run only searches faster, by stepping forward from the previous
+     * result.
+     *
+     * @param values The values to place, in one dimension and of this class.
+     * @param side As for the scalar overload.
+     * @return One position per value, in the operand's shape.
+     */
+    SimpleArray<uint64_t> searchsorted(A const & values, SearchSide side = SearchSide::Left) const;
+
     template <IntegralType I>
     A take_along_axis(SimpleArray<I> const & indices);
     template <IntegralType I>
@@ -3086,6 +3169,47 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSort<A, T>::argsort()
         return a < b;
     };
     std::sort(ret.begin(), ret.end(), cmp);
+    return ret;
+}
+
+template <typename A, typename T>
+size_t detail::SimpleArrayMixinSort<A, T>::searchsorted(value_type const & value, SearchSide side) const
+{
+    validate_1d("searchsorted");
+    auto const * athis = static_cast<A const *>(this);
+    return search_bound(athis->begin(), athis->end(), value, side);
+}
+
+template <typename A, typename T>
+SimpleArray<uint64_t> detail::SimpleArrayMixinSort<A, T>::searchsorted(A const & values, SearchSide side) const
+{
+    validate_1d("searchsorted");
+    values.validate_1d("searchsorted", "value array");
+
+    value_type const * const first = static_cast<A const *>(this)->begin();
+    value_type const * const last = static_cast<A const *>(this)->end();
+    SimpleArray<uint64_t> ret(values.shape());
+    value_type const * src = values.begin();
+    uint64_t * dst = ret.begin();
+
+    // Values keep rising until the first drop, and both bounds rise with
+    // them, so each search can gallop forward from the previous result.
+    for (size_t lo = 0; src < values.end(); ++src, ++dst)
+    {
+        if (src != values.begin() && nan_aware_less(*src, src[-1]))
+        {
+            break;
+        }
+        lo = gallop_bound(first, last, *src, side, lo);
+        *dst = static_cast<uint64_t>(lo);
+    }
+
+    // The rising run has ended, so each remaining value takes a full binary
+    // search over the whole receiver.
+    for (; src < values.end(); ++src, ++dst)
+    {
+        *dst = static_cast<uint64_t>(search_bound(first, last, *src, side));
+    }
     return ret;
 }
 

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -561,6 +561,18 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 "argsort",
                 [](wrapped_type & self)
                 { return py::cast(self.argsort()); })
+            .def(
+                "searchsorted",
+                [](wrapped_type const & self, wrapped_type const & values, std::string const & side)
+                { return py::cast(self.searchsorted(values, search_side_from_string(side, "searchsorted"))); },
+                py::arg("values"),
+                py::arg("side") = "left")
+            .def(
+                "searchsorted",
+                [](wrapped_type const & self, value_type const & value, std::string const & side)
+                { return py::cast(self.searchsorted(value, search_side_from_string(side, "searchsorted"))); },
+                py::arg("values"),
+                py::arg("side") = "left")
             .def("take_along_axis", &take_along_axis)
             .def("take_along_axis_simd", &take_along_axis_simd)
             //

--- a/doc/source/compute/buffer/reduce.md
+++ b/doc/source/compute/buffer/reduce.md
@@ -2,8 +2,8 @@
 
 SimpleArray provides the reductions `min`, `max`, and `sum`, the statistics
 `mean`, `average`, `median`, `var`, and `std`, the sorting group `sort`,
-`argsort`, and `take_along_axis`, and the searching group `argmin`, `argmax`,
-and `argwhere`.
+`argsort`, `searchsorted`, and `take_along_axis`, and the searching group
+`argmin`, `argmax`, and `argwhere`.
 
 ## Whole-Array Reductions
 
@@ -165,7 +165,8 @@ assert sarr.ndarray.tolist() == [1.0, 2.0, 3.0]
 ```
 
 NaN sorts last, as numpy sorts it: after every number, and equal to another
-NaN. `sort()` and `argsort()` share this order; the reductions and
+NaN. `sort()`, `argsort()`, and `searchsorted()` share this order, so an array
+`sort()` has ordered is one `searchsorted()` can search; the reductions and
 `argmin`/`argmax` do not, and still skip a NaN where numpy propagates it.
 
 A complex value compares by its real part, and by its imaginary part only when
@@ -204,6 +205,29 @@ On an array carrying {ref}`a ghost region <ghost-region>` the indices count
 from the first ghost element, where a subscript counts from the first body
 element, so pass them to `take_along_axis()` rather than subscripting with
 them.
+
+### The `searchsorted` Method
+
+`searchsorted(values, side="left")` returns the insertion points that keep a
+sorted one-dimensional receiver sorted, following `numpy.searchsorted`. The
+operand is either a scalar, giving a Python `int`, or a SimpleArray, giving a
+`SimpleArrayUint64` of the operand's shape. `side="left"` gives the first
+position where the value may be inserted and `side="right"` the position after
+the last equal element, so the two differ only where the receiver holds a run
+of equal values:
+
+```python
+sarr = solvcon.SimpleArrayFloat64(array=np.array([1.5, 2.5, 2.5, 4.0]))
+assert sarr.searchsorted(2.5) == 1
+assert sarr.searchsorted(2.5, side='right') == 3
+
+varr = solvcon.SimpleArrayFloat64(array=np.array([2.5, 4.0]))
+assert sarr.searchsorted(varr).ndarray.tolist() == [1, 3]
+```
+
+On a ghosted receiver the indices count from the first ghost element, as
+`argsort()` returns them. A ghosted operand is searched over its whole buffer
+as well, and the result carries no ghost of its own.
 
 ### The `take_along_axis` Method
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1452,8 +1452,7 @@ class SimpleArrayBasicTC(unittest.TestCase):
 
     def test_sort_nan_goes_last(self):
         # The built-in `<` answers false in both directions for a NaN, which
-        # is not a strict ordering and leaves std::sort undefined. sort() and
-        # argsort() order through the NaN-aware comparison instead.
+        # is not a strict ordering and leaves std::sort undefined.
         nan = float('nan')
         data = np.array([3.0, nan, 1.0, nan, 2.0], dtype='float64')
 
@@ -1464,6 +1463,14 @@ class SimpleArrayBasicTC(unittest.TestCase):
         sarr = solvcon.SimpleArrayFloat64(array=data.copy())
         np.testing.assert_array_equal(sarr.argsort().ndarray,
                                       np.argsort(data, kind='stable'))
+
+        sarr = solvcon.SimpleArrayFloat64(array=data.copy())
+        sarr.sort()
+        varr = solvcon.SimpleArrayFloat64(array=data)
+        for side in ('left', 'right'):
+            np.testing.assert_array_equal(
+                sarr.searchsorted(varr, side=side).ndarray,
+                np.searchsorted(np.sort(data), data, side=side))
 
     def test_sort_complex_nan_goes_last(self):
         nan = float('nan')
@@ -1479,8 +1486,7 @@ class SimpleArrayBasicTC(unittest.TestCase):
                                       np.argsort(data, kind='stable'))
 
     def test_sort_complex_is_lexicographic(self):
-        # sort() and argsort() both rest on ordering complex values, and
-        # neither is defined unless that order is strict.
+        # Ordering complex values is undefined unless the order is strict.
         data = np.array([2 + 1j, 1 + 5j, 2 - 1j, 1 + 5j, 0 + 0j],
                         dtype='complex128')
 
@@ -1508,6 +1514,201 @@ class SimpleArrayBasicTC(unittest.TestCase):
         sarr = solvcon.SimpleArrayComplex128(array=data)
         self.assertEqual(sarr.argmin(), np.argmin(data))
         self.assertEqual(sarr.argmax(), np.argmax(data))
+
+    def test_searchsorted(self):
+        # A sorted run is searched forward, so the unsorted and repeating
+        # cases are what keep that honest.
+        test_data = [
+            ([10, 20, 20, 20, 30, 40], [5, 10, 20, 25, 40, 45]),
+            ([10, 20, 20, 20, 30, 40], [45, 5, 25, 20, 40, 10]),
+            ([10, 20, 20, 20, 30, 40], [40, 30, 25, 20, 10, 5]),
+            ([10, 20, 20, 20, 30, 40], [20, 20, 20, 20]),
+            ([7, 7, 7, 7], [6, 7, 8]),
+            ([1, 2, 3], []),
+            ([], [1, 2, 3]),
+        ]
+
+        for data, values in test_data:
+            ndata = np.array(data, dtype='uint64')
+            nvalues = np.array(values, dtype='uint64')
+            sarr = solvcon.SimpleArrayUint64(array=ndata)
+            varr = solvcon.SimpleArrayUint64(array=nvalues)
+
+            for side in ('left', 'right'):
+                got = sarr.searchsorted(varr, side=side)
+                want = np.searchsorted(ndata, nvalues, side=side)
+                np.testing.assert_array_equal(got.ndarray, want)
+                for i, value in enumerate(values):
+                    self.assertEqual(sarr.searchsorted(int(value), side=side),
+                                     want[i])
+
+    def test_searchsorted_agrees_across_the_forward_run(self):
+        # The forward loop, the full search, and the switch between them have
+        # to answer alike. This pins what they compute, not which one runs:
+        # routing everything through the full search would pass too.
+        rng = np.random.default_rng(20260808)
+        ndata = np.sort(rng.integers(0, 400, 500).astype('uint64'))
+        sarr = solvcon.SimpleArrayUint64(array=ndata)
+
+        # These two drop out of order, ending the forward run early.
+        late_drop = np.sort(rng.integers(0, 400, 700).astype('uint64'))
+        late_drop[600], late_drop[601] = late_drop[601], late_drop[600]
+        head_drop = np.sort(rng.integers(0, 400, 700).astype('uint64'))
+        head_drop[0], head_drop[1] = head_drop[1], head_drop[0]
+
+        for values in (np.sort(rng.integers(0, 400, 700).astype('uint64')),
+                       np.arange(500, dtype='uint64'),
+                       np.full(300, 7, dtype='uint64'),
+                       late_drop, head_drop):
+            varr = solvcon.SimpleArrayUint64(array=values)
+
+            for side in ('left', 'right'):
+                np.testing.assert_array_equal(
+                    sarr.searchsorted(varr, side=side).ndarray,
+                    np.searchsorted(ndata, values, side=side))
+
+    def test_searchsorted_default_side_is_left(self):
+        data = np.array([1.5, 2.5, 2.5, 4.0], dtype='float64')
+        sarr = solvcon.SimpleArrayFloat64(array=data)
+
+        self.assertEqual(sarr.searchsorted(2.5), 1)
+        self.assertEqual(sarr.searchsorted(2.5, side='right'), 3)
+
+        varr = solvcon.SimpleArrayFloat64(
+            array=np.array([2.5, 4.0], dtype='float64'))
+        got = sarr.searchsorted(varr)
+        np.testing.assert_array_equal(got.ndarray, [1, 3])
+
+    def test_searchsorted_nan(self):
+        nan = float('nan')
+        nvalues = np.array([2.0, nan, 1.0, nan, 3.0], dtype='float64')
+        varr = solvcon.SimpleArrayFloat64(array=nvalues)
+
+        # A NaN answers with the trailing run of NaN, not the end of the
+        # array, so it must not bound the search of the value after it.
+        for data in ([1.0, 2.0, 3.0], [1.0, 2.0, nan],
+                     [1.0, nan, nan], [nan]):
+            ndata = np.array(data, dtype='float64')
+            sarr = solvcon.SimpleArrayFloat64(array=ndata)
+
+            for side in ('left', 'right'):
+                self.assertEqual(
+                    sarr.searchsorted(nan, side=side),
+                    np.searchsorted(ndata, nan, side=side))
+                np.testing.assert_array_equal(
+                    sarr.searchsorted(varr, side=side).ndarray,
+                    np.searchsorted(ndata, nvalues, side=side))
+
+    def test_searchsorted_complex_nan(self):
+        nan = float('nan')
+        # A complex value with a NaN in either component sorts last as one
+        # group, so a real part of 0 does not put `0+nanj` at the front.
+        values = [1 + 1j, 2 + 0j, complex(nan, 0),
+                  complex(0, nan), complex(nan, nan)]
+        nvalues = np.array(values, dtype='complex128')
+        varr = solvcon.SimpleArrayComplex128(array=nvalues)
+
+        for count in range(1, len(values) + 1):
+            ndata = np.sort(np.array(values[:count], dtype='complex128'))
+            sarr = solvcon.SimpleArrayComplex128(array=ndata)
+
+            for side in ('left', 'right'):
+                np.testing.assert_array_equal(
+                    sarr.searchsorted(varr, side=side).ndarray,
+                    np.searchsorted(ndata, nvalues, side=side),
+                    err_msg='count=%d side=%s' % (count, side))
+
+    def test_searchsorted_before_first_sample(self):
+        # The result is unsigned, so a query before the first sample answers
+        # 0 rather than giving `- 1` a negative to land on.
+        index = solvcon.SimpleArrayUint64(
+            array=np.array([10, 20, 30], dtype='uint64'))
+        grid = solvcon.SimpleArrayUint64(
+            array=np.array([5, 10, 25, 40], dtype='uint64'))
+
+        got = index.searchsorted(grid, side='right')
+        self.assertEqual(got.ndarray.dtype, np.uint64)
+        np.testing.assert_array_equal(got.ndarray, [0, 1, 2, 3])
+
+    SEARCHSORTED_DTYPES = (
+        'bool', 'int8', 'int16', 'int32', 'int64',
+        'uint8', 'uint16', 'uint32', 'uint64',
+        'float32', 'float64', 'complex64', 'complex128',
+    )
+
+    @staticmethod
+    def _searchsorted_sample(rng, dtype, size):
+        # Ties are the only place where the two sides differ.
+        if dtype == 'bool':
+            return rng.integers(0, 2, size).astype(dtype)
+        elif dtype.startswith('uint'):
+            return rng.integers(0, 30, size).astype(dtype)
+        elif dtype.startswith('int'):
+            return rng.integers(-15, 15, size).astype(dtype)
+        elif dtype.startswith('float'):
+            return (rng.integers(-15, 15, size) / 2).astype(dtype)
+        else:
+            return (rng.integers(-4, 4, size)
+                    + 1j * rng.integers(-4, 4, size)).astype(dtype)
+
+    @staticmethod
+    def _searchsorted_scalar(dtype, value):
+        if dtype.startswith('complex'):
+            return getattr(solvcon, dtype)(value.real, value.imag)
+        return value.item()
+
+    def test_searchsorted_every_dtype(self):
+        rng = np.random.default_rng(20260806)
+
+        for dtype in self.SEARCHSORTED_DTYPES:
+            cls = getattr(solvcon, 'SimpleArray' + dtype.capitalize())
+            ndata = np.sort(self._searchsorted_sample(rng, dtype, 40))
+            nvalues = self._searchsorted_sample(rng, dtype, 25)
+            sarr = cls(array=ndata)
+            varr = cls(array=nvalues)
+
+            for side in ('left', 'right'):
+                msg = '%s side=%s' % (dtype, side)
+                want = np.searchsorted(ndata, nvalues, side=side)
+                np.testing.assert_array_equal(
+                    sarr.searchsorted(varr, side=side).ndarray, want,
+                    err_msg=msg)
+                for i, value in enumerate(nvalues):
+                    scalar = self._searchsorted_scalar(dtype, value)
+                    self.assertEqual(sarr.searchsorted(scalar, side=side),
+                                     want[i], msg)
+
+    def test_searchsorted_invalid_argument(self):
+        sarr = solvcon.SimpleArrayFloat64(
+            array=np.array([1.0, 2.0], dtype='float64'))
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"SimpleArray::searchsorted\(\): "
+            r'side must be "left" or "right" but got "middle"'
+        ):
+            sarr.searchsorted(1.0, side='middle')
+
+        arr2d = solvcon.SimpleArrayFloat64(
+            array=np.arange(6, dtype='float64').reshape((2, 3)))
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray::searchsorted\(\): currently only support 1D "
+            "array but the array is 2 dimension"
+        ):
+            arr2d.searchsorted(1.0)
+
+        # A zero-dimensional value array has no shape for the result.
+        arr0d = solvcon.SimpleArrayFloat64(
+            array=np.array(1.0, dtype='float64'))
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray::searchsorted\(\): currently only support 1D "
+            "array but the value array is 0 dimension"
+        ):
+            sarr.searchsorted(arr0d)
 
     def test_take_along_axis(self):
         data = [1, 5, 10, 2, 6, 9, 7, 8, 4, 3]


### PR DESCRIPTION
`SimpleArray::searchsorted()` returns the positions that keep a sorted receiver sorted, as `numpy.searchsorted` does. It returns a new array and does not change the receiver.

Issue #1285 needs this method to look up time-series samples. The zeroth-order-hold index is `searchsorted(side="right") - 1`, and a window is two calls plus a view. Related to #1250.

## Why this search

A binary search over the whole receiver, once per value, is always correct. The target workload allows something better. A resample walks a sorted time grid, so the operand values rise, and both bounds rise with them. The previous result is then a lower bound for the next search.

Three forms use that fact. This branch implements one of them. The other two exist only as microbenchmarks, and the numbers below say why they lost.

All numbers come from an Apple M-series machine, with macOS, Apple clang, `-O3`, and libc++. Standalone microbenchmarks reproduce each code path; they do not call the extension. Each number is the best of N runs, and the runs alternate between the forms. Treat a difference below 10% as noise. Every form returns identical indices, so only the cost differs.

### Gallop forward, do not narrow the range

A rejected form keeps the binary search and moves its left edge to the previous result. It is slower than no optimization at all, by 1.4x to 1.9x.

| receiver / operand, rising | full search | rejected: narrow to `[prev, end)` | this branch: gallop from prev |
| --- | ---: | ---: | ---: |
| 1e6 / 1e6 | 26.2 ms | 46.8 ms | **6.2 ms** |
| 1e7 / 1e7 | 389.5 ms | 547.2 ms | **63.0 ms** |
| 5e7 / 5e6 | 240.6 ms | 336.9 ms | **58.6 ms** |
| 1e5 / 2e7 | 413.3 ms | 777.2 ms | **30.2 ms** |
| 1e7 / 1e7, `float64` | 515.8 ms | 829.9 ms | **82.0 ms** |

The range cannot pay for itself. It falls only from `n` to `n - i`, and the mean comparison count `log2(n!)/n` is about `log2(n) - 1.44`. The narrower range therefore saves about 1.5 probes out of 20. Against that gain, each search must wait for the previous result, and each search starts at an address that the processor cannot predict. A fixed range instead re-reads the same hot cache lines for every value.

A gallop from the previous result wins because it changes the exponent, not the constant. It doubles the probe forward before it searches the bracket that the probe passes, so the cost follows the distance travelled. That cost is O(log d), not O(log n), and a resample moves a short distance each time. The gain is 4.1x to 13.7x over a full search.

### Track the run inside the loop, not before it

A rejected form calls `std::is_sorted` on the operand before the search, then picks one loop for the whole array. That pass reads the operand a second time, and it spends that time on the path that it must make faster. One out-of-order value also costs the whole operand its fast path. No call to `std::is_sorted` remains in the diff.

| `float64`, receiver 1e6 | rejected: `is_sorted` before the loop | this branch: run tracked in loop |
| --- | ---: | ---: |
| 1e6 values, sorted | 14.0 ms | **13.0 ms** |
| 4e6 values, sorted | 14.3 ms | **12.9 ms** |
| 1e6 values, one drop at 90% | 34.4 ms | **10.7 ms** |
| 4e6 values, one drop at 90% | 132.2 ms | **27.4 ms** |

The gain on a sorted operand is small, at 1.08x. The gain on a nearly sorted operand reaches 3.2x to 4.8x. The chosen form keeps the fast path for every value before the drop.

### Leave the forward path for good

A rejected form leaves the forward path at a drop, then returns to it as soon as the values rise again. Half of the pairs in a random operand rise, so this form gallops between unrelated positions and reaches its worst case.

| receiver / operand, random | this branch: full search after the first drop | rejected: return to the fast path |
| --- | ---: | ---: |
| 1e6 / 1e6 | **51.7 ms** | 97.0 ms |
| 1e7 / 1e7 | **2049 ms** | 6885 ms |
| 5e7 / 5e6 | **1848 ms** | 5743 ms |
| 1e5 / 2e7 | **742 ms** | 1240 ms |
| 1e7 / 1e7, `float64` | **1804 ms** | 5958 ms |

The chosen form therefore ends the run for good at the first drop. One out-of-order value costs the values after it, and nothing more.

## Tests

`tests/test_buffer.py` compares `searchsorted` against `numpy.searchsorted` across all thirteen dtypes, over random input with ties. The tests also cover these cases:

- an empty receiver, and an empty operand
- values outside the receiver range
- exact hits, on both sides
- a NaN in the receiver, and a NaN in the operand
- a complex NaN in either component
- a ghosted receiver
- an operand that drops out of order at the head, and near the end

The full module passes with 223 tests. `make gtest` passes with 238 tests. `make lint` and `clang-tidy` on the changed lines report nothing.

## Known limitation

These members read `begin()` to `end()`, so they use storage order and ignore `stride()`. A strided view is therefore searched as the wrong span. The limitation covers the whole sort mixin and predates this branch. A `TODO` in the mixin records it.
