### PR TITLE
Rename reminaing `mm`/`modmesh` code

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -593,15 +593,15 @@ solvcon::real_type local_function(solvcon::int_type value);
 } /* end namespace */
 ```
 
-The namespace `solvcon` may be aliased to `mm` in a local scope. No alias
+The namespace `solvcon` may be aliased to `sc` in a local scope. No alias
 should be use outside a local scope.
 
 ```cpp
 solvcon::real_type local_function(solvcon::int_type value)
 {
-    // Alias the solvcon namespace to mm.
-    namespace mm = solvcon;
-    return mm::real_type(value); // Same as solvcon::real_type(value);
+    // Alias the solvcon namespace to sc.
+    namespace sc = solvcon;
+    return sc::real_type(value); // Same as solvcon::real_type(value);
 }
 ```
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -286,7 +286,7 @@ from matplotlib import figure
 from PySide6 import QtCore, QtWidgets, QtGui
 
 # Modules in the current project.
-import solvcon as mm
+import solvcon as sc
 from solvcon import onedim
 from solvcon.plot import svg
 
@@ -297,7 +297,7 @@ from . import _base_app
 
 > **Note:**
 >
-> `solvcon` can be shorthanded as `mm`.
+> `solvcon` can be shorthanded as `sc`.
 
 Do not import module content (classes, functions, or constants) directly.
 Always use the `foo.bar` pattern to access classes, functions, or constants:

--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -401,7 +401,7 @@ else
   export CMAKE_PREFIX_PATH=${SCDV_USRDIR}
 fi
 
-# solvcon's _solvcon module constructs a QApplication during PyInit__modmesh;
+# solvcon's _solvcon module constructs a QApplication during PyInit__solvcon;
 # without a display or QT_QPA_PLATFORM Qt aborts in
 # QGuiApplicationPrivate::createPlatformIntegration. Default to the offscreen
 # platform when nothing is set and no display is available, so plain `import

--- a/contrib/dependency/showdep.sh
+++ b/contrib/dependency/showdep.sh
@@ -7,7 +7,7 @@ echo "gcc path: $(which gcc)"
 echo "gcc version: $(gcc --version)"
 echo "g++ path: $(which g++ 2>/dev/null || echo not-installed)"
 echo "g++ version: $(g++ --version 2>/dev/null | head -1 || echo not-installed)"
-# modmesh's SimpleArray.hpp needs C++23 <mdspan> (GCC >= 14); flag a compiler
+# solvcon's SimpleArray.hpp needs C++23 <mdspan> (GCC >= 14); flag a compiler
 # too old to build it before the build itself does.
 echo "C++23 <mdspan>: $(echo '#include <mdspan>' \
   | ${CXX:-g++} -std=c++23 -x c++ -fsyntax-only - 2>/dev/null \

--- a/contrib/standalone_buffer/Makefile
+++ b/contrib/standalone_buffer/Makefile
@@ -1,8 +1,8 @@
 # Copyright (c) 2022, solvcon team <contact@solvcon.net>
 # BSD 3-Clause License, see COPYING
 
-MMROOT := $(realpath ../..)
-SETUPROOT ?= $(MMROOT)/$(BUILD_PATH)/standalone_buffer
+SCROOT := $(realpath ../..)
+SETUPROOT ?= $(SCROOT)/$(BUILD_PATH)/standalone_buffer
 
 ifeq ($(SETUPROOT),)
 	SETUPROOT := local_standalone_buffer
@@ -104,16 +104,16 @@ copy:
 	@echo "standalone buffer root": $(SETUPROOT)
 	rm -rf $(SETUPROOT)/solvcon
 	mkdir -p $(SETUPROOT)/solvcon
-	cp $(MMROOT)/cpp/solvcon/base.hpp $(SETUPROOT)/solvcon/base.hpp
-	cp -a $(MMROOT)/cpp/solvcon/buffer $(SETUPROOT)/solvcon/buffer
+	cp $(SCROOT)/cpp/solvcon/base.hpp $(SETUPROOT)/solvcon/base.hpp
+	cp -a $(SCROOT)/cpp/solvcon/buffer $(SETUPROOT)/solvcon/buffer
 	mkdir -p $(SETUPROOT)/solvcon/python
-	cp $(MMROOT)/cpp/solvcon/python/common.hpp $(SETUPROOT)/solvcon/python/common.hpp
-	cp -a $(MMROOT)/cpp/solvcon/toggle $(SETUPROOT)/solvcon/toggle
+	cp $(SCROOT)/cpp/solvcon/python/common.hpp $(SETUPROOT)/solvcon/python/common.hpp
+	cp -a $(SCROOT)/cpp/solvcon/toggle $(SETUPROOT)/solvcon/toggle
 	rm -rf $(SETUPROOT)/solvcon/toggle/pymod
-	cp -a $(MMROOT)/cpp/solvcon/profiling $(SETUPROOT)/solvcon/profiling
+	cp -a $(SCROOT)/cpp/solvcon/profiling $(SETUPROOT)/solvcon/profiling
 	rm -rf $(SETUPROOT)/solvcon/profiling/pymod
-	cp -a $(MMROOT)/cpp/solvcon/math $(SETUPROOT)/solvcon/math
+	cp -a $(SCROOT)/cpp/solvcon/math $(SETUPROOT)/solvcon/math
 	rm -rf $(SETUPROOT)/solvcon/math/pymod
-	cp -a $(MMROOT)/cpp/solvcon/simd $(SETUPROOT)/solvcon/simd
-	cp $(MMROOT)/cpp/solvcon/base.hpp $(SETUPROOT)/solvcon/
+	cp -a $(SCROOT)/cpp/solvcon/simd $(SETUPROOT)/solvcon/simd
+	cp $(SCROOT)/cpp/solvcon/base.hpp $(SETUPROOT)/solvcon/
 	find $(SETUPROOT) -name CMakeLists.txt -delete

--- a/cpp/solvcon/inout/gmsh.hpp
+++ b/cpp/solvcon/inout/gmsh.hpp
@@ -289,8 +289,8 @@ private:
 inline GmshElementDef GmshElementDef::by_id(uint16_t id)
 {
 #define VEC(...) __VA_ARGS__
-#define SC_DECL_SWITCH_ELEMENT_TYPE(ID, NDIM, NNDS, MMTPN, MMCL) \
-    case ID: return GmshElementDef(NDIM, NNDS, MMTPN, small_vector<uint8_t>{MMCL}); break;
+#define SC_DECL_SWITCH_ELEMENT_TYPE(ID, NDIM, NNDS, SCTPN, SCCL) \
+    case ID: return GmshElementDef(NDIM, NNDS, SCTPN, small_vector<uint8_t>{SCCL}); break;
     switch (id)
     {
         // clang-format off

--- a/cpp/solvcon/python/common.cpp
+++ b/cpp/solvcon/python/common.cpp
@@ -63,10 +63,10 @@ Interpreter & Interpreter::finalize()
     return *this;
 }
 
-Interpreter & Interpreter::setup_modmesh_path()
+Interpreter & Interpreter::setup_solvcon_path()
 {
     // The hard-coded Python in C++ is difficult to debug. Any better way?
-    std::string const cmd = R""""(def _set_modmesh_path():
+    std::string const cmd = R""""(def _set_solvcon_path():
     import os
     import sys
     filename = os.path.join('solvcon', '__init__.py')
@@ -81,7 +81,7 @@ Interpreter & Interpreter::setup_modmesh_path()
             path = os.path.dirname(path)
     if path:
         sys.path.insert(0, path)
-_set_modmesh_path())"""";
+_set_solvcon_path())"""";
     try
     {
         pybind11::exec(cmd);

--- a/cpp/solvcon/python/common.hpp
+++ b/cpp/solvcon/python/common.hpp
@@ -518,7 +518,7 @@ public:
     void preload_module(std::string const & name);
     void preload_modules(std::vector<std::string> const & names);
 
-    Interpreter & setup_modmesh_path();
+    Interpreter & setup_solvcon_path();
     Interpreter & setup_process();
 
     int enter_main();

--- a/cpp/solvcon/python/module.cpp
+++ b/cpp/solvcon/python/module.cpp
@@ -66,7 +66,7 @@ int program_entrance(int argc, char ** argv)
     // Initialize the Python interpreter.
     Interpreter::instance()
         .initialize()
-        .setup_modmesh_path()
+        .setup_solvcon_path()
         .setup_process();
 
     int ret = 0;

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -27,10 +27,10 @@ TEST(ConcreteBuffer, iterator)
 
 TEST(SimpleArray, construction)
 {
-    namespace mm = solvcon;
-    mm::SimpleArray<double> arr_double(10);
+    namespace sc = solvcon;
+    sc::SimpleArray<double> arr_double(10);
     EXPECT_EQ(arr_double.nbody(), 10);
-    mm::SimpleArray<int> arr_int(17);
+    sc::SimpleArray<int> arr_int(17);
     EXPECT_EQ(arr_int.nbody(), 17);
 }
 

--- a/gtests/test_nopython_mdspan.cpp
+++ b/gtests/test_nopython_mdspan.cpp
@@ -20,10 +20,10 @@
 
 TEST(SignedStrideLayout, positive_strides)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
     using extents_type = std::dextents<ssize_t, 2>;
-    using mapping_type = mm::detail::SignedStrideLayout::mapping<extents_type>;
+    using mapping_type = sc::detail::SignedStrideLayout::mapping<extents_type>;
 
     mapping_type const mapping(extents_type(2, 3), std::array<ssize_t, 2>{4, 1});
 
@@ -36,10 +36,10 @@ TEST(SignedStrideLayout, positive_strides)
 
 TEST(SignedStrideLayout, negative_strides)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
     using extents_type = std::dextents<ssize_t, 2>;
-    using layout_type = mm::detail::SignedStrideLayout;
+    using layout_type = sc::detail::SignedStrideLayout;
     using mapping_type = layout_type::mapping<extents_type>;
 
     static_assert(std::regular<mapping_type>);
@@ -62,10 +62,10 @@ TEST(SignedStrideLayout, negative_strides)
 
 TEST(SignedStrideLayout, mixed_strides_with_padding)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
     using extents_type = std::dextents<ssize_t, 3>;
-    using mapping_type = mm::detail::SignedStrideLayout::mapping<extents_type>;
+    using mapping_type = sc::detail::SignedStrideLayout::mapping<extents_type>;
 
     mapping_type const mapping(extents_type(2, 3, 4), std::array<ssize_t, 3>{-16, 4, -1});
 
@@ -80,10 +80,10 @@ TEST(SignedStrideLayout, mixed_strides_with_padding)
 
 TEST(SignedStrideLayout, empty_extent)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
     using extents_type = std::dextents<ssize_t, 3>;
-    using mapping_type = mm::detail::SignedStrideLayout::mapping<extents_type>;
+    using mapping_type = sc::detail::SignedStrideLayout::mapping<extents_type>;
 
     mapping_type const mapping(extents_type(2, 0, 3), std::array<ssize_t, 3>{-3, 3, 1});
 
@@ -94,10 +94,10 @@ TEST(SignedStrideLayout, empty_extent)
 
 TEST(SignedStrideLayout, scalar)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
     using extents_type = std::extents<ssize_t>;
-    using mapping_type = mm::detail::SignedStrideLayout::mapping<extents_type>;
+    using mapping_type = sc::detail::SignedStrideLayout::mapping<extents_type>;
 
     mapping_type const mapping;
 
@@ -109,10 +109,10 @@ TEST(SignedStrideLayout, scalar)
 
 TEST(SignedStrideLayout, mdspan_with_positive_strides)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
     using extents_type = std::dextents<ssize_t, 2>;
-    using layout_type = mm::detail::SignedStrideLayout;
+    using layout_type = sc::detail::SignedStrideLayout;
     using mapping_type = layout_type::mapping<extents_type>;
 
     mapping_type const mapping(extents_type(2, 3), std::array<ssize_t, 2>{4, 1});
@@ -127,10 +127,10 @@ TEST(SignedStrideLayout, mdspan_with_positive_strides)
 
 TEST(SignedStrideLayout, mdspan_with_negative_strides)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
     using extents_type = std::dextents<ssize_t, 2>;
-    using layout_type = mm::detail::SignedStrideLayout;
+    using layout_type = sc::detail::SignedStrideLayout;
     using mapping_type = layout_type::mapping<extents_type>;
 
     mapping_type const mapping(extents_type(3, 4), std::array<ssize_t, 2>{-4, 1});
@@ -145,9 +145,9 @@ TEST(SignedStrideLayout, mdspan_with_negative_strides)
 
 TEST(SimpleArray, mdspan_1d)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{6});
+    sc::SimpleArray<double> arr(sc::small_vector<ssize_t>{6});
     for (size_t i = 0; i < 6; ++i) { arr(i) = static_cast<double>(i); }
 
     auto ms = arr.as_mdspan<1>();
@@ -166,9 +166,9 @@ TEST(SimpleArray, mdspan_1d)
 
 TEST(SimpleArray, mdspan_1d_const)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{6}, 5.0);
+    sc::SimpleArray<double> arr(sc::small_vector<ssize_t>{6}, 5.0);
     const auto & carr = arr;
 
     auto ms = carr.as_mdspan<1>();
@@ -184,10 +184,10 @@ TEST(SimpleArray, mdspan_1d_const)
 
 TEST(SimpleArray, mdspan_1d_ghost)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
     // 1D array: 5 total elements, 1 ghost at the front.
-    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{5});
+    sc::SimpleArray<double> arr(sc::small_vector<ssize_t>{5});
     arr.set_nghost(1);
     for (size_t i = 0; i < 5; ++i) { arr.data(i) = static_cast<double>(i); }
 
@@ -203,9 +203,9 @@ TEST(SimpleArray, mdspan_1d_ghost)
 
 TEST(SimpleArray, mdspan_2d)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{3, 4});
+    sc::SimpleArray<double> arr(sc::small_vector<ssize_t>{3, 4});
     for (size_t i = 0; i < 3; ++i)
     {
         for (size_t j = 0; j < 4; ++j)
@@ -244,9 +244,9 @@ TEST(SimpleArray, mdspan_2d)
 
 TEST(SimpleArray, mdspan_2d_const)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{2, 3}, 7.0);
+    sc::SimpleArray<double> arr(sc::small_vector<ssize_t>{2, 3}, 7.0);
     const auto & carr = arr;
 
     auto ms = carr.as_mdspan<2>();
@@ -267,10 +267,10 @@ TEST(SimpleArray, mdspan_2d_const)
 
 TEST(SimpleArray, mdspan_2d_ghost)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
     // shape {5, 4}: 5 rows (1 ghost + 4 body), 4 columns.
-    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{5, 4});
+    sc::SimpleArray<double> arr(sc::small_vector<ssize_t>{5, 4});
     arr.set_nghost(1);
     for (size_t idx = 0; idx < arr.size(); ++idx) { arr.data(idx) = static_cast<double>(idx); }
 
@@ -303,9 +303,9 @@ TEST(SimpleArray, mdspan_2d_ghost)
 
 TEST(SimpleArray, mdspan_3d)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{2, 3, 4});
+    sc::SimpleArray<double> arr(sc::small_vector<ssize_t>{2, 3, 4});
     for (size_t i = 0; i < 2; ++i)
     {
         for (size_t j = 0; j < 3; ++j)
@@ -352,10 +352,10 @@ TEST(SimpleArray, mdspan_3d)
 
 TEST(SimpleArray, mdspan_3d_ghost)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
     // shape {4, 3, 2}: 4 slices (2 ghost + 2 body), 3 rows, 2 columns.
-    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{4, 3, 2});
+    sc::SimpleArray<double> arr(sc::small_vector<ssize_t>{4, 3, 2});
     arr.set_nghost(2);
     for (size_t idx = 0; idx < arr.size(); ++idx) { arr.data(idx) = static_cast<double>(idx); }
 
@@ -395,9 +395,9 @@ TEST(SimpleArray, mdspan_3d_ghost)
 
 TEST(SimpleArray, mdspan_4d)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{2, 3, 4, 5});
+    sc::SimpleArray<double> arr(sc::small_vector<ssize_t>{2, 3, 4, 5});
     for (size_t i = 0; i < 2; ++i)
     {
         for (size_t j = 0; j < 3; ++j)
@@ -454,10 +454,10 @@ TEST(SimpleArray, mdspan_4d)
 
 TEST(SimpleArray, mdspan_4d_ghost)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
     // shape {4, 3, 2, 2}: 4 slices (1 ghost + 3 body), 3 rows, 2 columns, 2 depth.
-    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{4, 3, 2, 2});
+    sc::SimpleArray<double> arr(sc::small_vector<ssize_t>{4, 3, 2, 2});
     arr.set_nghost(1);
     for (size_t idx = 0; idx < arr.size(); ++idx) { arr.data(idx) = static_cast<double>(idx); }
 
@@ -504,22 +504,22 @@ TEST(SimpleArray, mdspan_4d_ghost)
 
 TEST(SimpleArray, mdspan_rank_mismatch)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{3, 4});
+    sc::SimpleArray<double> arr(sc::small_vector<ssize_t>{3, 4});
     EXPECT_THROW(arr.as_mdspan<3>(), std::out_of_range);
 }
 
 TEST(SimpleArray, mdspan_non_contiguous)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
     // Build a 3x4 view whose stride differs from the row-major layout, so the
     // array is neither C- nor F-contiguous over the underlying buffer.
-    using array_type = mm::SimpleArray<double>;
+    using array_type = sc::SimpleArray<double>;
     array_type::shape_type const shape{3, 4};
     array_type::shape_type const stride{8, 1};
-    auto buffer = mm::ConcreteBuffer::construct(3 * 8 * sizeof(double));
+    auto buffer = sc::ConcreteBuffer::construct(3 * 8 * sizeof(double));
     array_type arr(shape, stride, buffer);
     for (size_t i = 0; i < 24; ++i) { arr.data(i) = static_cast<double>(i); }
 
@@ -562,15 +562,15 @@ TEST(SimpleArray, mdspan_non_contiguous)
 
 TEST(SimpleArray, mdspan_positive_strides_with_data_offset)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
-    auto buffer = mm::ConcreteBuffer::construct(6 * sizeof(double));
+    auto buffer = sc::ConcreteBuffer::construct(6 * sizeof(double));
     for (size_t i = 0; i < 6; ++i) { buffer->data<double>()[i] = static_cast<double>(i); }
 
-    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{4}, buffer, 2 * sizeof(double));
+    sc::SimpleArray<double> arr(sc::small_vector<ssize_t>{4}, buffer, 2 * sizeof(double));
     auto ms = arr.as_mdspan<1>();
 
-    static_assert(std::is_same_v<typename decltype(ms)::layout_type, mm::detail::SignedStrideLayout>);
+    static_assert(std::is_same_v<typename decltype(ms)::layout_type, sc::detail::SignedStrideLayout>);
     EXPECT_EQ(ms.mapping().origin_offset(), 0);
     EXPECT_EQ(&ms[0], arr.logical_data());
     for (size_t i = 0; i < 4; ++i) { EXPECT_EQ(ms[i], arr(i)); }
@@ -582,12 +582,12 @@ TEST(SimpleArray, mdspan_positive_strides_with_data_offset)
 
 TEST(SimpleArray, mdspan_negative_strides)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
-    using array_type = mm::SimpleArray<double>;
+    using array_type = sc::SimpleArray<double>;
     array_type::shape_type const shape{2, 3};
     array_type::shape_type const stride{-3, -1};
-    auto buffer = mm::ConcreteBuffer::construct(6 * sizeof(double));
+    auto buffer = sc::ConcreteBuffer::construct(6 * sizeof(double));
     for (size_t i = 0; i < 6; ++i) { buffer->data<double>()[i] = static_cast<double>(i); }
 
     array_type arr(shape, stride, buffer, 5 * sizeof(double));
@@ -611,7 +611,7 @@ TEST(SimpleArray, mdspan_negative_strides)
     EXPECT_EQ(arr(0, 1), 42.0);
     EXPECT_EQ(buffer->data<double>()[4], 42.0);
 
-    mm::SimpleArray<double> const & carr = arr;
+    sc::SimpleArray<double> const & carr = arr;
     auto cms = carr.as_mdspan<2>();
     static_assert(std::is_same_v<typename decltype(cms)::element_type, double const>);
     EXPECT_EQ((cms[0, 1]), 42.0);
@@ -619,12 +619,12 @@ TEST(SimpleArray, mdspan_negative_strides)
 
 TEST(SimpleArray, mdspan_mixed_strides_with_padding)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
-    using array_type = mm::SimpleArray<double>;
+    using array_type = sc::SimpleArray<double>;
     array_type::shape_type const shape{2, 3, 2, 4};
     array_type::shape_type const stride{-40, 10, -5, 1};
-    auto buffer = mm::ConcreteBuffer::construct(72 * sizeof(double));
+    auto buffer = sc::ConcreteBuffer::construct(72 * sizeof(double));
     for (size_t i = 0; i < 72; ++i) { buffer->data<double>()[i] = static_cast<double>(i); }
 
     array_type arr(shape, stride, buffer, 47 * sizeof(double));
@@ -657,9 +657,9 @@ TEST(SimpleArray, mdspan_mixed_strides_with_padding)
 
 TEST(SimpleArray, mdspan_empty_extent)
 {
-    namespace mm = solvcon;
+    namespace sc = solvcon;
 
-    mm::SimpleArray<double> arr(mm::small_vector<ssize_t>{2, 0, 3});
+    sc::SimpleArray<double> arr(sc::small_vector<ssize_t>{2, 0, 3});
     auto ms = arr.as_mdspan<3>();
 
     EXPECT_EQ(ms.extent(0), 2);
@@ -670,7 +670,7 @@ TEST(SimpleArray, mdspan_empty_extent)
     EXPECT_EQ(ms.mapping().required_span_size(), 0);
     EXPECT_EQ(ms.data_handle(), nullptr);
 
-    mm::SimpleArray<double> const & carr = arr;
+    sc::SimpleArray<double> const & carr = arr;
     auto cms = carr.as_mdspan<3>();
     EXPECT_EQ(cms.size(), 0);
     EXPECT_EQ(cms.data_handle(), nullptr);

--- a/gtests/test_nopython_radixtree.cpp
+++ b/gtests/test_nopython_radixtree.cpp
@@ -45,15 +45,15 @@ std::string get_info(solvcon::RadixTreeNode<T> & r)
 
 TEST(RadixTree, construction)
 {
-    namespace mm = solvcon;
-    mm::RadixTree<TestedTimedEntry> radix_tree;
+    namespace sc = solvcon;
+    sc::RadixTree<TestedTimedEntry> radix_tree;
     EXPECT_EQ(radix_tree.get_unique_node(), 0);
 }
 
 TEST(RadixTree, single_insertion)
 {
-    namespace mm = solvcon;
-    mm::RadixTree<TestedTimedEntry> radix_tree;
+    namespace sc = solvcon;
+    sc::RadixTree<TestedTimedEntry> radix_tree;
     TestedTimedEntry & entry1 = radix_tree.entry("a");
     entry1.add_time(5.2);
 
@@ -61,41 +61,41 @@ TEST(RadixTree, single_insertion)
     EXPECT_DOUBLE_EQ(entry1.time(), 5.2);
     EXPECT_EQ(radix_tree.get_unique_node(), 1);
 
-    mm::RadixTreeNode<TestedTimedEntry> * node = radix_tree.get_current_node();
+    sc::RadixTreeNode<TestedTimedEntry> * node = radix_tree.get_current_node();
     EXPECT_EQ(node->name(), "a");
     EXPECT_EQ(get_info(*node), "a - Count: 1 - Time: 5.2");
 }
 
 TEST(RadixTree, multiple_insertion)
 {
-    namespace mm = solvcon;
-    mm::RadixTree<TestedTimedEntry> radix_tree;
+    namespace sc = solvcon;
+    sc::RadixTree<TestedTimedEntry> radix_tree;
     TestedTimedEntry & entry1 = radix_tree.entry("a");
     entry1.add_time(5.2);
-    const mm::RadixTreeNode<TestedTimedEntry> * const node1 = radix_tree.get_current_node();
+    const sc::RadixTreeNode<TestedTimedEntry> * const node1 = radix_tree.get_current_node();
 
     TestedTimedEntry & entry2 = radix_tree.entry("b");
     entry2.add_time(10.1);
 
     EXPECT_EQ(radix_tree.get_unique_node(), 2);
 
-    const mm::RadixTreeNode<TestedTimedEntry> * const node2 = radix_tree.get_current_node();
+    const sc::RadixTreeNode<TestedTimedEntry> * const node2 = radix_tree.get_current_node();
     EXPECT_EQ(node2->get_prev(), node1);
 }
 
 TEST(RadixTree, move_current_pointer)
 {
-    namespace mm = solvcon;
-    mm::RadixTree<TestedTimedEntry> radix_tree;
+    namespace sc = solvcon;
+    sc::RadixTree<TestedTimedEntry> radix_tree;
     TestedTimedEntry & entry1 = radix_tree.entry("a");
     entry1.add_time(5.2);
-    const mm::RadixTreeNode<TestedTimedEntry> * const node1 = radix_tree.get_current_node();
+    const sc::RadixTreeNode<TestedTimedEntry> * const node1 = radix_tree.get_current_node();
 
     TestedTimedEntry & entry2 = radix_tree.entry("b");
     entry2.add_time(10.1);
 
     radix_tree.move_current_to_parent();
-    const mm::RadixTreeNode<TestedTimedEntry> * const node2 = radix_tree.get_current_node();
+    const sc::RadixTreeNode<TestedTimedEntry> * const node2 = radix_tree.get_current_node();
 
     EXPECT_EQ(radix_tree.get_unique_node(), 2);
     EXPECT_EQ(node2->name(), "a");

--- a/solvcon/pylibmgr.py
+++ b/solvcon/pylibmgr.py
@@ -8,7 +8,7 @@ import importlib.abc
 import importlib.machinery
 
 
-class ModmeshPathFinder(importlib.abc.MetaPathFinder):
+class SolvconPathFinder(importlib.abc.MetaPathFinder):
     def __init__(self, lib_paths):
         self.lib_paths = lib_paths
 
@@ -46,8 +46,8 @@ class ModmeshPathFinder(importlib.abc.MetaPathFinder):
         return None
 
 
-def is_modmesh_meta_path_finder_registered():
-    return any(isinstance(finder, ModmeshPathFinder)
+def is_solvcon_meta_path_finder_registered():
+    return any(isinstance(finder, SolvconPathFinder)
                for finder in sys.meta_path)
 
 
@@ -90,6 +90,6 @@ def search_library_root(curr_path, lib_root_name, timeout=1.0):
         if os.path.isdir(os.path.join(_path, item)):
             lib_path[item] = os.path.join(_path, item)
 
-    if not is_modmesh_meta_path_finder_registered():
-        sys.meta_path.append(ModmeshPathFinder(lib_path))
+    if not is_solvcon_meta_path_finder_registered():
+        sys.meta_path.append(SolvconPathFinder(lib_path))
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/system.py
+++ b/solvcon/system.py
@@ -81,14 +81,14 @@ def _run_pytest(extra_args=None):
     # solvcon.
     import pytest
     import shlex
-    mmpath = os.path.join(os.path.dirname(solvcon.__file__), '..', 'tests')
-    mmpath = os.path.abspath(mmpath)
+    testpath = os.path.join(os.path.dirname(solvcon.__file__), '..', 'tests')
+    testpath = os.path.abspath(testpath)
     if extra_args:
         opts = list(extra_args)
     else:
         env_opts = os.environ.get('PYTEST_OPTS', '')
         opts = shlex.split(env_opts) if env_opts else ['-v', '-x']
-    return pytest.main(opts + [mmpath])
+    return pytest.main(opts + [testpath])
 
 
 def setup_process(argv):

--- a/solvcon/system.py
+++ b/solvcon/system.py
@@ -26,7 +26,7 @@ __all__ = [
 ]
 
 
-class ModmeshArgumentParser(argparse.ArgumentParser):
+class SolvconArgumentParser(argparse.ArgumentParser):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
         self.exited = False
@@ -41,7 +41,7 @@ class ModmeshArgumentParser(argparse.ArgumentParser):
 
 
 def _parse_command_line(argv):
-    parser = ModmeshArgumentParser(description="Pilot")
+    parser = SolvconArgumentParser(description="Pilot")
     parser.add_argument('--mode', dest='mode', action='store',
                         default='pilot',
                         choices=['pilot', 'python', 'pytest'],

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -11,17 +11,17 @@ import solvcon as sc
 class ComplexTB(sc.testing.TestBase):
 
     def test_construct_default(self):
-        cplx = self.mm_complex()
+        cplx = self.sc_complex()
         self.assert_allclose(cplx.real, 0.0)
         self.assert_allclose(cplx.imag, 0.0)
 
     def test_construct_random(self):
-        cplx = self.mm_complex(self.real1, self.imag1)
+        cplx = self.sc_complex(self.real1, self.imag1)
         self.assert_allclose(cplx.real, self.real1)
         self.assert_allclose(cplx.imag, self.imag1)
 
     def test_operator_add(self):
-        cplx = self.mm_complex(self.real1, self.imag1)
+        cplx = self.sc_complex(self.real1, self.imag1)
         realv = self.np_float(2.0)
 
         result = cplx + realv
@@ -34,8 +34,8 @@ class ComplexTB(sc.testing.TestBase):
         self.assert_allclose(result.real, realv + cplx.real)
         self.assert_allclose(result.imag, cplx.imag)
 
-        cplx1 = self.mm_complex(self.real1, self.imag1)
-        cplx2 = self.mm_complex(self.real2, self.imag2)
+        cplx1 = self.sc_complex(self.real1, self.imag1)
+        cplx2 = self.sc_complex(self.real2, self.imag2)
 
         result = cplx1 + cplx2
 
@@ -46,7 +46,7 @@ class ComplexTB(sc.testing.TestBase):
         self.assert_allclose(result.imag, expected_imag)
 
     def test_operator_sub(self):
-        cplx = self.mm_complex(self.real1, self.imag1)
+        cplx = self.sc_complex(self.real1, self.imag1)
         realv = self.np_float(2.0)
 
         result = cplx - realv
@@ -59,8 +59,8 @@ class ComplexTB(sc.testing.TestBase):
         self.assert_allclose(result.real, realv - cplx.real)
         self.assert_allclose(result.imag, -cplx.imag)
 
-        cplx1 = self.mm_complex(self.real1, self.imag1)
-        cplx2 = self.mm_complex(self.real2, self.imag2)
+        cplx1 = self.sc_complex(self.real1, self.imag1)
+        cplx2 = self.sc_complex(self.real2, self.imag2)
 
         result = cplx1 - cplx2
 
@@ -71,7 +71,7 @@ class ComplexTB(sc.testing.TestBase):
         self.assert_allclose(result.imag, expected_imag)
 
     def test_operator_mul(self):
-        cplx = self.mm_complex(self.real1, self.imag1)
+        cplx = self.sc_complex(self.real1, self.imag1)
         realv = self.np_float(2.0)
 
         result = cplx * realv
@@ -80,13 +80,13 @@ class ComplexTB(sc.testing.TestBase):
         self.assert_allclose(result.imag, self.imag1 * realv)
 
         result = realv * cplx
-        golden = self.mm_complex(realv, 0.0) * cplx
+        golden = self.sc_complex(realv, 0.0) * cplx
 
         self.assert_allclose(result.real, golden.real)
         self.assert_allclose(result.imag, golden.imag)
 
-        cplx1 = self.mm_complex(self.real1, self.imag1)
-        cplx2 = self.mm_complex(self.real2, self.imag2)
+        cplx1 = self.sc_complex(self.real1, self.imag1)
+        cplx2 = self.sc_complex(self.real2, self.imag2)
 
         result = cplx1 * cplx2
 
@@ -99,7 +99,7 @@ class ComplexTB(sc.testing.TestBase):
         self.assert_allclose(result.imag, expected_imag)
 
     def test_operator_div(self):
-        cplx = self.mm_complex(self.real1, self.imag1)
+        cplx = self.sc_complex(self.real1, self.imag1)
         realv = self.np_float(2.0)
 
         result = cplx / realv
@@ -117,8 +117,8 @@ class ComplexTB(sc.testing.TestBase):
         self.assert_allclose(result.real, expected_real)
         self.assert_allclose(result.imag, expected_imag)
 
-        cplx1 = self.mm_complex(self.real1, self.imag1)
-        cplx2 = self.mm_complex(self.real2, self.imag2)
+        cplx1 = self.sc_complex(self.real1, self.imag1)
+        cplx2 = self.sc_complex(self.real2, self.imag2)
 
         result = cplx1 / cplx2
 
@@ -133,8 +133,8 @@ class ComplexTB(sc.testing.TestBase):
         self.assert_allclose(result.imag, expected_imag)
 
     def test_operator_comparison(self):
-        cplx1 = self.mm_complex(self.real1, self.imag1)
-        cplx2 = self.mm_complex(self.real2, self.imag2)
+        cplx1 = self.sc_complex(self.real1, self.imag1)
+        cplx2 = self.sc_complex(self.real2, self.imag2)
 
         # Numpy uses lexicographic ordering to compare complex numbers, as
         # documented in
@@ -150,7 +150,7 @@ class ComplexTB(sc.testing.TestBase):
         self.assertEqual(cplx1 < cplx2, compare())
 
     def test_norm(self):
-        cplx = self.mm_complex(self.real1, self.imag1)
+        cplx = self.sc_complex(self.real1, self.imag1)
 
         result = cplx.norm()
 
@@ -162,8 +162,8 @@ class ComplexTB(sc.testing.TestBase):
         self.assertEqual(self.dtype, self.expected_dtype)
 
     def test_complex_array(self):
-        cplx = self.mm_complex(self.real1, self.imag1)
-        sarr = self.mm_simplearraycomplex(10)
+        cplx = self.sc_complex(self.real1, self.imag1)
+        sarr = self.sc_simplearraycomplex(10)
         sarr.fill(cplx)
         ndarr = np.array(sarr, copy=False, dtype=self.dtype)
 
@@ -173,7 +173,7 @@ class ComplexTB(sc.testing.TestBase):
 
         self.assertEqual(ndarr.dtype, self.dtype)
 
-        sarr = self.mm_simplearraycomplex(array=ndarr)
+        sarr = self.sc_simplearraycomplex(array=ndarr)
 
         for i in range(10):
             self.assertEqual(sarr[i].real, self.real1)
@@ -183,8 +183,8 @@ class ComplexTB(sc.testing.TestBase):
         self.assertEqual(10 * self.esize, sarr.nbytes)
 
     def test_complex_conj(self):
-        cplx = self.mm_complex(self.real1, self.imag1)
-        cplx_conj = self.mm_complex(self.real1, -self.imag1)
+        cplx = self.sc_complex(self.real1, self.imag1)
+        cplx_conj = self.sc_complex(self.real1, -self.imag1)
 
         self.assertEqual(cplx.conj().real, cplx_conj.real)
         self.assertEqual(cplx.conj().imag, cplx_conj.imag)
@@ -197,13 +197,13 @@ class ComplexFp32TC(ComplexTB, unittest.TestCase):
             kw['rtol'] = 1.e-7
         return super().assert_allclose(*args, **kw)
 
-    def mm_complex(self, real=None, imag=None):
+    def sc_complex(self, real=None, imag=None):
         if real is not None and imag is not None:
             return sc.complex64(real, imag)
         else:
             return sc.complex64()
 
-    def mm_simplearraycomplex(self, size=None, array=None):
+    def sc_simplearraycomplex(self, size=None, array=None):
         if size is not None:
             return sc.SimpleArrayComplex64(size)
         if array is not None:
@@ -231,13 +231,13 @@ class ComplexFp64TC(ComplexTB, unittest.TestCase):
             kw['rtol'] = 1.e-15
         return super().assert_allclose(*args, **kw)
 
-    def mm_complex(self, real=None, imag=None):
+    def sc_complex(self, real=None, imag=None):
         if real is not None and imag is not None:
             return sc.complex128(real, imag)
         else:
             return sc.complex128()
 
-    def mm_simplearraycomplex(self, size=None, array=None):
+    def sc_simplearraycomplex(self, size=None, array=None):
         if size is not None:
             return sc.SimpleArrayComplex128(size)
         if array is not None:

--- a/tests/test_pylibmgr.py
+++ b/tests/test_pylibmgr.py
@@ -17,7 +17,7 @@ class pylibmgrTC(unittest.TestCase):
         # thirdparty, it is located at solvcon project root: /path/to/solvcon.
         pylibmgr.search_library_root(os.getcwd(), 'thirdparty')
         finder = next(finder for finder in sys.meta_path
-                      if isinstance(finder, pylibmgr.ModmeshPathFinder))
+                      if isinstance(finder, pylibmgr.SolvconPathFinder))
         self.assertNotEqual(finder.lib_paths, {})
 
         # Reset library patch record

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -22,75 +22,75 @@ class FourierTransformTB(sc.testing.TestBase):
     def test_numpy_dft_comparison(self):
         input_size = 100
 
-        mm_input = self.SimpleArray(input_size)
+        sc_input = self.SimpleArray(input_size)
         for i in range(input_size):
-            mm_input[i] = self.complex(self.real_rng(), self.imag_rng())
+            sc_input[i] = self.complex(self.real_rng(), self.imag_rng())
 
-        np_input = np.array(mm_input, copy=False)
+        np_input = np.array(sc_input, copy=False)
 
-        mm_output = self.SimpleArray(input_size, self.complex())
-        sc.FourierTransform.dft(mm_input, mm_output)
+        sc_output = self.SimpleArray(input_size, self.complex())
+        sc.FourierTransform.dft(sc_input, sc_output)
 
         np_output = np.fft.fft(np_input)
 
         for i in range(input_size):
-            self.assert_allclose(mm_output[i].real, np_output[i].real)
-            self.assert_allclose(mm_output[i].imag, np_output[i].imag)
+            self.assert_allclose(sc_output[i].real, np_output[i].real)
+            self.assert_allclose(sc_output[i].imag, np_output[i].imag)
 
     def test_numpy_duplicate_dft_comparison(self):
         input_size = 100
 
-        mm_input = self.SimpleArray(input_size)
+        sc_input = self.SimpleArray(input_size)
         for i in range(input_size):
-            mm_input[i] = self.complex(self.real_rng(), self.imag_rng())
+            sc_input[i] = self.complex(self.real_rng(), self.imag_rng())
 
-        np_input = np.array(mm_input, copy=False)
+        np_input = np.array(sc_input, copy=False)
 
-        mm_output = self.SimpleArray(input_size, self.complex())
-        sc.FourierTransform.dft(mm_input, mm_output)
-        sc.FourierTransform.dft(mm_input, mm_output)
+        sc_output = self.SimpleArray(input_size, self.complex())
+        sc.FourierTransform.dft(sc_input, sc_output)
+        sc.FourierTransform.dft(sc_input, sc_output)
 
         np_output = np.fft.fft(np_input)
 
         for i in range(input_size):
-            self.assert_allclose(mm_output[i].real, np_output[i].real)
-            self.assert_allclose(mm_output[i].imag, np_output[i].imag)
+            self.assert_allclose(sc_output[i].real, np_output[i].real)
+            self.assert_allclose(sc_output[i].imag, np_output[i].imag)
 
     def test_numpy_fft_comparison(self):
         input_size = 100
 
-        mm_input = self.SimpleArray(input_size)
+        sc_input = self.SimpleArray(input_size)
         for i in range(input_size):
-            mm_input[i] = self.complex(self.real_rng(), self.imag_rng())
+            sc_input[i] = self.complex(self.real_rng(), self.imag_rng())
 
-        np_input = np.array(mm_input, copy=False)
+        np_input = np.array(sc_input, copy=False)
 
-        mm_output = self.SimpleArray(input_size, self.complex())
-        sc.FourierTransform.fft(mm_input, mm_output)
+        sc_output = self.SimpleArray(input_size, self.complex())
+        sc.FourierTransform.fft(sc_input, sc_output)
 
         np_output = np.fft.fft(np_input)
 
         for i in range(input_size):
-            self.assert_allclose(mm_output[i].real, np_output[i].real)
-            self.assert_allclose(mm_output[i].imag, np_output[i].imag)
+            self.assert_allclose(sc_output[i].real, np_output[i].real)
+            self.assert_allclose(sc_output[i].imag, np_output[i].imag)
 
     def test_numpy_ifft_comparison(self):
         input_size = 100
 
-        mm_input = self.SimpleArray(input_size)
+        sc_input = self.SimpleArray(input_size)
         for i in range(input_size):
-            mm_input[i] = self.complex(self.real_rng(), self.imag_rng())
+            sc_input[i] = self.complex(self.real_rng(), self.imag_rng())
 
-        np_input = np.array(mm_input, copy=False)
+        np_input = np.array(sc_input, copy=False)
 
-        mm_output = self.SimpleArray(input_size, self.complex())
-        sc.FourierTransform.ifft(mm_input, mm_output)
+        sc_output = self.SimpleArray(input_size, self.complex())
+        sc.FourierTransform.ifft(sc_input, sc_output)
 
         np_output = np.fft.ifft(np_input)
 
         for i in range(input_size):
-            self.assert_allclose(mm_output[i].real, np_output[i].real)
-            self.assert_allclose(mm_output[i].imag, np_output[i].imag)
+            self.assert_allclose(sc_output[i].real, np_output[i].real)
+            self.assert_allclose(sc_output[i].imag, np_output[i].imag)
 
 
 class TransformFp32TC(FourierTransformTB, unittest.TestCase):


### PR DESCRIPTION
For part 2 of issue #1295.

This PR clears the `mm` and `modmesh` names that the `contrib/lint/` rename scripts and the later `SC_` macro pass left behind. Seven commits, one per kind:

- `mm_x` in the Python tests becomes `sc_x`, matching the `sc` import every test already uses.
- The gtest namespace alias `mm` becomes `sc`.
- The `MMTPN` and `MMCL` parameters of `SC_DECL_SWITCH_ELEMENT_TYPE` become `SCTPN` and `SCCL`.
- `MMROOT` becomes `SCROOT` in the standalone buffer make file.
- The four `Modmesh`-prefixed identifiers become `Solvcon`-prefixed.
- The `mmpath` local in the pytest runner becomes `testpath`.
- Two stale comments in the dependency scripts drop the old project name.

The `STYLE.md` is also updated to write solvcon/sc instead of modmesh/mm. The `Modmesh` identifiers get no compatibility alias, since renaming the package already broke every import path an out-of-tree caller could have held.

The `solvcon/modmesh#814` citation in `check_skip_ci.yml` stays, and after this PR it is the only `modmesh` string outside the two rename scripts.