### PR TITLE
Tune batched vector matmul routes

### DIFF
--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -33,6 +33,87 @@ inline constexpr bool can_matmul_blas_v = std::is_same_v<T, float> ||
                                           std::is_same_v<T, Complex<double>>;
 
 /**
+ * @brief Identify the contraction kernel fixed before batch traversal.
+ */
+enum class MatmulKernel : std::uint8_t
+{
+    Generic,
+    BlasDot,
+    BlasGevm,
+    BlasGemv,
+    BlasGemm,
+}; /* end enum class MatmulKernel */
+
+/**
+ * @brief Identify operands that must be materialized into row-major storage.
+ */
+struct PackingState
+{
+    bool lhs = false;
+    bool rhs = false;
+
+    explicit operator bool() const noexcept { return lhs || rhs; }
+}; /* end struct PackingState */
+
+/**
+ * @brief Group measured thresholds by matmul dispatch decision.
+ *
+ * A tuning table supplies the workload boundaries used to compare generic,
+ * direct BLAS, and packing routes. Keeping the values separate from dispatch
+ * code allows a backend or value type to provide another table.
+ *
+ * @note MatmulExecutor currently uses one compile-time table for every
+ * supported BLAS backend and value type.
+ */
+struct MatmulTuning
+{
+    /**
+     * @brief Select BLAS when the supplied operands have compatible layouts.
+     */
+    struct DirectBlas
+    {
+        ssize_t dot_min_length;
+        ssize_t compact_gevm_min_elements;
+        ssize_t gemv_min_dimension;
+        ssize_t gemm_min_dimension;
+    }; /* end struct DirectBlas */
+
+    /**
+     * @brief Pack reused matrices that cannot be described directly to BLAS.
+     */
+    struct MatrixPacking
+    {
+        ssize_t gemm_min_dimension;
+    }; /* end struct MatrixPacking */
+
+    /**
+     * @brief Select direct or packed BLAS for batched vector-matrix products.
+     */
+    struct BatchedVector
+    {
+        ssize_t direct_min_matrix_elements;
+        size_t always_pack_min_matrix_elements;
+        size_t pack_min_matrix_elements;
+        size_t pack_min_batch_size;
+        size_t reuse_min_matrix_elements;
+        size_t reuse_min_total_output_elements;
+    }; /* end struct BatchedVector */
+
+    DirectBlas direct_blas;
+    MatrixPacking matrix_packing;
+    BatchedVector batched_vector;
+}; /* end struct MatmulTuning */
+
+/**
+ * @brief Record the fixed kernel and packing for one matmul call.
+ */
+struct MatmulSelection
+{
+    MatmulKernel kernel = MatmulKernel::Generic;
+    PackingState packing;
+}; /* end struct MatmulSelection */
+
+/**
  * @brief Describe matmul operands as an execution-independent contraction.
  *
  * MatmulPlan interprets trailing axes as vector or matrix roles and leading
@@ -44,17 +125,12 @@ inline constexpr bool can_matmul_blas_v = std::is_same_v<T, float> ||
  *
  * For `(2,1,3,4) @ (1,5,4,6)`, the plan records batch shape `(2,5)`, M=3,
  * N=6, K=4, output shape `(2,5,3,6)`, and zero-stride batch mappings for
- * the broadcast axes. It does not allocate the output or evaluate the ten
- * matrix pairs.
+ * the broadcast axes.
  *
  * For `(K,) @ (B,K,N)`, the plan keeps a synthetic M=1 for execution but
  * omits that axis from the `(B,N)` output. Matrix-vector products similarly
  * omit synthetic N=1, while vector-vector products retain SimpleArray's
  * existing `(1,)` dot-result convention.
- *
- * @note This implementation plans vector and matrix operand roles with
- * broadcast leading batch shapes. It records the batch domain and mappings,
- * M, N, K, the output shape, and signed contraction strides.
  */
 class MatmulPlan
 {
@@ -80,6 +156,7 @@ public:
     bool lhs_has_zero_batch_stride() const noexcept { return m_batch.m_lhs_has_zero_stride; }
     bool rhs_has_zero_batch_stride() const noexcept { return m_batch.m_rhs_has_zero_stride; }
     bool has_batch_axes() const noexcept { return m_batch.m_domain.rank() != 0; }
+    size_t batch_size() const noexcept { return m_batch.m_domain.size(); }
     MappedOffsetCursor batch_cursor() const & { return MappedOffsetCursor(m_batch.m_domain, m_batch.m_mappings); }
     MappedOffsetCursor batch_cursor() const && = delete;
 
@@ -153,23 +230,22 @@ private:
 }; /* end class MatmulPlan */
 
 /**
- * @brief Execute a MatmulPlan with a layout-appropriate contraction route.
+ * @brief Select and execute one contraction kernel for a MatmulPlan.
  *
- * MatmulExecutor maps vector and matrix roles to DOT, GEMV, or GEMM, then
- * selects generic, tiled, direct BLAS, or pack-once BLAS execution. It owns
- * BLAS eligibility, packing reuse, and size thresholds. The executor stores
- * its plan by value and binds caller-owned arrays. Packing rebuilds physical
- * layout metadata without changing the contraction or result shape.
+ * MatmulExecutor combines plan metadata with MatmulTuning to select a
+ * MatmulSelection. It applies the selected operand preparation, rebuilds the
+ * plan when a physical layout changes, and traverses every batch offset with
+ * the same kernel. Generic kernels read signed strides directly, while BLAS
+ * kernels consume compatible vector and matrix descriptors.
  *
  * For `(2,1,3,4) @ (1,5,4,6)`, the executor visits ten batch offsets and
  * evaluates one `(3,4) @ (4,6)` contraction at each offset. The results are
  * written into the allocated `(2,5,3,6)` output.
  *
- * @note This implementation provides generic signed-stride routes, direct
- * BLAS routes, and pack-once GEMM for reused matrix operands. Batched-vector
- * tuning remains follow-up work. Pack-once applies when shape broadcasting
- * reuses an unsupported layout. Unsupported equal-batch layouts remain
- * generic.
+ * @note The current implementation selects generic or direct BLAS kernels for
+ * DOT, GEVM, GEMV, and GEMM. Packing materializes a reused broadcast matrix or
+ * vector once in row-major storage before traversal. Unsupported equal-batch
+ * matrix layouts remain generic.
  */
 template <typename Array>
 class MatmulExecutor
@@ -197,29 +273,46 @@ private:
         Rhs,
     };
 
-    struct PackingState
-    {
-        bool lhs = false;
-        bool rhs = false;
+    static constexpr MatmulTuning TUNING = {
+        .direct_blas = {
+            .dot_min_length = 128,
+            .compact_gevm_min_elements = 729,
+            .gemv_min_dimension = 32,
+            .gemm_min_dimension = 8,
+        },
+        .matrix_packing = {
+            .gemm_min_dimension = 16,
+        },
+        .batched_vector = {
+            .direct_min_matrix_elements = 512,
+            .always_pack_min_matrix_elements = 4096,
+            .pack_min_matrix_elements = 1024,
+            .pack_min_batch_size = 4,
+            .reuse_min_matrix_elements = 576,
+            .reuse_min_total_output_elements = 128,
+        },
+    };
 
-        explicit operator bool() const noexcept { return lhs || rhs; }
-    }; /* end struct PackingState */
-
-    static constexpr ssize_t BLAS_DOT_MIN_LENGTH = 128;
-    static constexpr ssize_t BLAS_COMPACT_GEVM_MIN_ELEMENTS = 729;
-    static constexpr ssize_t BLAS_GEMV_MIN_DIMENSION = 32;
-    static constexpr ssize_t BLAS_GEMM_MIN_DIMENSION = 8;
-    static constexpr ssize_t BLAS_GEMM_PACK_MIN_DIMENSION = 16;
-
-    PackingState select_packing() const;
+    MatmulSelection select_execution() const;
+    MatmulSelection select_dot() const;
+    MatmulSelection select_gevm() const;
+    MatmulSelection select_gemv() const;
+    MatmulSelection select_gemm() const;
+    PackingState select_matrix_packing(PackingState required) const;
+    PackingState select_vector_packing(PackingState required) const;
+    bool should_pack_vector() const;
     void pack(PackingState const & packing);
+
+    template <MatmulKernel Kernel>
     void execute_contractions();
+
+    template <MatmulKernel Kernel>
     void execute_at(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base);
-    bool try_execute_blas(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base);
-    bool try_dot(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
-    bool try_gevm(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
-    bool try_gemv(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
-    bool try_gemm(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
+
+    void execute_dot_blas(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
+    void execute_gevm_blas(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
+    void execute_gemv_blas(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
+    void execute_gemm_blas(value_type * output, value_type const * lhs_data, value_type const * rhs_data);
     std::optional<matrix_view_type> lhs_matrix_view(value_type const * data) const;
     std::optional<matrix_view_type> rhs_matrix_view(value_type const * data) const;
     static std::optional<matrix_view_type> make_matrix_view(
@@ -500,45 +593,214 @@ MatmulExecutor<Array>::MatmulExecutor(MatmulPlan plan, Array & output, Array con
 template <typename Array>
 void MatmulExecutor<Array>::execute()
 {
-    PackingState const packing = select_packing();
+    MatmulSelection const selection = select_execution();
 
-    if (packing)
+    if (selection.packing)
     {
-        pack(packing);
+        pack(selection.packing);
     }
 
-    execute_contractions();
+    switch (selection.kernel)
+    {
+    case MatmulKernel::Generic:
+        execute_contractions<MatmulKernel::Generic>();
+        return;
+    case MatmulKernel::BlasDot:
+        execute_contractions<MatmulKernel::BlasDot>();
+        return;
+    case MatmulKernel::BlasGevm:
+        execute_contractions<MatmulKernel::BlasGevm>();
+        return;
+    case MatmulKernel::BlasGemv:
+        execute_contractions<MatmulKernel::BlasGemv>();
+        return;
+    case MatmulKernel::BlasGemm:
+        execute_contractions<MatmulKernel::BlasGemm>();
+        return;
+    }
+    throw std::logic_error("MatmulExecutor::execute(): invalid kernel");
 }
 
 template <typename Array>
-typename MatmulExecutor<Array>::PackingState MatmulExecutor<Array>::select_packing() const
+MatmulSelection MatmulExecutor<Array>::select_execution() const
 {
-    PackingState packing;
 #if (defined(__APPLE__) && defined(__arm64__)) || defined(SC_HAS_CBLAS)
     if constexpr (can_matmul_blas_v<value_type>)
     {
-        if (m_plan.lhs_is_vector() || m_plan.rhs_is_vector() ||
-            std::min({m_plan.rows(), m_plan.columns(), m_plan.inner_size()}) < BLAS_GEMM_PACK_MIN_DIMENSION)
+        if (m_plan.lhs_is_vector() && m_plan.rhs_is_vector())
         {
-            return packing;
+            return select_dot();
         }
-        if (!m_plan.lhs_is_broadcast() && !m_plan.rhs_is_broadcast())
+        if (m_plan.lhs_is_vector())
         {
-            return packing;
+            return select_gevm();
         }
-        packing.lhs = !lhs_matrix_view(m_lhs_data);
-        packing.rhs = !rhs_matrix_view(m_rhs_data);
-        bool const lhs_supported =
-            !packing.lhs || (m_plan.lhs_is_broadcast() && !m_plan.lhs_has_zero_batch_stride());
-        bool const rhs_supported =
-            !packing.rhs || (m_plan.rhs_is_broadcast() && !m_plan.rhs_has_zero_batch_stride());
-        if (!lhs_supported || !rhs_supported)
+        if (m_plan.rhs_is_vector())
         {
-            return PackingState{};
+            return select_gemv();
         }
+        return select_gemm();
     }
 #endif
-    return packing;
+    return MatmulSelection{};
+}
+
+template <typename Array>
+MatmulSelection MatmulExecutor<Array>::select_dot() const
+{
+    ssize_t const lhs_stride = m_plan.lhs_inner_stride();
+    ssize_t const rhs_stride = m_plan.rhs_inner_stride();
+    bool const strides_supported = (lhs_stride == 1 && rhs_stride == 1) ||
+                                   (lhs_stride == -1 && rhs_stride == -1);
+    bool const use_blas = m_plan.inner_size() >= TUNING.direct_blas.dot_min_length && strides_supported;
+    return MatmulSelection{
+        .kernel = use_blas ? MatmulKernel::BlasDot : MatmulKernel::Generic,
+        .packing = {},
+    };
+}
+
+template <typename Array>
+MatmulSelection MatmulExecutor<Array>::select_gevm() const
+{
+    auto const matrix = rhs_matrix_view(m_rhs_data);
+    if (!matrix)
+    {
+        return MatmulSelection{};
+    }
+    if (m_plan.has_batch_axes())
+    {
+        PackingState const required{.lhs = m_plan.lhs_inner_stride() <= 0};
+        PackingState const packing = select_vector_packing(required);
+        bool const use_blas = packing ||
+                              (m_plan.lhs_inner_stride() > 0 &&
+                               m_plan.inner_size() * m_plan.columns() >=
+                                   TUNING.batched_vector.direct_min_matrix_elements);
+        return MatmulSelection{
+            .kernel = use_blas ? MatmulKernel::BlasGevm : MatmulKernel::Generic,
+            .packing = packing,
+        };
+    }
+    if (m_plan.lhs_inner_stride() <= 0)
+    {
+        return MatmulSelection{};
+    }
+
+    bool const is_compact = matrix->m_transpose == BlasTranspose::None &&
+                            matrix->m_leading_dimension == m_plan.columns();
+    bool const use_blas = is_compact
+                              ? m_plan.inner_size() * m_plan.columns() >=
+                                    TUNING.direct_blas.compact_gevm_min_elements
+                              : std::min(m_plan.inner_size(), m_plan.columns()) >=
+                                    TUNING.direct_blas.gemv_min_dimension;
+    return MatmulSelection{
+        .kernel = use_blas ? MatmulKernel::BlasGevm : MatmulKernel::Generic,
+        .packing = {},
+    };
+}
+
+template <typename Array>
+MatmulSelection MatmulExecutor<Array>::select_gemv() const
+{
+    auto const matrix = lhs_matrix_view(m_lhs_data);
+    if (!matrix)
+    {
+        return MatmulSelection{};
+    }
+    if (m_plan.has_batch_axes())
+    {
+        PackingState const required{.rhs = m_plan.rhs_inner_stride() <= 0};
+        PackingState const packing = select_vector_packing(required);
+        bool const use_blas = packing ||
+                              (m_plan.rhs_inner_stride() > 0 &&
+                               m_plan.rows() * m_plan.inner_size() >=
+                                   TUNING.batched_vector.direct_min_matrix_elements);
+        return MatmulSelection{
+            .kernel = use_blas ? MatmulKernel::BlasGemv : MatmulKernel::Generic,
+            .packing = packing,
+        };
+    }
+
+    bool const use_blas = m_plan.rhs_inner_stride() > 0 &&
+                          std::min(m_plan.rows(), m_plan.inner_size()) >= TUNING.direct_blas.gemv_min_dimension;
+    return MatmulSelection{
+        .kernel = use_blas ? MatmulKernel::BlasGemv : MatmulKernel::Generic,
+        .packing = {},
+    };
+}
+
+template <typename Array>
+MatmulSelection MatmulExecutor<Array>::select_gemm() const
+{
+    ssize_t const minimum_dimension =
+        std::min({m_plan.rows(), m_plan.columns(), m_plan.inner_size()});
+    bool const lhs_blas_compatible = bool(lhs_matrix_view(m_lhs_data));
+    bool const rhs_blas_compatible = bool(rhs_matrix_view(m_rhs_data));
+    if (minimum_dimension >= TUNING.direct_blas.gemm_min_dimension && lhs_blas_compatible && rhs_blas_compatible)
+    {
+        return MatmulSelection{.kernel = MatmulKernel::BlasGemm, .packing = {}};
+    }
+    if (minimum_dimension >= TUNING.matrix_packing.gemm_min_dimension)
+    {
+        PackingState const required{
+            .lhs = !lhs_blas_compatible,
+            .rhs = !rhs_blas_compatible,
+        };
+        PackingState const packing = select_matrix_packing(required);
+        if (packing)
+        {
+            return MatmulSelection{.kernel = MatmulKernel::BlasGemm, .packing = packing};
+        }
+    }
+    return MatmulSelection{};
+}
+
+template <typename Array>
+PackingState MatmulExecutor<Array>::select_matrix_packing(PackingState required) const
+{
+    bool const lhs_supported =
+        !required.lhs || (m_plan.lhs_is_broadcast() && !m_plan.lhs_has_zero_batch_stride());
+    bool const rhs_supported =
+        !required.rhs || (m_plan.rhs_is_broadcast() && !m_plan.rhs_has_zero_batch_stride());
+    if (!required || !lhs_supported || !rhs_supported)
+    {
+        return PackingState{};
+    }
+    return required;
+}
+
+template <typename Array>
+PackingState MatmulExecutor<Array>::select_vector_packing(PackingState required) const
+{
+    if (!required)
+    {
+        return PackingState{};
+    }
+    bool const vector_reused = required.lhs ? m_plan.lhs_is_broadcast() : m_plan.rhs_is_broadcast();
+    return vector_reused && should_pack_vector() ? required : PackingState{};
+}
+
+template <typename Array>
+bool MatmulExecutor<Array>::should_pack_vector() const
+{
+    auto const output_size = static_cast<size_t>(
+        m_plan.lhs_is_vector() ? m_plan.columns() : m_plan.rows());
+    size_t const matrix_elements = static_cast<size_t>(m_plan.inner_size()) * output_size;
+    if (matrix_elements >= TUNING.batched_vector.always_pack_min_matrix_elements)
+    {
+        return true;
+    }
+    if (matrix_elements >= TUNING.batched_vector.pack_min_matrix_elements &&
+        m_plan.batch_size() >= TUNING.batched_vector.pack_min_batch_size)
+    {
+        return true;
+    }
+    if (matrix_elements < TUNING.batched_vector.reuse_min_matrix_elements || output_size == 0)
+    {
+        return false;
+    }
+    size_t const minimum_batch_size =
+        (TUNING.batched_vector.reuse_min_total_output_elements + output_size - 1) / output_size;
+    return m_plan.batch_size() >= minimum_batch_size;
 }
 
 template <typename Array>
@@ -561,17 +823,18 @@ void MatmulExecutor<Array>::pack(PackingState const & packing)
 }
 
 template <typename Array>
+template <MatmulKernel Kernel>
 void MatmulExecutor<Array>::execute_contractions()
 {
     if (!m_plan.has_batch_axes())
     {
-        execute_at(0, 0, 0);
+        execute_at<Kernel>(0, 0, 0);
         return;
     }
 
     for (MappedOffsetCursor cursor = m_plan.batch_cursor(); cursor; cursor.advance())
     {
-        execute_at(
+        execute_at<Kernel>(
             cursor.offset(MappingSlot::Output),
             cursor.offset(MappingSlot::Lhs),
             cursor.offset(MappingSlot::Rhs));
@@ -579,49 +842,50 @@ void MatmulExecutor<Array>::execute_contractions()
 }
 
 template <typename Array>
-void MatmulExecutor<Array>::execute_at(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base)
+template <MatmulKernel Kernel>
+void MatmulExecutor<Array>::execute_at(
+    ssize_t output_base,
+    ssize_t lhs_base,
+    ssize_t rhs_base)
 {
-    if (!try_execute_blas(output_base, lhs_base, rhs_base))
+    if constexpr (Kernel == MatmulKernel::Generic)
     {
         execute_generic(output_base, lhs_base, rhs_base);
     }
-}
-
-template <typename Array>
-bool MatmulExecutor<Array>::try_execute_blas(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base)
-{
+    else
+    {
 #if (defined(__APPLE__) && defined(__arm64__)) || defined(SC_HAS_CBLAS)
-    if constexpr (can_matmul_blas_v<value_type>)
-    {
-        value_type * output = m_output_data + output_base;
-        value_type const * lhs_data = m_lhs_data + lhs_base;
-        value_type const * rhs_data = m_rhs_data + rhs_base;
-        if (m_plan.lhs_is_vector() && m_plan.rhs_is_vector())
+        if constexpr (can_matmul_blas_v<value_type>)
         {
-            return try_dot(output, lhs_data, rhs_data);
+            value_type * output = m_output_data + output_base;
+            value_type const * lhs_data = m_lhs_data + lhs_base;
+            value_type const * rhs_data = m_rhs_data + rhs_base;
+            if constexpr (Kernel == MatmulKernel::BlasDot)
+            {
+                execute_dot_blas(output, lhs_data, rhs_data);
+            }
+            else if constexpr (Kernel == MatmulKernel::BlasGevm)
+            {
+                execute_gevm_blas(output, lhs_data, rhs_data);
+            }
+            else if constexpr (Kernel == MatmulKernel::BlasGemv)
+            {
+                execute_gemv_blas(output, lhs_data, rhs_data);
+            }
+            else if constexpr (Kernel == MatmulKernel::BlasGemm)
+            {
+                execute_gemm_blas(output, lhs_data, rhs_data);
+            }
+            return;
         }
-        if (m_plan.lhs_is_vector())
-        {
-            return !m_plan.has_batch_axes() && try_gevm(output, lhs_data, rhs_data);
-        }
-        if (m_plan.rhs_is_vector())
-        {
-            return !m_plan.has_batch_axes() && try_gemv(output, lhs_data, rhs_data);
-        }
-        return try_gemm(output, lhs_data, rhs_data);
-    }
 #endif
-    return false;
+        throw std::logic_error("MatmulExecutor::execute_at(): unavailable BLAS kernel");
+    }
 }
 
 template <typename Array>
-bool MatmulExecutor<Array>::try_dot(value_type * output, value_type const * lhs_data, value_type const * rhs_data)
+void MatmulExecutor<Array>::execute_dot_blas(value_type * output, value_type const * lhs_data, value_type const * rhs_data)
 {
-    if (m_plan.inner_size() < BLAS_DOT_MIN_LENGTH)
-    {
-        return false;
-    }
-
     ssize_t lhs_stride = m_plan.lhs_inner_stride();
     ssize_t rhs_stride = m_plan.rhs_inner_stride();
     if (lhs_stride == -1 && rhs_stride == -1)
@@ -631,69 +895,34 @@ bool MatmulExecutor<Array>::try_dot(value_type * output, value_type const * lhs_
         lhs_stride = -lhs_stride;
         rhs_stride = -rhs_stride;
     }
-    if (lhs_stride != 1 || rhs_stride != 1)
-    {
-        return false;
-    }
 
     vector_view_type const lhs{lhs_data, lhs_stride};
     vector_view_type const rhs{rhs_data, rhs_stride};
     output[0] = dot_blas(m_plan.inner_size(), lhs, rhs);
-    return true;
 }
 
 template <typename Array>
-bool MatmulExecutor<Array>::try_gevm(value_type * output, value_type const * lhs_data, value_type const * rhs_data)
+void MatmulExecutor<Array>::execute_gevm_blas(value_type * output, value_type const * lhs_data, value_type const * rhs_data)
 {
-    ssize_t const vector_stride = m_plan.lhs_inner_stride();
-    auto const matrix = rhs_matrix_view(rhs_data);
-    if (vector_stride <= 0 || !matrix)
-    {
-        return false;
-    }
-    bool const is_compact = matrix->m_transpose == BlasTranspose::None &&
-                            matrix->m_leading_dimension == m_plan.columns();
-    bool const is_large_enough = is_compact
-                                     ? m_plan.inner_size() * m_plan.columns() >= BLAS_COMPACT_GEVM_MIN_ELEMENTS
-                                     : std::min(m_plan.inner_size(), m_plan.columns()) >= BLAS_GEMV_MIN_DIMENSION;
-    if (!is_large_enough)
-    {
-        return false;
-    }
-    vector_view_type const vector{lhs_data, vector_stride};
-    gemv_blas(m_plan.inner_size(), m_plan.columns(), *matrix, vector, output, BlasTranspose::Transpose);
-    return true;
+    matrix_view_type const matrix = rhs_matrix_view(rhs_data).value();
+    vector_view_type const vector{lhs_data, m_plan.lhs_inner_stride()};
+    gemv_blas(m_plan.inner_size(), m_plan.columns(), matrix, vector, output, BlasTranspose::Transpose);
 }
 
 template <typename Array>
-bool MatmulExecutor<Array>::try_gemv(value_type * output, value_type const * lhs_data, value_type const * rhs_data)
+void MatmulExecutor<Array>::execute_gemv_blas(value_type * output, value_type const * lhs_data, value_type const * rhs_data)
 {
-    auto const matrix = lhs_matrix_view(lhs_data);
-    ssize_t const vector_stride = m_plan.rhs_inner_stride();
-    if (std::min(m_plan.rows(), m_plan.inner_size()) < BLAS_GEMV_MIN_DIMENSION || !matrix || vector_stride <= 0)
-    {
-        return false;
-    }
-    vector_view_type const vector{rhs_data, vector_stride};
-    gemv_blas(m_plan.rows(), m_plan.inner_size(), *matrix, vector, output, BlasTranspose::None);
-    return true;
+    matrix_view_type const matrix = lhs_matrix_view(lhs_data).value();
+    vector_view_type const vector{rhs_data, m_plan.rhs_inner_stride()};
+    gemv_blas(m_plan.rows(), m_plan.inner_size(), matrix, vector, output, BlasTranspose::None);
 }
 
 template <typename Array>
-bool MatmulExecutor<Array>::try_gemm(value_type * output, value_type const * lhs_data, value_type const * rhs_data)
+void MatmulExecutor<Array>::execute_gemm_blas(value_type * output, value_type const * lhs_data, value_type const * rhs_data)
 {
-    if (std::min({m_plan.rows(), m_plan.columns(), m_plan.inner_size()}) < BLAS_GEMM_MIN_DIMENSION)
-    {
-        return false;
-    }
-    auto const lhs = lhs_matrix_view(lhs_data);
-    auto const rhs = rhs_matrix_view(rhs_data);
-    if (!lhs || !rhs)
-    {
-        return false;
-    }
-    gemm_blas(m_plan.rows(), m_plan.columns(), m_plan.inner_size(), *lhs, *rhs, output);
-    return true;
+    matrix_view_type const lhs = lhs_matrix_view(lhs_data).value();
+    matrix_view_type const rhs = rhs_matrix_view(rhs_data).value();
+    gemm_blas(m_plan.rows(), m_plan.columns(), m_plan.inner_size(), lhs, rhs, output);
 }
 
 template <typename Array>

--- a/profiling/profile_matrix_ops.py
+++ b/profiling/profile_matrix_ops.py
@@ -214,8 +214,21 @@ def iter_planned_cases(dtype):
         yield ("Cross-broadcast GEMM", cross_lhs, cross_rhs)
 
 
+def iter_batched_vector_threshold_cases(dtype):
+    cases = ((24, 4), (24, 8), (32, 2), (32, 4), (64, 2))
+    for side, batch_size in cases:
+        vector = make_data(dtype, (side,))
+        matrix = make_data(dtype, (batch_size, side, side))
+        yield (f"Batched GEVM B={batch_size}", vector, matrix)
+        yield (f"Batched GEMV B={batch_size}", matrix, vector)
+
+
 def profile_planned_suite(dtype, warmups=1, samples=1, rounds=3):
-    for title, lhs, rhs in iter_planned_cases(dtype):
+    cases = itertools.chain(
+        iter_planned_cases(dtype),
+        iter_batched_vector_threshold_cases(dtype),
+    )
+    for title, lhs, rhs in cases:
         for case_name, case_lhs, case_rhs in iter_stride_cases(lhs, rhs):
             profile_planned_case(
                 title, dtype, case_name, case_lhs, case_rhs,

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -87,8 +87,9 @@ class MatmulTestBase(sc.testing.TestBase):
 
     @classmethod
     def make_matrix_stride_cases(cls, data, axis):
-        f_contiguous = np.array(
-            data, dtype=data.dtype.name, order='F', copy=True)
+        transposed = data.swapaxes(-1, -2)
+        f_contiguous = np.ascontiguousarray(
+            transposed, dtype=data.dtype.name).swapaxes(-1, -2)
         storage_shape = list(data.shape)
         storage_shape[-1] += 2
         storage = np.empty(storage_shape, dtype=data.dtype.name)
@@ -523,6 +524,40 @@ class MatmulTestBase(sc.testing.TestBase):
                 expected = np.atleast_1d(np.matmul(lhs_data, rhs_data))
                 self.assert_matmul_planned(
                     lhs, rhs, expected)
+
+    def test_large_batched_vector_strides(self):
+        """Batched vector roles preserve layouts across tuned sizes."""
+        dtype = np.dtype(self.dtype).name
+        for side, batch_size in ((24, 2), (24, 8), (32, 4)):
+            vector_data = np.arange(side, dtype=dtype)
+            vector_cases = (
+                ('contiguous', vector_data),
+                ('negative_stride',
+                 self.make_strided_view(vector_data, 0, -1)),
+                ('step_two', self.make_strided_view(vector_data, 0, 2)),
+            )
+            matrix_data = np.arange(
+                batch_size * side * side, dtype=dtype).reshape(
+                    batch_size, side, side)
+            role_cases = (
+                ('gevm', vector_cases,
+                 self.make_matrix_stride_cases(matrix_data, -2)[:2]),
+                ('gemv', self.make_matrix_stride_cases(
+                    matrix_data, -1)[:2], vector_cases),
+            )
+            for role, lhs_cases, rhs_cases in role_cases:
+                for lhs_case, rhs_case in itertools.product(
+                        lhs_cases, rhs_cases):
+                    lhs_name, lhs_data = lhs_case
+                    rhs_name, rhs_data = rhs_case
+                    lhs = self.SimpleArray(array=lhs_data)
+                    rhs = self.SimpleArray(array=rhs_data)
+                    expected = np.matmul(lhs_data, rhs_data)
+
+                    with self.subTest(
+                            role=role, side=side, batch=batch_size,
+                            lhs=lhs_name, rhs=rhs_name):
+                        self.assert_matmul_planned(lhs, rhs, expected)
 
     def test_batch_axes_align_right(self):
         """Leading batch axes align from the right like NumPy matmul."""


### PR DESCRIPTION
`matmul_planned()` already dispatches BLAS-compatible matrix-matrix products, but batched vector-matrix `(K,) @ (B,K,N)` and matrix-vector `(B,M,K) @ (K,)` products still use the generic signed-stride loop. The same vector is reused at every batch coordinate, so these calls repeat scalar traversal even when each matrix can be passed directly to CBLAS.

`MatmulExecutor` now records one `MatmulSelection` before batch traversal. It selects direct BLAS for a C- or F-compatible matrix and a positive vector stride, packs a reused negative-stride vector once before BLAS when the copy is amortized, and otherwise keeps generic execution. `MatmulTuning` stores the measured boundaries, while `MatmulPlan` remains independent of backend policy.

## Profiling

The benchmark compares head `7b40cb46`, its parent `f5824e1a`, and NumPy 2.5.1 on an Apple M1 using one Accelerate thread. All 112 points whose route changes are faster than the parent, with a median 5.03x speedup and a range of 1.15x to 31.54x.

All 32 negative-stride points that pack the reused vector once are faster than NumPy, with a median 6.24x speedup. All 80 positive-stride direct-BLAS points are faster than the parent; 16 are faster than NumPy, and their median runtime is 1.06 times NumPy.

### float32

<img width="2400" height="900" alt="pr1259-c-matrix-stride1-float32" src="https://github.com/user-attachments/assets/2f347879-900c-4c56-8463-589868b202ce" />

<img width="2400" height="900" alt="pr1259-c-matrix-stride2-float32" src="https://github.com/user-attachments/assets/1347694f-5dee-4ba8-85d2-758af4464106" />

<img width="2400" height="900" alt="pr1259-c-matrix-negative-float32" src="https://github.com/user-attachments/assets/392c2495-d054-4086-b6be-9a63f2f7fc75" />

<img width="2400" height="900" alt="pr1259-f-matrix-stride1-float32" src="https://github.com/user-attachments/assets/21240dd8-7277-4c2d-a00e-df1d42812f6c" />

<img width="2400" height="900" alt="pr1259-f-matrix-stride2-float32" src="https://github.com/user-attachments/assets/93cdf320-8a7d-48a9-b51d-bf4352f3cdea" />

<img width="2400" height="900" alt="pr1259-f-matrix-negative-float32" src="https://github.com/user-attachments/assets/765427f1-b172-4dcd-834a-77e6c33be086" />

### float64

<img width="2400" height="900" alt="pr1259-c-matrix-stride1-float64" src="https://github.com/user-attachments/assets/16858323-7ad8-40ff-8571-9b23ba29016c" />

<img width="2400" height="900" alt="pr1259-c-matrix-stride2-float64" src="https://github.com/user-attachments/assets/70de89bd-ad90-4844-aaeb-b8c58d750666" />

<img width="2400" height="900" alt="pr1259-c-matrix-negative-float64" src="https://github.com/user-attachments/assets/cb2e1b40-814e-4435-ae69-ad7e42738b8e" />

<img width="2400" height="900" alt="pr1259-f-matrix-stride1-float64" src="https://github.com/user-attachments/assets/b2223799-d57b-4425-944b-479030bd18aa" />

<img width="2400" height="900" alt="pr1259-f-matrix-stride2-float64" src="https://github.com/user-attachments/assets/7d2261a8-dbeb-4ae9-ae76-93de6921e6e8" />

<img width="2400" height="900" alt="pr1259-f-matrix-negative-float64" src="https://github.com/user-attachments/assets/093ec29f-f05b-4a5a-971a-e875ae0bb90c" />

<details>
<summary>Measurement method and raw data</summary>

- The compared implementations run in separate persistent processes. NumPy and solvcon both use Apple Accelerate with one BLAS thread.
- Workloads use batch size 4; `S` in 8, 12, 16, 24, 32, 64, 128, and 256; float32 and float64; C- and per-matrix F-compatible matrices; and vector strides 1, 2, and -1.
- Each point uses two warmups and five timed batches per round for 12 rounds. A timed batch is calibrated to about 15 ms, and the plotted value is the median of 60 per-call times.
- The 12 rounds use all six execution orders twice. Four `S=24`, vector-stride-1 points also received 12 confirmation rounds; their paired bootstrap 95% lower bounds are 1.044x to 1.239x.
- The maximum relative Frobenius error is `2.32e-7`.
- [Formal benchmark output: 6,912 JSONL records](https://github.com/user-attachments/files/30860020/pr1259-formal-profiling.jsonl.txt)
- [Targeted confirmation output: 144 JSONL records](https://github.com/user-attachments/files/30860041/pr1259-targeted-confirmation.jsonl.txt)

</details>

Related to #1172.
