### PR TITLE
Need no residual and steady state detector for obsrefl

### DIFF
--- a/solvcon/multidim/euler/_field.py
+++ b/solvcon/multidim/euler/_field.py
@@ -43,13 +43,6 @@ class EulerField(object):
         return (('density',) + self.MOMENTA[:self.svr.ndim]
                 + ('total_energy',))
 
-    def conserved_column(self, val):
-        """Return the column of :attr:`conserved` carrying ``val``."""
-        conserveds = self.conserveds
-        if val not in conserveds:
-            raise ValueError(f"unknown conserved variable '{val}'")
-        return conserveds.index(val)
-
     @property
     def conserved(self):
         """The newest order-0 solution, ``[ncell, neq]``.
@@ -134,33 +127,5 @@ class EulerField(object):
     def calc_overall_mass(self):
         """Return the density integrated over the whole domain."""
         return float(np.sum(self.density * self.volume))
-
-    def calc_residual(self, val='density'):
-        r"""Return the root-mean-square change of a conserved variable per
-        unit time.
-
-        .. math::
-
-            r = \frac{2}{\Delta t}
-                \sqrt{\frac{1}{N} \sum_{i=1}^{N}
-                      \left(u^{n}_{i} - u^{c}_{i}\right)^{2}}
-
-        ``val`` is one of :attr:`conserveds`.  Only a conserved variable
-        has an older value to difference against: a CESE substep advances
-        half a :attr:`EulerCore.time_increment` :math:`\Delta t` and leaves
-        the solution it started from in ``so0c``, so the change against
-        ``so0n`` spans that half step.  Averaging over the :math:`N` body
-        cells keeps meshes of different size comparable, and dividing by
-        the half step makes a rate, in the unit of :math:`u` per unit time,
-        that a run marching toward a steady state drives to zero.
-
-        Density is the default because it is the variable every wave of
-        the Euler system carries, so it settles last.
-        """
-        icol = self.conserved_column(val)
-        old = self.svr.so0c
-        change = self.conserved[:, icol] - old.ndarray[old.nghost:, icol]
-        return float(np.sqrt(np.mean(change * change))
-                     / (self.svr.time_increment / 2.0))
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/apps/obsrefl/_session.py
+++ b/solvcon/pilot/apps/obsrefl/_session.py
@@ -3,18 +3,23 @@
 
 
 """
-Run the oblique-shock reflection to a steady state.
+Drive one oblique-shock reflection run.
 
-A reflection run is one long march that has to be watched: it is driven a
-chunk at a time so a caller stays responsive between chunks, it has to keep
-what each chunk measured, and it has to know when marching further buys
-nothing.  :class:`ReflectionSession` holds all three, so the GUI timer, a
+A reflection run is one long march that has to be watched, so it is driven a
+chunk at a time: a caller stays responsive between chunks and keeps what each
+one measured.  :class:`ReflectionSession` holds both, so the GUI timer, a
 script loop, and a test drive the same run the same way::
 
     sess = ReflectionSession(mach=3.0, angle=10.0)
     while not sess.finished:
         sess.advance()
     sess.zone_info()
+
+The march is time-accurate, and the session judges it against the analytic
+solution rather than against itself: what a run is worth is what
+:mod:`._analytic` measures of its field, not how little the field moved
+between two steps.  A run therefore ends on the step cap or on request, and
+how long to march is the caller's to choose.
 """
 
 import collections
@@ -26,13 +31,13 @@ __all__ = [
     'ReflectionSession',
     'RunHistory',
     'RunRecord',
-    'SteadyDetector',
 ]
 
 
-#: What one marched chunk leaves behind: the step it ended on, the density
-#: residual there, and the total mass, which flattens as the run settles.
-RunRecord = collections.namedtuple('RunRecord', ['step', 'residual', 'mass'])
+#: What one marched chunk leaves behind: the step it ended on and the mass the
+#: domain held there, which the inflow and the outflow move as the flow
+#: develops.
+RunRecord = collections.namedtuple('RunRecord', ['step', 'mass'])
 
 
 class RunHistory(object):
@@ -49,9 +54,9 @@ class RunHistory(object):
     def __len__(self):
         return len(self.records)
 
-    def append(self, step, residual, mass):
+    def append(self, step, mass):
         """Record one chunk; returns the new :class:`RunRecord`."""
-        record = RunRecord(step, residual, mass)
+        record = RunRecord(step, mass)
         self.records.append(record)
         return record
 
@@ -61,57 +66,9 @@ class RunHistory(object):
         return self.records[-1] if self.records else None
 
     @property
-    def residuals(self):
-        """The ``(step, residual)`` pairs, oldest first."""
-        return [(rec.step, rec.residual) for rec in self.records]
-
-    @property
     def masses(self):
         """The ``(step, mass)`` pairs, oldest first."""
         return [(rec.step, rec.mass) for rec in self.records]
-
-
-class SteadyDetector(object):
-    """Decide when a marching run has settled.
-
-    Two conditions have to hold together, because either alone misreads a
-    run.  The residual has to have fallen to :attr:`drop` times the largest
-    residual the run has seen, which keeps the slow start of a run that has
-    not built its shocks yet from passing for convergence.  It also has to
-    have stopped improving for :attr:`patience` consecutive chunks, which
-    keeps a transient dip from doing the same.  A chunk improves when it
-    lowers the best residual so far by more than :attr:`rtol`; anything less
-    counts as flat.
-
-    :ivar drop: Fraction of the peak residual a steady run reaches.
-    :ivar rtol: Relative fall that still counts as an improvement.
-    :ivar patience: Flat chunks a plateau takes to be believed.
-    :ivar peak: Largest residual seen.
-    :ivar best: Smallest residual seen.
-    :ivar flat: Chunks since the last improvement.
-    :ivar steady: Whether the newest chunk is steady.
-    """
-
-    def __init__(self, drop=1.e-2, rtol=1.e-3, patience=20):
-        self.drop = drop
-        self.rtol = rtol
-        self.patience = patience
-        self.peak = 0.0
-        self.best = float('inf')
-        self.flat = 0
-        self.steady = False
-
-    def update(self, residual):
-        """Fold one chunk's residual in; returns :attr:`steady`."""
-        self.peak = max(self.peak, residual)
-        if residual < self.best * (1.0 - self.rtol):
-            self.flat = 0
-        else:
-            self.flat += 1
-        self.best = min(self.best, residual)
-        self.steady = (self.flat >= self.patience
-                       and residual <= self.peak * self.drop)
-        return self.steady
 
 
 class ReflectionSession(object):
@@ -119,16 +76,14 @@ class ReflectionSession(object):
 
     Building the session builds the flow constants, the mesh, and the solver,
     so a session exists only around a run that is ready to march.  Each
-    :meth:`advance` marches a chunk and records what it measured; the run
-    ends on the steady state, on the step cap, or on :meth:`stop`, and
-    :attr:`stop_reason` says which.
+    :meth:`advance` marches a chunk and records what it measured; the run ends
+    on the step cap or on :meth:`stop`, and :attr:`stop_reason` says which.
 
     :ivar shock: The :class:`~._driver.ObliqueShock` being marched.
     :ivar analysis: The :class:`~._analytic.Reflection` of its field.
     :ivar history: The :class:`RunHistory` of the chunks marched so far.
-    :ivar detector: The :class:`SteadyDetector` ending the run.
     :ivar steps_per_chunk: Full CESE steps one :meth:`advance` marches.
-    :ivar max_steps: Steps after which the run ends whatever the residual.
+    :ivar max_steps: Steps after which the run ends.
     :ivar step: Steps marched so far.
     :ivar stop_reason: What ended the run, or None while it runs.
     """
@@ -150,7 +105,6 @@ class ReflectionSession(object):
                                    nx=nx, ny=ny)
         self.analysis = Reflection(self.shock)
         self.history = RunHistory()
-        self.detector = SteadyDetector()
         self.steps_per_chunk = steps_per_chunk
         self.max_steps = max_steps
         self.step = 0
@@ -166,11 +120,6 @@ class ReflectionSession(object):
         """Whether the run has ended."""
         return self.stop_reason is not None
 
-    @property
-    def steady(self):
-        """Whether the run ended on the steady state."""
-        return 'steady' == self.stop_reason
-
     def advance(self):
         """March the next chunk and record it.
 
@@ -182,11 +131,9 @@ class ReflectionSession(object):
         steps = min(self.steps_per_chunk, self.max_steps - self.step)
         self.shock.march(steps)
         self.step += steps
-        record = self.history.append(self.step, self.field.calc_residual(),
+        record = self.history.append(self.step,
                                      self.field.calc_overall_mass())
-        if self.detector.update(record.residual):
-            self.stop_reason = 'steady'
-        elif self.step >= self.max_steps:
+        if self.step >= self.max_steps:
             self.stop_reason = 'cap'
         return record
 
@@ -200,11 +147,6 @@ class ReflectionSession(object):
         """End the run where it stands, keeping the field and the history."""
         if not self.finished:
             self.stop_reason = 'stopped'
-
-    def residual(self):
-        """The residual of the newest chunk, or nan before the first."""
-        record = self.history.last
-        return record.residual if record else float('nan')
 
     def zone_info(self, name='density'):
         """See :meth:`Reflection.zone_info`."""

--- a/tests/apps/obsrefl/test_session.py
+++ b/tests/apps/obsrefl/test_session.py
@@ -4,55 +4,17 @@
 
 """The run session of the oblique-shock reflection.
 
-The stop rule is checked on residual sequences rather than on runs, so the
-cases that matter (a run still falling, a plateau that never converged, a
-transient dip) are all reachable without marching anything.  One coarse run
-is then marched to its steady state, which is what pins the session, the
-analysis, and the solver together against the analytic answer.
+The chunking is checked on a mesh coarse enough to march in milliseconds, and
+one such run is then marched to its step cap, which is what pins the session,
+the analysis, and the solver together against the analytic answer.  That
+answer is the only thing a run is judged by: the march is time-accurate, so
+there is nothing to be said for a step that changed the field little.
 """
 
-import math
 import unittest
 
 from solvcon.pilot.apps.obsrefl import ReflectionSession
-from solvcon.pilot.apps.obsrefl._session import RunHistory, SteadyDetector
-
-
-class SteadyDetectorTC(unittest.TestCase):
-    """The stop rule needs both of its conditions."""
-
-    def _feed(self, residuals, **kw):
-        kw.setdefault('patience', 3)
-        detector = SteadyDetector(**kw)
-        for residual in residuals:
-            detector.update(residual)
-        return detector
-
-    def test_a_falling_residual_keeps_the_run_going(self):
-        # Every chunk improves on the last, so the plateau never starts even
-        # though the residual has long passed the drop.
-        detector = self._feed([0.5 ** it for it in range(40)])
-        self.assertFalse(detector.steady)
-        self.assertEqual(0, detector.flat)
-
-    def test_a_plateau_short_of_the_drop_keeps_the_run_going(self):
-        # A run stuck at a tenth of its peak has flattened, but it has not
-        # converged; only the drop condition can tell the two apart.
-        detector = self._feed([1.0] + [0.1] * 20)
-        self.assertFalse(detector.steady)
-        self.assertGreater(detector.flat, detector.patience)
-
-    def test_a_plateau_below_the_drop_ends_the_run(self):
-        # The run has to sit flat for the whole patience: three chunks after
-        # the improving one, not two.
-        self.assertFalse(self._feed([1.0, 1.e-3, 1.e-3, 1.e-3]).steady)
-        self.assertTrue(self._feed([1.0, 1.e-3, 1.e-3, 1.e-3, 1.e-3]).steady)
-
-    def test_a_dip_does_not_end_the_run(self):
-        # A transient dip below the drop is not a steady state; the residual
-        # climbing back leaves the run above the drop again.
-        detector = self._feed([1.0, 1.e-3, 1.e-3, 1.e-3, 0.5, 0.5, 0.5])
-        self.assertFalse(detector.steady)
+from solvcon.pilot.apps.obsrefl._session import RunHistory
 
 
 class RunHistoryTC(unittest.TestCase):
@@ -63,10 +25,9 @@ class RunHistoryTC(unittest.TestCase):
         history = RunHistory(length=3)
         self.assertIsNone(history.last)
         for step in range(1, 6):
-            history.append(step, 1.0 / step, 1.0)
+            history.append(step, 1.0 / step)
         self.assertEqual(3, len(history))
-        self.assertEqual([(3, 1 / 3), (4, 0.25), (5, 0.2)],
-                         history.residuals)
+        self.assertEqual([(3, 1 / 3), (4, 0.25), (5, 0.2)], history.masses)
         self.assertEqual(5, history.last.step)
 
 
@@ -84,7 +45,6 @@ class ReflectionSessionTC(unittest.TestCase):
         self.assertFalse(sess.finished)
         self.assertIsNone(sess.stop_reason)
         self.assertEqual(0, len(sess.history))
-        self.assertTrue(math.isnan(sess.residual()))
         # The driver is built through the solver, and the analysis reads it.
         self.assertEqual(sess.shock.mesh.ncell, sess.shock.svr.ncell)
         self.assertIs(sess.field, sess.analysis.field)
@@ -94,10 +54,8 @@ class ReflectionSessionTC(unittest.TestCase):
         record = sess.advance()
         self.assertEqual(3, sess.step)
         self.assertEqual(3, record.step)
-        self.assertEqual(record.residual, sess.residual())
-        self.assertGreater(record.residual, 0.0)
         self.assertAlmostEqual(record.mass, sess.field.calc_overall_mass())
-        self.assertEqual([(3, record.residual)], sess.history.residuals)
+        self.assertEqual([(3, record.mass)], sess.history.masses)
         self.assertFalse(sess.finished)
 
     def test_the_last_chunk_lands_on_the_step_cap(self):
@@ -108,7 +66,6 @@ class ReflectionSessionTC(unittest.TestCase):
         self.assertEqual(4, sess.advance().step)
         self.assertEqual(6, sess.advance().step)
         self.assertEqual('cap', sess.stop_reason)
-        self.assertFalse(sess.steady)
         self.assertIsNone(sess.advance())
         self.assertEqual(6, sess.step)
 
@@ -125,33 +82,31 @@ class ReflectionSessionTC(unittest.TestCase):
         self.assertEqual('stopped', sess.stop_reason)
 
 
-class SteadyRunTC(unittest.TestCase):
-    """One run marched all the way to its steady state.
+class AnalyticAgreementTC(unittest.TestCase):
+    """One run marched to its cap and judged against the analytic answer.
 
-    This is the check that the reflection is solved at all: the session has
-    to end itself on the steady state, and the field it settles on has to be
-    the analytic three-zone answer.
+    This is the check that the reflection is solved at all: the field the run
+    reaches has to be the analytic three-zone answer, with the shock standing
+    where the relations put it.
 
     Two things keep it to a few hundredths of a second.  The mesh is coarse,
-    and a coarse mesh takes a long step: the run below sits at a CFL of
-    about 0.76 with a time increment twenty times the default, so it covers
-    the same flow time in a twentieth of the steps.  The stop rule is also
-    made less patient, since a plateau still has to fall two orders of
-    magnitude from the peak to count, and waiting out twenty flat chunks
-    only confirms what five already showed.
+    and a coarse mesh takes a long step: the run below sits at a CFL of about
+    0.76 with a time increment twenty times the default, so it covers the same
+    flow time in a twentieth of the steps.  The cap is then set from
+    measurement rather than guessed: this case reaches its final field well
+    inside two hundred steps, and the errors below do not move when the cap is
+    raised to twelve hundred.
 
     The errors are percents on a mesh this coarse.  They shrink with
     refinement, which is what a resolution control is for, and the bounds
     below are loose enough to leave that to the panel rather than pin it.
     """
 
-    def test_a_coarse_run_settles_onto_the_analytic_answer(self):
+    def test_a_coarse_run_reaches_the_analytic_answer(self):
         sess = ReflectionSession(nx=12, ny=4, time_increment=4.e-2,
-                                 steps_per_chunk=20, max_steps=2000)
-        sess.detector = SteadyDetector(patience=5)
-        self.assertEqual('steady', sess.run())
-        self.assertLess(sess.step, sess.max_steps)
-        self.assertEqual(sess.step // 20, len(sess.history))
+                                 steps_per_chunk=20, max_steps=200)
+        self.assertEqual('cap', sess.run())
+        self.assertEqual(sess.max_steps // 20, len(sess.history))
         # The long step is only legitimate below a CFL of one.
         cflc = sess.shock.svr.cflc
         self.assertLess(float(cflc.ndarray[cflc.nghost:].max()), 1.0)

--- a/tests/multidim/euler/test_field.py
+++ b/tests/multidim/euler/test_field.py
@@ -4,8 +4,8 @@
 
 """The body-cell views of the multi-dimensional Euler solution.
 
-The mesh is three triangles fanning around the origin, small enough that
-the body slice, the cell volumes, and the residual are all known by hand.
+The mesh is three triangles fanning around the origin, small enough that the
+body slice, the cell volumes, and the mass over them are all known by hand.
 """
 
 import math
@@ -23,7 +23,7 @@ class _EulerFieldTB:
 
     #: Total area of the three triangles.
     AREA = 2.0
-    #: Full CESE step; a substep advances half of it.
+    #: Full CESE step the core is built with.
     DT = 1.e-2
 
     def setUp(self):
@@ -40,11 +40,8 @@ class _EulerFieldTB:
         self.field = euler.EulerField(self.svr, mh)
 
     def _seed(self, name, densities):
-        self._seed_column(name, 0, densities)
-
-    def _seed_column(self, name, icol, values):
         arr = getattr(self.svr, name)
-        arr.ndarray[arr.nghost:, icol] = values
+        arr.ndarray[arr.nghost:, 0] = densities
 
 
 class EulerFieldTC(_EulerFieldTB, unittest.TestCase):
@@ -78,42 +75,12 @@ class EulerFieldTC(_EulerFieldTB, unittest.TestCase):
         self._seed('so0n', (2.0, 2.0, 2.0))
         assert_almost_equal(self.field.calc_overall_mass(), 2.0 * self.AREA)
 
-    def test_residual_is_the_rms_change_over_the_half_step(self):
-        self._seed('so0c', (1.0, 1.0, 1.0))
-        self._seed('so0n', (1.1, 0.9, 1.0))
-        expected = math.sqrt((0.1 ** 2 + 0.1 ** 2) / 3.0) / (self.DT / 2.0)
-        assert_almost_equal(self.field.calc_residual(), expected)
-
-    def test_residual_vanishes_on_a_frozen_solution(self):
-        self._seed('so0c', (1.0, 2.0, 3.0))
-        self._seed('so0n', (1.0, 2.0, 3.0))
-        self.assertEqual(self.field.calc_residual(), 0.0)
-
-    def test_residual_of_another_conserved_variable(self):
-        # Every column of the solution has an older value to difference
-        # against, and a run settles them one at a time; density alone can
-        # sit still while the momentum still moves.
-        self._seed('so0c', (1.0, 1.0, 1.0))
-        self._seed('so0n', (1.0, 1.0, 1.0))
-        self._seed_column('so0c', 2, (0.0, 0.0, 0.0))
-        self._seed_column('so0n', 2, (0.3, -0.3, 0.0))
-        self.assertEqual(self.field.calc_residual('density'), 0.0)
-        expected = math.sqrt((0.3 ** 2 + 0.3 ** 2) / 3.0) / (self.DT / 2.0)
-        assert_almost_equal(self.field.calc_residual('momy'), expected)
-
     def test_the_conserved_variables_span_the_solution(self):
         # The names are the columns of the solution table, so a 2D run
         # carries the two momentum components between density and energy.
         self.assertEqual(('density', 'momx', 'momy', 'total_energy'),
                          self.field.conserveds)
         self.assertEqual(self.svr.neq, len(self.field.conserveds))
-        self.assertEqual(3, self.field.conserved_column('total_energy'))
-
-    def test_residual_of_a_derived_field_is_refused(self):
-        # Pressure is derived, not marched, so nothing holds its older
-        # value to difference against.
-        with self.assertRaises(ValueError):
-            self.field.calc_residual('pressure')
 
 
 class DerivedFieldTC(_EulerFieldTB, unittest.TestCase):


### PR DESCRIPTION
For issue #1269.

The time-accurate solver using the CESE method should not use a residual calculator based on the half time step.  The staggering stencil requires a full time step (composed of two half time step) for the desired error convergence.  The numerical method does not guarantee accuracy between two half time steps.

As such, the steady state detector is not useful.  All related code and testing are removed.