### PR TITLE
Drive an agent turn as a bounded loop

### DIFF
--- a/solvcon/agent/__init__.py
+++ b/solvcon/agent/__init__.py
@@ -7,14 +7,16 @@ Agent: drive the 2D ``World`` with an AI backend, with or without a GUI.
 
 This package lives outside :mod:`solvcon.pilot` so it can also drive pure
 computation that needs no graphics.  The headless core (:mod:`_core`), the
-backend abstraction (:mod:`_backend`), and the command framework
-(:mod:`_command`) load without Qt, so they run in CI and a headless build.  A
-command family such as :mod:`solvcon.agent.draw` builds on the framework here.
+turn loop (:mod:`_turn`), the backend abstraction (:mod:`_backend`), and the
+command framework (:mod:`_command`) load without Qt, so they run in CI and a
+headless build.  A command family such as :mod:`solvcon.agent.draw` builds on
+the framework here.
 """
 
 from . import _command  # noqa: F401
-from . import _core  # noqa: F401
 from . import _backend  # noqa: F401
+from . import _turn  # noqa: F401
+from . import _core  # noqa: F401
 from . import _backends_impl  # noqa: F401
 
 # _command.py
@@ -38,6 +40,7 @@ list_of_core = [
 # _backend.py
 list_of_backend = [
     'AgentBackend',
+    'TurnRequest',
     'BackendResponse',
     'BackendSetting',
     'TransportOutcome',
@@ -48,6 +51,15 @@ list_of_backend = [
     'format_tool_surface',
     'format_history',
     'BackendRegistry',
+]
+
+# _turn.py
+list_of_turn = [
+    'Turn',
+    'StopReason',
+    'run_turn',
+    'default_scene',
+    'default_token',
 ]
 
 # _backends_impl.py
@@ -65,7 +77,7 @@ list_of_backends_impl = [
 Agent = None
 
 __all__ = (  # noqa: F822
-    list_of_command + list_of_core + list_of_backend
+    list_of_command + list_of_core + list_of_backend + list_of_turn
     + list_of_backends_impl + ['Agent']
 )
 
@@ -78,6 +90,7 @@ def _load(module, symbol_list):
 _load(_command, list_of_command)
 _load(_core, list_of_core)
 _load(_backend, list_of_backend)
+_load(_turn, list_of_turn)
 _load(_backends_impl, list_of_backends_impl)
 
 del _load

--- a/solvcon/agent/_backend.py
+++ b/solvcon/agent/_backend.py
@@ -339,6 +339,24 @@ class BackendSetting:
     tooltip: str = ""
 
 
+@dataclasses.dataclass(frozen=True)
+class TurnRequest:
+    """The arguments of :meth:`AgentBackend.send` as one frozen object.
+
+    A driver composes it on its own thread and hands it to a worker, so what
+    the backend is asked cannot shift under it while the call runs.
+    """
+
+    prompt: str
+    scene_context: str = ""
+    tool_surface: list = dataclasses.field(default_factory=list)
+    history: list = dataclasses.field(default_factory=list)
+
+    def send_to(self, backend):
+        return backend.send(self.prompt, self.scene_context,
+                            self.tool_surface, self.history)
+
+
 class TransportOutcome(enum.Enum):
     """How the exchange that carried a request ended.
 
@@ -381,14 +399,19 @@ class BackendResponse:
     status: ParseStatus = None
 
     def __post_init__(self):
-        if self.status is not None:
-            return
-        if self.commands:
-            self.status = ParseStatus.COMMANDS
-        elif self.text:
-            self.status = ParseStatus.PROSE
-        else:
-            self.status = ParseStatus.EMPTY
+        if self.status is None:
+            if self.commands:
+                self.status = ParseStatus.COMMANDS
+            elif self.text:
+                self.status = ParseStatus.PROSE
+            else:
+                self.status = ParseStatus.EMPTY
+        if (self.error and self.status is ParseStatus.EMPTY
+                and self.outcome is TransportOutcome.OK):
+            # An error carrying nothing else is a backend reporting failure
+            # through the older field alone.  Left as ok it would be
+            # indistinguishable from the model answering that it is done.
+            self.outcome = TransportOutcome.TRANSPORT
 
 
 class AgentBackend(abc.ABC):

--- a/solvcon/agent/_core.py
+++ b/solvcon/agent/_core.py
@@ -82,16 +82,20 @@ class AgentSession:
         """The recorded turns, oldest first (a copy)."""
         return list(self._transcript)
 
-    def history(self):
+    def history(self, skip=None):
         """The turns to replay to the backend, oldest first.
 
         Trailing user turns are left out: the composed request already carries
-        the current prompt.
+        the current prompt.  ``skip`` drops the turn at that index, which is
+        how a multi-step turn leaves out a prompt no longer trailing.
         """
         end = len(self._transcript)
         while end and self._transcript[end - 1].role == "user":
             end -= 1
-        return self._transcript[:end]
+        turns = self._transcript[:end]
+        if skip is not None and 0 <= skip < end:
+            del turns[skip]
+        return turns
 
     @property
     def runner(self):
@@ -111,16 +115,19 @@ class AgentSession:
         a command aimed at an id that now belongs to something else.
         """
         if world is not self.world and self._transcript:
-            self._mark("canvas switched")
+            self.mark("canvas switched")
         self.world = world
         if not self._runner_injected:
             self._runner = None
 
-    def _mark(self, text):
-        """Record ``text`` as a marker turn, unless one already closes the
-        transcript: consecutive markers say nothing the first did not."""
+    def mark(self, text):
+        """Record ``text`` as a marker turn.
+
+        A marker that would follow another is dropped; consecutive markers say
+        nothing the first did not.
+        """
         role = _backend.HistoryFormatter.MARKER_ROLE
-        if self._transcript[-1].role == role:
+        if self._transcript and self._transcript[-1].role == role:
             return
         self._transcript.append(TranscriptTurn(role=role, text=text))
 
@@ -267,11 +274,12 @@ class AgentSession:
     def record_prompt(self, prompt):
         """Record the user's ``prompt`` as a turn.
 
-        Split out of :meth:`run_turn` so a GUI can record the prompt, run the
-        slow backend call off the main thread, and finish the turn later with
-        :meth:`complete_turn` or :meth:`fail_turn`.
+        Split out so a caller can record the prompt, run the slow backend call
+        elsewhere, and finish with :meth:`complete_turn` or :meth:`fail_turn`.
+        Returns where the turn landed, which is what :meth:`history` skips.
         """
         self._transcript.append(TranscriptTurn(role="user", text=prompt))
+        return len(self._transcript) - 1
 
     def complete_turn(self, response):
         """Finish a turn from a :class:`~solvcon.agent.BackendResponse`: run
@@ -286,29 +294,8 @@ class AgentSession:
             failed=bool(response.error))
 
     def fail_turn(self, error):
-        """Record a failed agent turn for a backend that raised, so the turn
-        still lands in the transcript instead of propagating."""
+        """Record a failed agent turn for a transport or error outcome, so the
+        turn still lands in the transcript instead of propagating."""
         return self._record_agent("[error] %s" % error, failed=True)
-
-    def run_turn(self, prompt):
-        """Drive one user request end to end.
-
-        Record the user's ``prompt``, ask the backend for commands against the
-        current scene, tool surface, and the turns so far, run them, and record
-        one agent turn carrying the reply text, the commands, and their
-        results.  With no backend, record only the user turn and return
-        ``None``.  A backend that raises is recorded as a failed agent turn
-        rather than propagated, so a headless caller always gets a turn back.
-        """
-        self.record_prompt(prompt)
-        if self.backend is None:
-            return None
-        try:
-            response = self.backend.send(
-                prompt, self.scene_context(), self.tool_surface(),
-                self.history())
-        except Exception as exc:
-            return self.fail_turn("%s: %s" % (type(exc).__name__, exc))
-        return self.complete_turn(response)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/agent/_turn.py
+++ b/solvcon/agent/_turn.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+The bounded turn loop of the Agent.
+
+:class:`Turn` drives one user request to a stop under a step budget.
+:meth:`Turn.next_request` freezes scene and token on the caller's thread;
+:meth:`Turn.feed` applies the reply and decides whether to continue.  Splitting
+the two lets a GUI keep the slow backend call on a worker while state reads and
+commands stay on the owning thread.  :func:`run_turn` loops the pair on one
+thread; a budget of one is a single shot.  No Qt is imported.
+"""
+
+import enum
+import hashlib
+
+from . import _backend
+
+
+class StopReason(enum.Enum):
+    """Why a turn ended.
+
+    ``COMPLETED`` is an empty batch, ``PROSE`` is words instead of commands,
+    ``BUDGET`` is steps exhausted with work still proposed, ``STATE`` is a
+    token mismatch, and ``STOPPED`` is an external halt between steps.  The
+    four transport reasons share names with
+    :class:`~solvcon.agent.TransportOutcome`, so a non-``ok`` outcome maps
+    straight onto one.
+    """
+
+    COMPLETED = "completed"
+    PROSE = "prose"
+    BUDGET = "budget"
+    STATE = "state"
+    STOPPED = "stopped"
+    NO_BACKEND = "no backend"
+    TRANSPORT = _backend.TransportOutcome.TRANSPORT.value
+    TIMEOUT = _backend.TransportOutcome.TIMEOUT.value
+    CANCELLED = _backend.TransportOutcome.CANCELLED.value
+
+
+_NO_REQUEST = object()  # a token seam may legitimately return None
+
+
+def default_scene(session):
+    return session.scene_context()
+
+
+def default_token(session, scene):
+    """The headless state token: the bound world's identity and a digest of
+    the scene composed against it.
+
+    Identity comes first because content alone cannot tell two blank worlds
+    apart.  The world itself rides along so that identity stays valid: an id
+    outlives the object it named, and CPython hands the address straight back
+    to the next allocation.  The digest sees only what the scene summary says,
+    so a change the summary does not show does not trip it.
+    """
+    digest = hashlib.sha256(scene.encode("utf-8")).hexdigest()
+    return (id(session.world), session.world, digest)
+
+
+class Turn:
+    """One user request driven to a stop under a step budget.
+
+    Construction records the prompt and freezes the tool surface, which the
+    steps of one turn all share.  ``scene`` and ``token`` are the seams a
+    GUI replaces: ``scene(session)`` returns the scene text, and
+    ``token(session, scene)`` returns whatever must not change between
+    composing a request and applying its commands.
+    """
+
+    def __init__(self, session, prompt, budget=2, scene=None, token=None):
+        budget = int(budget)
+        if budget < 1:
+            raise ValueError("budget must be at least 1 step")
+        self._session = session
+        self._prompt = prompt
+        self._budget = budget
+        self._scene = scene if scene is not None else default_scene
+        self._token = token if token is not None else default_token
+        self._steps = 0
+        self._stop = None
+        self._pending = _NO_REQUEST
+        self._tool_surface = session.tool_surface()
+        self._index = session.record_prompt(prompt)
+
+    @property
+    def done(self):
+        return self._stop is not None
+
+    @property
+    def stop_reason(self):
+        return self._stop
+
+    def next_request(self):
+        """The next :class:`~solvcon.agent.TurnRequest`, or ``None`` when done.
+
+        Exhausting a multi-step budget records a marker so the transcript does
+        not look like the model went silent; a one-shot budget of one records
+        nothing, because a single step is the whole turn.
+        """
+        if self.done:
+            return None
+        if self._steps >= self._budget:
+            note = ("step budget of %d reached; turn ended with work still "
+                    "proposed" % self._budget) if self._budget > 1 else None
+            self._finish(StopReason.BUDGET, note)
+            return None
+        scene = self._scene(self._session)
+        self._pending = self._token(self._session, scene)
+        self._steps += 1
+        return _backend.TurnRequest(
+            prompt=self._prompt, scene_context=scene,
+            tool_surface=self._tool_surface,
+            history=self._session.history(skip=self._index))
+
+    def feed(self, response):
+        """Apply one backend reply and decide whether the turn goes on.
+
+        Returns the transcript turn it recorded, or ``None`` when it recorded
+        nothing: a state mismatch, or a reply that lands after :meth:`stop`.
+        Feeding with no outstanding request raises.
+        """
+        if self.done:
+            return None
+        if self._pending is _NO_REQUEST:
+            raise RuntimeError("feed() without an outstanding request")
+        token, self._pending = self._pending, _NO_REQUEST
+        outcome = response.outcome
+        if outcome is not _backend.TransportOutcome.OK:
+            # The model never answered, so there is nothing to fix and a
+            # retry would only spend the budget on the same failure.
+            self._stop = StopReason(outcome.value)
+            return self._session.fail_turn(
+                response.error or "backend %s" % outcome.value)
+        if token != self._token(self._session, self._scene(self._session)):
+            self._finish(
+                StopReason.STATE,
+                "canvas state changed mid-turn; %d commands dropped"
+                % len(response.commands))
+            return None
+        turn = self._session.complete_turn(response)
+        if response.status is _backend.ParseStatus.EMPTY:
+            self._stop = StopReason.COMPLETED
+        elif response.status is _backend.ParseStatus.PROSE:
+            self._stop = StopReason.PROSE
+        # MALFORMED and COMMANDS both go on: the model is shown the parse
+        # error or the command results and gets another step to act on them.
+        return turn
+
+    def stop(self, reason=StopReason.STOPPED):
+        """End the turn from outside, between steps.
+
+        An outstanding request is forgotten, so a reply that lands after it is
+        dropped rather than applied.
+        """
+        if self.done:
+            return
+        self._pending = _NO_REQUEST
+        self._finish(reason, None)
+
+    def _finish(self, reason, note):
+        self._stop = reason
+        if note:
+            self._session.mark(note)
+
+
+def run_turn(session, prompt, budget=2, scene=None, token=None):
+    """Drive one request on ``session`` to a stop and return the last turn it
+    recorded.
+
+    The backend runs on this thread.  A backend that raises is folded into a
+    transport outcome, so the loop ends the way a backend reporting one does
+    rather than propagating to a headless caller.  With no backend the prompt
+    is recorded and ``None`` comes back.
+    """
+    turn = Turn(session, prompt, budget=budget, scene=scene, token=token)
+    if session.backend is None:
+        turn.stop(StopReason.NO_BACKEND)
+        return None
+    recorded = None
+    while True:
+        request = turn.next_request()
+        if request is None:
+            return recorded
+        try:
+            response = request.send_to(session.backend)
+        except Exception as exc:
+            response = _backend.BackendResponse(
+                error="%s: %s" % (type(exc).__name__, exc),
+                outcome=_backend.TransportOutcome.TRANSPORT)
+        recorded = turn.feed(response) or recorded
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_core.py
+++ b/tests/test_agent_core.py
@@ -119,13 +119,13 @@ class _FakeBackend:
 
 
 class RunTurnTC(unittest.TestCase):
-    def test_records_user_and_agent_turns_and_runs_commands(self):
+    def test_one_step_records_user_and_agent_turns_and_runs_commands(self):
         cmds = [{"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0}]
         backend = _FakeBackend(
             agent.BackendResponse(text="drawing", commands=cmds))
         runner = _RecordingRunner()
         session = agent.AgentSession(backend=backend, runner=runner)
-        turn = session.run_turn("draw a circle")
+        turn = agent.run_turn(session, "draw a circle", budget=1)
         self.assertEqual(runner.commands, cmds)
         self.assertEqual([t.role for t in session.transcript],
                          ["user", "agent"])
@@ -136,14 +136,14 @@ class RunTurnTC(unittest.TestCase):
 
     def test_no_backend_records_only_the_user_turn(self):
         session = agent.AgentSession()
-        self.assertIsNone(session.run_turn("hello"))
+        self.assertIsNone(agent.run_turn(session, "hello"))
         self.assertEqual([t.role for t in session.transcript], ["user"])
 
     def test_empty_command_batch_builds_no_runner(self):
         backend = _FakeBackend(
             agent.BackendResponse(text="echo: hi", commands=[]))
         session = agent.AgentSession(backend=backend)
-        turn = session.run_turn("hi")
+        turn = agent.run_turn(session, "hi")
         self.assertEqual(turn.text, "echo: hi")
         self.assertEqual(turn.results, [])
         self.assertIsNone(session._runner)
@@ -154,7 +154,7 @@ class RunTurnTC(unittest.TestCase):
                 raise RuntimeError("backend down")
 
         session = agent.AgentSession(backend=_Boom())
-        turn = session.run_turn("draw")
+        turn = agent.run_turn(session, "draw")
         # The turn is recorded, not propagated, so a headless caller still
         # gets a transcript with the failure.
         self.assertEqual([t.role for t in session.transcript],
@@ -170,7 +170,7 @@ class RunTurnTC(unittest.TestCase):
         backend = _FakeBackend(agent.BackendResponse(
             commands=[{"op": "add_circle"}, {"op": "add_square"}]))
         session = _Session(backend=backend)
-        turn = session.run_turn("draw two shapes")
+        turn = agent.run_turn(session, "draw two shapes", budget=1)
         # Results line up with commands even when the runner cannot be built.
         self.assertEqual(len(turn.results), 2)
         self.assertFalse(any(r.ok for r in turn.results))
@@ -180,7 +180,7 @@ class RunTurnTC(unittest.TestCase):
     def test_backend_error_is_folded_into_the_reply(self):
         backend = _FakeBackend(agent.BackendResponse(error="claude timed out"))
         session = agent.AgentSession(backend=backend)
-        turn = session.run_turn("draw")
+        turn = agent.run_turn(session, "draw")
         self.assertIn("claude timed out", turn.text)
 
     def test_bind_world_drops_the_lazy_runner(self):
@@ -271,8 +271,8 @@ class HistoryTC(unittest.TestCase):
     def test_run_turn_hands_the_earlier_turns_to_the_backend(self):
         backend = _FakeBackend(agent.BackendResponse(text="ok"))
         session = agent.AgentSession(backend=backend)
-        session.run_turn("draw a truck")
-        session.run_turn("move it right")
+        agent.run_turn(session, "draw a truck")
+        agent.run_turn(session, "move it right")
         prompt, _, _, history = backend.seen
         self.assertEqual(prompt, "move it right")
         self.assertEqual([turn.text for turn in history],

--- a/tests/test_agent_turn.py
+++ b/tests/test_agent_turn.py
@@ -1,0 +1,287 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Tests for the bounded turn loop."""
+
+import unittest
+
+import solvcon
+from solvcon import agent
+
+
+_TOOLS = [{"name": "add_circle", "category": "create",
+           "description": "add a circle"}]
+
+
+class _Runner:
+    """Command runner that fails whatever op it was told to fail."""
+
+    def __init__(self, failing=()):
+        self.failing = set(failing)
+        self.commands = []
+
+    def run(self, command):
+        self.commands.append(command)
+        op = agent.op_of(command)
+        if op in self.failing:
+            return agent.CommandResult(op, False, error="%s: bad args" % op)
+        return agent.CommandResult(op, True, value={"shape_id": 1})
+
+    def tool_definitions(self):
+        return _TOOLS
+
+    def commands_by_category(self):
+        return {"create": ["add_circle"], "delete": []}
+
+
+class _ScriptedBackend(agent.AgentBackend):
+    """Backend that replays canned replies and records what it was asked.
+
+    A reply is either the text a model would have printed, run through the
+    real :class:`ToolCallParser`, or a ready :class:`BackendResponse` for the
+    transport outcomes no text can express.  A script that runs short raises,
+    which says the test asked for a step it did not plan for.
+    """
+
+    name = "scripted (offline)"
+
+    def __init__(self, replies=()):
+        self.replies = list(replies)
+        self.requests = []
+
+    def available(self):
+        return True
+
+    def send(self, prompt, scene_context, tool_surface, history=()):
+        self.requests.append(agent.TurnRequest(
+            prompt=prompt, scene_context=scene_context,
+            tool_surface=list(tool_surface or ()), history=list(history)))
+        reply = self.replies.pop(0)
+        if isinstance(reply, agent.BackendResponse):
+            return reply
+        return agent.ToolCallParser.parse_reply(reply).response(reply)
+
+
+def _session(replies, runner=None, **kwargs):
+    return agent.AgentSession(
+        backend=_ScriptedBackend(replies),
+        runner=runner if runner is not None else _Runner(), **kwargs)
+
+
+def _ask(session, turn):
+    """One step's reply, composed and sent the way a driver would."""
+    return turn.next_request().send_to(session.backend)
+
+
+def _drain(session, turn):
+    """Run ``turn`` to its stop."""
+    while True:
+        request = turn.next_request()
+        if request is None:
+            return
+        turn.feed(request.send_to(session.backend))
+
+
+class TurnLoopTC(unittest.TestCase):
+    def test_model_fixes_its_own_failed_command_within_budget(self):
+        runner = _Runner(failing={"add_blob"})
+        session = _session(['[{"op": "add_blob"}]',
+                            '[{"op": "add_circle"}]',
+                            "[]"], runner=runner)
+        agent.run_turn(session, "draw a circle", budget=4)
+        self.assertEqual([agent.op_of(c) for c in runner.commands],
+                         ["add_blob", "add_circle"])
+        # The failed command's error is what the second step was composed
+        # against, so the model could see what to fix.
+        second = session.backend.requests[1]
+        self.assertIn("bad args",
+                      agent.format_history(second.history))
+
+    def test_empty_batch_ends_the_turn_as_completion(self):
+        session = _session(['[{"op": "add_circle"}]', "[]",
+                            '[{"op": "add_circle"}]'])
+        turn = agent.Turn(session, "draw", budget=4)
+        _drain(session, turn)
+        self.assertEqual(turn.stop_reason, agent.StopReason.COMPLETED)
+        self.assertEqual(len(session.backend.requests), 2)
+        self.assertEqual(len(session.backend.replies), 1)
+
+    def test_prose_ends_the_turn_with_the_text_recorded(self):
+        session = _session(["I cannot draw that."])
+        turn = agent.Turn(session, "draw", budget=4)
+        _drain(session, turn)
+        self.assertEqual(turn.stop_reason, agent.StopReason.PROSE)
+        self.assertIn("I cannot draw that.", session.transcript[-1].text)
+
+    def test_malformed_costs_a_step_and_retries_with_the_error_shown(self):
+        session = _session(['[{"op": "add_circle",}]',
+                            '[{"op": "add_circle"}]', "[]"])
+        turn = agent.Turn(session, "draw", budget=4)
+        _drain(session, turn)
+        self.assertEqual(turn.stop_reason, agent.StopReason.COMPLETED)
+        self.assertEqual(len(session.backend.requests), 3)
+        retry = session.backend.requests[1]
+        self.assertIn("malformed", agent.format_history(retry.history))
+
+    def test_transport_outcome_aborts_with_no_retry(self):
+        gone = agent.BackendResponse(
+            error="claude exit 1", outcome=agent.TransportOutcome.TRANSPORT)
+        session = _session([gone, '[{"op": "add_circle"}]'])
+        turn = agent.Turn(session, "draw", budget=4)
+        _drain(session, turn)
+        self.assertEqual(turn.stop_reason, agent.StopReason.TRANSPORT)
+        self.assertEqual(len(session.backend.requests), 1)
+        self.assertIn("claude exit 1", session.transcript[-1].text)
+        self.assertTrue(session.transcript[-1].failed)
+
+    def test_an_error_without_an_outcome_does_not_read_as_completion(self):
+        # A backend that fills only the older error field leaves the outcome
+        # ok and the batch empty, which must not pass for the model saying it
+        # has finished.
+        session = _session([agent.BackendResponse(error="claude timed out")])
+        turn = agent.Turn(session, "draw", budget=4)
+        _drain(session, turn)
+        self.assertNotEqual(turn.stop_reason, agent.StopReason.COMPLETED)
+        self.assertTrue(session.transcript[-1].failed)
+
+    def test_cancelled_and_timeout_map_to_their_own_reasons(self):
+        for outcome, reason in (
+                (agent.TransportOutcome.TIMEOUT, agent.StopReason.TIMEOUT),
+                (agent.TransportOutcome.CANCELLED,
+                 agent.StopReason.CANCELLED)):
+            session = _session(
+                [agent.BackendResponse(error="stopped", outcome=outcome)])
+            turn = agent.Turn(session, "draw", budget=4)
+            _drain(session, turn)
+            self.assertEqual(turn.stop_reason, reason)
+
+    def test_unknown_op_fails_alone_without_killing_its_batch(self):
+        # The op the model invented is not caught while parsing, so the good
+        # command in the same batch still runs and only the bad one fails.
+        world = solvcon.WorldFp64()
+        session = agent.AgentSession(
+            world=world,
+            backend=_ScriptedBackend([
+                '[{"op": "add_circle", "cx": 0, "cy": 0, "r": 1},'
+                ' {"op": "delete_universe"}]', "[]"]))
+        turn = agent.Turn(session, "draw", budget=4)
+        _drain(session, turn)
+        results = session.transcript[1].results
+        self.assertEqual([result.ok for result in results], [True, False])
+        self.assertIn("unknown op", results[1].error)
+        self.assertEqual(world.nshape, 1)
+
+    def test_budget_exhaustion_is_recorded(self):
+        session = _session(['[{"op": "add_circle"}]'] * 4)
+        turn = agent.Turn(session, "draw", budget=2)
+        _drain(session, turn)
+        self.assertEqual(turn.stop_reason, agent.StopReason.BUDGET)
+        self.assertEqual(len(session.backend.requests), 2)
+        last = session.transcript[-1]
+        self.assertEqual(last.role, agent.HistoryFormatter.MARKER_ROLE)
+        self.assertIn("step budget", last.text)
+
+    def test_one_shot_budget_records_no_budget_marker(self):
+        session = _session(['[{"op": "add_circle"}]'])
+        turn = agent.Turn(session, "draw", budget=1)
+        _drain(session, turn)
+        self.assertEqual(turn.stop_reason, agent.StopReason.BUDGET)
+        self.assertEqual([t.role for t in session.transcript],
+                         ["user", "agent"])
+
+    def test_stop_between_steps_leaves_a_clean_transcript(self):
+        session = _session(['[{"op": "add_circle"}]'] * 2)
+        turn = agent.Turn(session, "draw", budget=4)
+        turn.feed(_ask(session, turn))
+        turn.stop()
+        self.assertTrue(turn.done)
+        self.assertEqual(turn.stop_reason, agent.StopReason.STOPPED)
+        self.assertIsNone(turn.next_request())
+        self.assertEqual([t.role for t in session.transcript],
+                         ["user", "agent"])
+
+
+class StateTokenTC(unittest.TestCase):
+    """The seam that keeps a reply from landing on the wrong target."""
+
+    def test_mismatch_drops_the_commands_and_ends_the_turn(self):
+        runner = _Runner()
+        session = _session(['[{"op": "add_circle"}]'], runner=runner)
+        moved = [False]
+        turn = agent.Turn(session, "draw", budget=4,
+                          token=lambda s, scene: moved[0])
+        request = turn.next_request()
+        moved[0] = True  # the canvas changed while the backend was running
+        turn.feed(request.send_to(session.backend))
+        self.assertEqual(turn.stop_reason, agent.StopReason.STATE)
+        self.assertEqual(runner.commands, [])
+        last = session.transcript[-1]
+        self.assertEqual(last.role, agent.HistoryFormatter.MARKER_ROLE)
+        self.assertIn("changed mid-turn", last.text)
+
+    def test_a_token_of_none_is_a_token_not_a_missing_request(self):
+        # A GUI seam may have nothing to key on, and a turn whose token is
+        # None must still feed rather than raise into a Qt slot.
+        session = _session(["[]"])
+        turn = agent.Turn(session, "draw", token=lambda s, scene: None)
+        turn.feed(_ask(session, turn))
+        self.assertEqual(turn.stop_reason, agent.StopReason.COMPLETED)
+
+    def test_default_token_separates_two_blank_worlds(self):
+        class _World:
+            def describe_state(self, level="basic"):
+                return '{"shapes": []}'
+
+        session = agent.AgentSession(world=_World(), runner=_Runner())
+        first = agent.default_token(session, session.scene_context())
+        session.world = _World()
+        second = agent.default_token(session, session.scene_context())
+        # Identical scenes, different worlds: content alone cannot tell them
+        # apart, so identity has to be in the token.
+        self.assertNotEqual(first, second)
+
+
+class TurnGuardTC(unittest.TestCase):
+    def test_a_late_reply_after_stop_is_dropped_not_raised(self):
+        # The worker's reply lands after the user hit Stop, in a Qt slot where
+        # an exception has nowhere to go.  Nothing of it may be applied.
+        runner = _Runner()
+        session = _session(['[{"op": "add_circle"}]'], runner=runner)
+        turn = agent.Turn(session, "draw")
+        request = turn.next_request()
+        turn.stop()
+        self.assertIsNone(turn.feed(request.send_to(session.backend)))
+        self.assertEqual(runner.commands, [])
+        self.assertEqual([t.role for t in session.transcript], ["user"])
+
+    def test_the_prompt_is_not_replayed_beside_itself(self):
+        # From step 2 on the prompt is no longer the trailing user turn, so
+        # the history would repeat what the request tail already carries.
+        session = _session(['[{"op": "add_circle"}]', "[]"])
+        agent.run_turn(session, "draw a circle")
+        replayed = agent.format_history(session.backend.requests[1].history)
+        self.assertNotIn("user:", replayed)
+        self.assertIn("add_circle", replayed)
+
+
+class RunTurnWrapperTC(unittest.TestCase):
+    def test_it_loops_until_the_model_stops(self):
+        runner = _Runner()
+        session = _session(['[{"op": "add_circle"}]',
+                            '[{"op": "add_circle"}]', "[]"], runner=runner)
+        agent.run_turn(session, "draw two circles", budget=4)
+        self.assertEqual(len(runner.commands), 2)
+        self.assertEqual([t.role for t in session.transcript],
+                         ["user", "agent", "agent", "agent"])
+
+    def test_the_second_step_carries_the_first_step_results(self):
+        session = _session(['[{"op": "add_circle"}]', "[]"])
+        agent.run_turn(session, "draw a circle")
+        second = session.backend.requests[1]
+        replayed = agent.format_history(second.history)
+        self.assertIn("add_circle", replayed)
+        self.assertIn("shape_id", replayed)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`Turn` in `solvcon/agent/_turn.py` drives one user request to a stop under a step budget. A turn can now take more than one exchange, so the model sees the result of its own commands.

A turn was a single exchange: ask once, apply the reply, stop. A command that failed ended the turn instead of becoming something the model could correct. A GUI could not pump the exchange without blocking its own thread.

`next_request` composes the request on the caller's thread and freezes the scene and a state token into a `TurnRequest`. `feed` re-checks that token, applies the reply, and decides whether the turn continues. The split keeps the slow backend call on a worker, while every state read and every command stays on the thread that owns the state. `run_turn` loops the pair for a caller that can block. The default budget of two buys one action plus one repair; a budget of one is a single shot.

The stop rules read the statuses that the previous step added. A non-`ok` outcome, an empty batch, and prose each end the turn. A malformed batch costs a step and returns to the model with the parse error. A command that fails is an observation the model can act on. Exhausted steps get a marker, not silence.

The state token is the seam the pilot will use. Headless it holds the identity of the bound world, the world object, and a digest of the scene. It keeps the object because CPython gives a freed address to the next allocation. If the token changes between request and reply, the loop drops the commands and ends the turn. A reply cannot land on a canvas the user changed.

Three smaller changes come with the loop. `BackendResponse` resolves an error-only reply to `transport` instead of `empty`, which a driver could not tell from the model saying it is done. `history` gains `skip`, so the loop leaves out the prompt it recorded once that prompt is no longer trailing. `mark` is public and guards an empty transcript, where it raised `IndexError` before. `AgentSession.run_turn` is removed rather than kept as a second way to drive a turn; nothing called it.

The pilot GUI does not use `Turn` yet. Step 4 of #1206 moves it on: the panel calls `next_request` and `feed` on the Qt main thread and keeps `send` in the worker. That step also replaces the token with the active window, the world, and the view transform, and wires a Stop control to `stop()`. Step 5 adds the headless entry point and the scripted smoke tests. Both call `run_turn`, and the error-recovery test needs the step budget.

The scripted backend in the tests is a private double, not a shipped class. Of about 620 diff lines, `tests/test_agent_turn.py` is close to half.

`make pytest` passes: 2142 passed, 14 skipped, 3 xfailed. `make lint` passes.

Related to #1136, #966.
