### PR TITLE
Keep Qt out of the core library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,7 +362,7 @@ endif()
 message(STATUS "PYSIDE6_LIBFILE: ${PYSIDE6_LIBFILE}")
 message(STATUS "SHIBOKEN6_LIBFILE: ${SHIBOKEN6_LIBFILE}")
 
-# An empty PYSIDE6_LIBFILE links solvcon_primary against nothing and defers the
+# An empty PYSIDE6_LIBFILE links solvcon_graphic against nothing and defers the
 # failure to an undefined PySide::getWrapperForQObject at link time.
 if(BUILD_QT AND "${PYSIDE6_LIBFILE}" STREQUAL "")
     message(FATAL_ERROR

--- a/cpp/binary/pilot/CMakeLists.txt
+++ b/cpp/binary/pilot/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(Qt6 COMPONENTS Core)
 find_package(Qt6 COMPONENTS Widgets)
 find_package(Qt6 COMPONENTS Gui)
 # Imported targets are directory-scoped, so finalizing pilot needs the two
-# components that solvcon_primary links declared here as well.
+# components that solvcon_graphic links declared here as well.
 find_package(Qt6 COMPONENTS Svg)
 find_package(Qt6 QUIET OPTIONAL_COMPONENTS GuiPrivate)
 
@@ -46,7 +46,7 @@ endif()
 target_link_libraries(
     pilot PUBLIC
     pybind11::embed
-    solvcon_primary
+    solvcon_entry
 )
 if(WIN32)
     set_target_properties(
@@ -78,7 +78,7 @@ target_compile_options(
 if(APPLE)
     # pilot.cpp pulls in apple's accelerate/veclib headers, whose CF_ENUM
     # macros trip clang-diagnostic-elaborated-enum-base, and the lint job
-    # runs clang-tidy with -warnings-as-errors=*. solvcon_primary already
+    # runs clang-tidy with -warnings-as-errors=*. solvcon_graphic already
     # suppresses this; the pilot target needs it too. The library's other
     # -Wno flags are not needed here: pilot.cpp lints clean on Linux
     # without them, so this stays apple-only.
@@ -125,11 +125,17 @@ add_custom_target(run_pilot $<TARGET_FILE:pilot>)
 add_custom_target(run_pilot_pytest $<TARGET_FILE:pilot> --mode=pytest)
 
 if(DO_CLANG_TIDY_DIFF)
-    get_target_property(
-        SOLVCON_PRIMARY_FILES
-        solvcon_primary
-        SOURCES
-    )
+    # The core, the pilot, and the entry unit are three targets, and the diff
+    # has to span all of them: the pilot sources this target exists to lint
+    # live in solvcon_graphic. SOLVCON_LIBRARIES names them, so the list
+    # follows whatever cpp/solvcon built rather than restating it here.
+    set(SOLVCON_LINT_FILES)
+    foreach (SOLVCON_LIBRARY IN LISTS SOLVCON_LIBRARIES)
+        get_target_property(SOLVCON_LIBRARY_FILES ${SOLVCON_LIBRARY} SOURCES)
+        if (SOLVCON_LIBRARY_FILES)
+            list(APPEND SOLVCON_LINT_FILES ${SOLVCON_LIBRARY_FILES})
+        endif ()
+    endforeach ()
 
     string(
         CONCAT
@@ -137,7 +143,7 @@ if(DO_CLANG_TIDY_DIFF)
         "test -n \"$SOLVCON_DIFF_BASE\""
         " && "
         "git diff --no-color -U0 \"$SOLVCON_DIFF_BASE\" HEAD"
-        " -- $<JOIN:${SOLVCON_PRIMARY_FILES};${CMAKE_CURRENT_SOURCE_DIR}, >"
+        " -- $<JOIN:${SOLVCON_LINT_FILES};${CMAKE_CURRENT_SOURCE_DIR}, >"
         " | "
         "$<JOIN:${DO_CLANG_TIDY_DIFF}, > -path \"${CMAKE_BINARY_DIR}\""
     )

--- a/cpp/binary/pymod_solvcon/CMakeLists.txt
+++ b/cpp/binary/pymod_solvcon/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 target_link_libraries(
     _solvcon PUBLIC
     pybind11::module
-    solvcon_primary
+    solvcon_entry
 )
 
 if (HIDE_SYMBOL)

--- a/cpp/solvcon/CMakeLists.txt
+++ b/cpp/solvcon/CMakeLists.txt
@@ -4,10 +4,6 @@
 cmake_minimum_required(VERSION 4.0.1)
 
 if (BUILD_QT)
-    set(CMAKE_AUTOMOC ON)
-    set(CMAKE_AUTORCC ON)
-    set(CMAKE_AUTOUIC ON)
-
     find_package(Qt6 QUIET)
     if(NOT Qt6_FOUND)
         if(MSVC)
@@ -109,16 +105,47 @@ set(SOLVCON_GRAPHIC_FILES
     ${SOLVCON_PILOT_FILES}
     CACHE FILEPATH "" FORCE)
 
+# Qt reaches only the pilot, so only the pilot is built against it. The two
+# settings of BUILD_QT used to produce one library each, over a source list
+# that differed by the pilot but a command line that differed everywhere:
+# linking Qt PUBLIC put its include directories and its QT_*_LIB definitions
+# on every unit in the core. A build that compiles both settings, which the
+# devbuild workflow does, therefore compiled the core twice over and shared
+# nothing between the passes, not even through ccache.
+#
+# Three libraries instead of one. `solvcon_primary` is the core and never sees
+# Qt. `solvcon_graphic` is the pilot and is the only target that does.
+# `solvcon_entry` is the single unit that has to know which of the two it was
+# built with. Only the last two are rebuilt when BUILD_QT changes.
+add_library(
+    solvcon_primary
+    STATIC
+    ${SOLVCON_TERMINAL_FILES}
+)
+
+set(SOLVCON_LIBRARIES solvcon_primary)
+
 if (BUILD_QT)
     qt_add_library(
-        solvcon_primary
+        solvcon_graphic
         STATIC
-        ${SOLVCON_TERMINAL_FILES}
         ${SOLVCON_GRAPHIC_FILES}
+    )
+    list(APPEND SOLVCON_LIBRARIES solvcon_graphic)
+
+    # The moc/rcc/uic passes belong to this target alone. As directory
+    # properties they also handed the core an autogen include directory, which
+    # is one more way for its command line to move with BUILD_QT.
+    set_target_properties(
+        solvcon_graphic PROPERTIES
+        AUTOMOC ON
+        AUTORCC ON
+        AUTOUIC ON
     )
 
     target_link_libraries(
-        solvcon_primary PUBLIC
+        solvcon_graphic PUBLIC
+        solvcon_primary
         Qt::Widgets
         Qt::Core
         Qt::Gui
@@ -129,13 +156,13 @@ if (BUILD_QT)
     # CMake target when present; otherwise add the private include directory
     # directly (the QRhi symbols themselves are exported from Qt::Gui).
     if (TARGET Qt6::GuiPrivate)
-        target_link_libraries(solvcon_primary PUBLIC Qt::GuiPrivate)
+        target_link_libraries(solvcon_graphic PUBLIC Qt::GuiPrivate)
     else ()
         get_target_property(SOLVCON_QTGUI_INCS Qt6::Gui INTERFACE_INCLUDE_DIRECTORIES)
         set(SOLVCON_FOUND_QRHI FALSE)
         foreach (SOLVCON_INC IN LISTS SOLVCON_QTGUI_INCS)
             if (EXISTS "${SOLVCON_INC}/${Qt6Gui_VERSION}/QtGui/rhi/qrhi.h")
-                target_include_directories(solvcon_primary PRIVATE
+                target_include_directories(solvcon_graphic PRIVATE
                     "${SOLVCON_INC}/${Qt6Gui_VERSION}/QtGui")
                 set(SOLVCON_FOUND_QRHI TRUE)
             endif ()
@@ -149,7 +176,7 @@ if (BUILD_QT)
 
     # Bake the pilot GLSL shaders to .qsb and embed them in the Qt resource
     # system under :/solvcon/pilot/shaders/. Loaded by RMaterial at runtime.
-    qt6_add_shaders(solvcon_primary "solvcon_pilot_shaders"
+    qt6_add_shaders(solvcon_graphic "solvcon_pilot_shaders"
         BATCHABLE
         PREFIX "/solvcon/pilot"
         BASE "${SOLVCON_PILOT_SHADERDIR}/.."
@@ -157,32 +184,51 @@ if (BUILD_QT)
     )
 
     target_link_libraries(
-        solvcon_primary PUBLIC
+        solvcon_graphic PUBLIC
         ${PYSIDE6_LIBFILE}
-    )
-else () # BUILD_QT
-    add_library(
-        solvcon_primary
-        STATIC
-        ${SOLVCON_TERMINAL_FILES}
     )
 endif () # BUILD_QT
 
-set_target_properties(solvcon_primary PROPERTIES POSITION_INDEPENDENT_CODE ON)
+add_library(
+    solvcon_entry
+    STATIC
+    ${SOLVCON_ENTRY_SOURCES}
+)
 
-if (CLANG_TIDY_EXE AND USE_CLANG_TIDY)
-    set_target_properties(
-        solvcon_primary PROPERTIES
-        CXX_CLANG_TIDY "${DO_CLANG_TIDY}"
-    )
-endif () # CLANG_TIDY
+# Everything that links the extension module or the pilot binary links this
+# one target and reaches the rest through it. Under BUILD_QT the Qt link is
+# what defines QT_CORE_LIB for `module.cpp`, which is how it decides whether
+# to register the pilot submodule; the macro is Qt's own, so nothing here has
+# to restate the setting.
+target_link_libraries(solvcon_entry PUBLIC ${SOLVCON_LIBRARIES})
+
+list(APPEND SOLVCON_LIBRARIES solvcon_entry)
+
+# `cpp/binary/pilot` is a sibling subtree and cannot see a normal variable set
+# here, so the list reaches `pilot_clang_tidy_diff` through the cache.
+set(SOLVCON_LIBRARIES "${SOLVCON_LIBRARIES}" CACHE STRING "" FORCE)
+
+foreach (SOLVCON_LIBRARY IN LISTS SOLVCON_LIBRARIES)
+    set_target_properties(${SOLVCON_LIBRARY} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+    if (CLANG_TIDY_EXE AND USE_CLANG_TIDY)
+        set_target_properties(
+            ${SOLVCON_LIBRARY} PROPERTIES
+            CXX_CLANG_TIDY "${DO_CLANG_TIDY}"
+        )
+    endif () # CLANG_TIDY
+endforeach ()
 
 # Hack: add a .clang-tidy file in the generated .rcc directory.
 # See https://gitlab.kitware.com/cmake/cmake/-/merge_requests/777
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/.rcc/.clang-tidy" "---
+# Both directories are generated by solvcon_graphic, so neither exists, and
+# neither holds anything for clang-tidy to read, without BUILD_QT.
+if (BUILD_QT)
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/.rcc/.clang-tidy" "---
 Checks: '-*,llvm-twine-local'")
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/solvcon_primary_autogen/.clang-tidy" "---
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/solvcon_graphic_autogen/.clang-tidy" "---
 Checks: '-bugprone-suspicious-include,llvm-twine-local'")
+endif () # BUILD_QT
 
 if (APPLE)
     find_library(APPLE_FWK_FOUNDATION Foundation REQUIRED)
@@ -284,20 +330,26 @@ if (NOT APPLE)
     endif ()
 endif () # NOT APPLE
 
-if (MSVC)
-    target_compile_options(
-        solvcon_primary PRIVATE
-        ${COMMON_COMPILER_OPTIONS}
-        /bigobj # C1128: number of sections exceeded object file format limit
-    )
-else () # MSVC
-    target_compile_options(
-        solvcon_primary PRIVATE
-        ${COMMON_COMPILER_OPTIONS}
-        -Wno-unused-value # for PYBIND11_EXPAND_SIDE_EFFECTS in pybind11.h
-        -Wno-noexcept-type # GCC
-        -Wno-elaborated-enum-base # for apple accelerate/veclib
-    )
-endif () # MSVC
+# The three libraries were one, so what the one carried they all carry. The
+# pilot sources and `module.cpp` are the units that need the pybind11 and
+# Accelerate suppressions most, and `wrap_pilot.cpp` is the one most likely
+# to want /bigobj.
+foreach (SOLVCON_LIBRARY IN LISTS SOLVCON_LIBRARIES)
+    if (MSVC)
+        target_compile_options(
+            ${SOLVCON_LIBRARY} PRIVATE
+            ${COMMON_COMPILER_OPTIONS}
+            /bigobj # C1128: number of sections exceeded object file format limit
+        )
+    else () # MSVC
+        target_compile_options(
+            ${SOLVCON_LIBRARY} PRIVATE
+            ${COMMON_COMPILER_OPTIONS}
+            -Wno-unused-value # for PYBIND11_EXPAND_SIDE_EFFECTS in pybind11.h
+            -Wno-noexcept-type # GCC
+            -Wno-elaborated-enum-base # for apple accelerate/veclib
+        )
+    endif () # MSVC
+endforeach ()
 
 # vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/python/CMakeLists.txt
+++ b/cpp/solvcon/python/CMakeLists.txt
@@ -11,6 +11,13 @@ set(SOLVCON_PYTYON_HEADERS
 
 set(SOLVCON_PYTHON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/common.cpp
+    CACHE FILEPATH "" FORCE)
+
+# `module.cpp` is the only unit outside the pilot whose text depends on Qt: it
+# registers the pilot submodule and sets `HAS_PILOT` behind `QT_CORE_LIB`. It
+# compiles into a library of its own so that the rest of the core can be built
+# without ever seeing a Qt flag.
+set(SOLVCON_ENTRY_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/module.cpp
     CACHE FILEPATH "" FORCE)
 


### PR DESCRIPTION
`solvcon_primary` was one library under both settings of `BUILD_QT`, and it linked Qt `PUBLIC`, so Qt's include directories and `QT_*_LIB` definitions landed on every unit in the core. The `build` job of `devbuild` compiles `BUILD_QT=OFF` and then `BUILD_QT=ON` in the same build directory, so the second pass found a changed command line on every core object and rebuilt the whole core.

Only the pilot needs Qt. Every `#include <Q...>` and every `Q_OBJECT` under `cpp/solvcon` sits in `pilot/`, and the one unit outside it that varies with the setting is `python/module.cpp`, which registers the pilot submodule behind `QT_CORE_LIB`.

So the one library becomes three:

- `solvcon_primary`, the core, never sees Qt.
- `solvcon_graphic`, the pilot, is the only target that links Qt. It carries moc, rcc, and uic as target properties instead of directory properties, which used to hand the core an autogen include directory too.
- `solvcon_entry` is `module.cpp` alone. The extension module and the pilot binary link it and reach the rest through it, and `QT_CORE_LIB` still decides what it compiles.

```
    _solvcon (Python ext)      pilot (binary)
              \                  /
               solvcon_entry              module.cpp, knows whether Qt is here
                /          \
    solvcon_graphic   solvcon_primary     the pilot (Qt)   the core (no Qt)
```

Units compiled, replaying the job's step sequence:

| step | master | this PR |
| --- | --- | --- |
| `make buildext BUILD_QT=OFF` | 72 | 72 |
| `make buildext BUILD_QT=ON` | 115 | 45 |
| `make pilot` | 3 | 3 |

Of the units the two passes share, 57 changed command line before and 2 change now.

`make buildext BUILD_QT=ON` on a runner, this branch's run 31270521406 against master's run 31270363328:

| runner | master | this PR |
| --- | --- | --- |
| ubuntu-24.04 Release | 9m38s | 2m25s |
| macos-26 RelWithDebInfo | 1m58s | 1m32s |

The two runs held different ccache contents. The untouched `BUILD_QT=OFF` step moved by 85s on ubuntu and 54s on macos, so the ubuntu gain is real and the macos gain is below that floor. Against an isolated ccache the pass takes 51s before and 27s after when the cache holds only the `BUILD_QT=OFF` pass, and 5s either way once both settings are cached.

Two notes for review. The per-target compile options now cover all three libraries, because the pilot sources and `module.cpp` need the pybind11 and Accelerate suppressions and `wrap_pilot.cpp` may want `/bigobj`. And `pilot_clang_tidy_diff` collects its file list from all three, since the pilot sources it lints no longer live in `solvcon_primary`.
