### PR TITLE
Correct Python header CMake variable

### DIFF
--- a/cpp/solvcon/python/CMakeLists.txt
+++ b/cpp/solvcon/python/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 4.0.1)
 
-set(SOLVCON_PYTYON_HEADERS
+set(SOLVCON_PYTHON_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/python.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/common.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/module.hpp


### PR DESCRIPTION
Correct the misspelled `SOLVCON_PYTHON_HEADERS` definition so the Python headers are included in `SOLVCON_PYTHON_FILES` and the target-derived lint file set.

Validation: `contrib/lint/check_ascii.py` and `contrib/lint/check_ascii.py --check-tws`.

Related to #1311.