### PR TITLE
Raise the CI build parallelism

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -118,12 +118,10 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_BUILD || vars.MMGH_TIMEOUT_BUILD || '45') }}
 
     env:
-      # Cap build parallelism. The github-hosted runners have only 3 (macOS)
-      # / 4 (ubuntu) virtual cores shared with co-tenant VMs, so the default
-      # unbounded `make -j` oversubscribes memory and CPU; on the 7 GB arm64
-      # macOS runner that swaps until the job hits its timeout. -j2 is the
-      # safe bet on both.
-      MAKE_PARALLEL: -j2
+      # A matrix entry naming no parallelism must fall back here rather than
+      # reach the Makefile empty: `MAKE_PARALLEL ?=` tests whether the
+      # variable is set, not whether it holds anything.
+      MAKE_PARALLEL: ${{ matrix.make_parallel || '-j2' }}
       # Every step in this job builds one build type, and the Makefile derives
       # the build tree from it. Setting it here rather than per step keeps a
       # bare `make buildext` on the tree the preceding `make cmake`
@@ -143,12 +141,17 @@ jobs:
           # One build type per host rather than the same one twice. macOS
           # takes RelWithDebInfo, which is what a bare `make` configures and
           # what no other job on a pull request builds; ubuntu and the
-          # Windows job cover Release.
+          # Windows job cover Release. Parallelism follows the host as well:
+          # ubuntu-24.04 has 4 virtual cores and 16 GB, while macos-26 has 3
+          # cores and 7 GB, where a third compiler swaps until the job hits
+          # its timeout.
           include:
             - os: ubuntu-24.04
               cmake_build_type: Release
+              make_parallel: -j4
             - os: macos-26
               cmake_build_type: RelWithDebInfo
+              make_parallel: -j2
 
         fail-fast: false
 

--- a/Makefile
+++ b/Makefile
@@ -236,9 +236,12 @@ bundle-test:
 standalone_buffer_setup:
 	$(MAKE) -C contrib/standalone_buffer copy
 
+# A recursive make inherits no job slots from a parent invoked without -j, so
+# the sub-make has to state its own. Under a parent that does carry -j, this
+# opts out of the jobserver and the two counts add up.
 .PHONY: standalone_buffer
 standalone_buffer:
-	$(MAKE) -C contrib/standalone_buffer build
+	$(MAKE) $(MAKE_PARALLEL) -C contrib/standalone_buffer build
 	$(MAKE) -C contrib/standalone_buffer run
 
 CLANG_FORMAT ?= clang-format


### PR DESCRIPTION
The `build` job of the `devbuild` workflow spends most of its time compiling whenever the compiler cache misses, and two things hold that compilation back.

`make standalone_buffer`, which gates every other job in the workflow, compiled its fifteen translation units one at a time, because a recursive `make` inherits no job slots from a parent invoked without `-j`. The first commit hands the sub-make `MAKE_PARALLEL`, the same variable the other build targets already use. Locally those fifteen units drop from 100s to 31s at `-j4`.

The job also capped `make` at `-j2` on both runners. That is right for `macos-26`, a 3-core, 7 GB machine where a third compiler swaps until the job times out, and low for `ubuntu-24.04`, which has 4 cores and 16 GB. The second commit moves the cap into the matrix, so ubuntu takes `-j4` and macOS keeps `-j2`.

No coverage changes, and no check is renamed. A cache-cold CI probe puts the gate job at 206s against 385s without the change. The ubuntu build job moved from 1339s to 1157s in the same probe, which a single run cannot separate from run-to-run noise.
