### PR TITLE
Rename the `MM_` macros and the `MMGH_` repository variables

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -21,9 +21,9 @@ concurrency:
 jobs:
 
   check_skip:
-    # A fork inherits no MMGH_NIGHTLY, so this gate stops the nightly cron
+    # A fork inherits no SCGH_NIGHTLY, so this gate stops the nightly cron
     # from allocating a runner there.
-    if: github.event_name != 'schedule' || vars.MMGH_NIGHTLY == 'enable'
+    if: github.event_name != 'schedule' || (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'
     uses: ./.github/workflows/check_skip_ci.yml
     permissions:
       contents: read
@@ -38,15 +38,15 @@ jobs:
       needs.check_skip.outputs.skip != 'true' && (
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
-       (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
-        contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
-      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable'))
+       ((vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH) == '*' ||
+        contains(vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
+      (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'))
 
     name: standalone_buffer_${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_STANDALONE_BUFFER || '10') }}
+    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_STANDALONE_BUFFER || vars.MMGH_TIMEOUT_STANDALONE_BUFFER || '10') }}
 
     strategy:
       matrix:
@@ -100,16 +100,16 @@ jobs:
       needs.check_skip.outputs.skip != 'true' && (
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
-       (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
-        contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
+       ((vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH) == '*' ||
+        contains(vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
       (github.event_name == 'schedule' &&
-      vars.MMGH_NIGHTLY == 'enable'))
+      (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'))
 
     name: build_${{ matrix.os }}_${{ matrix.cmake_build_type }}
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_BUILD || '45') }}
+    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_BUILD || vars.MMGH_TIMEOUT_BUILD || '45') }}
 
     env:
       # Cap build parallelism. The github-hosted runners have only 3 (macOS)
@@ -272,16 +272,16 @@ jobs:
       needs.check_skip.outputs.cpp != 'false' && (
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
-       (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
-        contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
+       ((vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH) == '*' ||
+        contains(vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
       (github.event_name == 'schedule' &&
-      vars.MMGH_NIGHTLY == 'enable'))
+      (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'))
 
     name: build_${{ matrix.os }}_${{ matrix.cmake_build_type }}
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_BUILD || '60') }}
+    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_BUILD || vars.MMGH_TIMEOUT_BUILD || '60') }}
 
     env:
       QT_DEBUG_PLUGINS: 1
@@ -301,7 +301,7 @@ jobs:
         # only Windows Debug compile (lint.yml has no Windows job), but it is
         # heavy and rarely breaks on its own, so it runs on the nightly
         # schedule only.
-        cmake_build_type: ${{ (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable' && fromJSON('["Release", "Debug"]')) || fromJSON('["Release"]') }}
+        cmake_build_type: ${{ (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable' && fromJSON('["Release", "Debug"]')) || fromJSON('["Release"]') }}
 
       fail-fast: false
 
@@ -429,7 +429,7 @@ jobs:
           echo "::endgroup::"
 
       - name: generate portable
-        if: ${{ matrix.cmake_build_type == 'Release' && github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable' }}
+        if: ${{ matrix.cmake_build_type == 'Release' && github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable' }}
         run: |
           echo "::group::generate portable"
           # Get the Python version installed and extract the major+minor version components
@@ -484,7 +484,7 @@ jobs:
           echo "::endgroup::"
 
       - name: archive portable artifacts
-        if: ${{ matrix.cmake_build_type == 'Release' && github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable' }}
+        if: ${{ matrix.cmake_build_type == 'Release' && github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable' }}
         uses: actions/upload-artifact@v7
         with:
           name: solvcon-pilot-win64
@@ -495,19 +495,19 @@ jobs:
     needs: [check_skip]
 
     # A genuine -DUSE_SANITIZER=ON ASAN/UBSAN build. It is slow, so it runs on
-    # the nightly schedule only (set MMGH_FORCE_SANITIZER to 'enable' to force
+    # the nightly schedule only (set SCGH_FORCE_SANITIZER to 'enable' to force
     # it on a fork). This restores the real sanitizer coverage that the build
     # job used to stub out by configuring -DUSE_SANITIZER=OFF.
     if: |
       needs.check_skip.outputs.skip != 'true' && (
-      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') ||
-      vars.MMGH_FORCE_SANITIZER == 'enable')
+      (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable') ||
+      (vars.SCGH_FORCE_SANITIZER || vars.MMGH_FORCE_SANITIZER) == 'enable')
 
     name: sanitizer_${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_BUILD || '45') }}
+    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_BUILD || vars.MMGH_TIMEOUT_BUILD || '45') }}
 
     env:
       MAKE_PARALLEL: -j2
@@ -564,18 +564,18 @@ jobs:
     # The MSVC counterpart of the sanitizer job. MSVC ships only
     # AddressSanitizer. The gtest binary and pilot.exe both link the ASan
     # runtime directly, so it starts with the process and instruments the C++
-    # core and the Qt pilot. Slow, so nightly-only (set MMGH_FORCE_SANITIZER to
+    # core and the Qt pilot. Slow, so nightly-only (set SCGH_FORCE_SANITIZER to
     # force it on a fork).
     if: |
       needs.check_skip.outputs.skip != 'true' && (
-      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') ||
-      vars.MMGH_FORCE_SANITIZER == 'enable')
+      (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable') ||
+      (vars.SCGH_FORCE_SANITIZER || vars.MMGH_FORCE_SANITIZER) == 'enable')
 
     name: sanitizer_${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_BUILD || '60') }}
+    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_BUILD || vars.MMGH_TIMEOUT_BUILD || '60') }}
 
     env:
       AQT_CONFIG: "thirdparty/aqt_settings.ini"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,9 +21,9 @@ concurrency:
 jobs:
 
   check_skip:
-    # A fork inherits no MMGH_NIGHTLY, so this gate stops the nightly cron
+    # A fork inherits no SCGH_NIGHTLY, so this gate stops the nightly cron
     # from allocating a runner there.
-    if: github.event_name != 'schedule' || vars.MMGH_NIGHTLY == 'enable'
+    if: github.event_name != 'schedule' || (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'
     uses: ./.github/workflows/check_skip_ci.yml
     permissions:
       contents: read
@@ -40,13 +40,13 @@ jobs:
       needs.check_skip.outputs.skip != 'true' && (
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
-       (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
-        contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
-      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable'))
+       ((vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH) == '*' ||
+        contains(vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
+      (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'))
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_LINT || '45') }}
+    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_LINT || vars.MMGH_TIMEOUT_LINT || '45') }}
 
     env:
       JOB_MAKE_ARGS: VERBOSE=1 BUILD_QT=ON USE_CLANG_TIDY=ON LINT_AS_ERRORS=ON

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -21,9 +21,9 @@ concurrency:
 jobs:
 
   check_skip:
-    # A fork inherits no MMGH_NIGHTLY, so this gate stops the nightly cron
+    # A fork inherits no SCGH_NIGHTLY, so this gate stops the nightly cron
     # from allocating a runner there.
-    if: github.event_name != 'schedule' || vars.MMGH_NIGHTLY == 'enable'
+    if: github.event_name != 'schedule' || (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'
     uses: ./.github/workflows/check_skip_ci.yml
     permissions:
       contents: read
@@ -37,19 +37,19 @@ jobs:
     # The setup.py install path re-verifies packaging and duplicates the build
     # job's pytest. It does not gate correctness on a pull request, so it runs
     # on the nightly schedule and on release tag pushes only, not on pull
-    # requests or master pushes. Set the MMGH_FORCE_NOUSE_INSTALL variable to
+    # requests or master pushes. Set the SCGH_FORCE_NOUSE_INSTALL variable to
     # 'enable' to force it on a fork.
     if: |
       needs.check_skip.outputs.skip != 'true' && (
-      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') ||
+      (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-      vars.MMGH_FORCE_NOUSE_INSTALL == 'enable')
+      (vars.SCGH_FORCE_NOUSE_INSTALL || vars.MMGH_FORCE_NOUSE_INSTALL) == 'enable')
 
     name: nouse_install_${{ matrix.os }}_Release
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_NOUSE_INSTALL || '30') }}
+    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_NOUSE_INSTALL || vars.MMGH_TIMEOUT_NOUSE_INSTALL || '30') }}
 
     env:
       JOB_CMAKE_ARGS: -DBUILD_QT=OFF -DUSE_CLANG_TIDY=OFF -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -9,15 +9,15 @@ on:
 jobs:
   profile:
 
-    # Run profiling only on schedule or when MMGH_FORCE_PROFILE is set to 'enable'
-    # You can refer to https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables to set MMGH_FORCE_PROFILE in the fork repository settings for testing purposes.
-    if: ${{ (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') || vars.MMGH_FORCE_PROFILE == 'enable' }}
+    # Run profiling only on schedule or when SCGH_FORCE_PROFILE is set to 'enable'
+    # You can refer to https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables to set SCGH_FORCE_PROFILE in the fork repository settings for testing purposes.
+    if: ${{ (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable') || (vars.SCGH_FORCE_PROFILE || vars.MMGH_FORCE_PROFILE) == 'enable' }}
 
     name: profile_${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_PROFILE || '30') }}
+    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_PROFILE || vars.MMGH_TIMEOUT_PROFILE || '30') }}
 
     env:
       QT_DEBUG_PLUGINS: 1

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -19,7 +19,7 @@ jobs:
     # Both conditions are required so that a non-fork copy of the repository
     # respects the setting.
     if: |
-      github.repository == (vars.MMGH_REMIND_REPOSITORY || 'solvcon/solvcon') &&
+      github.repository == (vars.SCGH_REMIND_REPOSITORY || vars.MMGH_REMIND_REPOSITORY || 'solvcon/solvcon') &&
       github.event.repository.fork == false
 
     runs-on: ubuntu-latest

--- a/STYLE.md
+++ b/STYLE.md
@@ -625,7 +625,7 @@ namespace detail
 
 ## C Pre-Processor Macro
 
-Prefix macros with `MM_DECL_`. If they are not supposed to be used as a
+Prefix macros with `SC_DECL_`. If they are not supposed to be used as a
 global helper, delete them after consumption.
 
 ## C++ Standard

--- a/cpp/solvcon/CMakeLists.txt
+++ b/cpp/solvcon/CMakeLists.txt
@@ -198,9 +198,9 @@ if (APPLE)
         ${APPLE_FWK_METAL}
     )
     # Accelerate/vecLib provides BLAS + LAPACK.
-    target_compile_definitions(solvcon_primary PUBLIC MM_HAS_VENDOR_LAPACK)
+    target_compile_definitions(solvcon_primary PUBLIC SC_HAS_VENDOR_LAPACK)
     if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
-        target_compile_definitions(solvcon_primary PUBLIC MM_HAS_CBLAS)
+        target_compile_definitions(solvcon_primary PUBLIC SC_HAS_CBLAS)
     endif ()
 endif () # APPLE
 
@@ -220,7 +220,7 @@ if (NOT APPLE)
     # Its single dynamic runtime (mkl_rt, LP64) exports both the reference CBLAS
     # entry points and the Fortran LAPACK symbols declared in lapack_compat.hpp,
     # so it feeds the same matmul_blas()/EigenSystem paths as OpenBLAS.
-    set(MM_BLAS_FOUND OFF)
+    set(SC_BLAS_FOUND OFF)
     if (SOLVCON_USE_MKL)
         find_library(MKL_LIB NAMES mkl_rt)
         find_path(MKL_INCLUDE_DIR NAMES mkl_cblas.h)
@@ -229,8 +229,8 @@ if (NOT APPLE)
             target_include_directories(solvcon_primary PUBLIC ${MKL_INCLUDE_DIR})
             target_link_libraries(solvcon_primary PUBLIC ${MKL_LIB})
             target_compile_definitions(solvcon_primary PUBLIC
-                MM_HAS_CBLAS MM_HAS_MKL MM_HAS_VENDOR_LAPACK)
-            set(MM_BLAS_FOUND ON)
+                SC_HAS_CBLAS SC_HAS_MKL SC_HAS_VENDOR_LAPACK)
+            set(SC_BLAS_FOUND ON)
         else ()
             message(STATUS
                 "SOLVCON_USE_MKL is ON but Intel MKL was not found; "
@@ -238,7 +238,7 @@ if (NOT APPLE)
         endif ()
     endif ()
 
-    if (NOT MM_BLAS_FOUND)
+    if (NOT SC_BLAS_FOUND)
         # The CBLAS header is needed for SimpleArray::matmul_blas() to use
         # the vendor BLAS backend.
         # Linux OpenBLAS packages also ship LAPACK symbols for EigenSystem.
@@ -264,7 +264,7 @@ if (NOT APPLE)
             message(STATUS "Found OpenBLAS: ${OPENBLAS_LIB}")
             target_include_directories(solvcon_primary PUBLIC ${OPENBLAS_INCLUDE_DIR})
             target_link_libraries(solvcon_primary PUBLIC ${OPENBLAS_LIB})
-            target_compile_definitions(solvcon_primary PUBLIC MM_HAS_CBLAS)
+            target_compile_definitions(solvcon_primary PUBLIC SC_HAS_CBLAS)
         else ()
             message(STATUS "OpenBLAS/CBLAS not found; CBLAS matmul will not be built.")
         endif ()
@@ -274,12 +274,12 @@ if (NOT APPLE)
             if (LAPACK_FOUND)
                 message(STATUS "Found LAPACK: ${LAPACK_LIBRARIES}")
                 target_link_libraries(solvcon_primary PUBLIC LAPACK::LAPACK)
-                target_compile_definitions(solvcon_primary PUBLIC MM_HAS_VENDOR_LAPACK)
+                target_compile_definitions(solvcon_primary PUBLIC SC_HAS_VENDOR_LAPACK)
             else ()
                 message(STATUS "LAPACK not found; EigenSystem will not be built.")
             endif ()
         elseif (OPENBLAS_LIB)
-            target_compile_definitions(solvcon_primary PUBLIC MM_HAS_VENDOR_LAPACK)
+            target_compile_definitions(solvcon_primary PUBLIC SC_HAS_VENDOR_LAPACK)
         endif ()
     endif ()
 endif () # NOT APPLE

--- a/cpp/solvcon/buffer/SimpleArray.cpp
+++ b/cpp/solvcon/buffer/SimpleArray.cpp
@@ -456,7 +456,7 @@ DataType DataType::from<Complex<double>>()
 // According to the `DataType`, create the corresponding `SimpleArray<T>` instance
 // and assign it to `m_instance_ptr`. The `m_instance_ptr` is a void pointer, so
 // we need to use `reinterpret_cast` to convert the pointer of the array instance.
-#define DECL_MM_CREATE_SIMPLE_ARRAY(DataType, ArrayType, ...)                  \
+#define SC_DECL_CREATE_SIMPLE_ARRAY(DataType, ArrayType, ...)                  \
     case DataType:                                                             \
         /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) */      \
         m_instance_ptr = reinterpret_cast<void *>(new ArrayType(__VA_ARGS__)); \
@@ -468,19 +468,19 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const DataType data_t
 {
     switch (data_type)
     {
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Complex64, SimpleArrayComplex64, shape)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Complex128, SimpleArrayComplex128, shape)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Complex64, SimpleArrayComplex64, shape)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Complex128, SimpleArrayComplex128, shape)
     default:
         throw std::invalid_argument("Unsupported datatype");
     }
@@ -492,55 +492,55 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const std::shared_ptr
 {
     switch (data_type)
     {
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape, buffer)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape, buffer)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape, buffer)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape, buffer)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape, buffer)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape, buffer)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape, buffer)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape, buffer)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape, buffer)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape, buffer)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape, buffer)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Complex64, SimpleArrayComplex64, shape, buffer)
-        DECL_MM_CREATE_SIMPLE_ARRAY(DataType::Complex128, SimpleArrayComplex128, shape, buffer)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Bool, SimpleArrayBool, shape, buffer)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Int8, SimpleArrayInt8, shape, buffer)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Int16, SimpleArrayInt16, shape, buffer)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Int32, SimpleArrayInt32, shape, buffer)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Int64, SimpleArrayInt64, shape, buffer)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint8, SimpleArrayUint8, shape, buffer)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape, buffer)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape, buffer)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape, buffer)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape, buffer)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape, buffer)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Complex64, SimpleArrayComplex64, shape, buffer)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Complex128, SimpleArrayComplex128, shape, buffer)
     default:
         throw std::invalid_argument("Unsupported datatype");
     }
 }
 
-#undef DECL_MM_CREATE_SIMPLE_ARRAY
+#undef SC_DECL_CREATE_SIMPLE_ARRAY
 
 SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const DataType data_type, size_t alignment)
     : m_data_type(data_type)
     , m_has_instance_ownership(true)
 {
-#define DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType, ArrayType)                            \
+#define SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType, ArrayType)                            \
     case DataType:                                                                                 \
         m_instance_ptr = static_cast<void *>(new ArrayType(shape, alignment, with_alignment_t{})); \
         break;
 
     switch (data_type)
     {
-        DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Bool, SimpleArrayBool)
-        DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Int8, SimpleArrayInt8)
-        DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Int16, SimpleArrayInt16)
-        DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Int32, SimpleArrayInt32)
-        DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Int64, SimpleArrayInt64)
-        DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Uint8, SimpleArrayUint8)
-        DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Uint16, SimpleArrayUint16)
-        DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Uint32, SimpleArrayUint32)
-        DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Uint64, SimpleArrayUint64)
-        DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Float32, SimpleArrayFloat32)
-        DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Float64, SimpleArrayFloat64)
-        DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Complex64, SimpleArrayComplex64)
-        DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Complex128, SimpleArrayComplex128)
+        SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Bool, SimpleArrayBool)
+        SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Int8, SimpleArrayInt8)
+        SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Int16, SimpleArrayInt16)
+        SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Int32, SimpleArrayInt32)
+        SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Int64, SimpleArrayInt64)
+        SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Uint8, SimpleArrayUint8)
+        SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Uint16, SimpleArrayUint16)
+        SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Uint32, SimpleArrayUint32)
+        SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Uint64, SimpleArrayUint64)
+        SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Float32, SimpleArrayFloat32)
+        SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Float64, SimpleArrayFloat64)
+        SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Complex64, SimpleArrayComplex64)
+        SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Complex128, SimpleArrayComplex128)
     default:
         throw std::invalid_argument("Unsupported datatype");
     }
 
-#undef DECL_MM_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT
+#undef SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT
 }
 
 SimpleArrayPlex::SimpleArrayPlex(SimpleArrayPlex const & other)

--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -514,7 +514,7 @@ template <typename Array>
 typename MatmulExecutor<Array>::PackingState MatmulExecutor<Array>::select_packing() const
 {
     PackingState packing;
-#if (defined(__APPLE__) && defined(__arm64__)) || defined(MM_HAS_CBLAS)
+#if (defined(__APPLE__) && defined(__arm64__)) || defined(SC_HAS_CBLAS)
     if constexpr (can_matmul_blas_v<value_type>)
     {
         if (m_plan.lhs_is_vector() || m_plan.rhs_is_vector() ||
@@ -590,7 +590,7 @@ void MatmulExecutor<Array>::execute_at(ssize_t output_base, ssize_t lhs_base, ss
 template <typename Array>
 bool MatmulExecutor<Array>::try_execute_blas(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base)
 {
-#if (defined(__APPLE__) && defined(__arm64__)) || defined(MM_HAS_CBLAS)
+#if (defined(__APPLE__) && defined(__arm64__)) || defined(SC_HAS_CBLAS)
     if constexpr (can_matmul_blas_v<value_type>)
     {
         value_type * output = m_output_data + output_base;

--- a/cpp/solvcon/buffer/pymod/SimpleArrayCaster.hpp
+++ b/cpp/solvcon/buffer/pymod/SimpleArrayCaster.hpp
@@ -21,7 +21,7 @@ namespace detail
 {
 
 // Define the Pybind11 caster for SimpleArray<T>
-#define DECL_MM_SIMPLE_ARRAY_CASTER(DATATYPE)                                                                                                                 \
+#define SC_DECL_SIMPLE_ARRAY_CASTER(DATATYPE)                                                                                                                 \
     template <> /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                                                                                              \
     struct type_caster<solvcon::SimpleArray##DATATYPE> : public type_caster_base<solvcon::SimpleArray##DATATYPE>                                              \
     {                                                                                                                                                         \
@@ -64,21 +64,21 @@ namespace detail
         }                                                                                                                                                     \
     } /* end struct type_caster */
 
-DECL_MM_SIMPLE_ARRAY_CASTER(Bool);
-DECL_MM_SIMPLE_ARRAY_CASTER(Int8);
-DECL_MM_SIMPLE_ARRAY_CASTER(Int16);
-DECL_MM_SIMPLE_ARRAY_CASTER(Int32);
-DECL_MM_SIMPLE_ARRAY_CASTER(Int64);
-DECL_MM_SIMPLE_ARRAY_CASTER(Uint8);
-DECL_MM_SIMPLE_ARRAY_CASTER(Uint16);
-DECL_MM_SIMPLE_ARRAY_CASTER(Uint32);
-DECL_MM_SIMPLE_ARRAY_CASTER(Uint64);
-DECL_MM_SIMPLE_ARRAY_CASTER(Float32);
-DECL_MM_SIMPLE_ARRAY_CASTER(Float64);
-DECL_MM_SIMPLE_ARRAY_CASTER(Complex64);
-DECL_MM_SIMPLE_ARRAY_CASTER(Complex128);
+SC_DECL_SIMPLE_ARRAY_CASTER(Bool);
+SC_DECL_SIMPLE_ARRAY_CASTER(Int8);
+SC_DECL_SIMPLE_ARRAY_CASTER(Int16);
+SC_DECL_SIMPLE_ARRAY_CASTER(Int32);
+SC_DECL_SIMPLE_ARRAY_CASTER(Int64);
+SC_DECL_SIMPLE_ARRAY_CASTER(Uint8);
+SC_DECL_SIMPLE_ARRAY_CASTER(Uint16);
+SC_DECL_SIMPLE_ARRAY_CASTER(Uint32);
+SC_DECL_SIMPLE_ARRAY_CASTER(Uint64);
+SC_DECL_SIMPLE_ARRAY_CASTER(Float32);
+SC_DECL_SIMPLE_ARRAY_CASTER(Float64);
+SC_DECL_SIMPLE_ARRAY_CASTER(Complex64);
+SC_DECL_SIMPLE_ARRAY_CASTER(Complex128);
 
-#undef DECL_MM_SIMPLE_ARRAY_CASTER
+#undef SC_DECL_SIMPLE_ARRAY_CASTER
 
 } /* end namespace detail */
 } /* end namespace pybind11 */

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -569,26 +569,26 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
         py_typename[0] = tolower(py_typename[0]);
         const DataType dt(py_typename);
 
-#define DECL_MM_TAKE_ALONG_AXIS_TYPED(IntDataType) \
+#define SC_DECL_TAKE_ALONG_AXIS_TYPED(IntDataType) \
     case DataType::IntDataType:                    \
         return pybind11::cast(self.take_along_axis(indices.cast<SimpleArray##IntDataType>()));
 
         switch (dt)
         {
-            DECL_MM_TAKE_ALONG_AXIS_TYPED(Int8)
-            DECL_MM_TAKE_ALONG_AXIS_TYPED(Int16)
-            DECL_MM_TAKE_ALONG_AXIS_TYPED(Int32)
-            DECL_MM_TAKE_ALONG_AXIS_TYPED(Int64)
-            DECL_MM_TAKE_ALONG_AXIS_TYPED(Uint8)
-            DECL_MM_TAKE_ALONG_AXIS_TYPED(Uint16)
-            DECL_MM_TAKE_ALONG_AXIS_TYPED(Uint32)
-            DECL_MM_TAKE_ALONG_AXIS_TYPED(Uint64)
+            SC_DECL_TAKE_ALONG_AXIS_TYPED(Int8)
+            SC_DECL_TAKE_ALONG_AXIS_TYPED(Int16)
+            SC_DECL_TAKE_ALONG_AXIS_TYPED(Int32)
+            SC_DECL_TAKE_ALONG_AXIS_TYPED(Int64)
+            SC_DECL_TAKE_ALONG_AXIS_TYPED(Uint8)
+            SC_DECL_TAKE_ALONG_AXIS_TYPED(Uint16)
+            SC_DECL_TAKE_ALONG_AXIS_TYPED(Uint32)
+            SC_DECL_TAKE_ALONG_AXIS_TYPED(Uint64)
         default:
             break;
         }
         return pybind11::cast(std::move(self));
 
-#undef DECL_MM_TAKE_ALONG_AXIS_TYPED
+#undef SC_DECL_TAKE_ALONG_AXIS_TYPED
     }
 
     static pybind11::object take_along_axis_simd(wrapped_type & self, pybind11::object const & indices)
@@ -604,26 +604,26 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
         py_typename[0] = tolower(py_typename[0]);
         const DataType dt(py_typename);
 
-#define DECL_MM_TAKE_ALONG_AXIS_SIMD_TYPED(IntDataType) \
+#define SC_DECL_TAKE_ALONG_AXIS_SIMD_TYPED(IntDataType) \
     case DataType::IntDataType:                         \
         return pybind11::cast(self.take_along_axis_simd(indices.cast<SimpleArray##IntDataType>()));
 
         switch (dt)
         {
-            DECL_MM_TAKE_ALONG_AXIS_SIMD_TYPED(Int8)
-            DECL_MM_TAKE_ALONG_AXIS_SIMD_TYPED(Int16)
-            DECL_MM_TAKE_ALONG_AXIS_SIMD_TYPED(Int32)
-            DECL_MM_TAKE_ALONG_AXIS_SIMD_TYPED(Int64)
-            DECL_MM_TAKE_ALONG_AXIS_SIMD_TYPED(Uint8)
-            DECL_MM_TAKE_ALONG_AXIS_SIMD_TYPED(Uint16)
-            DECL_MM_TAKE_ALONG_AXIS_SIMD_TYPED(Uint32)
-            DECL_MM_TAKE_ALONG_AXIS_SIMD_TYPED(Uint64)
+            SC_DECL_TAKE_ALONG_AXIS_SIMD_TYPED(Int8)
+            SC_DECL_TAKE_ALONG_AXIS_SIMD_TYPED(Int16)
+            SC_DECL_TAKE_ALONG_AXIS_SIMD_TYPED(Int32)
+            SC_DECL_TAKE_ALONG_AXIS_SIMD_TYPED(Int64)
+            SC_DECL_TAKE_ALONG_AXIS_SIMD_TYPED(Uint8)
+            SC_DECL_TAKE_ALONG_AXIS_SIMD_TYPED(Uint16)
+            SC_DECL_TAKE_ALONG_AXIS_SIMD_TYPED(Uint32)
+            SC_DECL_TAKE_ALONG_AXIS_SIMD_TYPED(Uint64)
         default:
             break;
         }
         return pybind11::cast(std::move(self));
 
-#undef DECL_MM_TAKE_ALONG_AXIS_SIMD_TYPED
+#undef SC_DECL_TAKE_ALONG_AXIS_SIMD_TYPED
     }
 
     wrapper_type & wrap_search()
@@ -701,27 +701,27 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 "SimpleArray::where(): x and y must have the same dtype");
         }
 
-#define DECL_MM_WHERE_TYPED(DataTypeName) \
+#define SC_DECL_WHERE_TYPED(DataTypeName) \
     case DataType::DataTypeName:          \
         return pybind11::cast(self.where(x.cast<SimpleArray##DataTypeName>(), y.cast<SimpleArray##DataTypeName>()));
 
         switch (dt_x)
         {
-            DECL_MM_WHERE_TYPED(Int8)
-            DECL_MM_WHERE_TYPED(Int16)
-            DECL_MM_WHERE_TYPED(Int32)
-            DECL_MM_WHERE_TYPED(Int64)
-            DECL_MM_WHERE_TYPED(Uint8)
-            DECL_MM_WHERE_TYPED(Uint16)
-            DECL_MM_WHERE_TYPED(Uint32)
-            DECL_MM_WHERE_TYPED(Uint64)
-            DECL_MM_WHERE_TYPED(Float32)
-            DECL_MM_WHERE_TYPED(Float64)
+            SC_DECL_WHERE_TYPED(Int8)
+            SC_DECL_WHERE_TYPED(Int16)
+            SC_DECL_WHERE_TYPED(Int32)
+            SC_DECL_WHERE_TYPED(Int64)
+            SC_DECL_WHERE_TYPED(Uint8)
+            SC_DECL_WHERE_TYPED(Uint16)
+            SC_DECL_WHERE_TYPED(Uint32)
+            SC_DECL_WHERE_TYPED(Uint64)
+            SC_DECL_WHERE_TYPED(Float32)
+            SC_DECL_WHERE_TYPED(Float64)
         default:
             break;
         }
 
-#undef DECL_MM_WHERE_TYPED
+#undef SC_DECL_WHERE_TYPED
 
         throw std::invalid_argument("SimpleArray::where(): unsupported dtype");
     }

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -26,7 +26,7 @@ requires solvcon::IsSameRemoveConstType<A, SimpleArrayPlex>
 static auto execute_callback_with_typed_array(A & arrayplex, C && callback)
 {
 // We get the typed array from the arrayplex and call the callback function with the typed array.
-#define DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType, ArrayType)                                            \
+#define SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType, ArrayType)                                            \
     case DataType:                                                                                            \
     {                                                                                                         \
         using ArrayTypePtr = typename std::conditional_t<std::is_const_v<A>, const ArrayType *, ArrayType *>; \
@@ -37,26 +37,26 @@ static auto execute_callback_with_typed_array(A & arrayplex, C && callback)
 
     switch (arrayplex.data_type())
     {
-        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Bool, SimpleArrayBool)
-        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Int8, SimpleArrayInt8)
-        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Int16, SimpleArrayInt16)
-        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Int32, SimpleArrayInt32)
-        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Int64, SimpleArrayInt64)
-        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Uint8, SimpleArrayUint8)
-        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Uint16, SimpleArrayUint16)
-        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Uint32, SimpleArrayUint32)
-        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Uint64, SimpleArrayUint64)
-        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Float32, SimpleArrayFloat32)
-        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Float64, SimpleArrayFloat64)
-        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Complex64, SimpleArrayComplex64)
-        DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Complex128, SimpleArrayComplex128)
+        SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Bool, SimpleArrayBool)
+        SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Int8, SimpleArrayInt8)
+        SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Int16, SimpleArrayInt16)
+        SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Int32, SimpleArrayInt32)
+        SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Int64, SimpleArrayInt64)
+        SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Uint8, SimpleArrayUint8)
+        SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Uint16, SimpleArrayUint16)
+        SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Uint32, SimpleArrayUint32)
+        SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Uint64, SimpleArrayUint64)
+        SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Float32, SimpleArrayFloat32)
+        SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Float64, SimpleArrayFloat64)
+        SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Complex64, SimpleArrayComplex64)
+        SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY(DataType::Complex128, SimpleArrayComplex128)
     default:
     {
         throw std::invalid_argument("Unsupported datatype");
     }
     }
 
-#undef DECL_MM_RUN_CALLBACK_WITH_TYPED_ARRAY
+#undef SC_DECL_RUN_CALLBACK_WITH_TYPED_ARRAY
 }
 
 /// Check the data type of the python value match the given data type. If not, throw a type error.
@@ -125,7 +125,7 @@ template <typename T>
 // NOLINTNEXTLINE(misc-use-anonymous-namespace)
 static pybind11::object get_typed_array_value(const SimpleArrayPlex & array_plex, T key)
 {
-#define DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType, ArrayType)                     \
+#define SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType, ArrayType)                     \
     case DataType:                                                                      \
     {                                                                                   \
         const auto * array = static_cast<const ArrayType *>(array_plex.instance_ptr()); \
@@ -134,32 +134,32 @@ static pybind11::object get_typed_array_value(const SimpleArrayPlex & array_plex
 
     switch (array_plex.data_type())
     {
-        DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Bool, SimpleArrayBool)
-        DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Int8, SimpleArrayInt8)
-        DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Int16, SimpleArrayInt16)
-        DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Int32, SimpleArrayInt32)
-        DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Int64, SimpleArrayInt64)
-        DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Uint8, SimpleArrayUint8)
-        DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Uint16, SimpleArrayUint16)
-        DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Uint32, SimpleArrayUint32)
-        DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Uint64, SimpleArrayUint64)
-        DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Float32, SimpleArrayFloat32)
-        DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Float64, SimpleArrayFloat64)
-        DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Complex64, SimpleArrayComplex64)
-        DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Complex128, SimpleArrayComplex128)
+        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Bool, SimpleArrayBool)
+        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Int8, SimpleArrayInt8)
+        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Int16, SimpleArrayInt16)
+        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Int32, SimpleArrayInt32)
+        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Int64, SimpleArrayInt64)
+        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Uint8, SimpleArrayUint8)
+        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Uint16, SimpleArrayUint16)
+        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Uint32, SimpleArrayUint32)
+        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Uint64, SimpleArrayUint64)
+        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Float32, SimpleArrayFloat32)
+        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Float64, SimpleArrayFloat64)
+        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Complex64, SimpleArrayComplex64)
+        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Complex128, SimpleArrayComplex128)
     default:
     {
         throw std::runtime_error("Unsupported datatype");
     }
     }
-#undef DECL_MM_GET_TYPED_ARRAY_VALUE_BY_INDEX
+#undef SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX
 }
 
 /// Get the typed array from the arrayplex
 // NOLINTNEXTLINE(misc-use-anonymous-namespace)
 static pybind11::object get_typed_array(const SimpleArrayPlex & array_plex)
 {
-#define DECL_MM_GET_TYPED_ARRAY(DataType, ArrayType)                                    \
+#define SC_DECL_GET_TYPED_ARRAY(DataType, ArrayType)                                    \
     case DataType:                                                                      \
     {                                                                                   \
         const auto * array = static_cast<const ArrayType *>(array_plex.instance_ptr()); \
@@ -168,25 +168,25 @@ static pybind11::object get_typed_array(const SimpleArrayPlex & array_plex)
 
     switch (array_plex.data_type())
     {
-        DECL_MM_GET_TYPED_ARRAY(DataType::Bool, SimpleArrayBool)
-        DECL_MM_GET_TYPED_ARRAY(DataType::Int8, SimpleArrayInt8)
-        DECL_MM_GET_TYPED_ARRAY(DataType::Int16, SimpleArrayInt16)
-        DECL_MM_GET_TYPED_ARRAY(DataType::Int32, SimpleArrayInt32)
-        DECL_MM_GET_TYPED_ARRAY(DataType::Int64, SimpleArrayInt64)
-        DECL_MM_GET_TYPED_ARRAY(DataType::Uint8, SimpleArrayUint8)
-        DECL_MM_GET_TYPED_ARRAY(DataType::Uint16, SimpleArrayUint16)
-        DECL_MM_GET_TYPED_ARRAY(DataType::Uint32, SimpleArrayUint32)
-        DECL_MM_GET_TYPED_ARRAY(DataType::Uint64, SimpleArrayUint64)
-        DECL_MM_GET_TYPED_ARRAY(DataType::Float32, SimpleArrayFloat32)
-        DECL_MM_GET_TYPED_ARRAY(DataType::Float64, SimpleArrayFloat64)
-        DECL_MM_GET_TYPED_ARRAY(DataType::Complex64, SimpleArrayComplex64)
-        DECL_MM_GET_TYPED_ARRAY(DataType::Complex128, SimpleArrayComplex128)
+        SC_DECL_GET_TYPED_ARRAY(DataType::Bool, SimpleArrayBool)
+        SC_DECL_GET_TYPED_ARRAY(DataType::Int8, SimpleArrayInt8)
+        SC_DECL_GET_TYPED_ARRAY(DataType::Int16, SimpleArrayInt16)
+        SC_DECL_GET_TYPED_ARRAY(DataType::Int32, SimpleArrayInt32)
+        SC_DECL_GET_TYPED_ARRAY(DataType::Int64, SimpleArrayInt64)
+        SC_DECL_GET_TYPED_ARRAY(DataType::Uint8, SimpleArrayUint8)
+        SC_DECL_GET_TYPED_ARRAY(DataType::Uint16, SimpleArrayUint16)
+        SC_DECL_GET_TYPED_ARRAY(DataType::Uint32, SimpleArrayUint32)
+        SC_DECL_GET_TYPED_ARRAY(DataType::Uint64, SimpleArrayUint64)
+        SC_DECL_GET_TYPED_ARRAY(DataType::Float32, SimpleArrayFloat32)
+        SC_DECL_GET_TYPED_ARRAY(DataType::Float64, SimpleArrayFloat64)
+        SC_DECL_GET_TYPED_ARRAY(DataType::Complex64, SimpleArrayComplex64)
+        SC_DECL_GET_TYPED_ARRAY(DataType::Complex128, SimpleArrayComplex128)
     default:
     {
         throw std::runtime_error("Unsupported datatype");
     }
     }
-#undef DECL_MM_GET_TYPED_ARRAY
+#undef SC_DECL_GET_TYPED_ARRAY
 }
 
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<WrapSimpleArrayPlex, SimpleArrayPlex>
@@ -197,7 +197,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
 
     friend root_base_type;
 
-#define DECL_MM_EXECUTE_TYPED_ARRAY_METHOD(typed_array_method)          \
+#define SC_DECL_EXECUTE_TYPED_ARRAY_METHOD(typed_array_method)          \
     [](wrapped_type & self) { return execute_callback_with_typed_array( \
                                   self, [](auto & array) { return array.typed_array_method(); }); }
 
@@ -259,9 +259,9 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
                             using data_type = typename std::remove_reference_t<decltype(array[0])>;
                             return ArrayPropertyHelper<data_type>::get_buffer_info(array); });
                 })
-            .def_property_readonly("nbytes", DECL_MM_EXECUTE_TYPED_ARRAY_METHOD(nbytes))
-            .def_property_readonly("size", DECL_MM_EXECUTE_TYPED_ARRAY_METHOD(size))
-            .def_property_readonly("itemsize", DECL_MM_EXECUTE_TYPED_ARRAY_METHOD(itemsize))
+            .def_property_readonly("nbytes", SC_DECL_EXECUTE_TYPED_ARRAY_METHOD(nbytes))
+            .def_property_readonly("size", SC_DECL_EXECUTE_TYPED_ARRAY_METHOD(size))
+            .def_property_readonly("itemsize", SC_DECL_EXECUTE_TYPED_ARRAY_METHOD(itemsize))
             .def_property_readonly("alignment", &wrapped_type::alignment)
             .def_property_readonly(
                 "shape",
@@ -293,7 +293,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
                             return ret;
                         });
                 })
-            .def("__len__", DECL_MM_EXECUTE_TYPED_ARRAY_METHOD(size))
+            .def("__len__", SC_DECL_EXECUTE_TYPED_ARRAY_METHOD(size))
             .def("__getitem__", &get_typed_array_value<ssize_t>)
             .def("__getitem__", &get_typed_array_value<const std::vector<ssize_t> &>)
             .def("__setitem__",
@@ -315,11 +315,11 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
                        {
                         const auto shape = make_shape(py_shape);
                         return array.reshape(shape); }); })
-            .def_property_readonly("has_ghost", DECL_MM_EXECUTE_TYPED_ARRAY_METHOD(has_ghost))
+            .def_property_readonly("has_ghost", SC_DECL_EXECUTE_TYPED_ARRAY_METHOD(has_ghost))
             .def_property(
                 "nghost",
                 // getter
-                DECL_MM_EXECUTE_TYPED_ARRAY_METHOD(nghost),
+                SC_DECL_EXECUTE_TYPED_ARRAY_METHOD(nghost),
                 // setter
                 [](wrapped_type & self, ssize_t nghost)
                 {
@@ -330,7 +330,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
                             return array.set_nghost(nghost);
                         });
                 })
-            .def_property_readonly("nbody", DECL_MM_EXECUTE_TYPED_ARRAY_METHOD(nbody))
+            .def_property_readonly("nbody", SC_DECL_EXECUTE_TYPED_ARRAY_METHOD(nbody))
             .wrap_modifiers()
             .wrap_calculators()
             // ATTENTION: always keep the same interface between WrapSimpleArrayPlex and WrapSimpleArray
@@ -364,19 +364,19 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
 
     wrapper_type & wrap_calculators()
     {
-#define DECL_MM_EXECUTE_TYPED_ARRAY_METHOD_RETUN_TYPED_VALUE(typed_array_method) \
+#define SC_DECL_EXECUTE_TYPED_ARRAY_METHOD_RETUN_TYPED_VALUE(typed_array_method) \
     [](wrapped_type & self) { return execute_callback_with_typed_array(          \
                                   self, [](auto & array) { return pybind11::cast(array.typed_array_method()); }); }
 
         (*this)
-            .def("min", DECL_MM_EXECUTE_TYPED_ARRAY_METHOD_RETUN_TYPED_VALUE(min))
-            .def("max", DECL_MM_EXECUTE_TYPED_ARRAY_METHOD_RETUN_TYPED_VALUE(max))
-            .def("sum", DECL_MM_EXECUTE_TYPED_ARRAY_METHOD_RETUN_TYPED_VALUE(sum))
-            .def("abs", DECL_MM_EXECUTE_TYPED_ARRAY_METHOD_RETUN_TYPED_VALUE(abs))
+            .def("min", SC_DECL_EXECUTE_TYPED_ARRAY_METHOD_RETUN_TYPED_VALUE(min))
+            .def("max", SC_DECL_EXECUTE_TYPED_ARRAY_METHOD_RETUN_TYPED_VALUE(max))
+            .def("sum", SC_DECL_EXECUTE_TYPED_ARRAY_METHOD_RETUN_TYPED_VALUE(sum))
+            .def("abs", SC_DECL_EXECUTE_TYPED_ARRAY_METHOD_RETUN_TYPED_VALUE(abs))
             //
             ;
 
-#undef DECL_MM_EXECUTE_TYPED_ARRAY_METHOD_RETUN_TYPED_VALUE
+#undef SC_DECL_EXECUTE_TYPED_ARRAY_METHOD_RETUN_TYPED_VALUE
         return *this;
     }
 
@@ -423,7 +423,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
     }
     // NOLINTEND(bugprone-easily-swappable-parameters)
 
-#undef DECL_MM_EXECUTE_TYPED_ARRAY_METHOD
+#undef SC_DECL_EXECUTE_TYPED_ARRAY_METHOD
 
 }; /* end class WrapSimpleArrayPlex */
 

--- a/cpp/solvcon/inout/gmsh.hpp
+++ b/cpp/solvcon/inout/gmsh.hpp
@@ -289,51 +289,51 @@ private:
 inline GmshElementDef GmshElementDef::by_id(uint16_t id)
 {
 #define VEC(...) __VA_ARGS__
-#define MM_DECL_SWITCH_ELEMENT_TYPE(ID, NDIM, NNDS, MMTPN, MMCL) \
+#define SC_DECL_SWITCH_ELEMENT_TYPE(ID, NDIM, NNDS, MMTPN, MMCL) \
     case ID: return GmshElementDef(NDIM, NNDS, MMTPN, small_vector<uint8_t>{MMCL}); break;
     switch (id)
     {
         // clang-format off
         // NOLINTBEGIN(bugprone-branch-clone,-warnings-as-error)
         //                          id, dim, nnodes, cell type, cell order
-        MM_DECL_SWITCH_ELEMENT_TYPE( 1,   1,      2,         2, VEC(0, 1))                       // 2-node line
-        MM_DECL_SWITCH_ELEMENT_TYPE( 2,   2,      3,         4, VEC(0, 1, 2))                    // 3-node triangle
-        MM_DECL_SWITCH_ELEMENT_TYPE( 3,   2,      4,         3, VEC(0, 1, 2, 3))                 // 4-node quadrangle
-        MM_DECL_SWITCH_ELEMENT_TYPE( 4,   3,      4,         6, VEC(0, 1, 2, 3))                 // 4-node tetrahedron
-        MM_DECL_SWITCH_ELEMENT_TYPE( 5,   3,      8,         5, VEC(0, 1, 2, 3, 4, 5, 6, 7))     // 8-node hexahedron
-        MM_DECL_SWITCH_ELEMENT_TYPE( 6,   3,      6,         7, VEC(0, 2, 1, 3, 5, 4))           // 6-node prism
-        MM_DECL_SWITCH_ELEMENT_TYPE( 7,   3,      5,         8, VEC(0, 1, 2, 3, 4))              // 5-node pyramid
-        MM_DECL_SWITCH_ELEMENT_TYPE( 8,   1,      3,         2, VEC(0, 1))                       // 3-node line
-        MM_DECL_SWITCH_ELEMENT_TYPE( 9,   2,      6,         4, VEC(0, 1, 2))                    // 6-node triangle
-        MM_DECL_SWITCH_ELEMENT_TYPE(10,   2,      9,         3, VEC(0, 1, 2, 3))                 // 9-node quadrangle
-        MM_DECL_SWITCH_ELEMENT_TYPE(11,   3,     10,         6, VEC(0, 1, 2, 3))                 // 10-node tetrahedron
-        MM_DECL_SWITCH_ELEMENT_TYPE(12,   3,     27,         5, VEC(0, 1, 2, 3, 4, 5, 6, 7))     // 27-node hexahedron
-        MM_DECL_SWITCH_ELEMENT_TYPE(13,   3,     18,         7, VEC(0, 2, 1, 3, 5, 4))           // 18-node prism
-        MM_DECL_SWITCH_ELEMENT_TYPE(14,   3,     14,         8, VEC(0, 1, 2, 3, 4))              // 14-node pyramid
-        MM_DECL_SWITCH_ELEMENT_TYPE(15,   0,      1,         1, VEC(0))                          // 1-node point
-        MM_DECL_SWITCH_ELEMENT_TYPE(16,   2,      8,         3, VEC(0, 1, 2, 3))                 // 8-node quadrangle
-        MM_DECL_SWITCH_ELEMENT_TYPE(17,   3,     20,         5, VEC(0, 1, 2, 3, 4, 5, 6, 7))     // 20-node hexahedron
-        MM_DECL_SWITCH_ELEMENT_TYPE(18,   3,     15,         7, VEC(0, 2, 1, 3, 5, 4))           // 15-node prism
-        MM_DECL_SWITCH_ELEMENT_TYPE(19,   3,     13,         8, VEC(0, 1, 2, 3, 4))              // 13-node pyramid
-        MM_DECL_SWITCH_ELEMENT_TYPE(20,   2,      9,         4, VEC(0, 1, 2))                    // 9-node incomplete triangle
-        MM_DECL_SWITCH_ELEMENT_TYPE(21,   2,     10,         4, VEC(0, 1, 2))                    // 10-node triangle
-        MM_DECL_SWITCH_ELEMENT_TYPE(22,   2,     12,         4, VEC(0, 1, 2))                    // 12-node incomplete triangle
-        MM_DECL_SWITCH_ELEMENT_TYPE(23,   2,     15,         4, VEC(0, 1, 2))                    // 15-node triangle
-        MM_DECL_SWITCH_ELEMENT_TYPE(24,   2,     15,         4, VEC(0, 1, 2))                    // 15-node incomplete triangle
-        MM_DECL_SWITCH_ELEMENT_TYPE(25,   2,     21,         4, VEC(0, 1, 2))                    // 21-node incomplete triangle
-        MM_DECL_SWITCH_ELEMENT_TYPE(26,   1,      4,         2, VEC(0, 1))                       // 4-node edge
-        MM_DECL_SWITCH_ELEMENT_TYPE(27,   1,      5,         2, VEC(0, 1))                       // 5-node edge
-        MM_DECL_SWITCH_ELEMENT_TYPE(28,   1,      6,         2, VEC(0, 1))                       // 6-node edge
-        MM_DECL_SWITCH_ELEMENT_TYPE(29,   3,     20,         6, VEC(0, 1, 2, 3))                 // 20-node tetrahedron
-        MM_DECL_SWITCH_ELEMENT_TYPE(30,   3,     35,         6, VEC(0, 1, 2 ,3))                 // 35-node tetrahedron
-        MM_DECL_SWITCH_ELEMENT_TYPE(31,   3,     56,         6, VEC(0, 1, 2, 3))                 // 56-node tetrahedron
-        MM_DECL_SWITCH_ELEMENT_TYPE(92,   3,     64,         5, VEC(0, 1, 2, 3, 4, 5, 6, 7))     // 64-node hexahedron
-        MM_DECL_SWITCH_ELEMENT_TYPE(93,   3,    125,         5, VEC(0, 1, 2, 3, 4, 5, 6, 7))     // 125-node hexahedron
+        SC_DECL_SWITCH_ELEMENT_TYPE( 1,   1,      2,         2, VEC(0, 1))                       // 2-node line
+        SC_DECL_SWITCH_ELEMENT_TYPE( 2,   2,      3,         4, VEC(0, 1, 2))                    // 3-node triangle
+        SC_DECL_SWITCH_ELEMENT_TYPE( 3,   2,      4,         3, VEC(0, 1, 2, 3))                 // 4-node quadrangle
+        SC_DECL_SWITCH_ELEMENT_TYPE( 4,   3,      4,         6, VEC(0, 1, 2, 3))                 // 4-node tetrahedron
+        SC_DECL_SWITCH_ELEMENT_TYPE( 5,   3,      8,         5, VEC(0, 1, 2, 3, 4, 5, 6, 7))     // 8-node hexahedron
+        SC_DECL_SWITCH_ELEMENT_TYPE( 6,   3,      6,         7, VEC(0, 2, 1, 3, 5, 4))           // 6-node prism
+        SC_DECL_SWITCH_ELEMENT_TYPE( 7,   3,      5,         8, VEC(0, 1, 2, 3, 4))              // 5-node pyramid
+        SC_DECL_SWITCH_ELEMENT_TYPE( 8,   1,      3,         2, VEC(0, 1))                       // 3-node line
+        SC_DECL_SWITCH_ELEMENT_TYPE( 9,   2,      6,         4, VEC(0, 1, 2))                    // 6-node triangle
+        SC_DECL_SWITCH_ELEMENT_TYPE(10,   2,      9,         3, VEC(0, 1, 2, 3))                 // 9-node quadrangle
+        SC_DECL_SWITCH_ELEMENT_TYPE(11,   3,     10,         6, VEC(0, 1, 2, 3))                 // 10-node tetrahedron
+        SC_DECL_SWITCH_ELEMENT_TYPE(12,   3,     27,         5, VEC(0, 1, 2, 3, 4, 5, 6, 7))     // 27-node hexahedron
+        SC_DECL_SWITCH_ELEMENT_TYPE(13,   3,     18,         7, VEC(0, 2, 1, 3, 5, 4))           // 18-node prism
+        SC_DECL_SWITCH_ELEMENT_TYPE(14,   3,     14,         8, VEC(0, 1, 2, 3, 4))              // 14-node pyramid
+        SC_DECL_SWITCH_ELEMENT_TYPE(15,   0,      1,         1, VEC(0))                          // 1-node point
+        SC_DECL_SWITCH_ELEMENT_TYPE(16,   2,      8,         3, VEC(0, 1, 2, 3))                 // 8-node quadrangle
+        SC_DECL_SWITCH_ELEMENT_TYPE(17,   3,     20,         5, VEC(0, 1, 2, 3, 4, 5, 6, 7))     // 20-node hexahedron
+        SC_DECL_SWITCH_ELEMENT_TYPE(18,   3,     15,         7, VEC(0, 2, 1, 3, 5, 4))           // 15-node prism
+        SC_DECL_SWITCH_ELEMENT_TYPE(19,   3,     13,         8, VEC(0, 1, 2, 3, 4))              // 13-node pyramid
+        SC_DECL_SWITCH_ELEMENT_TYPE(20,   2,      9,         4, VEC(0, 1, 2))                    // 9-node incomplete triangle
+        SC_DECL_SWITCH_ELEMENT_TYPE(21,   2,     10,         4, VEC(0, 1, 2))                    // 10-node triangle
+        SC_DECL_SWITCH_ELEMENT_TYPE(22,   2,     12,         4, VEC(0, 1, 2))                    // 12-node incomplete triangle
+        SC_DECL_SWITCH_ELEMENT_TYPE(23,   2,     15,         4, VEC(0, 1, 2))                    // 15-node triangle
+        SC_DECL_SWITCH_ELEMENT_TYPE(24,   2,     15,         4, VEC(0, 1, 2))                    // 15-node incomplete triangle
+        SC_DECL_SWITCH_ELEMENT_TYPE(25,   2,     21,         4, VEC(0, 1, 2))                    // 21-node incomplete triangle
+        SC_DECL_SWITCH_ELEMENT_TYPE(26,   1,      4,         2, VEC(0, 1))                       // 4-node edge
+        SC_DECL_SWITCH_ELEMENT_TYPE(27,   1,      5,         2, VEC(0, 1))                       // 5-node edge
+        SC_DECL_SWITCH_ELEMENT_TYPE(28,   1,      6,         2, VEC(0, 1))                       // 6-node edge
+        SC_DECL_SWITCH_ELEMENT_TYPE(29,   3,     20,         6, VEC(0, 1, 2, 3))                 // 20-node tetrahedron
+        SC_DECL_SWITCH_ELEMENT_TYPE(30,   3,     35,         6, VEC(0, 1, 2 ,3))                 // 35-node tetrahedron
+        SC_DECL_SWITCH_ELEMENT_TYPE(31,   3,     56,         6, VEC(0, 1, 2, 3))                 // 56-node tetrahedron
+        SC_DECL_SWITCH_ELEMENT_TYPE(92,   3,     64,         5, VEC(0, 1, 2, 3, 4, 5, 6, 7))     // 64-node hexahedron
+        SC_DECL_SWITCH_ELEMENT_TYPE(93,   3,    125,         5, VEC(0, 1, 2, 3, 4, 5, 6, 7))     // 125-node hexahedron
         default: return GmshElementDef{}; break;
         // NOLINTEND(bugprone-branch-clone,-warnings-as-error)
         // clang-format on
     }
-#undef MM_DECL_SWITCH_ELEMENT_TYPE
+#undef SC_DECL_SWITCH_ELEMENT_TYPE
 #undef VEC
 }
 } /* end namespace inout */

--- a/cpp/solvcon/linalg/EigenSystem.cpp
+++ b/cpp/solvcon/linalg/EigenSystem.cpp
@@ -9,7 +9,7 @@
 
 // EigenSystem.hpp requires a vendor LAPACK; only compile the surrogate's
 // out-of-line bodies when one is available.  Without it this is an empty TU.
-#ifdef MM_HAS_VENDOR_LAPACK
+#ifdef SC_HAS_VENDOR_LAPACK
 
 #include <solvcon/linalg/EigenSystem.hpp>
 
@@ -111,6 +111,6 @@ bool EigenSystemPlex::done() const
 
 } /* end namespace solvcon */
 
-#endif /* MM_HAS_VENDOR_LAPACK */
+#endif /* SC_HAS_VENDOR_LAPACK */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/linalg/EigenSystem.hpp
+++ b/cpp/solvcon/linalg/EigenSystem.hpp
@@ -11,14 +11,14 @@
  * using LAPACK *GEEV: SGEEV (float), DGEEV (double), CGEEV (Complex<float>),
  * and ZGEEV (Complex<double>).
  *
- * The LAPACK backend is selected by the build system via MM_HAS_VENDOR_LAPACK:
+ * The LAPACK backend is selected by the build system via SC_HAS_VENDOR_LAPACK:
  * Apple's vecLib (Accelerate framework) on macOS and OpenBLAS on Linux.
  *
  * @ingroup group_numerics
  */
 
-#ifndef MM_HAS_VENDOR_LAPACK
-#error "solvcon/linalg/EigenSystem.hpp requires a vendor LAPACK (MM_HAS_VENDOR_LAPACK)."
+#ifndef SC_HAS_VENDOR_LAPACK
+#error "solvcon/linalg/EigenSystem.hpp requires a vendor LAPACK (SC_HAS_VENDOR_LAPACK)."
 #endif
 
 #include <algorithm>

--- a/cpp/solvcon/linalg/linalg.hpp
+++ b/cpp/solvcon/linalg/linalg.hpp
@@ -12,7 +12,7 @@
 #include <solvcon/linalg/factorization.hpp>
 #include <solvcon/linalg/lu_factorization.hpp>
 #include <solvcon/linalg/kalman_filter.hpp>
-#ifdef MM_HAS_VENDOR_LAPACK
+#ifdef SC_HAS_VENDOR_LAPACK
 #include <solvcon/linalg/EigenSystem.hpp>
 #endif
 

--- a/cpp/solvcon/linalg/pymod/wrap_EigenSystem.cpp
+++ b/cpp/solvcon/linalg/pymod/wrap_EigenSystem.cpp
@@ -13,7 +13,7 @@ namespace solvcon
 namespace python
 {
 
-#ifdef MM_HAS_VENDOR_LAPACK
+#ifdef SC_HAS_VENDOR_LAPACK
 
 template <typename T>
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapEigenSystem
@@ -160,11 +160,11 @@ WrapEigenSystemPlex::WrapEigenSystemPlex(pybind11::module & mod, char const * py
         .def_property_readonly("done", &wrapped_type::done);
 }
 
-#endif /* MM_HAS_VENDOR_LAPACK */
+#endif /* SC_HAS_VENDOR_LAPACK */
 
 void wrap_EigenSystem(pybind11::module & mod)
 {
-#ifdef MM_HAS_VENDOR_LAPACK
+#ifdef SC_HAS_VENDOR_LAPACK
     WrapEigenSystem<float>::commit(mod, "EigenSystemFloat32", "Eigen problem solver (float32)");
     WrapEigenSystem<double>::commit(mod, "EigenSystemFloat64", "Eigen problem solver (float64)");
     WrapEigenSystem<Complex<float>>::commit(mod, "EigenSystemComplex64", "Eigen problem solver (complex64)");
@@ -172,13 +172,13 @@ void wrap_EigenSystem(pybind11::module & mod)
     // EigenSystem is the type-erased, general entry point that infers the
     // element type from a SimpleArrayPlex (C++ class: EigenSystemPlex).
     WrapEigenSystemPlex::commit(mod, "EigenSystem", "Type-erased eigen problem solver");
-#else // MM_HAS_VENDOR_LAPACK
+#else // SC_HAS_VENDOR_LAPACK
     mod.attr("EigenSystemFloat32") = pybind11::none();
     mod.attr("EigenSystemFloat64") = pybind11::none();
     mod.attr("EigenSystemComplex64") = pybind11::none();
     mod.attr("EigenSystemComplex128") = pybind11::none();
     mod.attr("EigenSystem") = pybind11::none();
-#endif // MM_HAS_VENDOR_LAPACK
+#endif // SC_HAS_VENDOR_LAPACK
 }
 
 } /* end namespace python */

--- a/cpp/solvcon/linalg/pymod/wrap_factorization.cpp
+++ b/cpp/solvcon/linalg/pymod/wrap_factorization.cpp
@@ -55,7 +55,7 @@ void add_simple_array_lu_methods(pybind11::module & mod, char const * pyname)
 void wrap_factorization(pybind11::module & mod)
 {
     // clang-format off
-#define MM_DECL_LADEF(T)                                                     \
+#define SC_DECL_LADEF(T)                                                     \
     mod.def(                                                                 \
         "llt_factorization",                                                 \
         [](SimpleArray<T> const & a)                                         \
@@ -93,12 +93,12 @@ void wrap_factorization(pybind11::module & mod)
         pybind11::arg("a"));
     // clang-format on
 
-    MM_DECL_LADEF(float)
-    MM_DECL_LADEF(double)
-    MM_DECL_LADEF(Complex<float>)
-    MM_DECL_LADEF(Complex<double>)
+    SC_DECL_LADEF(float)
+    SC_DECL_LADEF(double)
+    SC_DECL_LADEF(Complex<float>)
+    SC_DECL_LADEF(Complex<double>)
 
-#undef MM_DECL_LADEF
+#undef SC_DECL_LADEF
 
     // Integer arrays are deliberately excluded: LU decomposition involves
     // division, which would silently truncate under integer arithmetic.

--- a/cpp/solvcon/math/blas_compat.cpp
+++ b/cpp/solvcon/math/blas_compat.cpp
@@ -14,9 +14,9 @@
 #endif
 #include <vecLib/cblas_new.h>
 
-#elifdef MM_HAS_MKL
+#elifdef SC_HAS_MKL
 #include <mkl_cblas.h>
-#elifdef MM_HAS_CBLAS
+#elifdef SC_HAS_CBLAS
 #include <cblas.h>
 #endif
 
@@ -28,7 +28,7 @@
 namespace solvcon
 {
 
-#if (defined(__APPLE__) && defined(__arm64__)) || defined(MM_HAS_CBLAS)
+#if (defined(__APPLE__) && defined(__arm64__)) || defined(SC_HAS_CBLAS)
 #if defined(__APPLE__) && defined(__arm64__)
 using blas_int_type = __LAPACK_int;
 #else

--- a/cpp/solvcon/math/blas_compat.hpp
+++ b/cpp/solvcon/math/blas_compat.hpp
@@ -127,7 +127,7 @@ void gemm(ssize_t m, ssize_t n, ssize_t k, BlasMatrixView<Complex<double>> lhs, 
 template <typename T>
 T dot_blas(ssize_t size, BlasVectorView<T> lhs, BlasVectorView<T> rhs)
 {
-#if (defined(__APPLE__) && defined(__arm64__)) || defined(MM_HAS_CBLAS)
+#if (defined(__APPLE__) && defined(__arm64__)) || defined(SC_HAS_CBLAS)
     return detail::dot(size, lhs, rhs);
 #else
     throw std::runtime_error("solvcon BLAS wrapper: CBLAS backend is unavailable");
@@ -137,7 +137,7 @@ T dot_blas(ssize_t size, BlasVectorView<T> lhs, BlasVectorView<T> rhs)
 template <typename T>
 void gemv_blas(ssize_t m, ssize_t n, BlasMatrixView<T> matrix, BlasVectorView<T> vector, T * result, BlasTranspose requested_transpose)
 {
-#if (defined(__APPLE__) && defined(__arm64__)) || defined(MM_HAS_CBLAS)
+#if (defined(__APPLE__) && defined(__arm64__)) || defined(SC_HAS_CBLAS)
     detail::gemv(m, n, matrix, vector, result, requested_transpose);
 #else
     throw std::runtime_error("solvcon BLAS wrapper: CBLAS backend is unavailable");
@@ -147,7 +147,7 @@ void gemv_blas(ssize_t m, ssize_t n, BlasMatrixView<T> matrix, BlasVectorView<T>
 template <typename T>
 void gemm_blas(ssize_t m, ssize_t n, ssize_t k, BlasMatrixView<T> lhs, BlasMatrixView<T> rhs, T * result)
 {
-#if (defined(__APPLE__) && defined(__arm64__)) || defined(MM_HAS_CBLAS)
+#if (defined(__APPLE__) && defined(__arm64__)) || defined(SC_HAS_CBLAS)
     detail::gemm(m, n, k, lhs, rhs, result);
 #else
     throw std::runtime_error("solvcon BLAS wrapper: CBLAS backend is unavailable");

--- a/cpp/solvcon/math/lapack_compat.hpp
+++ b/cpp/solvcon/math/lapack_compat.hpp
@@ -15,12 +15,12 @@
  *
  * Consumers should include this header and use `lapack_int_t` plus the
  * Fortran-named entry points (e.g. `dgeev_`) without conditional compilation.
- * The header itself requires `MM_HAS_VENDOR_LAPACK` to be defined by the build
+ * The header itself requires `SC_HAS_VENDOR_LAPACK` to be defined by the build
  * system.
  */
 
-#ifndef MM_HAS_VENDOR_LAPACK
-#error "solvcon/math/lapack_compat.hpp requires a vendor LAPACK (MM_HAS_VENDOR_LAPACK)."
+#ifndef SC_HAS_VENDOR_LAPACK
+#error "solvcon/math/lapack_compat.hpp requires a vendor LAPACK (SC_HAS_VENDOR_LAPACK)."
 #endif
 
 #include <solvcon/math/Complex.hpp>

--- a/cpp/solvcon/math/math.hpp
+++ b/cpp/solvcon/math/math.hpp
@@ -7,7 +7,7 @@
 
 #include <solvcon/math/Complex.hpp>
 #include <solvcon/math/blas_compat.hpp>
-#ifdef MM_HAS_VENDOR_LAPACK
+#ifdef SC_HAS_VENDOR_LAPACK
 #include <solvcon/math/lapack_compat.hpp>
 #endif
 

--- a/cpp/solvcon/mesh/StaticMesh.hpp
+++ b/cpp/solvcon/mesh/StaticMesh.hpp
@@ -106,27 +106,27 @@ static_assert(sizeof(CellType) == 4);
 inline CellType CellType::by_id(uint8_t id)
 {
 
-#define MM_DECL_SWITCH_CELL_TYPE(TYPE, NDIM, NNODE, NEDGE, NSURFACE) \
+#define SC_DECL_SWITCH_CELL_TYPE(TYPE, NDIM, NNODE, NEDGE, NSURFACE) \
     case TYPE: return CellType(TYPE, NDIM, NNODE, NEDGE, NSURFACE); break;
 
     switch (id)
     {
         // clang-format off
         //                        id, ndim, nnode, nedge, nsurface
-        MM_DECL_SWITCH_CELL_TYPE(  0,    0,     0,     0,        0 ) // non-type
-        MM_DECL_SWITCH_CELL_TYPE(  1,    0,     1,     0,        0 ) // point/node/vertex
-        MM_DECL_SWITCH_CELL_TYPE(  2,    1,     2,     0,        0 ) // line/edge
-        MM_DECL_SWITCH_CELL_TYPE(  3,    2,     4,     4,        0 ) // quadrilateral
-        MM_DECL_SWITCH_CELL_TYPE(  4,    2,     3,     3,        0 ) // triangle
-        MM_DECL_SWITCH_CELL_TYPE(  5,    3,     8,    12,        6 ) // hexahedron/brick
-        MM_DECL_SWITCH_CELL_TYPE(  6,    3,     4,     6,        4 ) // tetrahedron
-        MM_DECL_SWITCH_CELL_TYPE(  7,    3,     6,     9,        5 ) // prism
-        MM_DECL_SWITCH_CELL_TYPE(  8,    3,     5,     8,        5 ) // pyramid
+        SC_DECL_SWITCH_CELL_TYPE(  0,    0,     0,     0,        0 ) // non-type
+        SC_DECL_SWITCH_CELL_TYPE(  1,    0,     1,     0,        0 ) // point/node/vertex
+        SC_DECL_SWITCH_CELL_TYPE(  2,    1,     2,     0,        0 ) // line/edge
+        SC_DECL_SWITCH_CELL_TYPE(  3,    2,     4,     4,        0 ) // quadrilateral
+        SC_DECL_SWITCH_CELL_TYPE(  4,    2,     3,     3,        0 ) // triangle
+        SC_DECL_SWITCH_CELL_TYPE(  5,    3,     8,    12,        6 ) // hexahedron/brick
+        SC_DECL_SWITCH_CELL_TYPE(  6,    3,     4,     6,        4 ) // tetrahedron
+        SC_DECL_SWITCH_CELL_TYPE(  7,    3,     6,     9,        5 ) // prism
+        SC_DECL_SWITCH_CELL_TYPE(  8,    3,     5,     8,        5 ) // pyramid
         default: return CellType{}; break;
         // clang-format on
     }
 
-#undef MM_DECL_SWITCH_CELL_TYPE
+#undef SC_DECL_SWITCH_CELL_TYPE
 }
 
 /**
@@ -418,7 +418,7 @@ private:
     bool m_use_incenter = false; ///< While true, m_clcnd uses in-center for simplices.
 
 // Data arrays.
-#define MM_DECL_StaticMesh_ARRAY(TYPE, NAME)                            \
+#define SC_DECL_StaticMesh_ARRAY(TYPE, NAME)                            \
 public:                                                                 \
     SimpleArray<TYPE> const & NAME() const { return m_##NAME; }         \
     SimpleArray<TYPE> & NAME() { return m_##NAME; }                     \
@@ -431,27 +431,27 @@ private:                                                                \
     SimpleArray<TYPE> m_##NAME
 
     // geometry arrays.
-    MM_DECL_StaticMesh_ARRAY(real_type, ndcrd);
-    MM_DECL_StaticMesh_ARRAY(real_type, fccnd);
-    MM_DECL_StaticMesh_ARRAY(real_type, fcnml);
-    MM_DECL_StaticMesh_ARRAY(real_type, fcara);
-    MM_DECL_StaticMesh_ARRAY(real_type, clcnd);
-    MM_DECL_StaticMesh_ARRAY(real_type, clvol);
+    SC_DECL_StaticMesh_ARRAY(real_type, ndcrd);
+    SC_DECL_StaticMesh_ARRAY(real_type, fccnd);
+    SC_DECL_StaticMesh_ARRAY(real_type, fcnml);
+    SC_DECL_StaticMesh_ARRAY(real_type, fcara);
+    SC_DECL_StaticMesh_ARRAY(real_type, clcnd);
+    SC_DECL_StaticMesh_ARRAY(real_type, clvol);
     // meta arrays.
-    MM_DECL_StaticMesh_ARRAY(int_type, fctpn);
-    MM_DECL_StaticMesh_ARRAY(int_type, cltpn);
-    MM_DECL_StaticMesh_ARRAY(int_type, clgrp);
+    SC_DECL_StaticMesh_ARRAY(int_type, fctpn);
+    SC_DECL_StaticMesh_ARRAY(int_type, cltpn);
+    SC_DECL_StaticMesh_ARRAY(int_type, clgrp);
     // connectivity arrays.
-    MM_DECL_StaticMesh_ARRAY(int_type, fcnds);
-    MM_DECL_StaticMesh_ARRAY(int_type, fccls);
-    MM_DECL_StaticMesh_ARRAY(int_type, clnds);
-    MM_DECL_StaticMesh_ARRAY(int_type, clfcs);
-    MM_DECL_StaticMesh_ARRAY(int_type, ednds);
+    SC_DECL_StaticMesh_ARRAY(int_type, fcnds);
+    SC_DECL_StaticMesh_ARRAY(int_type, fccls);
+    SC_DECL_StaticMesh_ARRAY(int_type, clnds);
+    SC_DECL_StaticMesh_ARRAY(int_type, clfcs);
+    SC_DECL_StaticMesh_ARRAY(int_type, ednds);
     // boundary information.
-    MM_DECL_StaticMesh_ARRAY(int_type, bndfcs);
+    SC_DECL_StaticMesh_ARRAY(int_type, bndfcs);
     std::vector<std::shared_ptr<StaticMeshBc>> m_bcs;
 
-#undef MM_DECL_StaticMesh_ARRAY
+#undef SC_DECL_StaticMesh_ARRAY
 
 }; /* end class StaticMesh */
 

--- a/cpp/solvcon/mesh/StaticMesh_boundary.cpp
+++ b/cpp/solvcon/mesh/StaticMesh_boundary.cpp
@@ -190,7 +190,7 @@ void StaticMesh::build_ghost()
     m_ngstface = static_cast<uint_type>(std::get<1>(count_ghost_tuple));
     m_ngstcell = static_cast<uint_type>(std::get<2>(count_ghost_tuple));
 
-#define MM_DECL_GHOST_SWAP1(N, T, D1, I)                                                          \
+#define SC_DECL_GHOST_SWAP1(N, T, D1, I)                                                          \
     {                                                                                             \
         SimpleArray<T> arr(small_vector<ssize_t>{static_cast<ssize_t>(m_ngst##D1 + m_n##D1)}, I); \
         arr.set_nghost(m_ngst##D1);                                                               \
@@ -201,7 +201,7 @@ void StaticMesh::build_ghost()
         arr.swap(m_##N);                                                                          \
     }
 
-#define MM_DECL_GHOST_SWAP2(N, T, D1, D2, I)                                                          \
+#define SC_DECL_GHOST_SWAP2(N, T, D1, D2, I)                                                          \
     {                                                                                                 \
         SimpleArray<T> arr(small_vector<ssize_t>{static_cast<ssize_t>(m_ngst##D1 + m_n##D1), D2}, I); \
         arr.set_nghost(m_ngst##D1);                                                                   \
@@ -217,24 +217,24 @@ void StaticMesh::build_ghost()
     }
 
     // geometry arrays.
-    MM_DECL_GHOST_SWAP2(ndcrd, real_type, node, m_ndim, 0)
-    MM_DECL_GHOST_SWAP2(fccnd, real_type, face, m_ndim, 0)
-    MM_DECL_GHOST_SWAP2(fcnml, real_type, face, m_ndim, 0)
-    MM_DECL_GHOST_SWAP1(fcara, real_type, face, 0)
-    MM_DECL_GHOST_SWAP2(clcnd, real_type, cell, m_ndim, 0)
-    MM_DECL_GHOST_SWAP1(clvol, real_type, cell, 0)
+    SC_DECL_GHOST_SWAP2(ndcrd, real_type, node, m_ndim, 0)
+    SC_DECL_GHOST_SWAP2(fccnd, real_type, face, m_ndim, 0)
+    SC_DECL_GHOST_SWAP2(fcnml, real_type, face, m_ndim, 0)
+    SC_DECL_GHOST_SWAP1(fcara, real_type, face, 0)
+    SC_DECL_GHOST_SWAP2(clcnd, real_type, cell, m_ndim, 0)
+    SC_DECL_GHOST_SWAP1(clvol, real_type, cell, 0)
     // meta arrays.
-    MM_DECL_GHOST_SWAP1(fctpn, int_type, face, 0)
-    MM_DECL_GHOST_SWAP1(cltpn, int_type, cell, 0)
-    MM_DECL_GHOST_SWAP1(clgrp, int_type, cell, -1)
+    SC_DECL_GHOST_SWAP1(fctpn, int_type, face, 0)
+    SC_DECL_GHOST_SWAP1(cltpn, int_type, cell, 0)
+    SC_DECL_GHOST_SWAP1(clgrp, int_type, cell, -1)
     // connectivity arrays.
-    MM_DECL_GHOST_SWAP2(fcnds, int_type, face, FCMND + 1, -1)
-    MM_DECL_GHOST_SWAP2(fccls, int_type, face, FCREL, -1)
-    MM_DECL_GHOST_SWAP2(clnds, int_type, cell, CLMND + 1, -1)
-    MM_DECL_GHOST_SWAP2(clfcs, int_type, cell, CLMFC + 1, -1)
+    SC_DECL_GHOST_SWAP2(fcnds, int_type, face, FCMND + 1, -1)
+    SC_DECL_GHOST_SWAP2(fccls, int_type, face, FCREL, -1)
+    SC_DECL_GHOST_SWAP2(clnds, int_type, cell, CLMND + 1, -1)
+    SC_DECL_GHOST_SWAP2(clfcs, int_type, cell, CLMFC + 1, -1)
 
-#undef MM_DECL_GHOST_SWAP1
-#undef MM_DECL_GHOST_SWAP2
+#undef SC_DECL_GHOST_SWAP1
+#undef SC_DECL_GHOST_SWAP2
 
     fill_ghost();
 }

--- a/cpp/solvcon/mesh/pymod/wrap_StaticGrid.cpp
+++ b/cpp/solvcon/mesh/pymod/wrap_StaticGrid.cpp
@@ -98,7 +98,7 @@ WrapStaticGrid1d::WrapStaticGrid1d(pybind11::module & mod, char const * pyname, 
 }
 
 // clang-format off
-#define MM_DECL_StaticGridMD(NDIM) \
+#define SC_DECL_StaticGridMD(NDIM) \
 class \
 SOLVCON_PYTHON_WRAPPER_VISIBILITY \
 WrapStaticGrid ## NDIM ## d \
@@ -120,10 +120,10 @@ protected: \
 } /* end class WrapStaticGrid##NDIM##d */
 // clang-format on
 
-MM_DECL_StaticGridMD(2);
-MM_DECL_StaticGridMD(3);
+SC_DECL_StaticGridMD(2);
+SC_DECL_StaticGridMD(3);
 
-#undef MM_DECL_StaticGridMD
+#undef SC_DECL_StaticGridMD
 
 void wrap_StaticGrid(pybind11::module & mod)
 {

--- a/cpp/solvcon/mesh/pymod/wrap_StaticMesh.cpp
+++ b/cpp/solvcon/mesh/pymod/wrap_StaticMesh.cpp
@@ -78,20 +78,20 @@ WrapStaticMesh::WrapStaticMesh(pybind11::module & mod, char const * pyname, char
         //
         ;
 
-#define MM_DECL_STATIC(NAME) \
+#define SC_DECL_STATIC(NAME) \
     .def_property_readonly_static(#NAME, [](py::object const &) { return wrapped_type::NAME; })
 
     // clang-format off
         (*this)
-            MM_DECL_STATIC(FCMND)
-            MM_DECL_STATIC(CLMND)
-            MM_DECL_STATIC(CLMFC)
-            MM_DECL_STATIC(FCREL)
-            MM_DECL_STATIC(BFREL)
+            SC_DECL_STATIC(FCMND)
+            SC_DECL_STATIC(CLMND)
+            SC_DECL_STATIC(CLMFC)
+            SC_DECL_STATIC(FCREL)
+            SC_DECL_STATIC(BFREL)
         ;
     // clang-format on
 
-#undef MM_DECL_STATIC
+#undef SC_DECL_STATIC
 
     (*this)
         .def_property_readonly("ndim", &wrapped_type::ndim)
@@ -138,30 +138,30 @@ WrapStaticMesh::WrapStaticMesh(pybind11::module & mod, char const * pyname, char
         .def_property_readonly("bcs", [](wrapped_type & self)
                                { return self.bcs(); });
 
-#define MM_DECL_ARRAY(NAME) \
+#define SC_DECL_ARRAY(NAME) \
     .expose_SimpleArray(#NAME, [](wrapped_type & self) -> decltype(auto) { return self.NAME(); })
 
     // clang-format off
         (*this)
-            MM_DECL_ARRAY(ndcrd)
-            MM_DECL_ARRAY(fccnd)
-            MM_DECL_ARRAY(fcnml)
-            MM_DECL_ARRAY(fcara)
-            MM_DECL_ARRAY(clcnd)
-            MM_DECL_ARRAY(clvol)
-            MM_DECL_ARRAY(fctpn)
-            MM_DECL_ARRAY(cltpn)
-            MM_DECL_ARRAY(clgrp)
-            MM_DECL_ARRAY(fcnds)
-            MM_DECL_ARRAY(fccls)
-            MM_DECL_ARRAY(clnds)
-            MM_DECL_ARRAY(clfcs)
-            MM_DECL_ARRAY(ednds)
-            MM_DECL_ARRAY(bndfcs)
+            SC_DECL_ARRAY(ndcrd)
+            SC_DECL_ARRAY(fccnd)
+            SC_DECL_ARRAY(fcnml)
+            SC_DECL_ARRAY(fcara)
+            SC_DECL_ARRAY(clcnd)
+            SC_DECL_ARRAY(clvol)
+            SC_DECL_ARRAY(fctpn)
+            SC_DECL_ARRAY(cltpn)
+            SC_DECL_ARRAY(clgrp)
+            SC_DECL_ARRAY(fcnds)
+            SC_DECL_ARRAY(fccls)
+            SC_DECL_ARRAY(clnds)
+            SC_DECL_ARRAY(clfcs)
+            SC_DECL_ARRAY(ednds)
+            SC_DECL_ARRAY(bndfcs)
         ;
     // clang-format on
 
-#undef MM_DECL_ARRAY
+#undef SC_DECL_ARRAY
 
     this->cls().attr("NONCELLTYPE") = static_cast<uint8_t>(CellType::NONCELLTYPE);
     this->cls().attr("POINT") = static_cast<uint8_t>(CellType::POINT);

--- a/cpp/solvcon/multidim/pymod/wrap_multidim.cpp
+++ b/cpp/solvcon/multidim/pymod/wrap_multidim.cpp
@@ -380,29 +380,29 @@ WrapEulerCore & WrapEulerCore::wrap_boundary()
 
 WrapEulerCore & WrapEulerCore::wrap_array()
 {
-#define MM_DECL_ARRAY(NAME) \
+#define SC_DECL_ARRAY(NAME) \
     .expose_SimpleArray(#NAME, [](wrapped_type & self) -> decltype(auto) { return self.NAME(); })
 
     // clang-format off
     (*this)
-        MM_DECL_ARRAY(cevol)
-        MM_DECL_ARRAY(cecnd)
-        MM_DECL_ARRAY(sfcnd)
-        MM_DECL_ARRAY(sfnml)
-        MM_DECL_ARRAY(so0c)
-        MM_DECL_ARRAY(so0n)
-        MM_DECL_ARRAY(so0t)
-        MM_DECL_ARRAY(so1c)
-        MM_DECL_ARRAY(so1n)
-        MM_DECL_ARRAY(stm)
-        MM_DECL_ARRAY(cflo)
-        MM_DECL_ARRAY(cflc)
-        MM_DECL_ARRAY(gamma)
+        SC_DECL_ARRAY(cevol)
+        SC_DECL_ARRAY(cecnd)
+        SC_DECL_ARRAY(sfcnd)
+        SC_DECL_ARRAY(sfnml)
+        SC_DECL_ARRAY(so0c)
+        SC_DECL_ARRAY(so0n)
+        SC_DECL_ARRAY(so0t)
+        SC_DECL_ARRAY(so1c)
+        SC_DECL_ARRAY(so1n)
+        SC_DECL_ARRAY(stm)
+        SC_DECL_ARRAY(cflo)
+        SC_DECL_ARRAY(cflc)
+        SC_DECL_ARRAY(gamma)
         //
         ;
     // clang-format on
 
-#undef MM_DECL_ARRAY
+#undef SC_DECL_ARRAY
 
     return *this;
 }

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -587,7 +587,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                     self.pinchCamera(factor);
                 },
                 py::arg("factor"))
-#define MM_DECL_CAMERA_VECTOR(NAME, GETTER, SETTER)            \
+#define SC_DECL_CAMERA_VECTOR(NAME, GETTER, SETTER)            \
     .def_property(                                             \
         NAME,                                                  \
         [](wrapped_type & self)                                \
@@ -600,11 +600,11 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
             self.SETTER(QVector3D(v.at(0), v.at(1), v.at(2))); \
         })
             // clang-format off
-            MM_DECL_CAMERA_VECTOR("cameraPosition", cameraPosition, setCameraPosition)
-            MM_DECL_CAMERA_VECTOR("cameraTarget", cameraTarget, setCameraTarget)
-            MM_DECL_CAMERA_VECTOR("cameraUp", cameraUp, setCameraUp)
+            SC_DECL_CAMERA_VECTOR("cameraPosition", cameraPosition, setCameraPosition)
+            SC_DECL_CAMERA_VECTOR("cameraTarget", cameraTarget, setCameraTarget)
+            SC_DECL_CAMERA_VECTOR("cameraUp", cameraUp, setCameraUp)
         // clang-format on
-#undef MM_DECL_CAMERA_VECTOR
+#undef SC_DECL_CAMERA_VECTOR
             .def(
                 "saveImage",
                 [](wrapped_type & self, std::string const & filename)

--- a/cpp/solvcon/profiling/SerializableProfiler.hpp
+++ b/cpp/solvcon/profiling/SerializableProfiler.hpp
@@ -62,7 +62,7 @@ public:
     }
 
     // NOLINTNEXTLINE(misc-no-recursion)
-    MM_DECL_SERIALIZABLE(
+    SC_DECL_SERIALIZABLE(
         register_member("key", m_key);
         register_member("name", m_name);
         register_member("total_time", static_cast<double>(m_total_time.count()));
@@ -113,7 +113,7 @@ public:
     {
     }
 
-    MM_DECL_SERIALIZABLE(
+    SC_DECL_SERIALIZABLE(
         register_member("time_unit", m_time_unit);
         register_member("radix_tree", m_root);
         register_member("id_map", m_id_map);

--- a/cpp/solvcon/python/common.hpp
+++ b/cpp/solvcon/python/common.hpp
@@ -295,7 +295,7 @@ public:
     WrapBase & operator=(WrapBase &&) = delete;
     ~WrapBase() = default;
 
-#define DECL_MM_PYBIND_CLASS_METHOD_UNTIMED(METHOD)                           \
+#define SC_DECL_PYBIND_CLASS_METHOD_UNTIMED(METHOD)                           \
     template <class... Args> /* NOLINTNEXTLINE(bugprone-macro-parentheses) */ \
     wrapper_type & METHOD(Args &&... args)                                    \
     {                                                                         \
@@ -304,7 +304,7 @@ public:
     }
 
 // ref: https://pybind11.readthedocs.io/en/stable/advanced/functions.html#call-guard
-#define DECL_MM_PYBIND_CLASS_METHOD_TIMED(METHOD)                             \
+#define SC_DECL_PYBIND_CLASS_METHOD_TIMED(METHOD)                             \
     template <class... Args> /* NOLINTNEXTLINE(bugprone-macro-parentheses) */ \
     wrapper_type & METHOD##_timed(Args &&... args)                            \
     {                                                                         \
@@ -313,32 +313,32 @@ public:
         return *static_cast<std::add_pointer_t<wrapper_type>>(this);          \
     }
 
-#define DECL_MM_PYBIND_CLASS_METHOD(METHOD)     \
-    DECL_MM_PYBIND_CLASS_METHOD_UNTIMED(METHOD) \
-    DECL_MM_PYBIND_CLASS_METHOD_TIMED(METHOD)
+#define SC_DECL_PYBIND_CLASS_METHOD(METHOD)     \
+    SC_DECL_PYBIND_CLASS_METHOD_UNTIMED(METHOD) \
+    SC_DECL_PYBIND_CLASS_METHOD_TIMED(METHOD)
 
     // The args pack is forwarded inside the macro-generated bodies above;
     // clang-tidy misattributes the forwarding through the macro expansion.
     // NOLINTBEGIN(cppcoreguidelines-missing-std-forward)
-    DECL_MM_PYBIND_CLASS_METHOD(def)
-    DECL_MM_PYBIND_CLASS_METHOD(def_static)
+    SC_DECL_PYBIND_CLASS_METHOD(def)
+    SC_DECL_PYBIND_CLASS_METHOD(def_static)
 
-    DECL_MM_PYBIND_CLASS_METHOD(def_readwrite)
-    DECL_MM_PYBIND_CLASS_METHOD(def_readonly)
-    DECL_MM_PYBIND_CLASS_METHOD(def_readwrite_static)
-    DECL_MM_PYBIND_CLASS_METHOD(def_readonly_static)
+    SC_DECL_PYBIND_CLASS_METHOD(def_readwrite)
+    SC_DECL_PYBIND_CLASS_METHOD(def_readonly)
+    SC_DECL_PYBIND_CLASS_METHOD(def_readwrite_static)
+    SC_DECL_PYBIND_CLASS_METHOD(def_readonly_static)
 
-    DECL_MM_PYBIND_CLASS_METHOD(def_property)
-    DECL_MM_PYBIND_CLASS_METHOD(def_property_static)
-    DECL_MM_PYBIND_CLASS_METHOD(def_property_readonly)
-    DECL_MM_PYBIND_CLASS_METHOD(def_property_readonly_static)
+    SC_DECL_PYBIND_CLASS_METHOD(def_property)
+    SC_DECL_PYBIND_CLASS_METHOD(def_property_static)
+    SC_DECL_PYBIND_CLASS_METHOD(def_property_readonly)
+    SC_DECL_PYBIND_CLASS_METHOD(def_property_readonly_static)
 
-    DECL_MM_PYBIND_CLASS_METHOD_UNTIMED(def_buffer)
+    SC_DECL_PYBIND_CLASS_METHOD_UNTIMED(def_buffer)
     // NOLINTEND(cppcoreguidelines-missing-std-forward)
 
-#undef DECL_MM_PYBIND_CLASS_METHOD_UNTIMED
-#undef DECL_MM_PYBIND_CLASS_METHOD_TIMED
-#undef DECL_MM_PYBIND_CLASS_METHOD
+#undef SC_DECL_PYBIND_CLASS_METHOD_UNTIMED
+#undef SC_DECL_PYBIND_CLASS_METHOD_TIMED
+#undef SC_DECL_PYBIND_CLASS_METHOD
 
     wrapper_type & def_alias(char const * from_name, char const * to_name)
     {

--- a/cpp/solvcon/serialization/SerializableItem.cpp
+++ b/cpp/solvcon/serialization/SerializableItem.cpp
@@ -71,7 +71,7 @@ std::string trim_string(const std::string & str)
     return (start == std::string::npos) ? "" : str.substr(start, end - start + 1);
 }
 
-#define MM_DECL_CACULATE_LINE_COLUMN(CH) \
+#define SC_DECL_CACULATE_LINE_COLUMN(CH) \
     if (CH == '\n')                      \
     {                                    \
         line += 1;                       \
@@ -132,7 +132,7 @@ inline void scan_balanced_expression(const std::string & json, size_t & index, c
             break;
         }
 
-        MM_DECL_CACULATE_LINE_COLUMN(json[index])
+        SC_DECL_CACULATE_LINE_COLUMN(json[index])
         index += 1;
     }
 
@@ -165,7 +165,7 @@ JsonArray JsonNode::parse_array(const std::string & json)
 
         if (is_whitespace(c))
         {
-            MM_DECL_CACULATE_LINE_COLUMN(c)
+            SC_DECL_CACULATE_LINE_COLUMN(c)
             continue;
         }
 
@@ -255,7 +255,7 @@ JsonArray JsonNode::parse_array(const std::string & json)
                         break;
                     }
 
-                    MM_DECL_CACULATE_LINE_COLUMN(json[index])
+                    SC_DECL_CACULATE_LINE_COLUMN(json[index])
                     index += 1;
                 }
 
@@ -363,7 +363,7 @@ JsonMap JsonNode::parse_object(const std::string & json)
 
         if (is_whitespace(c))
         {
-            MM_DECL_CACULATE_LINE_COLUMN(c)
+            SC_DECL_CACULATE_LINE_COLUMN(c)
             continue;
         }
 
@@ -405,7 +405,7 @@ JsonMap JsonNode::parse_object(const std::string & json)
                         break;
                     }
                     key.push_back(json[index]);
-                    MM_DECL_CACULATE_LINE_COLUMN(json[index])
+                    SC_DECL_CACULATE_LINE_COLUMN(json[index])
                     index += 1;
                 }
                 if (!close)
@@ -494,7 +494,7 @@ JsonMap JsonNode::parse_object(const std::string & json)
                         break;
                     }
 
-                    MM_DECL_CACULATE_LINE_COLUMN(json[index])
+                    SC_DECL_CACULATE_LINE_COLUMN(json[index])
                     index += 1;
                 }
 
@@ -572,7 +572,7 @@ JsonMap JsonNode::parse_object(const std::string & json)
 }
 // NOLINTEND(readability-function-cognitive-complexity)
 
-#undef MM_DECL_CACULATE_LINE_COLUMN
+#undef SC_DECL_CACULATE_LINE_COLUMN
 
 } /* end namespace detail */
 

--- a/cpp/solvcon/serialization/SerializableItem.hpp
+++ b/cpp/solvcon/serialization/SerializableItem.hpp
@@ -325,7 +325,7 @@ void JsonHelper::from_json_string(const std::unique_ptr<JsonNode> & node, std::v
 /// The order of members in the JSON string is based on the order of `register_member` calls.
 /// The access modifier of the members can be public or private.
 /// The access modifier will be changed to private after the macro.
-#define MM_DECL_SERIALIZABLE(...)                                                                   \
+#define SC_DECL_SERIALIZABLE(...)                                                                   \
 public:                                                                                             \
     /* FIXME: NOLINTNEXTLINE(misc-no-recursion) */                                                  \
     std::string to_json() const override                                                            \
@@ -385,7 +385,7 @@ private:                                                                        
             }                                                                                       \
         };                                                                                          \
         __VA_ARGS__                                                                                 \
-    } /* end MM_DECL_SERIALIZABLE*/
+    } /* end SC_DECL_SERIALIZABLE*/
 
 } /* end namespace solvcon */
 

--- a/cpp/solvcon/simd/neon/neon_alias.hpp
+++ b/cpp/solvcon/simd/neon/neon_alias.hpp
@@ -23,7 +23,7 @@ namespace neon
 #define utype_t(N) uint##N##_t
 #define stype_t(N) int##N##_t
 
-#define DECL_MM_IMPL_VGETQ(N)                               \
+#define SC_DECL_IMPL_VGETQ(N)                               \
     template <size_t n>                                     \
     static utype_t(N) vgetq(type::vector_t<utype_t(N)> vec) \
     {                                                       \
@@ -37,14 +37,14 @@ namespace neon
         return vgetq_lane_s##N(vec, n);                     \
     }
 
-DECL_MM_IMPL_VGETQ(8)
-DECL_MM_IMPL_VGETQ(16)
-DECL_MM_IMPL_VGETQ(32)
-DECL_MM_IMPL_VGETQ(64)
+SC_DECL_IMPL_VGETQ(8)
+SC_DECL_IMPL_VGETQ(16)
+SC_DECL_IMPL_VGETQ(32)
+SC_DECL_IMPL_VGETQ(64)
 
-#undef DECL_MM_IMPL_VGETQ
+#undef SC_DECL_IMPL_VGETQ
 
-#define DECL_MM_IMPL_VDUPQ(N)                                      \
+#define SC_DECL_IMPL_VDUPQ(N)                                      \
     inline static type::vector_t<utype_t(N)> vdupq(utype_t(N) val) \
     {                                                              \
         return vdupq_n_u##N(val);                                  \
@@ -54,12 +54,12 @@ DECL_MM_IMPL_VGETQ(64)
         return vdupq_n_s##N(val);                                  \
     }
 
-DECL_MM_IMPL_VDUPQ(8)
-DECL_MM_IMPL_VDUPQ(16)
-DECL_MM_IMPL_VDUPQ(32)
-DECL_MM_IMPL_VDUPQ(64)
+SC_DECL_IMPL_VDUPQ(8)
+SC_DECL_IMPL_VDUPQ(16)
+SC_DECL_IMPL_VDUPQ(32)
+SC_DECL_IMPL_VDUPQ(64)
 
-#undef DECL_MM_IMPL_VDUPQ
+#undef SC_DECL_IMPL_VDUPQ
 
 inline static type::vector_t<float> vdupq(float val)
 {
@@ -71,7 +71,7 @@ inline static type::vector_t<double> vdupq(double val)
     return vdupq_n_f64(val);
 }
 
-#define DECL_MM_IMPL_VLD1Q(N)                                              \
+#define SC_DECL_IMPL_VLD1Q(N)                                              \
     inline static type::vector_t<utype_t(N)> vld1q(utype_t(N) * ptr)       \
     {                                                                      \
         return vld1q_u##N(ptr);                                            \
@@ -89,12 +89,12 @@ inline static type::vector_t<double> vdupq(double val)
         return vld1q_s##N(ptr);                                            \
     }
 
-DECL_MM_IMPL_VLD1Q(8)
-DECL_MM_IMPL_VLD1Q(16)
-DECL_MM_IMPL_VLD1Q(32)
-DECL_MM_IMPL_VLD1Q(64)
+SC_DECL_IMPL_VLD1Q(8)
+SC_DECL_IMPL_VLD1Q(16)
+SC_DECL_IMPL_VLD1Q(32)
+SC_DECL_IMPL_VLD1Q(64)
 
-#undef DECL_MM_IMPL_VLD1Q
+#undef SC_DECL_IMPL_VLD1Q
 
 inline static type::vector_t<float> vld1q(float * ptr)
 {
@@ -116,7 +116,7 @@ inline static type::vector_t<double> vld1q(double const * ptr)
     return vld1q_f64(ptr);
 }
 
-#define DECL_MM_IMPL_VST1Q(N)                                                  \
+#define SC_DECL_IMPL_VST1Q(N)                                                  \
     inline static void vst1q(utype_t(N) * ptr, type::vector_t<utype_t(N)> vec) \
     {                                                                          \
         return vst1q_u##N(ptr, vec);                                           \
@@ -126,12 +126,12 @@ inline static type::vector_t<double> vld1q(double const * ptr)
         return vst1q_s##N(ptr, vec);                                           \
     }
 
-DECL_MM_IMPL_VST1Q(8)
-DECL_MM_IMPL_VST1Q(16)
-DECL_MM_IMPL_VST1Q(32)
-DECL_MM_IMPL_VST1Q(64)
+SC_DECL_IMPL_VST1Q(8)
+SC_DECL_IMPL_VST1Q(16)
+SC_DECL_IMPL_VST1Q(32)
+SC_DECL_IMPL_VST1Q(64)
 
-#undef DECL_MM_IMPL_VST1Q
+#undef SC_DECL_IMPL_VST1Q
 
 inline static void vst1q(float * ptr, type::vector_t<float> vec)
 {
@@ -143,7 +143,7 @@ inline static void vst1q(double * ptr, type::vector_t<double> vec)
     vst1q_f64(ptr, vec);
 }
 
-#define DECL_MM_IMPL_VCGEQ(N)                                                                                          \
+#define SC_DECL_IMPL_VCGEQ(N)                                                                                          \
     inline static type::vector_t<utype_t(N)> vcgeq(type::vector_t<utype_t(N)> vec_a, type::vector_t<utype_t(N)> vec_b) \
     {                                                                                                                  \
         return vcgeq_u##N(vec_a, vec_b);                                                                               \
@@ -153,12 +153,12 @@ inline static void vst1q(double * ptr, type::vector_t<double> vec)
         return vcgeq_s##N(vec_a, vec_b);                                                                               \
     }
 
-DECL_MM_IMPL_VCGEQ(8)
-DECL_MM_IMPL_VCGEQ(16)
-DECL_MM_IMPL_VCGEQ(32)
-DECL_MM_IMPL_VCGEQ(64)
+SC_DECL_IMPL_VCGEQ(8)
+SC_DECL_IMPL_VCGEQ(16)
+SC_DECL_IMPL_VCGEQ(32)
+SC_DECL_IMPL_VCGEQ(64)
 
-#undef DECL_MM_IMPL_VCGEQ
+#undef SC_DECL_IMPL_VCGEQ
 
 inline static type::vector_t<float> vcgeq(type::vector_t<float> vec_a, type::vector_t<float> vec_b)
 {
@@ -170,7 +170,7 @@ inline static type::vector_t<double> vcgeq(type::vector_t<double> vec_a, type::v
     return vcgeq_f64(vec_a, vec_b);
 }
 
-#define DECL_MM_IMPL_VCLTQ(N)                                                                                          \
+#define SC_DECL_IMPL_VCLTQ(N)                                                                                          \
     inline static type::vector_t<utype_t(N)> vcltq(type::vector_t<utype_t(N)> vec_a, type::vector_t<utype_t(N)> vec_b) \
     {                                                                                                                  \
         return vcltq_u##N(vec_a, vec_b);                                                                               \
@@ -180,12 +180,12 @@ inline static type::vector_t<double> vcgeq(type::vector_t<double> vec_a, type::v
         return vcltq_s##N(vec_a, vec_b);                                                                               \
     }
 
-DECL_MM_IMPL_VCLTQ(8)
-DECL_MM_IMPL_VCLTQ(16)
-DECL_MM_IMPL_VCLTQ(32)
-DECL_MM_IMPL_VCLTQ(64)
+SC_DECL_IMPL_VCLTQ(8)
+SC_DECL_IMPL_VCLTQ(16)
+SC_DECL_IMPL_VCLTQ(32)
+SC_DECL_IMPL_VCLTQ(64)
 
-#undef DECL_MM_IMPL_VCLTQ
+#undef SC_DECL_IMPL_VCLTQ
 
 inline static type::vector_t<float> vcltq(type::vector_t<float> vec_a, type::vector_t<float> vec_b)
 {
@@ -197,7 +197,7 @@ inline static type::vector_t<double> vcltq(type::vector_t<double> vec_a, type::v
     return vcltq_f64(vec_a, vec_b);
 }
 
-#define DECL_MM_IMPL_VADDQ(N)                                                                                          \
+#define SC_DECL_IMPL_VADDQ(N)                                                                                          \
     inline static type::vector_t<utype_t(N)> vaddq(type::vector_t<utype_t(N)> vec_a, type::vector_t<utype_t(N)> vec_b) \
     {                                                                                                                  \
         return vaddq_u##N(vec_a, vec_b);                                                                               \
@@ -207,12 +207,12 @@ inline static type::vector_t<double> vcltq(type::vector_t<double> vec_a, type::v
         return vaddq_s##N(vec_a, vec_b);                                                                               \
     }
 
-DECL_MM_IMPL_VADDQ(8)
-DECL_MM_IMPL_VADDQ(16)
-DECL_MM_IMPL_VADDQ(32)
-DECL_MM_IMPL_VADDQ(64)
+SC_DECL_IMPL_VADDQ(8)
+SC_DECL_IMPL_VADDQ(16)
+SC_DECL_IMPL_VADDQ(32)
+SC_DECL_IMPL_VADDQ(64)
 
-#undef DECL_MM_IMPL_VADDQ
+#undef SC_DECL_IMPL_VADDQ
 
 inline static type::vector_t<float> vaddq(type::vector_t<float> vec_a, type::vector_t<float> vec_b)
 {
@@ -224,7 +224,7 @@ inline static type::vector_t<double> vaddq(type::vector_t<double> vec_a, type::v
     return vaddq_f64(vec_a, vec_b);
 }
 
-#define DECL_MM_IMPL_VSUBQ(N)                                                                                          \
+#define SC_DECL_IMPL_VSUBQ(N)                                                                                          \
     inline static type::vector_t<utype_t(N)> vsubq(type::vector_t<utype_t(N)> vec_a, type::vector_t<utype_t(N)> vec_b) \
     {                                                                                                                  \
         return vsubq_u##N(vec_a, vec_b);                                                                               \
@@ -234,12 +234,12 @@ inline static type::vector_t<double> vaddq(type::vector_t<double> vec_a, type::v
         return vsubq_s##N(vec_a, vec_b);                                                                               \
     }
 
-DECL_MM_IMPL_VSUBQ(8)
-DECL_MM_IMPL_VSUBQ(16)
-DECL_MM_IMPL_VSUBQ(32)
-DECL_MM_IMPL_VSUBQ(64)
+SC_DECL_IMPL_VSUBQ(8)
+SC_DECL_IMPL_VSUBQ(16)
+SC_DECL_IMPL_VSUBQ(32)
+SC_DECL_IMPL_VSUBQ(64)
 
-#undef DECL_MM_IMPL_VSUBQ
+#undef SC_DECL_IMPL_VSUBQ
 
 inline static type::vector_t<float> vsubq(type::vector_t<float> vec_a, type::vector_t<float> vec_b)
 {
@@ -251,7 +251,7 @@ inline static type::vector_t<double> vsubq(type::vector_t<double> vec_a, type::v
     return vsubq_f64(vec_a, vec_b);
 }
 
-#define DECL_MM_IMPL_VMULQ(N)                                                                                          \
+#define SC_DECL_IMPL_VMULQ(N)                                                                                          \
     inline static type::vector_t<utype_t(N)> vmulq(type::vector_t<utype_t(N)> vec_a, type::vector_t<utype_t(N)> vec_b) \
     {                                                                                                                  \
         return vmulq_u##N(vec_a, vec_b);                                                                               \
@@ -261,11 +261,11 @@ inline static type::vector_t<double> vsubq(type::vector_t<double> vec_a, type::v
         return vmulq_s##N(vec_a, vec_b);                                                                               \
     }
 
-DECL_MM_IMPL_VMULQ(8)
-DECL_MM_IMPL_VMULQ(16)
-DECL_MM_IMPL_VMULQ(32)
+SC_DECL_IMPL_VMULQ(8)
+SC_DECL_IMPL_VMULQ(16)
+SC_DECL_IMPL_VMULQ(32)
 
-#undef DECL_MM_IMPL_VMULQ
+#undef SC_DECL_IMPL_VMULQ
 
 inline static type::vector_t<float> vmulq(type::vector_t<float> vec_a, type::vector_t<float> vec_b)
 {

--- a/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
@@ -109,20 +109,20 @@ WrapFixedToggle::WrapFixedToggle(pybind11::module & mod, const char * pyname, co
 
     std::list<std::string> names;
 
-#define MM_PYTHON_TOGGLE_FIXED(NAME)                                                   \
+#define SC_PYTHON_TOGGLE_FIXED(NAME)                                                   \
     (*this).def_property(#NAME, &wrapped_type::get_##NAME, &wrapped_type::set_##NAME); \
     names.emplace_back(#NAME);
 
     // Instance properties.
     // clang-format off
-    MM_PYTHON_TOGGLE_FIXED(python_redirect)
-    MM_PYTHON_TOGGLE_FIXED(show_axis)
+    SC_PYTHON_TOGGLE_FIXED(python_redirect)
+    SC_PYTHON_TOGGLE_FIXED(show_axis)
     // clang-format on
 
     names.sort();
     cls().attr("NAMES") = names;
 
-#undef MM_PYTHON_TOGGLE_FIXED
+#undef SC_PYTHON_TOGGLE_FIXED
 }
 
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapHierarchicalToggleAccess

--- a/cpp/solvcon/toggle/toggle.cpp
+++ b/cpp/solvcon/toggle/toggle.cpp
@@ -45,7 +45,7 @@ std::string const DynamicToggleTable::sentinel_string = "";
 
 /* The macro gives debuggers a hard time. Manually expand it if you need to
  * step in a debugger. */
-#define MM_DECL_DYNGET(CTYPE, MTYPE, SENTINEL)                                 \
+#define SC_DECL_DYNGET(CTYPE, MTYPE, SENTINEL)                                 \
     CTYPE DynamicToggleTable::get_##MTYPE(std::string const & key) const       \
     {                                                                          \
         std::scoped_lock const guard(m_mutex);                                 \
@@ -63,18 +63,18 @@ std::string const DynamicToggleTable::sentinel_string = "";
     {                                                                          \
         return m_table->get_##MTYPE(rekey(key));                               \
     }
-MM_DECL_DYNGET(bool, bool, false)
-MM_DECL_DYNGET(int8_t, int8, 0)
-MM_DECL_DYNGET(int16_t, int16, 0)
-MM_DECL_DYNGET(int32_t, int32, 0)
-MM_DECL_DYNGET(int64_t, int64, 0)
-MM_DECL_DYNGET(double, real, std::nan("0"))
-MM_DECL_DYNGET(std::string const &, string, sentinel_string)
-#undef MM_DECL_DYNGET
+SC_DECL_DYNGET(bool, bool, false)
+SC_DECL_DYNGET(int8_t, int8, 0)
+SC_DECL_DYNGET(int16_t, int16, 0)
+SC_DECL_DYNGET(int32_t, int32, 0)
+SC_DECL_DYNGET(int64_t, int64, 0)
+SC_DECL_DYNGET(double, real, std::nan("0"))
+SC_DECL_DYNGET(std::string const &, string, sentinel_string)
+#undef SC_DECL_DYNGET
 
 /* The macro gives debuggers a hard time. Manually expand it if you need to
  * step in a debugger. */
-#define MM_DECL_DYNSET(CTYPE, MTYPE, MTYPEC)                                                                                     \
+#define SC_DECL_DYNSET(CTYPE, MTYPE, MTYPEC)                                                                                     \
     /* NOLINTNEXTLINE(bugprone-easily-swappable-parameters) */                                                                   \
     void DynamicToggleTable::set_##MTYPE(std::string const & key, CTYPE value)                                                   \
     {                                                                                                                            \
@@ -111,14 +111,14 @@ MM_DECL_DYNGET(std::string const &, string, sentinel_string)
     {                                                                                                                            \
         m_table->set_##MTYPE(rekey(key), value);                                                                                 \
     }
-MM_DECL_DYNSET(bool, bool, BOOL)
-MM_DECL_DYNSET(int8_t, int8, INT8)
-MM_DECL_DYNSET(int16_t, int16, INT16)
-MM_DECL_DYNSET(int32_t, int32, INT32)
-MM_DECL_DYNSET(int64_t, int64, INT64)
-MM_DECL_DYNSET(double, real, REAL)
-MM_DECL_DYNSET(std::string const &, string, STRING)
-#undef MM_DECL_DYNSET
+SC_DECL_DYNSET(bool, bool, BOOL)
+SC_DECL_DYNSET(int8_t, int8, INT8)
+SC_DECL_DYNSET(int16_t, int16, INT16)
+SC_DECL_DYNSET(int32_t, int32, INT32)
+SC_DECL_DYNSET(int64_t, int64, INT64)
+SC_DECL_DYNSET(double, real, REAL)
+SC_DECL_DYNSET(std::string const &, string, STRING)
+#undef SC_DECL_DYNSET
 
 HierarchicalToggleAccess HierarchicalToggleAccess::get_subkey(const std::string & key)
 {

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -204,21 +204,21 @@ struct DynamicToggleIndex
 template <typename T>
 struct ToggleTypeTraits;
 
-#define MM_TOGGLE_TYPE_TRAITS(CTYPE, TAG)               \
+#define SC_TOGGLE_TYPE_TRAITS(CTYPE, TAG)               \
     template <>                                         \
     struct ToggleTypeTraits<CTYPE>                      \
     {                                                   \
         static constexpr DynamicToggleIndex::Type tag = \
             DynamicToggleIndex::TAG;                    \
     }; /* end struct ToggleTypeTraits */
-MM_TOGGLE_TYPE_TRAITS(bool, TYPE_BOOL)
-MM_TOGGLE_TYPE_TRAITS(int8_t, TYPE_INT8)
-MM_TOGGLE_TYPE_TRAITS(int16_t, TYPE_INT16)
-MM_TOGGLE_TYPE_TRAITS(int32_t, TYPE_INT32)
-MM_TOGGLE_TYPE_TRAITS(int64_t, TYPE_INT64)
-MM_TOGGLE_TYPE_TRAITS(double, TYPE_REAL)
-MM_TOGGLE_TYPE_TRAITS(std::string, TYPE_STRING)
-#undef MM_TOGGLE_TYPE_TRAITS
+SC_TOGGLE_TYPE_TRAITS(bool, TYPE_BOOL)
+SC_TOGGLE_TYPE_TRAITS(int8_t, TYPE_INT8)
+SC_TOGGLE_TYPE_TRAITS(int16_t, TYPE_INT16)
+SC_TOGGLE_TYPE_TRAITS(int32_t, TYPE_INT32)
+SC_TOGGLE_TYPE_TRAITS(int64_t, TYPE_INT64)
+SC_TOGGLE_TYPE_TRAITS(double, TYPE_REAL)
+SC_TOGGLE_TYPE_TRAITS(std::string, TYPE_STRING)
+#undef SC_TOGGLE_TYPE_TRAITS
 
 namespace detail
 {

--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -147,7 +147,7 @@ public:
 
     // The shape type serializes to its lower-case name (e.g. "triangle") so
     // the rendered JSON stays human-readable; this is an output-only view.
-    MM_DECL_SERIALIZABLE(
+    SC_DECL_SERIALIZABLE(
         register_member("id", m_id);
         register_member("type", shape_type_name(m_type));
         register_member("bbox", m_bbox);
@@ -202,7 +202,7 @@ public:
     std::optional<WorldDiagnostics> const & diagnostics() const { return m_diagnostics; }
     std::optional<WorldDiagnostics> & diagnostics() { return m_diagnostics; }
 
-    MM_DECL_SERIALIZABLE(
+    SC_DECL_SERIALIZABLE(
         register_member("shapes", m_shapes);
         register_member("segments", m_segments);
         register_member("curves", m_curves);

--- a/cpp/solvcon/universe/WorldDiagnostics.hpp
+++ b/cpp/solvcon/universe/WorldDiagnostics.hpp
@@ -56,7 +56,7 @@ public:
     {
     }
 
-    MM_DECL_SERIALIZABLE(
+    SC_DECL_SERIALIZABLE(
         register_member("shapes", m_shapes);
         register_member("point", m_point);)
 
@@ -91,7 +91,7 @@ public:
     {
     }
 
-    MM_DECL_SERIALIZABLE(
+    SC_DECL_SERIALIZABLE(
         register_member("shape", m_shape);
         register_member("type", m_type);
         register_member("reason", m_reason);)
@@ -132,7 +132,7 @@ public:
         m_degeneracies.emplace_back(shape, std::move(type), std::move(reason));
     }
 
-    MM_DECL_SERIALIZABLE(
+    SC_DECL_SERIALIZABLE(
         register_member("intersections", m_intersections);
         register_member("degeneracies", m_degeneracies);)
 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -41,6 +41,6 @@ PREDEFINED           = "PYBIND11_EXPORT=" \
                        "Q_INVOKABLE=" \
                        "Q_SIGNALS=signals" \
                        "Q_SLOTS=slots" \
-                       "MM_DECL_SERIALIZABLE(x)="
+                       "SC_DECL_SERIALIZABLE(x)="
 
 # vim: set ft=conf ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79:

--- a/doc/source/devguide/testing.md
+++ b/doc/source/devguide/testing.md
@@ -97,40 +97,40 @@ These variables tune the workflows. Set them as repository variables (under
 Settings, then Secrets and variables, then Actions, then the Variables tab).
 Each is read with a default, so an unset variable keeps the default behavior.
 
-- `MMGH_NIGHTLY`: set to `enable` to let the nightly schedule run its jobs.
+- `SCGH_NIGHTLY`: set to `enable` to let the nightly schedule run its jobs.
   Unset, every scheduled run is skipped.
-- `MMGH_PUSH_RUN_BRANCH`: which branches run the fast set on a `push`. Use `*`
+- `SCGH_PUSH_RUN_BRANCH`: which branches run the fast set on a `push`. Use `*`
   for all branches, or a branch name (matched as a substring). Unset, a push
   runs nothing.
-- `MMGH_FORCE_PROFILE`, `MMGH_FORCE_NOUSE_INSTALL`, `MMGH_FORCE_SANITIZER`: set
+- `SCGH_FORCE_PROFILE`, `SCGH_FORCE_NOUSE_INSTALL`, `SCGH_FORCE_SANITIZER`: set
   any to `enable` to force that nightly-only job to run on any event, so it can
   be exercised from a pull request.
-- `MMGH_TIMEOUT_BUILD` (45), `MMGH_TIMEOUT_LINT` (45),
-  `MMGH_TIMEOUT_STANDALONE_BUFFER` (10), `MMGH_TIMEOUT_NOUSE_INSTALL` (30),
-  `MMGH_TIMEOUT_PROFILE` (30): per-job `timeout-minutes`. The number is the
-  default used when the variable is unset. `MMGH_TIMEOUT_BUILD` is shared by
+- `SCGH_TIMEOUT_BUILD` (45), `SCGH_TIMEOUT_LINT` (45),
+  `SCGH_TIMEOUT_STANDALONE_BUFFER` (10), `SCGH_TIMEOUT_NOUSE_INSTALL` (30),
+  `SCGH_TIMEOUT_PROFILE` (30): per-job `timeout-minutes`. The number is the
+  default used when the variable is unset. `SCGH_TIMEOUT_BUILD` is shared by
   the ubuntu, macOS, and sanitizer builds (default 45) and the Windows build,
   which defaults to 60 because its vcpkg plus MSVC compile runs slower than the
   others.
-- `MMGH_REMIND_REPOSITORY` (`solvcon/solvcon`): the repository whose monthly
+- `SCGH_REMIND_REPOSITORY` (`solvcon/solvcon`): the repository whose monthly
   `Update Contributors` cron files its reminder issue. The job also requires a
   non-fork repository, so a fork never files one whatever this is set to.
 
 ### Behavior on a forked repository
 
-- A fork inherits neither these variables nor the secrets, so `MMGH_NIGHTLY`
-  and `MMGH_PUSH_RUN_BRANCH` are unset there. By default only `pull_request`
+- A fork inherits neither these variables nor the secrets, so `SCGH_NIGHTLY`
+  and `SCGH_PUSH_RUN_BRANCH` are unset there. By default only `pull_request`
   events run, so the fast set runs on a pull request opened in the fork, while
   pushes and the nightly schedule run nothing until the variables are set.
 - GitHub creates a run entry for the nightly cron in every fork that has
-  Actions enabled, and offers no way to suppress it. `MMGH_NIGHTLY` gates
+  Actions enabled, and offers no way to suppress it. `SCGH_NIGHTLY` gates
   `check_skip` as well as the heavy jobs, so that entry holds no job and
   takes no runner.
 - Scheduled workflows run only on the default branch, and GitHub keeps Actions
   disabled on a new fork until it is enabled (a public fork's schedule also
   pauses after 60 days without activity).
 - To exercise a single nightly-only job on a fork, set the matching
-  `MMGH_FORCE_*` variable and open a pull request.
+  `SCGH_FORCE_*` variable and open a pull request.
 - A fork pull request on a non-default base branch runs cold, since it cannot
   read the warmed caches. The failure-notification job is guarded by
   `github.event.repository.fork == false`, so it never runs on a fork (and the

--- a/gtests/test_nopython_serializable.cpp
+++ b/gtests/test_nopython_serializable.cpp
@@ -18,7 +18,7 @@ struct Address : SerializableItem
     std::vector<std::string> phone_numbers;
     std::vector<int> zip_codes;
 
-    MM_DECL_SERIALIZABLE(
+    SC_DECL_SERIALIZABLE(
         register_member("country", country);
         register_member("city", city);
         register_member("phone_numbers", phone_numbers);
@@ -32,7 +32,7 @@ struct Pet : SerializableItem
     bool is_dog;
     bool is_cat;
 
-    MM_DECL_SERIALIZABLE(
+    SC_DECL_SERIALIZABLE(
         register_member("name", name);
         register_member("age", age);
         register_member("is_dog", is_dog);
@@ -47,7 +47,7 @@ struct Person : SerializableItem
     Address address;
     std::vector<Pet> pets;
 
-    MM_DECL_SERIALIZABLE(
+    SC_DECL_SERIALIZABLE(
         register_member("name", name);
         register_member("age", age);
         register_member("is_student", is_student);
@@ -98,7 +98,7 @@ public:
         return private_info;
     }
 
-    MM_DECL_SERIALIZABLE(
+    SC_DECL_SERIALIZABLE(
         /* not expose public_info */
         register_member("private_info", private_info);)
 }; /* end struct SecretItem */
@@ -107,7 +107,7 @@ struct EscapeItem : SerializableItem
 {
     std::string escape_string = "\"\\/\b\f\n\r\t";
 
-    MM_DECL_SERIALIZABLE(
+    SC_DECL_SERIALIZABLE(
         register_member("escape_string", escape_string);)
 }; /* end struct EscapeItem */
 
@@ -116,7 +116,7 @@ struct TestUnorderedMapItem : SerializableItem
     std::unordered_map<std::string, int> numer_map;
     std::unordered_map<std::string, Pet> pet_map;
 
-    MM_DECL_SERIALIZABLE(
+    SC_DECL_SERIALIZABLE(
         register_member("numer_map", numer_map);
         register_member("pet_map", pet_map);)
 }; /* end struct TestUnorderedMapItem */


### PR DESCRIPTION
Rename the `MM_` C++ preprocessor macros to the `SC_` prefix.  Some macros used an unconventional name like `DECL_MM_X`, and are renamed to `SC_DECL_X` too.

Update `STYLE.md` for the new convention (of using `SC`).

Rename the `MMGH_*` GitHub Actions repository variables to `SCGH_*`. The old `MMGH_*` will stay in the configuration files as fallback for a while.

For the part 1 of issue #1295.