### PR TITLE
Pack reused matmul matrices once

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -1210,9 +1210,9 @@ template <typename A, typename T>
 A SimpleArrayMixinCalculators<A, T>::matmul_planned(A const & other) const
 {
     auto const * athis = static_cast<A const *>(this);
-    MatmulPlan const plan = MatmulPlan::make(*athis, other);
+    MatmulPlan plan = MatmulPlan::make(*athis, other);
     A output(plan.output_shape());
-    MatmulExecutor<A> executor(plan, output, *athis, other);
+    MatmulExecutor<A> executor(std::move(plan), output, *athis, other);
     executor.execute();
     return output;
 }

--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -75,6 +75,10 @@ public:
 
     bool lhs_is_vector() const noexcept { return m_contraction.m_lhs_vector; }
     bool rhs_is_vector() const noexcept { return m_contraction.m_rhs_vector; }
+    bool lhs_is_broadcast() const noexcept { return m_batch.m_lhs_is_broadcast; }
+    bool rhs_is_broadcast() const noexcept { return m_batch.m_rhs_is_broadcast; }
+    bool lhs_has_zero_batch_stride() const noexcept { return m_batch.m_lhs_has_zero_stride; }
+    bool rhs_has_zero_batch_stride() const noexcept { return m_batch.m_rhs_has_zero_stride; }
     bool has_batch_axes() const noexcept { return m_batch.m_domain.rank() != 0; }
     MappedOffsetCursor batch_cursor() const & { return MappedOffsetCursor(m_batch.m_domain, m_batch.m_mappings); }
     MappedOffsetCursor batch_cursor() const && = delete;
@@ -100,10 +104,21 @@ private:
         ssize_t m_rhs_column_stride;
     }; /* end struct ContractionStrides */
 
+    struct BatchOperand
+    {
+        OperandMapping m_mapping;
+        bool m_is_broadcast = false;
+        bool m_has_zero_stride = false;
+    }; /* end struct BatchOperand */
+
     struct BatchMappings
     {
         LoopDomain m_domain;
         mapping_type m_mappings;
+        bool m_lhs_is_broadcast;
+        bool m_rhs_is_broadcast;
+        bool m_lhs_has_zero_stride;
+        bool m_rhs_has_zero_stride;
     }; /* end struct BatchMappings */
 
     MatmulPlan(shape_type output_shape, Contraction contraction, ContractionStrides strides, BatchMappings batch);
@@ -124,7 +139,7 @@ private:
     static shape_type make_batch_shape(Array const & lhs, Array const & rhs);
 
     template <typename Array>
-    static OperandMapping make_batch_mapping(Array const & operand, LoopDomain const & domain);
+    static BatchOperand make_batch_operand(Array const & operand, LoopDomain const & domain);
 
     static shape_type make_output_shape(BatchMappings const & batch, Contraction const & contraction);
 
@@ -142,23 +157,31 @@ private:
  *
  * MatmulExecutor maps vector and matrix roles to DOT, GEMV, or GEMM, then
  * selects generic, tiled, direct BLAS, or pack-once BLAS execution. It owns
- * BLAS eligibility, packing reuse, and size thresholds; these decisions do
- * not change the plan. The constructor only binds a plan and caller-owned
- * arrays; execute() evaluates the plan.
+ * BLAS eligibility, packing reuse, and size thresholds. The executor stores
+ * its plan by value and binds caller-owned arrays. Packing rebuilds physical
+ * layout metadata without changing the contraction or result shape.
  *
  * For `(2,1,3,4) @ (1,5,4,6)`, the executor visits ten batch offsets and
  * evaluates one `(3,4) @ (4,6)` contraction at each offset. The results are
  * written into the allocated `(2,5,3,6)` output.
  *
- * @note This implementation provides generic signed-stride routes and direct
- * BLAS routes for unit-stride DOT, positive-increment GEMV and GEVM, and
- * C/F-compatible GEMM. Packing and batched-vector tuning are follow-up work.
+ * @note This implementation provides generic signed-stride routes, direct
+ * BLAS routes, and pack-once GEMM for reused matrix operands. Batched-vector
+ * tuning remains follow-up work. Pack-once applies when shape broadcasting
+ * reuses an unsupported layout. Unsupported equal-batch layouts remain
+ * generic.
  */
 template <typename Array>
 class MatmulExecutor
 {
 public:
-    MatmulExecutor(MatmulPlan const & plan, Array & output, Array const & lhs, Array const & rhs);
+    MatmulExecutor(MatmulPlan plan, Array & output, Array const & lhs, Array const & rhs);
+    ~MatmulExecutor() = default;
+
+    MatmulExecutor(MatmulExecutor const &) = delete;
+    MatmulExecutor(MatmulExecutor &&) = delete;
+    MatmulExecutor & operator=(MatmulExecutor const &) = delete;
+    MatmulExecutor & operator=(MatmulExecutor &&) = delete;
 
     void execute();
 
@@ -174,17 +197,31 @@ private:
         Rhs,
     };
 
+    struct PackingState
+    {
+        bool lhs = false;
+        bool rhs = false;
+
+        explicit operator bool() const noexcept { return lhs || rhs; }
+    }; /* end struct PackingState */
+
     static constexpr ssize_t BLAS_DOT_MIN_LENGTH = 128;
     static constexpr ssize_t BLAS_COMPACT_GEVM_MIN_ELEMENTS = 729;
     static constexpr ssize_t BLAS_GEMV_MIN_DIMENSION = 32;
     static constexpr ssize_t BLAS_GEMM_MIN_DIMENSION = 8;
+    static constexpr ssize_t BLAS_GEMM_PACK_MIN_DIMENSION = 16;
 
+    PackingState select_packing() const;
+    void pack(PackingState const & packing);
+    void execute_contractions();
     void execute_at(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base);
     bool try_execute_blas(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base);
     bool try_dot(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
     bool try_gevm(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
     bool try_gemv(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
     bool try_gemm(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
+    std::optional<matrix_view_type> lhs_matrix_view(value_type const * data) const;
+    std::optional<matrix_view_type> rhs_matrix_view(value_type const * data) const;
     static std::optional<matrix_view_type> make_matrix_view(
         value_type const * data,
         ssize_t row_stride,
@@ -193,7 +230,11 @@ private:
         ssize_t columns);
     void execute_generic(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base);
 
-    MatmulPlan const & m_plan;
+    MatmulPlan m_plan;
+    Array const & m_lhs;
+    Array const & m_rhs;
+    std::optional<Array> m_packed_lhs;
+    std::optional<Array> m_packed_rhs;
     value_type * m_output_data;
     value_type const * m_lhs_data;
     value_type const * m_rhs_data;
@@ -305,14 +346,20 @@ MatmulPlan::BatchMappings MatmulPlan::make_batch_mappings(
     ssize_t output_block_size)
 {
     LoopDomain domain{make_batch_shape(lhs, rhs)};
+    BatchOperand lhs_operand = make_batch_operand(lhs, domain);
+    BatchOperand rhs_operand = make_batch_operand(rhs, domain);
     mapping_type mappings{
         OperandMapping::contiguous_blocks(domain, output_block_size),
-        make_batch_mapping(lhs, domain),
-        make_batch_mapping(rhs, domain),
+        std::move(lhs_operand.m_mapping),
+        std::move(rhs_operand.m_mapping),
     };
     return BatchMappings{
         .m_domain = std::move(domain),
         .m_mappings = std::move(mappings),
+        .m_lhs_is_broadcast = lhs_operand.m_is_broadcast,
+        .m_rhs_is_broadcast = rhs_operand.m_is_broadcast,
+        .m_lhs_has_zero_stride = lhs_operand.m_has_zero_stride,
+        .m_rhs_has_zero_stride = rhs_operand.m_has_zero_stride,
     };
 }
 
@@ -351,7 +398,7 @@ MatmulPlan::shape_type MatmulPlan::make_batch_shape(Array const & lhs, Array con
 }
 
 template <typename Array>
-OperandMapping MatmulPlan::make_batch_mapping(Array const & operand, LoopDomain const & domain)
+MatmulPlan::BatchOperand MatmulPlan::make_batch_operand(Array const & operand, LoopDomain const & domain)
 {
     size_t batch_axis_count = 0;
     if (operand.ndim() > 1)
@@ -360,15 +407,34 @@ OperandMapping MatmulPlan::make_batch_mapping(Array const & operand, LoopDomain 
     }
     size_t const batch_axis_offset = domain.rank() - batch_axis_count;
     batch_stride_type strides(domain.rank(), 0);
-    for (size_t axis = 0; axis < batch_axis_count; ++axis)
+    bool is_broadcast = false;
+    bool has_zero_stride = false;
+    for (size_t domain_axis = 0; domain_axis < domain.rank(); ++domain_axis)
     {
-        size_t const domain_axis = batch_axis_offset + axis;
-        if (operand.shape(axis) == domain.extent(domain_axis))
+        if (domain_axis < batch_axis_offset)
         {
-            strides[domain_axis] = operand.stride(axis);
+            is_broadcast = is_broadcast || domain.extent(domain_axis) > 1;
+            continue;
         }
+
+        size_t const operand_axis = domain_axis - batch_axis_offset;
+        ssize_t const operand_extent = operand.shape(operand_axis);
+        ssize_t const operand_stride = operand.stride(operand_axis);
+        if (operand_extent == domain.extent(domain_axis))
+        {
+            strides[domain_axis] = operand_stride;
+        }
+        else if (domain.extent(domain_axis) > 1)
+        {
+            is_broadcast = true;
+        }
+        has_zero_stride = has_zero_stride || (operand_extent > 1 && operand_stride == 0);
     }
-    return OperandMapping(std::move(strides));
+    return BatchOperand{
+        .m_mapping = OperandMapping(std::move(strides)),
+        .m_is_broadcast = is_broadcast,
+        .m_has_zero_stride = has_zero_stride,
+    };
 }
 
 inline MatmulPlan::shape_type MatmulPlan::make_output_shape(
@@ -421,8 +487,10 @@ std::string MatmulPlan::shape_string(Array const & array)
 }
 
 template <typename Array>
-MatmulExecutor<Array>::MatmulExecutor(MatmulPlan const & plan, Array & output, Array const & lhs, Array const & rhs)
-    : m_plan(plan)
+MatmulExecutor<Array>::MatmulExecutor(MatmulPlan plan, Array & output, Array const & lhs, Array const & rhs)
+    : m_plan(std::move(plan))
+    , m_lhs(lhs)
+    , m_rhs(rhs)
     , m_output_data(output.logical_data())
     , m_lhs_data(lhs.logical_data())
     , m_rhs_data(rhs.logical_data())
@@ -431,6 +499,69 @@ MatmulExecutor<Array>::MatmulExecutor(MatmulPlan const & plan, Array & output, A
 
 template <typename Array>
 void MatmulExecutor<Array>::execute()
+{
+    PackingState const packing = select_packing();
+
+    if (packing)
+    {
+        pack(packing);
+    }
+
+    execute_contractions();
+}
+
+template <typename Array>
+typename MatmulExecutor<Array>::PackingState MatmulExecutor<Array>::select_packing() const
+{
+    PackingState packing;
+#if (defined(__APPLE__) && defined(__arm64__)) || defined(MM_HAS_CBLAS)
+    if constexpr (can_matmul_blas_v<value_type>)
+    {
+        if (m_plan.lhs_is_vector() || m_plan.rhs_is_vector() ||
+            std::min({m_plan.rows(), m_plan.columns(), m_plan.inner_size()}) < BLAS_GEMM_PACK_MIN_DIMENSION)
+        {
+            return packing;
+        }
+        if (!m_plan.lhs_is_broadcast() && !m_plan.rhs_is_broadcast())
+        {
+            return packing;
+        }
+        packing.lhs = !lhs_matrix_view(m_lhs_data);
+        packing.rhs = !rhs_matrix_view(m_rhs_data);
+        bool const lhs_supported =
+            !packing.lhs || (m_plan.lhs_is_broadcast() && !m_plan.lhs_has_zero_batch_stride());
+        bool const rhs_supported =
+            !packing.rhs || (m_plan.rhs_is_broadcast() && !m_plan.rhs_has_zero_batch_stride());
+        if (!lhs_supported || !rhs_supported)
+        {
+            return PackingState{};
+        }
+    }
+#endif
+    return packing;
+}
+
+template <typename Array>
+void MatmulExecutor<Array>::pack(PackingState const & packing)
+{
+    if (packing.lhs)
+    {
+        m_packed_lhs.emplace(m_lhs.to_row_major());
+    }
+    if (packing.rhs)
+    {
+        m_packed_rhs.emplace(m_rhs.to_row_major());
+    }
+
+    Array const & lhs = m_packed_lhs ? *m_packed_lhs : m_lhs;
+    Array const & rhs = m_packed_rhs ? *m_packed_rhs : m_rhs;
+    m_plan = MatmulPlan::make(lhs, rhs);
+    m_lhs_data = lhs.logical_data();
+    m_rhs_data = rhs.logical_data();
+}
+
+template <typename Array>
+void MatmulExecutor<Array>::execute_contractions()
 {
     if (!m_plan.has_batch_axes())
     {
@@ -515,8 +646,7 @@ template <typename Array>
 bool MatmulExecutor<Array>::try_gevm(value_type * output, value_type const * lhs_data, value_type const * rhs_data)
 {
     ssize_t const vector_stride = m_plan.lhs_inner_stride();
-    auto const matrix = make_matrix_view(
-        rhs_data, m_plan.rhs_inner_stride(), m_plan.rhs_column_stride(), m_plan.inner_size(), m_plan.columns());
+    auto const matrix = rhs_matrix_view(rhs_data);
     if (vector_stride <= 0 || !matrix)
     {
         return false;
@@ -538,8 +668,7 @@ bool MatmulExecutor<Array>::try_gevm(value_type * output, value_type const * lhs
 template <typename Array>
 bool MatmulExecutor<Array>::try_gemv(value_type * output, value_type const * lhs_data, value_type const * rhs_data)
 {
-    auto const matrix = make_matrix_view(
-        lhs_data, m_plan.lhs_row_stride(), m_plan.lhs_inner_stride(), m_plan.rows(), m_plan.inner_size());
+    auto const matrix = lhs_matrix_view(lhs_data);
     ssize_t const vector_stride = m_plan.rhs_inner_stride();
     if (std::min(m_plan.rows(), m_plan.inner_size()) < BLAS_GEMV_MIN_DIMENSION || !matrix || vector_stride <= 0)
     {
@@ -557,16 +686,30 @@ bool MatmulExecutor<Array>::try_gemm(value_type * output, value_type const * lhs
     {
         return false;
     }
-    auto const lhs = make_matrix_view(
-        lhs_data, m_plan.lhs_row_stride(), m_plan.lhs_inner_stride(), m_plan.rows(), m_plan.inner_size());
-    auto const rhs = make_matrix_view(
-        rhs_data, m_plan.rhs_inner_stride(), m_plan.rhs_column_stride(), m_plan.inner_size(), m_plan.columns());
+    auto const lhs = lhs_matrix_view(lhs_data);
+    auto const rhs = rhs_matrix_view(rhs_data);
     if (!lhs || !rhs)
     {
         return false;
     }
     gemm_blas(m_plan.rows(), m_plan.columns(), m_plan.inner_size(), *lhs, *rhs, output);
     return true;
+}
+
+template <typename Array>
+std::optional<typename MatmulExecutor<Array>::matrix_view_type> MatmulExecutor<Array>::lhs_matrix_view(
+    value_type const * data) const
+{
+    return make_matrix_view(
+        data, m_plan.lhs_row_stride(), m_plan.lhs_inner_stride(), m_plan.rows(), m_plan.inner_size());
+}
+
+template <typename Array>
+std::optional<typename MatmulExecutor<Array>::matrix_view_type> MatmulExecutor<Array>::rhs_matrix_view(
+    value_type const * data) const
+{
+    return make_matrix_view(
+        data, m_plan.rhs_inner_stride(), m_plan.rhs_column_stride(), m_plan.inner_size(), m_plan.columns());
 }
 
 template <typename Array>

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -437,21 +437,32 @@ class MatmulTestBase(sc.testing.TestBase):
                     self.assert_matmul_planned(lhs, rhs, expected)
 
     def test_broadcast_matrix_strides(self):
-        """Broadcasting preserves signed matrix strides."""
+        """Broadcast matrix strides work across generic and packed routes."""
         dtype = np.dtype(self.dtype).name
-        lhs_data = np.arange(24, dtype=dtype).reshape(2, 1, 3, 4)
-        rhs_data = np.arange(40, dtype=dtype).reshape(1, 5, 4, 2)
-        cases = itertools.product(
-            self.make_matrix_stride_cases(lhs_data, 3),
-            self.make_matrix_stride_cases(rhs_data, 2),
-        )
-        for (lhs_case, case_lhs), (rhs_case, case_rhs) in cases:
-            lhs = self.SimpleArray(array=case_lhs)
-            rhs = self.SimpleArray(array=case_rhs)
-            expected = np.matmul(case_lhs, case_rhs)
+        for m, k, n in ((3, 4, 2), (17, 18, 19)):
+            lhs_data = np.arange(2 * m * k, dtype=dtype).reshape(
+                2, 1, m, k)
+            rhs_data = np.arange(5 * k * n, dtype=dtype).reshape(
+                1, 5, k, n)
+            lhs_cases = self.make_matrix_stride_cases(lhs_data, 3) + ((
+                'negative_batch_and_matrix',
+                self.make_strided_view(
+                    self.make_strided_view(lhs_data, 0, -1), 3, -1),
+            ),)
+            rhs_cases = self.make_matrix_stride_cases(rhs_data, 2) + ((
+                'negative_batch_and_matrix',
+                self.make_strided_view(
+                    self.make_strided_view(rhs_data, 1, -1), 2, -1),
+            ),)
+            cases = itertools.product(lhs_cases, rhs_cases)
+            for (lhs_case, case_lhs), (rhs_case, case_rhs) in cases:
+                lhs = self.SimpleArray(array=case_lhs)
+                rhs = self.SimpleArray(array=case_rhs)
+                expected = np.matmul(case_lhs, case_rhs)
 
-            with self.subTest(lhs=lhs_case, rhs=rhs_case):
-                self.assert_matmul_planned(lhs, rhs, expected)
+                with self.subTest(
+                        shape=(m, k, n), lhs=lhs_case, rhs=rhs_case):
+                    self.assert_matmul_planned(lhs, rhs, expected)
 
     def test_vector_strides(self):
         """Vector roles preserve signed vector, matrix, and batch strides."""


### PR DESCRIPTION
## Motivation

`matmul_planned()` sends C- and F-compatible matrices directly to CBLAS. A matrix layout that CBLAS cannot describe instead falls back to the generic strided executor, even when batch broadcasting reuses that matrix across multiple output coordinates. This PR optimizes that fallback by converting reusable unsupported layouts into a CBLAS-compatible representation once.

## Approach

`MatmulPlan` records which operands are reused by shape broadcasting. For sufficiently large float32 and float64 GEMM, `MatmulExecutor` packs each reused, CBLAS-incompatible operand once and sends every mapped contraction through the existing direct CBLAS route. Small matrices, vector products, explicit zero-stride views, and unsupported operands without broadcast reuse keep their existing routes.

## Profiling

The plots compare full-call times for NumPy 2.5.1, `matmul_planned()` before this PR, and the automatic pack-once route. They cover LHS, RHS, and cross-broadcast square GEMM with negative and step-two inner strides.

For `S >= 16`, the new route is faster at all 72 affected points: 3.30x-549.52x over the previous implementation and 1.11x-2.97x over NumPy. `S = 8` and `S = 12` remain on the generic route as controls.

### float32

<img width="2400" height="900" alt="pr1256-lhs-rhs-negative-float32" src="https://github.com/user-attachments/assets/861ca0da-f01c-47c5-85e0-c6768eb9a06c" />

<img width="1400" height="900" alt="pr1256-cross-negative-float32" src="https://github.com/user-attachments/assets/ec773f25-d158-4d66-a070-f009aee6d113" />

<img width="2400" height="900" alt="pr1256-lhs-rhs-step2-float32" src="https://github.com/user-attachments/assets/f045eb5f-1a9f-47e5-9ae7-5b972709e68e" />

<img width="1400" height="900" alt="pr1256-cross-step2-float32" src="https://github.com/user-attachments/assets/2f2b84aa-78a5-429f-a461-97a8c8ceaceb" />

### float64

<img width="2400" height="900" alt="pr1256-lhs-rhs-negative-float64" src="https://github.com/user-attachments/assets/72275190-63be-4428-bd47-7030ef9154e4" />

<img width="1400" height="900" alt="pr1256-cross-negative-float64" src="https://github.com/user-attachments/assets/ff8ba5a1-03a5-44bc-8b0a-3e9eeb7c89e0" />

<img width="2400" height="900" alt="pr1256-lhs-rhs-step2-float64" src="https://github.com/user-attachments/assets/b6e8955e-396b-4811-a181-880e57ba35be" />

<img width="1400" height="900" alt="pr1256-cross-step2-float64" src="https://github.com/user-attachments/assets/ae5f1d70-1df0-4901-bf3b-8f29bbd67a36" />

<details>
<summary>Measurement details</summary>

- Environment: native macOS arm64, Python 3.14.6, NumPy 2.5.1, and Accelerate. BLAS-related thread limits were set to one.
- Workloads: float32 and float64 square GEMM with `S` in 8, 12, 16, 24, 32, 64, 128, and 256; LHS, RHS, and cross-broadcast reuse; and negative or step-two inner strides.
- Sampling: each method received a discarded preconditioning run, two warmup batches, and 15 timed batches in each of six balanced rounds. Each plotted value is the untrimmed median of 90 per-call estimates.
- Validation: all 96 comparison points passed correctness and sampling audits. The maximum relative Frobenius error was 1.32e-16.

</details>

<details>
<summary>Complete isolated benchmark output</summary>

[Download the 1,728-record JSONL raw data](https://github.com/user-attachments/files/30812808/pr1256-exact-head-profiling.jsonl.txt)

</details>

Related to #1172.