### PR TITLE
Fence dependency builds by platform

### DIFF
--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -947,7 +947,22 @@ elif [ "${SCDV_ALLOW_UNSUPPORTED_PLATFORM}" = "1" ] ; then
        "'${SCDV_OS}/${SCDV_ARCH}'; continuing anyway." >&2
 else
   case "${SCDV_OS}:${SCDV_ARCH}" in
-    ubuntu:x86_64|macos:arm64)
+    macos:arm64)
+      ;;
+
+    ubuntu:x86_64)
+      # SCDV_OS=ubuntu covers every Linux (uname -s is just "Linux"), so
+      # confirm this is actually Ubuntu; other distros lack apt and the
+      # Debian/Ubuntu paths the recipes assume. Warn and proceed.
+      _scdv_id=""
+      if [ -r /etc/os-release ] ; then
+        _scdv_id=$(set +e ; . /etc/os-release 2>/dev/null ; printf '%s' "${ID:-}")
+      fi
+      if [ "${_scdv_id}" != "ubuntu" ] ; then
+        echo "warning: non-Ubuntu Linux (os-release ID='${_scdv_id:-unknown}');" \
+             ""the build assumes apt and Ubuntu-specific paths and may fail."" >&2
+      fi
+      unset _scdv_id
       ;;
 
     ubuntu:aarch64)
@@ -958,18 +973,6 @@ else
     macos:x86_64)
       # Intel Mac: some dependencies may not build. (e.g. numpy/scipy)
       echo "warning: some dependencies may not build correctly on macos/x86_64." >&2
-
-      if ! { : </dev/tty ; } 2>/dev/null ; then
-        echo "no controlling tty to confirm; rerun on a supported" \
-             "OS/architecture." >&2
-        exit 1
-      fi
-
-      read -r -p "Continue anyway? [y/N] " _ans </dev/tty
-      case "${_ans}" in
-        [Yy]*) ;;
-        *) echo "aborted." >&2 ; exit 1 ;;
-      esac
       ;;
 
     *)

--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -45,6 +45,8 @@
 #       ends with the two toolchains no build section installs: LaTeX, which
 #       the documentation needs to render its figures, then clang-format and
 #       clang-tidy for `make lint`, both from LLVM 22.
+#   ./build-scdv.sh --allow-unsupported-platform
+#       Proceed on an unsupported OS/architecture for platform testing.
 #
 # Overridable variables (search below for defaults):
 #   Platform:
@@ -861,6 +863,7 @@ SCDV_PRINT_PREFIX_ONLY=0
 SCDV_PRINT_DEPS_ONLY=0
 SCDV_NO_CONFIRM=0
 SCDV_ALLOW_WRITE_TO_ACTIVE_ENV=0
+SCDV_ALLOW_UNSUPPORTED_PLATFORM=${SCDV_ALLOW_UNSUPPORTED_PLATFORM:-0}
 SCDV_SKIP_LIST=""
 SCDV_KNOWN_PKGS="zlib openssl sqlite python pybind11 cython numpy scipy qt pyside6"
 
@@ -901,6 +904,9 @@ while [ $# -gt 0 ] ; do
     --allow-write-to-active-env)
       SCDV_ALLOW_WRITE_TO_ACTIVE_ENV=1
       ;;
+    --allow-unsupported-platform)
+      SCDV_ALLOW_UNSUPPORTED_PLATFORM=1
+      ;;
     --skip)
       shift
       if [ $# -eq 0 ] ; then
@@ -934,29 +940,56 @@ fi
 # The per-OS blocks assume x86_64 on Ubuntu and arm64 on macOS.
 SCDV_ARCH=$(uname -m)
 
-case "${SCDV_OS}:${SCDV_ARCH}" in
-  ubuntu:x86_64|macos:arm64)
-    ;;
-  macos:x86_64)
-    # Intel Mac: some dependencies may not build. (e.g. numpy/scipy)
-    echo "warning: some dependencies may not build correctly on" \
-         "macos/x86_64 (Intel Mac)." >&2
-    if ! { : </dev/tty ; } 2>/dev/null ; then
-      echo "no controlling tty to confirm; rerun on a supported" \
-           "OS/architecture." >&2
+if [ "${SCDV_ALLOW_UNSUPPORTED_PLATFORM}" = "1" ] ; then
+  echo "warning: platform support check overridden for" \
+       "'${SCDV_OS}/${SCDV_ARCH}'; continuing anyway." >&2
+else
+  case "${SCDV_OS}:${SCDV_ARCH}" in
+    ubuntu:x86_64|macos:arm64)
+      ;;
+
+    ubuntu:arm64)
+      echo "warning: some build settings currently assume x86_64 and" \
+           "may not work correctly on ubuntu/arm64." >&2
+
+      if ! { : </dev/tty ; } 2>/dev/null ; then
+        echo "no controlling tty to confirm; rerun on a supported" \
+             "OS/architecture." >&2
+        exit 1
+      fi
+
+      read -r -p "Continue anyway? [y/N] " _ans </dev/tty
+      case "${_ans}" in
+        [Yy]*) ;;
+        *) echo "aborted." >&2 ; exit 1 ;;
+      esac
+      ;;
+
+    macos:x86_64)
+      # Intel Mac: some dependencies may not build. (e.g. numpy/scipy)
+      echo "warning: some dependencies may not build correctly on macos/x86_64." >&2
+
+      if ! { : </dev/tty ; } 2>/dev/null ; then
+        echo "no controlling tty to confirm; rerun on a supported" \
+             "OS/architecture." >&2
+        exit 1
+      fi
+
+      read -r -p "Continue anyway? [y/N] " _ans </dev/tty
+      case "${_ans}" in
+        [Yy]*) ;;
+        *) echo "aborted." >&2 ; exit 1 ;;
+      esac
+      ;;
+
+    *)
+      echo "unsupported OS/architecture '${SCDV_OS}/${SCDV_ARCH}';" \
+           "use --allow-unsupported-platform or set" \
+           "SCDV_ALLOW_UNSUPPORTED_PLATFORM=1 to continue anyway." >&2
       exit 1
-    fi
-    read -r -p "Continue anyway? [y/N] " _ans </dev/tty
-    case "${_ans}" in
-      [Yy]*) ;;
-      *) echo "aborted." >&2 ; exit 1 ;;
-    esac
-    ;;
-  *)
-    echo "unsupported OS/architecture '${SCDV_OS}/${SCDV_ARCH}'" >&2
-    exit 1
-    ;;
-esac
+      ;;
+  esac
+fi
 
 # One-time platform setup (e.g. macOS BREW_PREFIX detection).
 plat_init

--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -937,6 +937,16 @@ if [ "${SCDV_PRINT_DEPS_ONLY}" = "1" ] ; then
   exit 0
 fi
 
+# Path prefix to SCDV_BASE.
+SCDV_PREFIX=${SCDV_PREFIX:-${HOME}/var/scdv/${SCDV_OS_TAG}}
+
+# Honor --print-prefix as soon as SCDV_PREFIX resolves, before any side
+# effect or further platform call.
+if [ "${SCDV_PRINT_PREFIX_ONLY}" = "1" ] ; then
+  echo "SCDV_PREFIX=${SCDV_PREFIX}"
+  exit 0
+fi
+
 # The per-OS blocks assume x86_64 on Ubuntu and arm64 on macOS.
 SCDV_ARCH=${SCDV_ARCH:-$(uname -m)}
 
@@ -996,16 +1006,6 @@ PYSIDE_VERSION=${PYSIDE_VERSION:-${QT_MAJOR_VER}.${QT_SUB_VER}}
 # default and runs only the explicitly selected sections.
 if [ -z "${SCDVBUILD_ALL:-}${SCDVBUILD_BASE:-}${SCDVBUILD_PYTHON:-}${SCDVBUILD_NUMPY:-}${SCDVBUILD_QT:-}" ] ; then
   SCDVBUILD_ALL=1
-fi
-
-# Path prefix to SCDV_BASE.
-SCDV_PREFIX=${SCDV_PREFIX:-${HOME}/var/scdv/${SCDV_OS_TAG}}
-
-# Honor --print-prefix as soon as SCDV_PREFIX resolves, before any side
-# effect or further platform call.
-if [ "${SCDV_PRINT_PREFIX_ONLY}" = "1" ] ; then
-  echo "SCDV_PREFIX=${SCDV_PREFIX}"
-  exit 0
 fi
 
 # An activated scdv/mmdv exports SCDV_BASE, which the assignment below would

--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -931,6 +931,33 @@ if [ "${SCDV_PRINT_DEPS_ONLY}" = "1" ] ; then
   exit 0
 fi
 
+# The per-OS blocks assume x86_64 on Ubuntu and arm64 on macOS.
+SCDV_ARCH=$(uname -m)
+
+case "${SCDV_OS}:${SCDV_ARCH}" in
+  ubuntu:x86_64|macos:arm64)
+    ;;
+  macos:x86_64)
+    # Intel Mac: some dependencies may not build. (e.g. numpy/scipy)
+    echo "warning: some dependencies may not build correctly on" \
+         "macos/x86_64 (Intel Mac)." >&2
+    if ! { : </dev/tty ; } 2>/dev/null ; then
+      echo "no controlling tty to confirm; rerun on a supported" \
+           "OS/architecture." >&2
+      exit 1
+    fi
+    read -r -p "Continue anyway? [y/N] " _ans </dev/tty
+    case "${_ans}" in
+      [Yy]*) ;;
+      *) echo "aborted." >&2 ; exit 1 ;;
+    esac
+    ;;
+  *)
+    echo "unsupported OS/architecture '${SCDV_OS}/${SCDV_ARCH}'" >&2
+    exit 1
+    ;;
+esac
+
 # One-time platform setup (e.g. macOS BREW_PREFIX detection).
 plat_init
 

--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -937,20 +937,12 @@ if [ "${SCDV_PRINT_DEPS_ONLY}" = "1" ] ; then
   exit 0
 fi
 
-# Path prefix to SCDV_BASE.
-SCDV_PREFIX=${SCDV_PREFIX:-${HOME}/var/scdv/${SCDV_OS_TAG}}
-
-# Honor --print-prefix as soon as SCDV_PREFIX resolves, before any side
-# effect or further platform call.
-if [ "${SCDV_PRINT_PREFIX_ONLY}" = "1" ] ; then
-  echo "SCDV_PREFIX=${SCDV_PREFIX}"
-  exit 0
-fi
-
 # The per-OS blocks assume x86_64 on Ubuntu and arm64 on macOS.
 SCDV_ARCH=${SCDV_ARCH:-$(uname -m)}
 
-if [ "${SCDV_ALLOW_UNSUPPORTED_PLATFORM}" = "1" ] ; then
+if [ "${SCDV_PRINT_PREFIX_ONLY}" = "1" ] ; then
+  :
+elif [ "${SCDV_ALLOW_UNSUPPORTED_PLATFORM}" = "1" ] ; then
   echo "warning: platform support check overridden for" \
        "'${SCDV_OS}/${SCDV_ARCH}'; continuing anyway." >&2
 else
@@ -1006,6 +998,16 @@ PYSIDE_VERSION=${PYSIDE_VERSION:-${QT_MAJOR_VER}.${QT_SUB_VER}}
 # default and runs only the explicitly selected sections.
 if [ -z "${SCDVBUILD_ALL:-}${SCDVBUILD_BASE:-}${SCDVBUILD_PYTHON:-}${SCDVBUILD_NUMPY:-}${SCDVBUILD_QT:-}" ] ; then
   SCDVBUILD_ALL=1
+fi
+
+# Path prefix to SCDV_BASE.
+SCDV_PREFIX=${SCDV_PREFIX:-${HOME}/var/scdv/${SCDV_OS_TAG}}
+
+# Honor --print-prefix as soon as SCDV_PREFIX resolves, before any side
+# effect or further platform call.
+if [ "${SCDV_PRINT_PREFIX_ONLY}" = "1" ] ; then
+  echo "SCDV_PREFIX=${SCDV_PREFIX}"
+  exit 0
 fi
 
 # An activated scdv/mmdv exports SCDV_BASE, which the assignment below would

--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -938,7 +938,7 @@ if [ "${SCDV_PRINT_DEPS_ONLY}" = "1" ] ; then
 fi
 
 # The per-OS blocks assume x86_64 on Ubuntu and arm64 on macOS.
-SCDV_ARCH=$(uname -m)
+SCDV_ARCH=${SCDV_ARCH:-$(uname -m)}
 
 if [ "${SCDV_ALLOW_UNSUPPORTED_PLATFORM}" = "1" ] ; then
   echo "warning: platform support check overridden for" \

--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -948,21 +948,9 @@ else
     ubuntu:x86_64|macos:arm64)
       ;;
 
-    ubuntu:arm64)
+    ubuntu:aarch64)
       echo "warning: some build settings currently assume x86_64 and" \
-           "may not work correctly on ubuntu/arm64." >&2
-
-      if ! { : </dev/tty ; } 2>/dev/null ; then
-        echo "no controlling tty to confirm; rerun on a supported" \
-             "OS/architecture." >&2
-        exit 1
-      fi
-
-      read -r -p "Continue anyway? [y/N] " _ans </dev/tty
-      case "${_ans}" in
-        [Yy]*) ;;
-        *) echo "aborted." >&2 ; exit 1 ;;
-      esac
+          "may not work correctly on ubuntu/aarch64." >&2
       ;;
 
     macos:x86_64)


### PR DESCRIPTION
Reject unsupported OS and architecture combinations before starting the dependency build. Allow Ubuntu on 64-bit x86 and macOS on Apple Silicon.

Related to #807

<!--
solvcon pull request guidelines.

- Subject: concise and informative.
- Description: clear prose.  Write single-line paragraphs separated by blank
  lines; GitHub reflows text to the viewer's width, so hard-wrapping at 79/80
  columns renders as ragged mid-sentence breaks.
- Draft until ready: open the PR as a draft while work is in progress.  When
  the PR is ready for review, post a global PR comment that explicitly asks for
  review.  Pushing the "ready for review" button alone is not a review request,
  because the push cannot be quoted in follow-ups.
- Inline annotations: as the author, add inline annotations on the diff to
  guide the reviewer, unless the diff is one-liner-ish.
- Issue reference: end the description with "Related to #xxx" or "For issue
  #xxx".  Do not use closing keywords (close, closes, closed, fix, fixes,
  fixed, resolve, resolves, resolved) followed by an issue number.  We do not
  let PR or commit text drive issue management.
- Authorship: PR text is treated as human-authored.  Tool assistance is OK, but
  you need to know what you wrote.

Delete this comment block before submitting.
-->

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
