### PR TITLE
Let each build system find ccache for itself

### DIFF
--- a/.github/actions/setup_macos/action.yml
+++ b/.github/actions/setup_macos/action.yml
@@ -43,10 +43,10 @@ runs:
         # brew install llvm@21 qt6
         brew install llvm@22
         # The macos-26 runner ships with Homebrew llvm@20 linked into
-        # /usr/local/bin/ (clang, clang++, clang-format, clang-tidy, etc.).
-        # Use -sf to overwrite the existing clang-tidy with our llvm@22
-        # version, and remove clang/clang++ so that ccache-action
-        # (create-symlink: true) can create its own symlinks.
+        # /usr/local/bin/ (clang, clang++, clang-format, clang-tidy, etc.),
+        # which precedes /usr/bin on PATH. Use -sf to overwrite the existing
+        # clang-tidy with our llvm@22 version, and remove clang/clang++ so a
+        # bare clang or clang++ resolves to the Xcode toolchain.
         # clang-format is installed separately via pip (see below) so that
         # both CI platforms use the version pinned by
         # CLANG_FORMAT_CI_VERSION in the Makefile.

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -75,6 +75,8 @@ jobs:
         with:
           key: ${{ runner.os }}-standalone-buffer-${{ matrix.cmake_build_type }}
           restore-keys: ${{ runner.os }}-standalone-buffer-${{ matrix.cmake_build_type }}
+          # contrib/standalone_buffer/Makefile compiles with a bare `c++`
+          # outside CMake, so the symlinks are this job's only route to ccache.
           create-symlink: true
           save: ${{ github.event_name != 'pull_request' }}
           # Bound the cache so it does not grow without limit across the rolling
@@ -160,7 +162,6 @@ jobs:
       with:
         key: ${{ runner.os }}-${{ matrix.cmake_build_type }}
         restore-keys: ${{ runner.os }}-${{ matrix.cmake_build_type }}
-        create-symlink: true
         save: ${{ github.event_name != 'pull_request' }}
         # Bound the cache so it does not grow without limit across the rolling
         # key. A master push or nightly run saves this cache; pull requests
@@ -540,7 +541,6 @@ jobs:
       with:
         key: ${{ runner.os }}-sanitizer-${{ matrix.cmake_build_type }}
         restore-keys: ${{ runner.os }}-sanitizer-${{ matrix.cmake_build_type }}
-        create-symlink: true
         save: ${{ github.event_name != 'pull_request' }}
         max-size: 1500M
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -102,7 +102,6 @@ jobs:
       with:
         key: ${{ runner.os }}-tidy-${{ matrix.cmake_build_type }}
         restore-keys: ${{ runner.os }}-tidy-${{ matrix.cmake_build_type }}
-        create-symlink: true
         save: ${{ github.event_name != 'pull_request' }}
         # Bound the cache so it does not grow without limit across the rolling
         # key. A master push or nightly run saves this cache; pull requests

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -88,7 +88,6 @@ jobs:
         with:
           key: ${{ runner.os }}-Release
           restore-keys: ${{ runner.os }}-Release
-          create-symlink: true
           save: ${{ github.event_name != 'pull_request' }}
           # Bound the cache so it does not grow without limit across the rolling
           # key. A master push or nightly run saves this cache; pull requests

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -86,8 +86,12 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
-          key: ${{ runner.os }}-Release
-          restore-keys: ${{ runner.os }}-Release
+          # This job builds `BUILD_QT=OFF` under the `setup.py` build
+          # directory, so its objects match neither the flags nor the paths
+          # that the `build` job stores under the plain `<os>-Release` key.
+          # Sharing that key only restores a cache it cannot hit.
+          key: ${{ runner.os }}-nouse-Release
+          restore-keys: ${{ runner.os }}-nouse-Release
           save: ${{ github.event_name != 'pull_request' }}
           # Bound the cache so it does not grow without limit across the rolling
           # key. A master push or nightly run saves this cache; pull requests

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -60,7 +60,6 @@ jobs:
         with:
           key: ${{ runner.os }}-Release
           restore-keys: ${{ runner.os }}-Release
-          create-symlink: true
           save: false
 
       - name: make buildext BUILD_QT=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,10 @@ endif()
 # ccache is detected here rather than named in the shared presets, so a host
 # without it configures and builds unchanged. The guard skips every case where
 # the wrap cannot pay: an explicit launcher, such as the sccache of the
-# ci-win-mkl preset; a compiler that is already ccache, which is how the Linux
-# and macOS CI jobs install it and where wrapping would hash ccache in place of
-# the real compiler; and MSVC, whose default debug information format ccache
-# refuses, leaving every unit to pay the wrap and return no hit.
+# ci-win-mkl preset; a compiler that is already ccache, as a masquerade symlink
+# ahead of the real one on PATH makes it, where wrapping would hash ccache in
+# place of the real compiler; and MSVC, whose default debug information format
+# ccache refuses, leaving every unit to pay the wrap and return no hit.
 option(USE_CCACHE "use ccache as the compiler launcher when it is available" ON)
 message(STATUS "USE_CCACHE: ${USE_CCACHE}")
 file(REAL_PATH "${CMAKE_CXX_COMPILER}" CCACHE_CXX_COMPILER_REALPATH)


### PR DESCRIPTION
Since #1297 `CMakeLists.txt` sets `CMAKE_CXX_COMPILER_LAUNCHER` when it finds `ccache`, so `create-symlink: true` on `ccache-action` left two ways to the same cache. CI took the symlink one, where the compiler CMake found was ccache itself, so the jobs never exercised the path a developer builds through. Dropping the symlinks leaves each build system to find the cache on its own and stops CI manipulating `PATH` for it.

`standalone_buffer` keeps them, because `contrib/standalone_buffer/Makefile` compiles with a bare `c++` and has no discovery step of its own. The `CMakeLists.txt` comment from #1297 is corrected here too, since this change is what made its claim about the CI jobs false.

A second commit gives `nouse_install` its own cache key. It shared the plain `<os>-Release` key with the `build` job while building `BUILD_QT=OFF` under the `setup.py` build directory, so neither its flags nor its paths matched what was stored there and every object missed.

Verified on a fork over two successive push runs, with the nightly-only jobs forced on. Everything passed both rounds. Round two reported 227/229 direct hits on the ubuntu-24.04 build, 114/115 on `profiling` for both ubuntu-24.04 and macos-26, and 115/117 on ubuntu `lint`, with `CMAKE_CXX_COMPILER` now `/usr/bin/c++`, so the launcher wraps the real compiler. Expect the first master push after merge to run cold and repopulate.

Related to #1297.
