### PR TITLE
Default build to `RelWithDebInfo` and remove `DEBUG_SYMBOL`

### DIFF
--- a/.claude/skills/ide-user-presets/SKILL.md
+++ b/.claude/skills/ide-user-presets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ide-user-presets
-description: Install or refresh an IDE's CMakeUserPresets.json from the checked-in template, substituting the scdv prefix so the `ide-scdv-rel` preset carries a real path. Use when setting an IDE up on a checkout, when an IDE cannot find Qt6 or pybind11, or after the template changes. Not a build step; agents build with `make`.
+description: Install or refresh an IDE's CMakeUserPresets.json from the checked-in template, substituting the scdv prefix so the `ide-scdv-reldbg` preset carries a real path. Use when setting an IDE up on a checkout, when an IDE cannot find Qt6 or pybind11, or after the template changes. Not a build step; agents build with `make`.
 ---
 
 # IDE User Presets (solvcon)
@@ -89,8 +89,8 @@ test -d "$(sed -n 's/.*"SCDV_USRDIR": "\(.*\)".*/\1/p' CMakeUserPresets.json)"
 
 The remaining `$env{SCDV_USRDIR}` in the cache variables is correct, and
 resolves from the `environment` map above them. Then `cmake --list-presets`
-has to show `ide-scdv-rel`, and `cmake --list-presets=build` has to show
-`ide-scdv-rel`, `ide-scdv-rel-module`, and `ide-scdv-rel-gtest`. Report the
+has to show `ide-scdv-reldbg`, and `cmake --list-presets=build` has to show
+`ide-scdv-reldbg`, `ide-scdv-reldbg-module`, and `ide-scdv-reldbg-gtest`. Report the
 preset names and the prefix they carry, then stop. Listing is the whole
 verification: configuring or building through an `ide-*` preset is the IDE's
 job, and a build of your own is `make`.

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -48,6 +48,10 @@ jobs:
 
     timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_STANDALONE_BUFFER || vars.MMGH_TIMEOUT_STANDALONE_BUFFER || '10') }}
 
+    env:
+      # The build type names this job's scratch directory and its cache key.
+      CMAKE_BUILD_TYPE: ${{ matrix.cmake_build_type }}
+
     strategy:
       matrix:
         os: [ubuntu-24.04]
@@ -120,6 +124,12 @@ jobs:
       # macOS runner that swaps until the job hits its timeout. -j2 is the
       # safe bet on both.
       MAKE_PARALLEL: -j2
+      # Every step in this job builds one build type, and the Makefile derives
+      # the build tree from it. Setting it here rather than per step keeps a
+      # bare `make buildext` on the tree the preceding `make cmake`
+      # configured; naming it in only some of them splits the job across two
+      # trees, and the second one configures from the preset defaults.
+      CMAKE_BUILD_TYPE: ${{ matrix.cmake_build_type }}
       QT_DEBUG_PLUGINS: 1
       # QT_QPA_PLATFORM is set per-OS by the setup actions (xcb on Linux via
       # Xvfb, offscreen on macOS). Do not set it at the job level.
@@ -130,8 +140,15 @@ jobs:
 
     strategy:
         matrix:
-          os: [ubuntu-24.04, macos-26]
-          cmake_build_type: [Release]
+          # One build type per host rather than the same one twice. macOS
+          # takes RelWithDebInfo, which is what a bare `make` configures and
+          # what no other job on a pull request builds; ubuntu and the
+          # Windows job cover Release.
+          include:
+            - os: ubuntu-24.04
+              cmake_build_type: Release
+            - os: macos-26
+              cmake_build_type: RelWithDebInfo
 
         fail-fast: false
 
@@ -517,7 +534,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        cmake_build_type: [Release]
+        # Sanitizer reports name a file and a line only when the binary
+        # carries debug symbols, so this job builds RelWithDebInfo.
+        cmake_build_type: [RelWithDebInfo]
 
       fail-fast: false
 
@@ -587,8 +606,9 @@ jobs:
 
     strategy:
       matrix:
+        # No build type here: this job configures through the ci-win-asan
+        # preset, which states its own.
         os: [windows-2022]
-        cmake_build_type: [Release]
 
       fail-fast: false
 

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -20,6 +20,11 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_PROFILE || vars.MMGH_TIMEOUT_PROFILE || '30') }}
 
     env:
+      # This job reads the compiler cache the devbuild build job saves and
+      # saves none of its own, so it has to compile what that job compiled on
+      # the same host. The matrix below mirrors that job's build type per
+      # host; the two have to move together or every object misses.
+      CMAKE_BUILD_TYPE: ${{ matrix.cmake_build_type }}
       QT_DEBUG_PLUGINS: 1
       # QT_QPA_PLATFORM is set per-OS by the setup actions (xcb on Linux via
       # Xvfb, offscreen on macOS). Do not set it at the job level.
@@ -30,7 +35,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-26]
+        include:
+          - os: ubuntu-24.04
+            cmake_build_type: Release
+          - os: macos-26
+            cmake_build_type: RelWithDebInfo
       fail-fast: false
 
     steps:
@@ -58,8 +67,8 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
-          key: ${{ runner.os }}-Release
-          restore-keys: ${{ runner.os }}-Release
+          key: ${{ runner.os }}-${{ matrix.cmake_build_type }}
+          restore-keys: ${{ runner.os }}-${{ matrix.cmake_build_type }}
           save: false
 
       - name: make buildext BUILD_QT=ON

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,8 +128,8 @@ when asked to set an IDE up.
   `make pytest-gui` runs only it. `tests/gui/README.md` states the rule and
   `make checktests` enforces it.
 - `make gtest` -- build and run the full C++ test suite.
-- `./build/rel<pyvminor>/gtests/run_gtest --gtest_filter=Suite.Test` -- run a
-  single gtest after `make gtest` has built the binary
+- `./build/reldbg<pyvminor>/gtests/run_gtest --gtest_filter=Suite.Test` -- run
+  a single gtest after `make gtest` has built the binary
   (`<pyvminor>` is the Python major+minor, e.g. `314`).
 - `make pyprof` -- run profiling benchmarks; results land in
   `profiling/results/`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,16 @@ project(solvcon)
 
 enable_testing()
 
+# The presets and the Makefile always state a build type. A configure that
+# names neither, which is a bare `cmake -S . -B <dir>`, would otherwise get an
+# empty one and compile with no optimization, no NDEBUG, and no debug info.
+# A multi-config generator carries its types in CMAKE_CONFIGURATION_TYPES and
+# ignores this one.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "build type" FORCE)
+endif()
+message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+
 # The Python, Qt6, and PySide6 that MSVC links ship release binaries only, so a
 # Debug build must match their runtime and configuration or it corrupts the heap
 # (issue #1058). Both default on; turn one off to link debug dependencies when
@@ -246,16 +256,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "Export compile commands")
 
 option(HIDE_SYMBOL "hide the symbols of python wrapper" OFF)
 message(STATUS "HIDE_SYMBOL: ${HIDE_SYMBOL}")
-
-option(DEBUG_SYMBOL "add debug information" ON)
-message(STATUS "DEBUG_SYMBOL: ${DEBUG_SYMBOL}")
-if(DEBUG_SYMBOL)
-    if(MSVC)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DEBUG")
-    else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
-    endif()
-endif()
 
 option(SOLVCON_PROFILE "enable profiler" OFF)
 message(STATUS "SOLVCON_PROFILE: ${SOLVCON_PROFILE}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,7 +8,6 @@
       "hidden": true,
       "cacheVariables": {
         "HIDE_SYMBOL": { "type": "BOOL", "value": "ON" },
-        "DEBUG_SYMBOL": { "type": "BOOL", "value": "ON" },
         "LINT_AS_ERRORS": { "type": "BOOL", "value": "ON" },
         "SKIP_PYTHON_EXECUTABLE": { "type": "BOOL", "value": "OFF" },
         "SOLVCON_PROFILE": { "type": "BOOL", "value": "OFF" },
@@ -46,7 +45,11 @@
       },
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
-        "BUILD_QT": { "type": "BOOL", "value": "ON" }
+        "BUILD_QT": { "type": "BOOL", "value": "ON" },
+        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": {
+          "type": "STRING",
+          "value": "-O3 -g -DNDEBUG"
+        }
       },
       "vendor": {
         "jetbrains.com/clion": { "enablePythonIntegration": true },
@@ -56,10 +59,19 @@
       }
     },
     {
+      "name": "dev-reldbg",
+      "inherits": "dev-base",
+      "displayName": "Developer Release with Debug Info",
+      "description": "Optimized _solvcon and pilot with debug symbols, for Linux and macOS.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "RelWithDebInfo" }
+      }
+    },
+    {
       "name": "dev-rel",
       "inherits": "dev-base",
       "displayName": "Developer Release",
-      "description": "Optimized _solvcon and pilot for Linux and macOS.",
+      "description": "Optimized _solvcon and pilot without debug symbols, for Linux and macOS.",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" }
       }
@@ -76,10 +88,10 @@
     {
       "name": "dev-noqt",
       "inherits": "dev-base",
-      "displayName": "Developer Release, no Qt",
+      "displayName": "Developer Release with Debug Info, no Qt",
       "description": "Optimized _solvcon without the pilot, for a headless host.",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" },
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "RelWithDebInfo" },
         "BUILD_QT": { "type": "BOOL", "value": "OFF" }
       }
     },
@@ -96,6 +108,10 @@
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
         "BUILD_QT": { "type": "BOOL", "value": "ON" },
+        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": {
+          "type": "STRING",
+          "value": "/O2 /Ob2 /DNDEBUG"
+        },
         "CMAKE_RUNTIME_OUTPUT_DIRECTORY": {
           "type": "PATH",
           "value": "${sourceDir}/build/${presetName}"
@@ -110,10 +126,20 @@
       }
     },
     {
+      "name": "win-reldbg",
+      "inherits": "win-base",
+      "displayName": "Windows Release with Debug Info (Ninja, MSVC)",
+      "description": "Optimized _solvcon and pilot with debug symbols, MSVC through Ninja.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "RelWithDebInfo" },
+        "BLA_VENDOR": { "type": "STRING", "value": "OpenBLAS" }
+      }
+    },
+    {
       "name": "win-rel",
       "inherits": "win-base",
       "displayName": "Windows Release (Ninja, MSVC)",
-      "description": "Optimized _solvcon and pilot built with MSVC through Ninja.",
+      "description": "Optimized _solvcon and pilot without debug symbols, MSVC through Ninja.",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" },
         "BLA_VENDOR": { "type": "STRING", "value": "OpenBLAS" }
@@ -172,9 +198,9 @@
       "name": "ci-win-asan",
       "inherits": "ci-win-base",
       "displayName": "CI: Windows AddressSanitizer",
-      "description": "For the Windows sanitizer CI job. A developer wants win-rel instead.",
+      "description": "For the Windows sanitizer CI job; RelWithDebInfo so a report names a file and a line. A developer wants win-reldbg instead.",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" },
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "RelWithDebInfo" },
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "VCPKG_TARGET_TRIPLET": "x64-windows",
         "USE_SANITIZER": { "type": "BOOL", "value": "ON" }
@@ -195,6 +221,30 @@
           "hostOS": ["Linux", "macOS"]
         }
       }
+    },
+    {
+      "name": "dev-reldbg",
+      "inherits": "dev-base",
+      "configurePreset": "dev-reldbg",
+      "displayName": "Developer Release with Debug Info",
+      "description": "Build the extension module and the pilot, RelWithDebInfo.",
+      "targets": ["_solvcon_py", "pilot"]
+    },
+    {
+      "name": "dev-reldbg-module",
+      "inherits": "dev-base",
+      "configurePreset": "dev-reldbg",
+      "displayName": "Developer Release with Debug Info, module only",
+      "description": "Build the extension module alone, RelWithDebInfo.",
+      "targets": ["_solvcon_py"]
+    },
+    {
+      "name": "dev-reldbg-gtest",
+      "inherits": "dev-base",
+      "configurePreset": "dev-reldbg",
+      "displayName": "Developer Release with Debug Info, C++ test binary",
+      "description": "Build the C++ gtest binary, RelWithDebInfo.",
+      "targets": ["test_nopython"]
     },
     {
       "name": "dev-rel",
@@ -248,7 +298,7 @@
       "name": "dev-noqt",
       "inherits": "dev-base",
       "configurePreset": "dev-noqt",
-      "displayName": "Developer Release, no Qt",
+      "displayName": "Developer Release with Debug Info, no Qt",
       "description": "Build the extension module alone, without the pilot.",
       "targets": ["_solvcon_py"]
     },
@@ -256,7 +306,7 @@
       "name": "dev-noqt-gtest",
       "inherits": "dev-base",
       "configurePreset": "dev-noqt",
-      "displayName": "Developer Release, no Qt, C++ test binary",
+      "displayName": "Developer Release with Debug Info, no Qt, C++ test binary",
       "description": "Build the C++ gtest binary, without the pilot.",
       "targets": ["test_nopython"]
     },
@@ -273,6 +323,30 @@
           "hostOS": ["Windows"]
         }
       }
+    },
+    {
+      "name": "win-reldbg",
+      "inherits": "win-base",
+      "configurePreset": "win-reldbg",
+      "displayName": "Windows Release with Debug Info",
+      "description": "Build the extension module and the pilot, RelWithDebInfo.",
+      "targets": ["_solvcon", "pilot"]
+    },
+    {
+      "name": "win-reldbg-module",
+      "inherits": "win-base",
+      "configurePreset": "win-reldbg",
+      "displayName": "Windows Release with Debug Info, module only",
+      "description": "Build the extension module alone, RelWithDebInfo.",
+      "targets": ["_solvcon"]
+    },
+    {
+      "name": "win-reldbg-gtest",
+      "inherits": "win-base",
+      "configurePreset": "win-reldbg",
+      "displayName": "Windows Release with Debug Info, C++ test binary",
+      "description": "Build the C++ gtest binary, RelWithDebInfo.",
+      "targets": ["test_nopython"]
     },
     {
       "name": "win-rel",
@@ -361,35 +435,42 @@
       }
     },
     {
+      "name": "dev-reldbg",
+      "inherits": "dev-base",
+      "configurePreset": "dev-reldbg",
+      "displayName": "Developer Release with Debug Info, every suite",
+      "description": "Run the C++, Python, and pilot suites."
+    },
+    {
+      "name": "dev-reldbg-cpp",
+      "inherits": "dev-base",
+      "configurePreset": "dev-reldbg",
+      "displayName": "Developer Release with Debug Info, C++ suite",
+      "description": "Run the C++ cases alone.",
+      "filter": { "include": { "label": "cpp" } }
+    },
+    {
+      "name": "dev-reldbg-python",
+      "inherits": "dev-base",
+      "configurePreset": "dev-reldbg",
+      "displayName": "Developer Release with Debug Info, Python suite",
+      "description": "Run the Python suite alone.",
+      "filter": { "include": { "label": "python" } }
+    },
+    {
+      "name": "dev-reldbg-pilot",
+      "inherits": "dev-base",
+      "configurePreset": "dev-reldbg",
+      "displayName": "Developer Release with Debug Info, pilot suite",
+      "description": "Run the Python suite inside the pilot binary.",
+      "filter": { "include": { "label": "pilot" } }
+    },
+    {
       "name": "dev-rel",
       "inherits": "dev-base",
       "configurePreset": "dev-rel",
       "displayName": "Developer Release, every suite",
       "description": "Run the C++, Python, and pilot suites."
-    },
-    {
-      "name": "dev-rel-cpp",
-      "inherits": "dev-base",
-      "configurePreset": "dev-rel",
-      "displayName": "Developer Release, C++ suite",
-      "description": "Run the C++ cases alone.",
-      "filter": { "include": { "label": "cpp" } }
-    },
-    {
-      "name": "dev-rel-python",
-      "inherits": "dev-base",
-      "configurePreset": "dev-rel",
-      "displayName": "Developer Release, Python suite",
-      "description": "Run the Python suite alone.",
-      "filter": { "include": { "label": "python" } }
-    },
-    {
-      "name": "dev-rel-pilot",
-      "inherits": "dev-base",
-      "configurePreset": "dev-rel",
-      "displayName": "Developer Release, pilot suite",
-      "description": "Run the Python suite inside the pilot binary.",
-      "filter": { "include": { "label": "pilot" } }
     },
     {
       "name": "dev-dbg",
@@ -402,7 +483,7 @@
       "name": "dev-noqt",
       "inherits": "dev-base",
       "configurePreset": "dev-noqt",
-      "displayName": "Developer Release, no Qt",
+      "displayName": "Developer Release with Debug Info, no Qt",
       "description": "Run the C++ and Python suites; there is no pilot suite."
     },
     {
@@ -419,6 +500,13 @@
           "hostOS": ["Windows"]
         }
       }
+    },
+    {
+      "name": "win-reldbg",
+      "inherits": "win-base",
+      "configurePreset": "win-reldbg",
+      "displayName": "Windows Release with Debug Info, every suite",
+      "description": "Run the C++, Python, and pilot suites."
     },
     {
       "name": "win-rel",

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@
 #   make VERBOSE=1
 # Build with clang-tidy
 #   make USE_CLANG_TIDY=ON
+# Build without debug symbols, which compiles faster:
+#   make CMAKE_BUILD_TYPE=Release
 
 SETUP_FILE ?= ./setup.mk
 
@@ -27,7 +29,7 @@ RUNENV += PYTHONPATH=$(SOLVCON_ROOT)
 # environment, or in setup.mk is layered on the selected preset as a -D flag,
 # and nothing else is passed, so a make build and a preset build stay the same
 # build. Setting a knob to its preset value therefore costs nothing.
-CMAKE_KNOBS = SKIP_PYTHON_EXECUTABLE HIDE_SYMBOL DEBUG_SYMBOL SOLVCON_PROFILE \
+CMAKE_KNOBS = SKIP_PYTHON_EXECUTABLE HIDE_SYMBOL SOLVCON_PROFILE \
 	BUILD_METAL BUILD_QT USE_CLANG_TIDY LINT_AS_ERRORS USE_GOOGLETEST \
 	USE_SANITIZER USE_CCACHE CMAKE_INSTALL_PREFIX \
 	CMAKE_LIBRARY_OUTPUT_DIRECTORY CMAKE_PREFIX_PATH
@@ -35,15 +37,24 @@ CMAKE_OVERRIDES = $(strip $(foreach knob,$(CMAKE_KNOBS), \
 	$(if $(filter-out undefined default,$(origin $(knob))),\
 	-D$(knob)=$($(knob)))))
 
-CMAKE_BUILD_TYPE ?= Release
-# The build type picks the preset, so it needs no -D of its own. Override
-# CMAKE_PRESET to build another one, for instance a preset of your own from
-# CMakeUserPresets.json.
-ifeq ($(CMAKE_BUILD_TYPE), Debug)
-	CMAKE_PRESET ?= dev-dbg
-else
-	CMAKE_PRESET ?= dev-rel
-endif
+# Debugging is the default story. Release drops the symbols for a session
+# that is not going to open a debugger.
+CMAKE_BUILD_TYPE ?= RelWithDebInfo
+# The build type picks the preset and the build tree, and it needs no -D of
+# its own because the preset states it. One table decides both, so the two
+# cannot drift apart. An unsupported build type leaves them empty, which the
+# configure rule below reports; the check waits until then so that a target
+# needing no build tree, `make lint` or `make cmakeclean`, still runs.
+CMAKE_PRESET_Debug = dev-dbg
+CMAKE_PRESET_Release = dev-rel
+CMAKE_PRESET_RelWithDebInfo = dev-reldbg
+BUILD_TAG_Debug = dbg
+BUILD_TAG_Release = rel
+BUILD_TAG_RelWithDebInfo = reldbg
+# Override CMAKE_PRESET to build another preset, for instance one of your own
+# from CMakeUserPresets.json. Set BUILD_PATH with it: the tree is named after
+# CMAKE_BUILD_TYPE, which a preset of another build type would contradict.
+CMAKE_PRESET ?= $(CMAKE_PRESET_$(CMAKE_BUILD_TYPE))
 # Number of online processors. Drives both build parallelism (MAKE_PARALLEL
 # below) and the lint targets. getconf works on both Linux and macOS; fall
 # back to 1 if unavailable. Override to cap parallelism, e.g. NPROC=2.
@@ -83,11 +94,7 @@ export DIRNAME_PYTHON := $(dir $(REALPATH_PYTHON))
 
 pyvminor := $(shell python3 -c 'import sys; print("%d%d" % sys.version_info[0:2])')
 
-ifeq ($(CMAKE_BUILD_TYPE), Debug)
-	BUILD_PATH ?= build/dbg$(pyvminor)$(BUILD_PATH_EXT)
-else
-	BUILD_PATH ?= build/rel$(pyvminor)$(BUILD_PATH_EXT)
-endif
+BUILD_PATH ?= build/$(BUILD_TAG_$(CMAKE_BUILD_TYPE))$(pyvminor)$(BUILD_PATH_EXT)
 export BUILD_PATH
 
 # Test with the build interpreter; an ABI-tagged _solvcon cannot load under a
@@ -113,10 +120,19 @@ xcode: $(BUILD_PATH)_xcode/Makefile
 # stays the one the clean target and the workflows expect from a make build.
 CMAKE_CMD = cmake --preset $(CMAKE_PRESET) $(CMAKE_OVERRIDES) $(CMAKE_ARGS)
 
+# The table above leaves CMAKE_PRESET empty for a build type it does not name.
+CHECK_BUILD_TYPE = test -n "$(CMAKE_PRESET)" || { \
+	echo "Error: CMAKE_BUILD_TYPE is '$(CMAKE_BUILD_TYPE)'."; \
+	echo "  Use RelWithDebInfo, Release, or Debug."; \
+	exit 1; \
+	}
+
 $(BUILD_PATH)/Makefile: CMakeLists.txt CMakePresets.json Makefile
+	@$(CHECK_BUILD_TYPE)
 	env $(RUNENV) $(CMAKE_CMD) -B $(BUILD_PATH) -G "Unix Makefiles"
 
 $(BUILD_PATH)_xcode/Makefile: CMakeLists.txt CMakePresets.json Makefile
+	@$(CHECK_BUILD_TYPE)
 	env $(RUNENV) $(CMAKE_CMD) -B $(BUILD_PATH)_xcode -G Xcode
 
 .PHONY: buildext

--- a/build.ps1
+++ b/build.ps1
@@ -7,10 +7,10 @@
 # contrib/dependency/windows/build-scdv-windows.ps1.  solvcon's Makefile and
 # setup.py shell out to "make", and its module-copy target runs
 # "python3-config"; neither exists on Windows.  This drives CMake directly
-# through the win-rel / win-dbg presets in CMakePresets.json, adding only the
-# scdv-specific cache variables, and places the module by hand.  Those three
-# path variables belong in CMakeUserPresets.json; pass -Preset <name> to build
-# such a preset and the script leaves them to it.  Start that file from
+# through the win-reldbg / win-rel / win-dbg presets in CMakePresets.json,
+# adding only the scdv-specific cache variables, and places the module by hand.
+# Those three path variables belong in CMakeUserPresets.json; pass -Preset
+# <name> to build such a preset and the script leaves them to it.  Start from
 # contrib/cmake/CMakeUserPresets.win-example.json: the other template inherits
 # presets that are disabled on Windows.
 #
@@ -22,9 +22,11 @@
 #
 # Usage:
 #   .\build.ps1
-#       Configure (preset win-rel) and build _solvcon and the pilot against the
-#       active scdv (or -ScdvBase), then place the module.
+#       Configure (preset win-reldbg) and build _solvcon and the pilot against
+#       the active scdv (or -ScdvBase), then place the module.
 #   .\build.ps1 -ScdvBase <dir>       activate the scdv at <dir> first
+#   .\build.ps1 -BuildType Release    use the win-rel preset, dropping the
+#                                     debug symbols to compile faster
 #   .\build.ps1 -BuildType Debug      use the win-dbg preset
 #   .\build.ps1 -Preset local         use a preset from CMakeUserPresets.json,
 #                                     which is expected to supply the
@@ -50,7 +52,8 @@
 param(
     [string]$ScdvBase,
     [string]$Repo,
-    [ValidateSet('Release', 'Debug')][string]$BuildType = 'Release',
+    [ValidateSet('RelWithDebInfo', 'Release', 'Debug')]
+    [string]$BuildType = 'RelWithDebInfo',
     [string]$Preset,
     [switch]$NoQt,
     [switch]$Gtest,
@@ -72,7 +75,7 @@ function Assert-LastExit {
 if ($Help) {
     Get-Content -LiteralPath $PSCommandPath | Select-Object -Skip 1 |
         ForEach-Object { if ($_ -notmatch '^\s*$') { $_ -replace '^#\s?', '' } } |
-        Select-Object -First 42
+        Select-Object -First 44
     exit 0
 }
 
@@ -89,7 +92,7 @@ if ($Sanitize) {
             'to run the pilot pytest suite under AddressSanitizer'
     }
     if ($BuildType -eq 'Debug') {
-        throw '-Sanitize needs the Release preset: MSVC ASan rejects the ' +
+        throw '-Sanitize cannot use the Debug preset: MSVC ASan rejects the ' +
             "Debug /RTC1 runtime checks. Drop -BuildType Debug."
     }
     if (-not $PilotTest) {
@@ -113,7 +116,11 @@ if ($Preset) {
     }
     $presetName = $Preset
 } else {
-    $presetName = if ($BuildType -eq 'Debug') { 'win-dbg' } else { 'win-rel' }
+    $presetName = switch ($BuildType) {
+        'Debug'   { 'win-dbg' }
+        'Release' { 'win-rel' }
+        default   { 'win-reldbg' }
+    }
 }
 
 function Get-ConfigurePresetBinaryDir {

--- a/contrib/cmake/CMakeUserPresets.example.json
+++ b/contrib/cmake/CMakeUserPresets.example.json
@@ -4,8 +4,8 @@
   "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
   "configurePresets": [
     {
-      "name": "ide-local-rel",
-      "inherits": "dev-rel",
+      "name": "ide-local-reldbg",
+      "inherits": "dev-reldbg",
       "displayName": "IDE or manual use: local prefix",
       "description": "A checked-in preset plus the paths of a local dependency prefix.",
       "cacheVariables": {
@@ -20,21 +20,21 @@
   ],
   "buildPresets": [
     {
-      "name": "ide-local-rel",
-      "inherits": "dev-rel",
-      "configurePreset": "ide-local-rel",
+      "name": "ide-local-reldbg",
+      "inherits": "dev-reldbg",
+      "configurePreset": "ide-local-reldbg",
       "displayName": "ide local rel"
     },
     {
-      "name": "ide-local-rel-module",
-      "inherits": "dev-rel-module",
-      "configurePreset": "ide-local-rel",
+      "name": "ide-local-reldbg-module",
+      "inherits": "dev-reldbg-module",
+      "configurePreset": "ide-local-reldbg",
       "displayName": "ide local rel module"
     },
     {
-      "name": "ide-local-rel-gtest",
-      "inherits": "dev-rel-gtest",
-      "configurePreset": "ide-local-rel",
+      "name": "ide-local-reldbg-gtest",
+      "inherits": "dev-reldbg-gtest",
+      "configurePreset": "ide-local-reldbg",
       "displayName": "ide local rel gtest"
     }
   ]

--- a/contrib/cmake/CMakeUserPresets.scdv.json
+++ b/contrib/cmake/CMakeUserPresets.scdv.json
@@ -4,8 +4,8 @@
   "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
   "configurePresets": [
     {
-      "name": "ide-scdv-rel",
-      "inherits": "dev-rel",
+      "name": "ide-scdv-reldbg",
+      "inherits": "dev-reldbg",
       "displayName": "IDE or manual use: scdv prefix",
       "description": "A checked-in preset plus the paths of an scdv environment. Installing substitutes the prefix into SCDV_USRDIR below.",
       "environment": {
@@ -23,21 +23,21 @@
   ],
   "buildPresets": [
     {
-      "name": "ide-scdv-rel",
-      "inherits": "dev-rel",
-      "configurePreset": "ide-scdv-rel",
+      "name": "ide-scdv-reldbg",
+      "inherits": "dev-reldbg",
+      "configurePreset": "ide-scdv-reldbg",
       "displayName": "ide scdv rel"
     },
     {
-      "name": "ide-scdv-rel-module",
-      "inherits": "dev-rel-module",
-      "configurePreset": "ide-scdv-rel",
+      "name": "ide-scdv-reldbg-module",
+      "inherits": "dev-reldbg-module",
+      "configurePreset": "ide-scdv-reldbg",
       "displayName": "ide scdv rel module"
     },
     {
-      "name": "ide-scdv-rel-gtest",
-      "inherits": "dev-rel-gtest",
-      "configurePreset": "ide-scdv-rel",
+      "name": "ide-scdv-reldbg-gtest",
+      "inherits": "dev-reldbg-gtest",
+      "configurePreset": "ide-scdv-reldbg",
       "displayName": "ide scdv rel gtest"
     }
   ]

--- a/contrib/cmake/CMakeUserPresets.win-example.json
+++ b/contrib/cmake/CMakeUserPresets.win-example.json
@@ -4,8 +4,8 @@
   "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
   "configurePresets": [
     {
-      "name": "ide-local-rel",
-      "inherits": "win-rel",
+      "name": "ide-local-reldbg",
+      "inherits": "win-reldbg",
       "displayName": "IDE or manual use: local prefix",
       "description": "A checked-in preset plus the paths of a local dependency prefix.",
       "cacheVariables": {
@@ -20,21 +20,21 @@
   ],
   "buildPresets": [
     {
-      "name": "ide-local-rel",
-      "inherits": "win-rel",
-      "configurePreset": "ide-local-rel",
+      "name": "ide-local-reldbg",
+      "inherits": "win-reldbg",
+      "configurePreset": "ide-local-reldbg",
       "displayName": "ide local rel"
     },
     {
-      "name": "ide-local-rel-module",
-      "inherits": "win-rel-module",
-      "configurePreset": "ide-local-rel",
+      "name": "ide-local-reldbg-module",
+      "inherits": "win-reldbg-module",
+      "configurePreset": "ide-local-reldbg",
       "displayName": "ide local rel module"
     },
     {
-      "name": "ide-local-rel-gtest",
-      "inherits": "win-rel-gtest",
-      "configurePreset": "ide-local-rel",
+      "name": "ide-local-reldbg-gtest",
+      "inherits": "win-reldbg-gtest",
+      "configurePreset": "ide-local-reldbg",
       "displayName": "ide local rel gtest"
     }
   ]

--- a/contrib/cmake/CMakeUserPresets.win-scdv.json
+++ b/contrib/cmake/CMakeUserPresets.win-scdv.json
@@ -4,8 +4,8 @@
   "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
   "configurePresets": [
     {
-      "name": "ide-scdv-rel",
-      "inherits": "win-rel",
+      "name": "ide-scdv-reldbg",
+      "inherits": "win-reldbg",
       "displayName": "IDE or manual use: scdv prefix",
       "description": "A checked-in preset plus the paths of an scdv environment. Installing substitutes the prefix into SCDV_USRDIR below.",
       "environment": {
@@ -23,21 +23,21 @@
   ],
   "buildPresets": [
     {
-      "name": "ide-scdv-rel",
-      "inherits": "win-rel",
-      "configurePreset": "ide-scdv-rel",
+      "name": "ide-scdv-reldbg",
+      "inherits": "win-reldbg",
+      "configurePreset": "ide-scdv-reldbg",
       "displayName": "ide scdv rel"
     },
     {
-      "name": "ide-scdv-rel-module",
-      "inherits": "win-rel-module",
-      "configurePreset": "ide-scdv-rel",
+      "name": "ide-scdv-reldbg-module",
+      "inherits": "win-reldbg-module",
+      "configurePreset": "ide-scdv-reldbg",
       "displayName": "ide scdv rel module"
     },
     {
-      "name": "ide-scdv-rel-gtest",
-      "inherits": "win-rel-gtest",
-      "configurePreset": "ide-scdv-rel",
+      "name": "ide-scdv-reldbg-gtest",
+      "inherits": "win-reldbg-gtest",
+      "configurePreset": "ide-scdv-reldbg",
       "displayName": "ide scdv rel gtest"
     }
   ]

--- a/doc/source/devguide/cmake.md
+++ b/doc/source/devguide/cmake.md
@@ -23,11 +23,18 @@ Makefile adds the ABI-tagged build directory, the generator, and whatever
 
 | Configure preset | Host          | What it configures                    |
 |:-----------------|:--------------|:--------------------------------------|
-| `dev-rel`        | Linux, macOS  | optimized module and pilot            |
+| `dev-reldbg`     | Linux, macOS  | optimized module and pilot, symbols   |
+| `dev-rel`        | Linux, macOS  | optimized module and pilot, no symbols |
 | `dev-dbg`        | Linux, macOS  | debuggable module and pilot           |
 | `dev-noqt`       | Linux, macOS  | optimized module, no pilot            |
-| `win-rel`        | Windows       | optimized module and pilot, MSVC      |
+| `win-reldbg`     | Windows       | optimized module and pilot, symbols, MSVC |
+| `win-rel`        | Windows       | optimized module and pilot, no symbols, MSVC |
 | `win-dbg`        | Windows       | debuggable module and pilot, MSVC     |
+
+The `reldbg` presets configure `RelWithDebInfo` and are the default a make
+build selects; the `rel` ones configure `Release`, which drops the debug
+symbols and picks up the pybind11 extras, link-time optimization and a strip
+of the extension module.  See {doc}`/start/build_solvcon` for which to pick.
 
 Each configure preset comes with three build presets, one per thing that is
 actually built:
@@ -45,19 +52,19 @@ entries.
 The build tree is `build/<configure preset>`, named through the
 `${presetName}` macro so that a preset inheriting another gets its own tree
 rather than writing into its parent's.  It is one tree per preset, which is
-what both IDEs assume, and it is not the Makefile's `build/rel<pyvminor>`, so
-a preset build and a make build never share a cache.  They do share where the
-extension module lands, `solvcon/` and the repository root, so whichever built
-last is the one Python imports.
+what both IDEs assume, and it is not the Makefile's `build/reldbg<pyvminor>`,
+so a preset build and a make build never share a cache.  They do share where
+the extension module lands, `solvcon/` and the repository root, so whichever
+built last is the one Python imports.
 
 Test presets run the suites CTest has registered.  There is one per configure
-preset, plus label-filtered ones on `dev-rel`:
+preset, plus label-filtered ones on `dev-reldbg`:
 
 ```sh
-ctest --preset dev-rel            # every suite
-ctest --preset dev-rel-cpp        # the C++ cases alone
-ctest --preset dev-rel-python     # the Python suite alone
-ctest --preset dev-rel-pilot      # the Python suite inside the pilot binary
+ctest --preset dev-reldbg         # every suite
+ctest --preset dev-reldbg-cpp     # the C++ cases alone
+ctest --preset dev-reldbg-python  # the Python suite alone
+ctest --preset dev-reldbg-pilot   # the Python suite inside the pilot binary
 ```
 
 The C++ cases come from `gtest_discover_tests`, which enumerates them by
@@ -66,10 +73,10 @@ running the built binary, and the plain build preset does not build it.  Build
 placeholder case `test_nopython_NOT_BUILT` and fails:
 
 ```sh
-cmake --preset dev-rel
-cmake --build --preset dev-rel
-cmake --build --preset dev-rel-gtest
-ctest --preset dev-rel
+cmake --preset dev-reldbg
+cmake --build --preset dev-reldbg
+cmake --build --preset dev-reldbg-gtest
+ctest --preset dev-reldbg
 ```
 
 CLion reads no test presets, so a CLion user reaches the same suites through
@@ -96,7 +103,7 @@ different interpreter reuses a stale cache.  Reconfigure with `--fresh` after
 switching interpreters:
 
 ```bash
-cmake --preset dev-rel --fresh
+cmake --preset dev-reldbg --fresh
 ```
 
 ## Machine paths belong in `CMakeUserPresets.json`
@@ -132,7 +139,7 @@ cp contrib/cmake/CMakeUserPresets.example.json CMakeUserPresets.json
 cp contrib/cmake/CMakeUserPresets.win-example.json CMakeUserPresets.json
 ```
 
-Each defines a configure preset named `ide-local-rel` that inherits a
+Each defines a configure preset named `ide-local-reldbg` that inherits a
 checked-in preset and adds the three variables, plus the three build presets
 that go with it:
 
@@ -141,8 +148,8 @@ that go with it:
   "version": 10,
   "configurePresets": [
     {
-      "name": "ide-local-rel",
-      "inherits": "dev-rel",
+      "name": "ide-local-reldbg",
+      "inherits": "dev-reldbg",
       "displayName": "IDE or manual use: local prefix",
       "cacheVariables": {
         "PYTHON_EXECUTABLE": {
@@ -155,8 +162,8 @@ that go with it:
     }
   ],
   "buildPresets": [
-    { "name": "ide-local-rel", "inherits": "dev-rel",
-      "configurePreset": "ide-local-rel" }
+    { "name": "ide-local-reldbg", "inherits": "dev-reldbg",
+      "configurePreset": "ide-local-reldbg" }
   ]
 }
 ```
@@ -164,13 +171,13 @@ that go with it:
 Every `inherits` in the file names a preset of one host family, and they have
 to stay a matched set.  A `dev-` build preset carries a condition that
 disables it on Windows and a `win-` one carries the opposite, so an
-`ide-local-rel` that inherits a `win-` configure preset and `dev-` build
+`ide-local-reldbg` that inherits a `win-` configure preset and `dev-` build
 presets configures and then refuses to build.  Change them together, or start
 from the template for the family you want.
 
 `pybind11_path` names the directory holding `pybind11Config.cmake`, which is
 what `python3 -m pybind11 --cmakedir` prints for the interpreter named above
-it.  After that, `ide-local-rel` appears in the IDE preset pickers alongside
+it.  After that, `ide-local-reldbg` appears in the IDE preset pickers alongside
 the checked-in presets.
 
 In CLion the `enablePythonIntegration` key in the `jetbrains.com/clion` vendor
@@ -180,7 +187,7 @@ interpreter to the configure step.  A CLion user can therefore drop the
 
 `CMakeUserPresets.scdv.json` and `CMakeUserPresets.win-scdv.json` sit beside
 the two templates above for a prefix that `build-scdv.sh` built (see
-{doc}`/start/build_dep`).  Their configure preset is `ide-scdv-rel`, and it
+{doc}`/start/build_dep`).  Their configure preset is `ide-scdv-reldbg`, and it
 names that prefix once rather than repeating it in three literal paths, so
 installing one substitutes a single value instead of editing three.  The
 `ide-user-presets` skill under `.claude/skills/` states the substitution and

--- a/doc/source/devguide/testing.md
+++ b/doc/source/devguide/testing.md
@@ -15,10 +15,11 @@ be reached from Python.
 After `make gtest` has built the binary, a single C++ test can be run directly:
 
 ```sh
-./build/rel<pyvminor>/gtests/run_gtest --gtest_filter=Suite.Test
+./build/reldbg<pyvminor>/gtests/run_gtest --gtest_filter=Suite.Test
 ```
 
 where `<pyvminor>` is the active Python major and minor version, e.g. `314`.
+The directory follows `CMAKE_BUILD_TYPE`; see {doc}`/start/build_solvcon`.
 
 ## Through CTest
 
@@ -28,10 +29,10 @@ tree.  This is what an IDE drives, and it is how the C++ cases become
 individually selectable.
 
 ```sh
-ctest --preset dev-rel            # every suite
-ctest --preset dev-rel-cpp        # the C++ cases alone
-ctest --preset dev-rel-python     # the Python suite alone
-ctest --preset dev-rel-pilot      # the Python suite inside the pilot binary
+ctest --preset dev-reldbg         # every suite
+ctest --preset dev-reldbg-cpp     # the C++ cases alone
+ctest --preset dev-reldbg-python  # the Python suite alone
+ctest --preset dev-reldbg-pilot   # the Python suite inside the pilot binary
 ```
 
 The presets are described in {doc}`/devguide/cmake`.  Against a build tree

--- a/doc/source/start/build_solvcon.md
+++ b/doc/source/start/build_solvcon.md
@@ -8,30 +8,61 @@ up without installation.
 - `make pilot`: build the Qt pilot GUI binary.
 - `make clean` / `make cmakeclean`: remove build artifacts.
 
-Release builds (the default) land in `build/rel<pyvminor>` and debug builds in
-`build/dbg<pyvminor>`, where `<pyvminor>` is the active Python major and minor
-version, e.g. `314`.
+## Build Types
+
+`CMAKE_BUILD_TYPE` selects one of CMake's three standard build types.  Each
+gets its own build tree, so switching between them never invalidates another
+one's cache.  `<pyvminor>` is the active Python major and minor version, e.g.
+`314`.
+
+| `CMAKE_BUILD_TYPE` | Build tree               | Flags             |
+|:-------------------|:-------------------------|:------------------|
+| `RelWithDebInfo`   | `build/reldbg<pyvminor>` | `-O3 -g -DNDEBUG` |
+| `Release`          | `build/rel<pyvminor>`    | `-O3 -DNDEBUG`    |
+| `Debug`            | `build/dbg<pyvminor>`    | `-g`, no `-O`     |
+
+The default is `RelWithDebInfo`: optimized, and carrying the debug symbols
+that let a debugger name a function and a line.  It is what you want unless
+you have a reason to want something else.
+
+`Release` drops the symbols, which compiles noticeably faster and leaves a
+much smaller build tree, so it suits a session that is only going to run the
+test suite.  It is not merely the default minus `-g`: pybind11 gives the
+extension module a set of extras for every build type except `Debug` and
+`RelWithDebInfo`, so under `Release` the module is also link-time optimized
+and stripped.  Stripping is why a debugger can name a frame inside
+`_solvcon` under the default and not under `Release`.
+
+`Debug` turns the optimizer off.  Reach for it when you need to step through
+code and inspect variables, which `RelWithDebInfo` does poorly because `-O3`
+inlines functions and discards variables.
+
+The trees are separate but they all write the extension module to `solvcon/`,
+so whichever built last is the one Python imports.  Building a tree whose
+objects are already current does not relink, which means switching build types
+alone does not replace the installed module.  Build the type you want last, or
+touch a source to force the relink.
 
 ## Build Options
 
 The Makefile configures through `cmake --preset`, so the defaults are the ones
-in `CMakePresets.json`: `dev-rel` for a release build and `dev-dbg` for a debug
-one.  It adds only the ABI-tagged build directory, the generator, and whatever
-options are set below, each of which becomes a `-D` flag layered on the preset.
-Set `CMAKE_PRESET` to build a different preset, for instance one of your own
-from `CMakeUserPresets.json`.
+in `CMakePresets.json`: `dev-reldbg`, `dev-rel`, and `dev-dbg` for the three
+build types above.  It adds only the ABI-tagged build directory, the generator,
+and whatever options are set below, each of which becomes a `-D` flag layered
+on the preset.  Set `CMAKE_PRESET` to build a different preset, for instance
+one of your own from `CMakeUserPresets.json`.
 
 Key options can be set on the command line, in `setup.mk` (which is read by
 `Makefile`), or as environment variables:
 
-| Variable             | Default   | Purpose                          |
-|:---------------------|:----------|:---------------------------------|
-| `CMAKE_BUILD_TYPE`   | `Release` | `Release` or `Debug`             |
-| `BUILD_QT`           | `ON`      | build the Qt GUI components      |
-| `BUILD_METAL`        | `OFF`     | build Metal GPU support (macOS)  |
-| `SOLVCON_PROFILE`    | `OFF`     | enable the runtime profiler      |
-| `USE_CLANG_TIDY`     | `OFF`     | run clang-tidy during the build  |
-| `USE_CCACHE`         | `ON`      | use ccache when it is installed  |
+| Variable           | Default          | Purpose                         |
+|:-------------------|:-----------------|:--------------------------------|
+| `CMAKE_BUILD_TYPE` | `RelWithDebInfo` | see the table above             |
+| `BUILD_QT`         | `ON`             | build the Qt GUI components     |
+| `BUILD_METAL`      | `OFF`            | build Metal GPU support (macOS) |
+| `SOLVCON_PROFILE`  | `OFF`            | enable the runtime profiler     |
+| `USE_CLANG_TIDY`   | `OFF`            | run clang-tidy during the build |
+| `USE_CCACHE`       | `ON`             | use ccache when it is installed |
 
 Install `ccache` (`brew install ccache`, `apt install ccache`) to make a
 rebuild after `make cmakeclean` mostly cache hits; a host without it builds


### PR DESCRIPTION
`DEBUG_SYMBOL` defaulted to `ON` in the `base` preset, so a `Release` build compiled `-O3 -g -DNDEBUG`: what this project called Release was RelWithDebInfo under another name, and CMake's actual `Release` had no way to be spelled. This deletes the option and lets `CMAKE_BUILD_TYPE` carry the axis it already owns.

| `CMAKE_BUILD_TYPE` | Build tree | GCC/Clang flags |
|:--|:--|:--|
| `RelWithDebInfo` (new default) | `build/reldbg<pyvminor>` | `-O3 -g -DNDEBUG` |
| `Release` | `build/rel<pyvminor>` | `-O3 -DNDEBUG` |
| `Debug` | `build/dbg<pyvminor>` | `-g`, no `-O` |

The default compiles what the old default compiled, so no build gets slower. Both preset bases pin the RelWithDebInfo flags to their Release counterparts (`-O3` for GCC and Clang, `/O2 /Ob2` for MSVC) because CMake's own values optimize a step lower and a rename should not cost an optimization level. `dev-reldbg` and `win-reldbg` configure the default and carry the build and test presets that `dev-rel` and `win-rel` used to; those two now configure a true `Release`. The `contrib/cmake` templates and `build.ps1` follow the default so IDE and Windows builds keep their symbols.

Two things change rather than staying put. pybind11 strips the extension module for every build type except Debug, RelWithDebInfo, and None, so the old default shipped a stripped `_solvcon` that a debugger could not see into; under the new default it is left alone, and `Release` still strips it. And the deleted option appended `/DEBUG` to `CMAKE_CXX_FLAGS` on MSVC, where `/DEBUG` is a linker option and `/D` defines a macro, so every Windows build has been defining `EBUG` and getting no debug information for it.

The sanitizer jobs move to `RelWithDebInfo`, since they asked for `Release`, were handed symbols anyway, and a sanitizer report names a file and a line only when it has them. The other CI jobs keep asking for `Release` and now get what they asked for. A `CMAKE_BUILD_TYPE` that is none of the three stops the build instead of quietly configuring the default.

Verified on macOS with Python 3.14: `make lint` clean; `make pytest` 2082 passed, 13 skipped, 3 xfailed; `make gtest` 238 passed. All three build types configure and build, and the flags land as tabled above. The pilot carries 113 debug-map entries under the default and none under `Release`; the extension module carries 112 and none respectively. Preset cross-references all resolve, including the Windows ones this host cannot configure.

Everyone gets one full rebuild when the default build type flips the cache, and `build/rel<pyvminor>` changes meaning for anyone who already has one. A `setup.mk` still setting `DEBUG_SYMBOL` is ignored rather than refused.

