### PR TITLE
Enable slicing for geometry pad

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -108,10 +108,27 @@ inline ssize_t buffer_offset(small_vector<ssize_t> const & stride, small_vector<
     return offset;
 }
 
+/**
+ * @brief Resolved bounds of a Python slice on one array axis.
+ *
+ * The three fields are what `PySlice_GetIndicesEx` yields against the axis
+ * extent: the position of the first selected element, the signed multiplier
+ * applied to the axis stride, and the number of selected elements.
+ *
+ * @ingroup group_core
+ */
+struct AxisSlice
+{
+    ssize_t start = 0;
+    ssize_t step = 1;
+    ssize_t length = 0;
+}; /* end struct AxisSlice */
+
 namespace detail
 {
 
 using shape_type = small_vector<ssize_t>;
+using slice_type = small_vector<AxisSlice>;
 
 /**
  * @brief Enumerate SimpleArray indices with nghost included.
@@ -206,6 +223,7 @@ struct SimpleArrayInternalTypes
 {
     using value_type = T;
     using shape_type = detail::shape_type;
+    using slice_type = detail::slice_type;
     using buffer_type = ConcreteBuffer;
 }; /* end struct SimpleArrayInternalTypes */
 
@@ -1617,6 +1635,7 @@ public:
     using rebind = SimpleArray<U>;
     using value_type = typename internal_types::value_type;
     using shape_type = typename internal_types::shape_type;
+    using slice_type = typename internal_types::slice_type;
     using buffer_type = typename internal_types::buffer_type;
 
     enum class ArrayOrder : std::uint8_t
@@ -2076,6 +2095,18 @@ public:
         return reshape(m_shape);
     }
 
+    /**
+     * Select a sub-array along every axis and return it as a view.
+     *
+     * The result shares the buffer of the receiver, so a write through
+     * either side is visible through the other. Its ghost region is unset,
+     * because the selected positions carry no partition of their own.
+     *
+     * @param slices One resolved slice per axis, in storage coordinates.
+     * @return A view over the selected elements.
+     */
+    SimpleArray slice(slice_type const & slices) const;
+
     void swap(SimpleArray & other) noexcept
     {
         if (this != &other)
@@ -2508,6 +2539,40 @@ void SimpleArray<T>::validate_layout(shape_type const & shape,
     {
         throw std::runtime_error("SimpleArray: shape and stride exceed buffer storage");
     }
+}
+
+template <typename T>
+SimpleArray<T> SimpleArray<T>::slice(slice_type const & slices) const
+{
+    if (!m_buffer)
+    {
+        throw std::runtime_error("SimpleArray: cannot slice a zero-dimensional array");
+    }
+    if (slices.size() != m_shape.size())
+    {
+        throw std::runtime_error(
+            std::format("SimpleArray: {} slices do not match {} dimensions",
+                        slices.size(),
+                        m_shape.size()));
+    }
+
+    shape_type new_shape(m_shape.size());
+    shape_type new_stride(m_shape.size());
+    ssize_t item_offset = 0;
+    for (size_t axis = 0; axis < m_shape.size(); ++axis)
+    {
+        new_shape[axis] = slices[axis].length;
+        new_stride[axis] = m_stride[axis] * slices[axis].step;
+        // An empty axis addresses no element and its start may sit outside
+        // the storage, so it must not move the origin of the view.
+        if (0 != slices[axis].length)
+        {
+            item_offset += m_stride[axis] * slices[axis].start;
+        }
+    }
+
+    ssize_t const byte_offset = static_cast<ssize_t>(logical_data_offset()) + item_offset * static_cast<ssize_t>(ITEMSIZE);
+    return SimpleArray(new_shape, new_stride, m_buffer, static_cast<size_t>(byte_offset));
 }
 
 template <typename A, typename T>
@@ -3600,6 +3665,15 @@ public:
     {
     }
 
+    /**
+     * Take over a typed array instead of copying it, so that a plex built
+     * from a view keeps sharing the buffer of the viewed array. The
+     * converting constructor above duplicates the buffer, which a view
+     * cannot afford.
+     */
+    template <typename T>
+    static SimpleArrayPlex adopt(SimpleArray<T> && array);
+
     SimpleArrayPlex(SimpleArrayPlex const & other);
     SimpleArrayPlex(SimpleArrayPlex && other) noexcept;
     SimpleArrayPlex & operator=(SimpleArrayPlex const & other);
@@ -3633,6 +3707,17 @@ private:
     void * m_instance_ptr = nullptr; /// the pointer of the SimpleArray<T> instance
     DataType m_data_type = DataType::Undefined; /// the data type for array casting
 }; /* end class SimpleArrayPlex */
+
+template <typename T>
+SimpleArrayPlex SimpleArrayPlex::adopt(SimpleArray<T> && array)
+{
+    SimpleArrayPlex plex;
+    plex.m_has_instance_ownership = true;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    plex.m_instance_ptr = reinterpret_cast<void *>(new SimpleArray<T>(std::move(array)));
+    plex.m_data_type = DataType::from<T>();
+    return plex;
+}
 
 } /* end namespace solvcon */
 

--- a/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
+++ b/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
@@ -20,12 +20,12 @@ namespace detail
 {
 
 inline solvcon::detail::shape_type shape_from_slices(
-    std::vector<solvcon::detail::shape_type> const & slices)
+    solvcon::detail::slice_type const & slices)
 {
     solvcon::detail::shape_type shape(slices.size());
     for (size_t axis = 0; axis < slices.size(); ++axis)
     {
-        shape[axis] = slices[axis][3];
+        shape[axis] = slices[axis].length;
     }
     return shape;
 }
@@ -36,6 +36,7 @@ template <typename T /* original type */, typename D /* for destination type */>
 struct TypeBroadcastImpl
 {
     using shape_type = solvcon::detail::shape_type;
+    using slice_type = solvcon::detail::slice_type;
 
     static ssize_t input_offset(pybind11::array_t<D> const & arr_in,
                                 shape_type const & sidx)
@@ -49,13 +50,13 @@ struct TypeBroadcastImpl
     }
 
     static ssize_t output_offset(SimpleArray<T> const & arr_out,
-                                 std::vector<shape_type> const & slices,
+                                 slice_type const & slices,
                                  shape_type const & sidx)
     {
         ssize_t offset = 0;
         for (ssize_t axis = 0; axis < arr_out.ndim(); ++axis)
         {
-            ssize_t const index = slices[axis][0] + sidx[axis] * slices[axis][2];
+            ssize_t const index = slices[axis].start + sidx[axis] * slices[axis].step;
             offset += arr_out.stride(axis) * index;
         }
         return offset;
@@ -63,7 +64,7 @@ struct TypeBroadcastImpl
 
     // NOLINTNEXTLINE(misc-no-recursion)
     static void copy_idx(SimpleArray<T> & arr_out,
-                         std::vector<shape_type> const & slices,
+                         slice_type const & slices,
                          pybind11::array_t<D> const * arr_in,
                          shape_type const & left_shape,
                          shape_type sidx,
@@ -100,7 +101,7 @@ struct TypeBroadcastImpl
     }
 
     static void broadcast(SimpleArray<T> & arr_out,
-                          std::vector<shape_type> const & slices,
+                          slice_type const & slices,
                           pybind11::array const & arr_in)
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
@@ -117,9 +118,10 @@ template <typename T>
 struct TypeBroadcast
 {
     using shape_type = solvcon::detail::shape_type;
+    using slice_type = solvcon::detail::slice_type;
 
     static void check_shape(SimpleArray<T> const & arr_out,
-                            std::vector<shape_type> const & slices,
+                            slice_type const & slices,
                             pybind11::array const & arr_in)
     {
         pybind11::ssize_t const right_ndim = arr_in.ndim();
@@ -147,7 +149,7 @@ struct TypeBroadcast
     }
 
     static void broadcast(SimpleArray<T> & arr_out,
-                          std::vector<shape_type> const & slices,
+                          slice_type const & slices,
                           pybind11::array const & arr_in)
     {
         if (dtype_is_type<bool>(arr_in))

--- a/cpp/solvcon/buffer/pymod/array_common.hpp
+++ b/cpp/solvcon/buffer/pymod/array_common.hpp
@@ -154,84 +154,35 @@ inline solvcon::detail::shape_type make_shape(pybind11::object const & shape_in)
     return shape;
 }
 
-/// Helper class for array property in Python.
+/**
+ * Parser of the Python subscript keys of an array.
+ *
+ * One instance binds to one array and serves both `__getitem__` and
+ * `__setitem__`, so the two operators read the same key grammar: a scalar
+ * key addresses one element, while a slice, an ellipsis, or a tuple
+ * containing either selects a region.
+ */
 template <typename T>
 class ArrayPropertyHelper
 {
 public:
     using shape_type = solvcon::detail::shape_type;
+    using slice_type = solvcon::detail::slice_type;
 
-    static void broadcast_array_using_ellipsis(SimpleArray<T> & arr_out, pybind11::array const & arr_in)
+    explicit ArrayPropertyHelper(SimpleArray<T> & arr)
+        : m_arr(arr)
     {
-        auto slices = make_default_slices(arr_out);
-        broadcast_array_using_slice(arr_out, slices, arr_in);
     }
 
-    // FIXME: NOLINTNEXTLINE(readability-function-cognitive-complexity)
-    static void setitem_parser(SimpleArray<T> & arr_out, pybind11::args const & args)
-    {
-        namespace py = pybind11;
+    /// Report whether the key selects a region rather than a single element.
+    static bool is_region_key(pybind11::object const & key);
 
-        if (args.size() == 2)
-        {
-            const py::object & py_key = args[0];
-            const py::object & py_value = args[1];
+    pybind11::object getitem(pybind11::object const & key) const;
 
-            const bool is_sequence_value = is_sequence(py_value);
-            const bool is_scalar_value = is_scalar(py_value);
+    void setitem(pybind11::object const & key, pybind11::object const & value);
 
-            // sarr[K] = V
-            if (py::isinstance<py::int_>(py_key) && is_scalar_value)
-            {
-                const auto key = py_key.cast<ssize_t>();
-                arr_out.at(key) = cast_scalar(py_value);
-                return;
-            }
-            // sarr[K1, K2, K3] = V
-            if (py::isinstance<py::tuple>(py_key) && is_scalar_value)
-            {
-                const auto key = py_key.cast<std::vector<ssize_t>>();
-                arr_out.at(key) = cast_scalar(py_value);
-                return;
-            }
-
-            // multi-dimension with slice and ellipsis
-            // sarr[slice, slice, ellipsis] = ndarr
-            if (py::isinstance<py::tuple>(py_key) && is_sequence_value)
-            {
-                const py::tuple tuple_in = py_key;
-                const py::array arr_in = py_value;
-
-                auto slices = make_default_slices(arr_out);
-                process_slices(tuple_in, slices, arr_out);
-
-                broadcast_array_using_slice(arr_out, slices, arr_in);
-                return;
-            }
-            // one-dimension with slice
-            // sarr[slice] = ndarr
-            if (py::isinstance<py::slice>(py_key) && is_sequence_value)
-            {
-                const auto slice_in = py_key.cast<py::slice>();
-                const auto arr_in = py_value.cast<py::array>();
-
-                auto slices = make_default_slices(arr_out);
-                copy_slice(slices[0], slice_in, arr_out.shape(0), arr_out.nghost());
-
-                broadcast_array_using_slice(arr_out, slices, arr_in);
-                return;
-            }
-            // sarr[ellipsis] = ndarr
-            if (py::isinstance<py::ellipsis>(py_key) && is_sequence_value)
-            {
-                const auto arr_in = py_value.cast<py::array>();
-
-                broadcast_array_using_ellipsis(arr_out, arr_in);
-                return;
-            }
-        }
-        throw std::runtime_error("unsupported operation.");
-    }
+    /// Build the view that a region key selects.
+    SimpleArray<T> slice(pybind11::object const & key) const { return m_arr.slice(slices_from_key(key)); }
 
     static pybind11::buffer_info get_buffer_info(SimpleArray<T> & array)
     {
@@ -271,6 +222,10 @@ public:
     }
 
 private:
+
+    static bool is_index(pybind11::handle key) { return 0 != PyIndex_Check(key.ptr()); }
+
+    static bool is_index_tuple(pybind11::object const & key);
 
     static bool is_sequence(pybind11::object const & py_value)
     {
@@ -323,145 +278,137 @@ private:
         }
     }
 
-    static std::vector<shape_type> make_default_slices(SimpleArray<T> const & arr)
-    {
-        std::vector<shape_type> slices;
-        auto const & shape = arr.shape();
-        slices.reserve(shape.size());
-        for (ssize_t const dim : shape)
-        {
-            shape_type default_slice(4);
-            default_slice[0] = 0; // start
-            default_slice[1] = dim; // stop
-            default_slice[2] = 1; // step
-            default_slice[3] = dim; // length
-            slices.push_back(std::move(default_slice));
-        }
-        return slices;
-    }
+    slice_type make_default_slices() const;
+
+    slice_type slices_from_key(pybind11::object const & key) const;
 
     static pybind11::object shift_slice_bound(pybind11::handle bound, ssize_t offset);
 
-    static void copy_slice(shape_type & slice_out,
+    static void copy_slice(AxisSlice & slice_out,
                            pybind11::slice const & slice_in,
                            ssize_t length,
-                           ssize_t offset)
-    {
-        pybind11::slice normalized_slice = slice_in;
-        if (offset != 0)
-        {
-            pybind11::object const start = shift_slice_bound(slice_in.attr("start"), offset);
-            pybind11::object const stop = shift_slice_bound(slice_in.attr("stop"), offset);
-            normalized_slice = pybind11::slice(start, stop, slice_in.attr("step"));
-        }
+                           ssize_t offset);
 
-        pybind11::ssize_t start = 0;
-        pybind11::ssize_t stop = 0;
-        pybind11::ssize_t step = 0;
-        pybind11::ssize_t slicelength = 0;
-        if (!normalized_slice.compute(length, &start, &stop, &step, &slicelength))
-        {
-            throw pybind11::error_already_set();
-        }
+    void slice_syntax_check(pybind11::tuple const & tuple) const;
 
-        slice_out[0] = start;
-        slice_out[1] = stop;
-        slice_out[2] = step;
-        slice_out[3] = slicelength;
-    }
+    void process_slices(pybind11::tuple const & tuple, slice_type & slices) const;
 
-    static void slice_syntax_check(pybind11::tuple const & tuple, ssize_t ndim)
-    {
-        namespace py = pybind11;
+    void broadcast_array_using_slice(slice_type const & slices, pybind11::array const & arr_in);
 
-        ssize_t ellipsis_cnt = 0;
-        ssize_t slice_cnt = 0;
-
-        for (auto it = tuple.begin(); it != tuple.end(); it++)
-        {
-            if (py::isinstance<py::ellipsis>(*it))
-            {
-                ellipsis_cnt += 1;
-            }
-            else if (py::isinstance<py::slice>(*it))
-            {
-                slice_cnt += 1;
-            }
-            else
-            {
-                throw std::runtime_error("unsupported operation.");
-            }
-        }
-
-        if (slice_cnt > ndim)
-        {
-            throw std::runtime_error("syntax error. dimensions mismatches");
-        }
-
-        if (ellipsis_cnt > 1)
-        {
-            throw std::runtime_error("syntax error. no more than one ellipsis.");
-        }
-    }
-
-    static void process_slices(pybind11::tuple const & tuple,
-                               std::vector<shape_type> & slices,
-                               SimpleArray<T> const & arr)
-    {
-        namespace py = pybind11;
-
-        ssize_t const ndim = arr.ndim();
-        slice_syntax_check(tuple, ndim);
-
-        // copy slices from the front until an ellipsis
-        bool ellipsis_flag = false;
-        for (auto it = tuple.begin(); it != tuple.end(); it++)
-        {
-            if (py::isinstance<py::ellipsis>(*it))
-            {
-                // stop here and iterator the tuple from back later
-                ellipsis_flag = true;
-                break;
-            }
-
-            ssize_t const axis = it - tuple.begin();
-            auto & slice_out = slices[axis];
-            const auto slice_in = (*it).cast<py::slice>();
-
-            ssize_t const bound_offset = axis == 0 ? arr.nghost() : 0;
-            copy_slice(slice_out, slice_in, arr.shape(axis), bound_offset);
-        }
-
-        // copy slices from the back until an ellipsis
-        if (ellipsis_flag)
-        {
-            ssize_t const tuple_size = tuple.size();
-            for (ssize_t offset = 0; offset < tuple_size; ++offset)
-            {
-                auto it = tuple.end() - offset - 1;
-
-                if (py::isinstance<py::ellipsis>(*it))
-                {
-                    break;
-                }
-                ssize_t const axis = ndim - offset - 1;
-                auto & slice_out = slices[axis];
-                const auto slice_in = (*it).cast<py::slice>();
-
-                ssize_t const bound_offset = axis == 0 ? arr.nghost() : 0;
-                copy_slice(slice_out, slice_in, arr.shape(axis), bound_offset);
-            }
-        }
-    }
-
-    static void broadcast_array_using_slice(SimpleArray<T> & arr_out,
-                                            std::vector<shape_type> const & slices,
-                                            pybind11::array const & arr_in)
-    {
-        TypeBroadcast<T>::check_shape(arr_out, slices, arr_in);
-        TypeBroadcast<T>::broadcast(arr_out, slices, arr_in);
-    }
+    SimpleArray<T> & m_arr;
 }; /* end class ArrayPropertyHelper */
+
+template <typename T>
+bool ArrayPropertyHelper<T>::is_region_key(pybind11::object const & key)
+{
+    namespace py = pybind11;
+
+    return py::isinstance<py::slice>(key) ||
+           py::isinstance<py::ellipsis>(key) ||
+           (py::isinstance<py::tuple>(key) && !is_index_tuple(key));
+}
+
+template <typename T>
+bool ArrayPropertyHelper<T>::is_index_tuple(pybind11::object const & key)
+{
+    const pybind11::tuple tuple_in = key;
+    for (auto it = tuple_in.begin(); it != tuple_in.end(); it++)
+    {
+        if (!is_index(*it))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+template <typename T>
+pybind11::object ArrayPropertyHelper<T>::getitem(pybind11::object const & key) const
+{
+    namespace py = pybind11;
+
+    // sarr[K]
+    if (is_index(key))
+    {
+        return py::cast(m_arr.at(key.cast<ssize_t>()), py::return_value_policy::copy);
+    }
+    // sarr[K1, K2, K3] and sarr[[K1, K2, K3]]
+    if (py::isinstance<py::list>(key) || (py::isinstance<py::tuple>(key) && is_index_tuple(key)))
+    {
+        return py::cast(m_arr.at(key.cast<std::vector<ssize_t>>()), py::return_value_policy::copy);
+    }
+    // sarr[slice], sarr[ellipsis], and sarr[slice, slice, ellipsis]
+    if (is_region_key(key))
+    {
+        return py::cast(slice(key));
+    }
+    throw std::runtime_error("unsupported operation.");
+}
+
+template <typename T>
+void ArrayPropertyHelper<T>::setitem(pybind11::object const & key, pybind11::object const & value)
+{
+    namespace py = pybind11;
+
+    if (is_scalar(value))
+    {
+        // sarr[K] = V
+        if (py::isinstance<py::int_>(key))
+        {
+            m_arr.at(key.cast<ssize_t>()) = cast_scalar(value);
+            return;
+        }
+        // sarr[K1, K2, K3] = V
+        if (py::isinstance<py::tuple>(key))
+        {
+            m_arr.at(key.cast<std::vector<ssize_t>>()) = cast_scalar(value);
+            return;
+        }
+    }
+    // sarr[slice] = ndarr, sarr[ellipsis] = ndarr, and
+    // sarr[slice, slice, ellipsis] = ndarr
+    else if (is_sequence(value) && is_region_key(key))
+    {
+        broadcast_array_using_slice(slices_from_key(key), value.cast<py::array>());
+        return;
+    }
+    throw std::runtime_error("unsupported operation.");
+}
+
+template <typename T>
+typename ArrayPropertyHelper<T>::slice_type ArrayPropertyHelper<T>::make_default_slices() const
+{
+    auto const & shape = m_arr.shape();
+    slice_type slices(shape.size());
+    for (size_t axis = 0; axis < shape.size(); ++axis)
+    {
+        slices[axis] = AxisSlice{.start = 0, .step = 1, .length = shape[axis]};
+    }
+    return slices;
+}
+
+template <typename T>
+typename ArrayPropertyHelper<T>::slice_type
+ArrayPropertyHelper<T>::slices_from_key(pybind11::object const & key) const
+{
+    namespace py = pybind11;
+
+    slice_type slices = make_default_slices();
+    if (py::isinstance<py::slice>(key))
+    {
+        if (0 == m_arr.ndim())
+        {
+            throw std::runtime_error("SimpleArray: cannot slice a zero-dimensional array");
+        }
+        copy_slice(slices[0], key.cast<py::slice>(), m_arr.shape(0), m_arr.nghost());
+    }
+    else if (py::isinstance<py::tuple>(key))
+    {
+        const py::tuple tuple_in = key;
+        process_slices(tuple_in, slices);
+    }
+    return slices;
+}
 
 template <typename T>
 pybind11::object ArrayPropertyHelper<T>::shift_slice_bound(
@@ -478,6 +425,125 @@ pybind11::object ArrayPropertyHelper<T>::shift_slice_bound(
         throw pybind11::error_already_set();
     }
     return pybind11::reinterpret_steal<pybind11::object>(index) + pybind11::int_(offset);
+}
+
+template <typename T>
+void ArrayPropertyHelper<T>::copy_slice(AxisSlice & slice_out,
+                                        pybind11::slice const & slice_in,
+                                        ssize_t length,
+                                        ssize_t offset)
+{
+    pybind11::slice normalized_slice = slice_in;
+    if (offset != 0)
+    {
+        pybind11::object const start = shift_slice_bound(slice_in.attr("start"), offset);
+        pybind11::object const stop = shift_slice_bound(slice_in.attr("stop"), offset);
+        normalized_slice = pybind11::slice(start, stop, slice_in.attr("step"));
+    }
+
+    pybind11::ssize_t start = 0;
+    pybind11::ssize_t stop = 0;
+    pybind11::ssize_t step = 0;
+    pybind11::ssize_t slicelength = 0;
+    if (!normalized_slice.compute(length, &start, &stop, &step, &slicelength))
+    {
+        throw pybind11::error_already_set();
+    }
+
+    slice_out.start = start;
+    slice_out.step = step;
+    slice_out.length = slicelength;
+}
+
+template <typename T>
+void ArrayPropertyHelper<T>::broadcast_array_using_slice(slice_type const & slices, pybind11::array const & arr_in)
+{
+    TypeBroadcast<T>::check_shape(m_arr, slices, arr_in);
+    TypeBroadcast<T>::broadcast(m_arr, slices, arr_in);
+}
+
+template <typename T>
+void ArrayPropertyHelper<T>::slice_syntax_check(pybind11::tuple const & tuple) const
+{
+    namespace py = pybind11;
+
+    ssize_t ellipsis_cnt = 0;
+    ssize_t slice_cnt = 0;
+
+    for (auto it = tuple.begin(); it != tuple.end(); it++)
+    {
+        if (py::isinstance<py::ellipsis>(*it))
+        {
+            ellipsis_cnt += 1;
+        }
+        else if (py::isinstance<py::slice>(*it))
+        {
+            slice_cnt += 1;
+        }
+        else
+        {
+            throw std::runtime_error("unsupported operation.");
+        }
+    }
+
+    if (slice_cnt > m_arr.ndim())
+    {
+        throw std::runtime_error("syntax error. dimensions mismatches");
+    }
+
+    if (ellipsis_cnt > 1)
+    {
+        throw std::runtime_error("syntax error. no more than one ellipsis.");
+    }
+}
+
+template <typename T>
+void ArrayPropertyHelper<T>::process_slices(pybind11::tuple const & tuple, slice_type & slices) const
+{
+    namespace py = pybind11;
+
+    ssize_t const ndim = m_arr.ndim();
+    slice_syntax_check(tuple);
+
+    // copy slices from the front until an ellipsis
+    bool ellipsis_flag = false;
+    for (auto it = tuple.begin(); it != tuple.end(); it++)
+    {
+        if (py::isinstance<py::ellipsis>(*it))
+        {
+            // stop here and iterate the tuple from the back later
+            ellipsis_flag = true;
+            break;
+        }
+
+        ssize_t const axis = it - tuple.begin();
+        auto & slice_out = slices[axis];
+        const auto slice_in = (*it).cast<py::slice>();
+
+        ssize_t const bound_offset = axis == 0 ? m_arr.nghost() : 0;
+        copy_slice(slice_out, slice_in, m_arr.shape(axis), bound_offset);
+    }
+
+    // copy slices from the back until an ellipsis
+    if (ellipsis_flag)
+    {
+        ssize_t const tuple_size = tuple.size();
+        for (ssize_t offset = 0; offset < tuple_size; ++offset)
+        {
+            auto it = tuple.end() - offset - 1;
+
+            if (py::isinstance<py::ellipsis>(*it))
+            {
+                break;
+            }
+            ssize_t const axis = ndim - offset - 1;
+            auto & slice_out = slices[axis];
+            const auto slice_in = (*it).cast<py::slice>();
+
+            ssize_t const bound_offset = axis == 0 ? m_arr.nghost() : 0;
+            copy_slice(slice_out, slice_in, m_arr.shape(axis), bound_offset);
+        }
+    }
 }
 
 } /* end namespace python */

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -107,13 +107,12 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def("__len__", &wrapped_type::size)
             .def(
                 "__getitem__",
-                [](wrapped_type const & self, ssize_t key)
-                { return self.at(key); })
+                [](wrapped_type & self, py::object const & key)
+                { return property_helper(self).getitem(key); })
             .def(
-                "__getitem__",
-                [](wrapped_type const & self, std::vector<ssize_t> const & key)
-                { return self.at(key); })
-            .def("__setitem__", &property_helper::setitem_parser)
+                "__setitem__",
+                [](wrapped_type & self, py::object const & key, py::object const & value)
+                { property_helper(self).setitem(key, value); })
             .def(
                 "reshape",
                 [](wrapped_type const & self, py::object const & shape)

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -119,42 +119,6 @@ static void verify_python_value_datatype(pybind11::object const & value, DataTyp
     }
 }
 
-/// Get the typed array value by the key
-/// @tparam T the type of the key
-template <typename T>
-// NOLINTNEXTLINE(misc-use-anonymous-namespace)
-static pybind11::object get_typed_array_value(const SimpleArrayPlex & array_plex, T key)
-{
-#define SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType, ArrayType)                     \
-    case DataType:                                                                      \
-    {                                                                                   \
-        const auto * array = static_cast<const ArrayType *>(array_plex.instance_ptr()); \
-        return pybind11::cast(array->at(key));                                          \
-    }
-
-    switch (array_plex.data_type())
-    {
-        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Bool, SimpleArrayBool)
-        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Int8, SimpleArrayInt8)
-        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Int16, SimpleArrayInt16)
-        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Int32, SimpleArrayInt32)
-        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Int64, SimpleArrayInt64)
-        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Uint8, SimpleArrayUint8)
-        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Uint16, SimpleArrayUint16)
-        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Uint32, SimpleArrayUint32)
-        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Uint64, SimpleArrayUint64)
-        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Float32, SimpleArrayFloat32)
-        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Float64, SimpleArrayFloat64)
-        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Complex64, SimpleArrayComplex64)
-        SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX(DataType::Complex128, SimpleArrayComplex128)
-    default:
-    {
-        throw std::runtime_error("Unsupported datatype");
-    }
-    }
-#undef SC_DECL_GET_TYPED_ARRAY_VALUE_BY_INDEX
-}
-
 /// Get the typed array from the arrayplex
 // NOLINTNEXTLINE(misc-use-anonymous-namespace)
 static pybind11::object get_typed_array(const SimpleArrayPlex & array_plex)
@@ -294,17 +258,35 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
                         });
                 })
             .def("__len__", SC_DECL_EXECUTE_TYPED_ARRAY_METHOD(size))
-            .def("__getitem__", &get_typed_array_value<ssize_t>)
-            .def("__getitem__", &get_typed_array_value<const std::vector<ssize_t> &>)
+            .def("__getitem__",
+                 [](wrapped_type & self, pybind11::object const & key)
+                 {
+                     return execute_callback_with_typed_array(
+                         self,
+                         // NOLINTNEXTLINE(fuchsia-trailing-return)
+                         [&key](auto & array) -> pybind11::object
+                         {
+                             using data_type = typename std::remove_reference_t<decltype(array[0])>;
+                             using helper_type = ArrayPropertyHelper<data_type>;
+                             const helper_type helper(array);
+                             // A region read must stay dtype-erased, and it must keep
+                             // sharing the buffer, so the view is adopted rather than copied.
+                             if (helper_type::is_region_key(key))
+                             {
+                                 return pybind11::cast(SimpleArrayPlex::adopt(helper.slice(key)));
+                             }
+                             return helper.getitem(key);
+                         });
+                 })
             .def("__setitem__",
-                 [](wrapped_type & self, pybind11::args const & args)
+                 [](wrapped_type & self, pybind11::object const & key, pybind11::object const & value)
                  {
                      execute_callback_with_typed_array(
                          self,
-                         [&args](auto & array)
+                         [&key, &value](auto & array)
                          {
                              using data_type = typename std::remove_reference_t<decltype(array[0])>;
-                             ArrayPropertyHelper<data_type>::setitem_parser(array, args);
+                             ArrayPropertyHelper<data_type>(array).setitem(key, value);
                          });
                  })
             .def("reshape", [](wrapped_type const & self, pybind11::object const & py_shape)

--- a/doc/source/compute/buffer/indexing.md
+++ b/doc/source/compute/buffer/indexing.md
@@ -1,24 +1,27 @@
 # Indexing, Shape, and Layout
 
-Every array in the SimpleArray family reads and writes single elements through
-the subscript operator, describes its layout through a set of properties, and
-manipulates its shape and memory order through `reshape` and the transpose
-family. This page defines those operations: which keys the subscript accepts,
-which right-hand sides assignment takes, what the layout properties report,
-and how the shape and layout of an array are changed. Arrays carrying a ghost
-region shift the index origin; the sections up to the layout conversions
-assume arrays without one, and
+Every array in the SimpleArray family reads and writes elements and regions
+through the subscript operator, describes its layout through a set of
+properties, and manipulates its shape and memory order through `reshape` and
+the transpose family. This page defines those operations: which keys the
+subscript accepts, which right-hand sides assignment takes, what the layout
+properties report, and how the shape and layout of an array are changed.
+Arrays carrying a ghost region shift the index origin; the sections up to the
+layout conversions assume arrays without one, and
 {ref}`the last section of this page <ghost-region>` defines the partition and
 every rule it changes.
 
 ## Element Access
 
-Element access matches numpy in the index arithmetic and the error behavior
-(negative wrapping and `IndexError`), and diverges from numpy in the subscript
-scope and the return type: a subscript must select exactly one element, and
-the result is a Python scalar, never a subarray or a view. A one-dimensional
-array takes a single integer, and a multi-dimensional array takes a full tuple
-with one integer per dimension:
+The subscript reads two families of keys. An integer key addresses exactly one
+element and returns a scalar, and that is what this section defines; a slice
+or an ellipsis selects a region and returns a view, which
+{ref}`the next section <slice-read>` defines. Element access matches numpy in
+the index arithmetic and the error behavior (negative wrapping and
+`IndexError`), and diverges from numpy in the return type, which is a Python
+scalar rather than a numpy one. A one-dimensional array takes a single
+integer, and a multi-dimensional array takes a full tuple with one integer per
+dimension:
 
 ```python
 sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
@@ -38,8 +41,8 @@ plain Python scalar is the desired behavior.
 
 Partial indexing does not produce subarrays. Where numpy resolves `ndarr[0]`
 on a three-dimensional array to a two-dimensional view, the SimpleArray
-classes require the index to address one element and raise `IndexError`
-otherwise:
+classes require an integer key to address one element and raise `IndexError`
+otherwise; a subarray is named with explicit slices instead:
 
 ```python
 sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
@@ -93,35 +96,87 @@ sarr[0, 3, 0]
 # IndexError: SimpleArray: dim 1 in [0, 3, 0] >= shape[1]: 3
 ```
 
-### No Slices on Read
+(slice-read)=
+## Region Access
 
-`__getitem__` accepts no slice and no ellipsis; only the integer and
-integer-tuple forms above exist. Passing a slice raises `TypeError` from the
-binding's argument matching:
+A slice, an ellipsis, or a tuple containing either selects a region, and the
+read returns an array of the same class holding that region. The key grammar
+is the one {ref}`the assignment section <region-assignment>` defines, so a key
+that writes a region reads the same region back:
 
 ```python
 sarr = solvcon.SimpleArrayFloat64(6)
-sarr[0:3]
-# TypeError: __getitem__(): incompatible function arguments. ...
+sarr[...] = np.arange(6, dtype='float64')
+
+sub = sarr[1:4]
+assert isinstance(sub, solvcon.SimpleArrayFloat64)
+assert sub.shape == (3,)
+assert sub.ndarray.tolist() == [1.0, 2.0, 3.0]
 ```
 
-This diverges from numpy, where a slice returns a view sharing the memory of
-the source. Whether the family should grow slice reads, and whether such a
-read would return a sharing view or a copy, is an open decision; this page
-records only the current behavior. Until the decision lands, the zero-copy
-path to sliced reads is the `ndarray` property: `sarr.ndarray[0:3]` is a numpy
-view over the array's memory.
+The result shares the memory of the source, matching numpy and the sharing
+`reshape` below: a write through either side is visible through the other.
+The `ndarray` property gives the same view as a numpy array, so
+`sarr[1:4].ndarray` and `sarr.ndarray[1:4]` describe the same memory.
 
+```python
+sub[0] = 100.0
+assert sarr[1] == 100.0
+sarr[3] = 200.0
+assert sub[2] == 200.0
+```
+
+Steps and negative bounds follow the Python slice rules. A step other than 1
+gives the view a strided layout, a negative step reverses it, and a key that
+selects nothing yields an array with a zero-length axis:
+
+```python
+sarr = solvcon.SimpleArrayFloat64(array=np.arange(6, dtype='float64'))
+assert sarr[::2].ndarray.tolist() == [0.0, 2.0, 4.0]
+assert sarr[::-1].ndarray.tolist() == [5.0, 4.0, 3.0, 2.0, 1.0, 0.0]
+assert sarr[3:3].shape == (0,)
+```
+
+A tuple key names one dimension per slice from the left, and an ellipsis
+stands for the full-extent slices of the dimensions it replaces. The syntax
+checks are those of the assignment section: more slices than dimensions raise
+`RuntimeError` ("syntax error. dimensions mismatches"), more than one ellipsis
+raises `RuntimeError` ("syntax error. no more than one ellipsis."), and a zero
+step raises `ValueError` ("slice step cannot be zero"):
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+sarr[...] = np.arange(24, dtype='float64').reshape((2, 3, 4))
+assert sarr[0:1, ::2, ...].shape == (1, 2, 4)
+assert sarr[..., ::2].shape == (2, 3, 2)
+```
+
+Mixing an integer with a slice in one tuple key is not accepted, so a region
+key cannot drop a dimension the way `ndarr[0, 1:3]` does in numpy. Such a key
+raises `RuntimeError` ("unsupported operation."), and a one-element slice is
+the working spelling: `sarr[0:1, 1:3]` keeps the first dimension with extent
+1. Chaining is the other route, since a view is itself subscriptable:
+
+```python
+sarr = solvcon.SimpleArrayFloat64(array=np.arange(12, dtype='float64'))
+assert sarr[2:10][::3].ndarray.tolist() == [2.0, 5.0, 8.0]
+```
+
+The dtype-erased `SimpleArray` reads a region the same way and returns another
+dtype-erased array over the shared memory, keeping its interface aligned with
+the typed classes.
+
+(region-assignment)=
 ## Element and Region Assignment
 
-`__setitem__` accepts two families of keys: the scalar keys of the read path,
-assigning one element, and slice or ellipsis keys, assigning a whole region
-from a sequence. A key and value combination outside the two families raises
-`RuntimeError`; in particular a scalar value cannot be assigned to a slice key
-(numpy would broadcast it over the region). The message depends on the
-rejection path: a scalar on a lone slice or an ellipsis reports "unsupported
-operation.", while a scalar on a tuple of slices fails earlier, in the key
-cast, with a pybind11 "Unable to cast" message.
+`__setitem__` accepts the same two families of keys as the read path: the
+integer keys, assigning one element, and slice or ellipsis keys, assigning a
+whole region from a sequence. A key and value combination outside the two
+families raises `RuntimeError`; in particular a scalar value cannot be
+assigned to a slice key (numpy would broadcast it over the region). The
+message depends on the rejection path: a scalar on a lone slice or an ellipsis
+reports "unsupported operation.", while a scalar on a tuple of slices fails
+earlier, in the key cast, with a pybind11 "Unable to cast" message.
 
 ### Scalar Assignment
 
@@ -586,14 +641,15 @@ array with `nghost = 1` reports 3. A zero-dimensional array reports 0. Neither
 `shape`, `size`, nor `len()` changes with the partition; they keep describing
 the full storage, as the layout properties above define.
 
-### Ghost-Shifted Slice Assignment
+### Ghost-Shifted Slice Bounds
 
-The slice keys of `__setitem__` interpret their explicit bounds on the first
-axis in the logical, ghost-shifted coordinates of this page: the parser adds
-`nghost` to an explicit start or stop bound and then applies the ordinary
-Python slice rules over the full first-axis extent. An omitted bound is not
-shifted; it means the storage edge, so with a forward step an omitted start
-begins at the first ghost element and an omitted stop runs to the end of
+Reads and writes parse a slice key the same way, so the bounds below name the
+same region on either side. The slice keys interpret their explicit bounds on
+the first axis in the logical, ghost-shifted coordinates of this page: the
+parser adds `nghost` to an explicit start or stop bound and then applies the
+ordinary Python slice rules over the full first-axis extent. An omitted bound
+is not shifted; it means the storage edge, so with a forward step an omitted
+start begins at the first ghost element and an omitted stop runs to the end of
 storage. The stop bound `0` therefore selects exactly the ghost region, and
 the start bound `0` selects the body:
 
@@ -605,8 +661,32 @@ sarr[-2:0] = np.array([10.0, 11.0])        # the ghost region
 sarr[0:] = np.array([12.0, 13.0, 14.0])    # the body
 assert sarr.ndarray.tolist() == [10, 11, 12, 13, 14]
 
+assert sarr[-2:0].ndarray.tolist() == [10, 11]      # read it back
+assert sarr[0:].ndarray.tolist() == [12, 13, 14]
+
 sarr[:0] = np.array([20.0, 21.0])          # also the ghost region
+assert sarr[:0].ndarray.tolist() == [20, 21]
 assert sarr.ndarray.tolist() == [20, 21, 12, 13, 14]
+```
+
+The read is a view of the same memory the write reaches, so the body region
+that `nghost` defines is addressable as an array in its own right, without
+leaving the class for `ndarray`:
+
+```python
+body = sarr[0:]
+body[0] = 120.0
+assert sarr[0] == 120.0
+```
+
+A region read does not carry the partition to its result. The view reports
+`nghost == 0`, because its first axis is the selected positions and they have
+no ghost and body split of their own; assign `nghost` on the view if the
+sub-array needs one:
+
+```python
+assert sarr[0:].nghost == 0
+assert sarr[...].nghost == 0     # even when the key covers the whole storage
 ```
 
 Because both bounds default to the storage edges, a bare slice, a stepped
@@ -621,6 +701,7 @@ assert sarr.ndarray.tolist() == [10, 0, 11, 0, 12]
 
 sarr[...] = np.arange(5, dtype='float64')
 assert sarr[-2] == 0.0 and sarr[2] == 4.0
+assert sarr[...].ndarray.tolist() == [0, 1, 2, 3, 4]
 ```
 
 In a tuple key only the first-axis slice is shifted; slices on the later axes
@@ -631,6 +712,7 @@ sarr = solvcon.SimpleArrayFloat64(shape=(5, 3), value=0)
 sarr.nghost = 2
 sarr[-2:0, ...] = np.arange(6, dtype='float64').reshape((2, 3))
 assert (sarr.ndarray[0:2] == np.arange(6).reshape((2, 3))).all()
+assert (sarr[-2:0, ...].ndarray == np.arange(6).reshape((2, 3))).all()
 ```
 
 The accepted right-hand sides, the exact-shape check, and the dtype conversion
@@ -697,6 +779,10 @@ pointer, which sits `nghost` positions above the start of the storage, so it
 skips the ghost region and runs the same number of positions past the end. The
 trailing rows of the result hold uninitialized values.
 
+A region read forms a third group. It neither duplicates nor rearranges the
+storage, and it re-bounds the first axis, so it drops `nghost` the way the
+rearranging operations do, as the slice section above states.
+
 ```python
 sarr = solvcon.SimpleArrayFloat64((4, 3))
 sarr.nghost = 2
@@ -704,6 +790,7 @@ assert sarr.clone().nghost == 2
 assert sarr.to_row_major().nghost == 2   # already row-major: a copy
 assert sarr.T.nghost == 2
 assert sarr.transpose_copy().nghost == 0
+assert sarr[...].nghost == 0
 ```
 
 Carrying `nghost` through a transpose reattaches the partition to a different

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -2,6 +2,7 @@
 # BSD 3-Clause License, see COPYING
 
 
+import gc
 import operator
 import unittest
 
@@ -1378,6 +1379,151 @@ class SimpleArrayBasicTC(unittest.TestCase):
         sarr[:1, :2] = ((1, 2),)
         self.assertEqual(sarr[0, 0], 1)
         self.assertEqual(sarr[0, 1], 2)
+
+    def test_SimpleArray_getitem_scalar_keys(self):
+        sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+        sarr[...] = np.arange(24, dtype='float64').reshape((2, 3, 4))
+
+        self.assertEqual(6.0, sarr[0, 1, 2])
+        self.assertEqual(6.0, sarr[[0, 1, 2]])
+        self.assertEqual(6.0, sarr[np.int64(0), 1, 2])
+        self.assertEqual(19.0, sarr[-1, -2, -1])
+
+        flat = solvcon.SimpleArrayFloat64(6)
+        flat[...] = np.arange(6, dtype='float64')
+        self.assertEqual(3.0, flat[3])
+        self.assertEqual(3.0, flat[np.int64(3)])
+
+    def test_SimpleArray_getitem_slice_is_view(self):
+        sarr = solvcon.SimpleArrayFloat64(6)
+        sarr[...] = np.arange(6, dtype='float64')
+
+        sub = sarr[1:4]
+        self.assertEqual((3,), sub.shape)
+        np.testing.assert_array_equal(
+            sub.ndarray, np.arange(1, 4, dtype='float64'))
+
+        sub[0] = 100.0
+        self.assertEqual(100.0, sarr[1])
+        sarr[3] = 200.0
+        self.assertEqual(200.0, sub[2])
+
+    def test_SimpleArray_getitem_slice_steps(self):
+        ndarr = np.arange(6, dtype='float64')
+        sarr = solvcon.SimpleArrayFloat64(array=ndarr)
+
+        for key in (np.s_[::2], np.s_[::-1], np.s_[1:5:2], np.s_[-2:],
+                    np.s_[4:1:-1], np.s_[:], np.s_[...]):
+            with self.subTest(key=key):
+                np.testing.assert_array_equal(
+                    sarr[key].ndarray, ndarr[key])
+
+    def test_SimpleArray_getitem_slice_empty(self):
+        sarr = solvcon.SimpleArrayFloat64(6)
+
+        for key in (np.s_[3:3], np.s_[6:], np.s_[-10::-1]):
+            with self.subTest(key=key):
+                self.assertEqual((0,), sarr[key].shape)
+
+    def test_SimpleArray_getitem_slice_multidimensional(self):
+        ndarr = np.arange(2 * 3 * 4, dtype='float64').reshape((2, 3, 4))
+        sarr = solvcon.SimpleArrayFloat64(array=ndarr)
+
+        keys = (
+            np.index_exp[:, ::2, :],
+            np.index_exp[::-1, ...],
+            np.index_exp[..., ::2],
+            np.index_exp[1:2, ..., 1:3],
+            np.index_exp[...],
+        )
+        for key in keys:
+            with self.subTest(key=key):
+                sub = sarr[key]
+                self.assertEqual(ndarr[key].shape, sub.shape)
+                np.testing.assert_array_equal(sub.ndarray, ndarr[key])
+
+    def test_SimpleArray_getitem_slice_of_slice(self):
+        ndarr = np.arange(12, dtype='float64')
+        sarr = solvcon.SimpleArrayFloat64(array=ndarr)
+
+        sub = sarr[2:10][::3]
+        np.testing.assert_array_equal(sub.ndarray, ndarr[2:10][::3])
+
+        sub[1] = 500.0
+        self.assertEqual(500.0, ndarr[5])
+
+    def test_SimpleArray_getitem_slice_ghost(self):
+        # The read bounds are ghost-shifted the same way the write bounds
+        # are: stop 0 is the ghost region and start 0 is the body.
+        sarr = solvcon.SimpleArrayFloat64(shape=5, value=0.0)
+        sarr.nghost = 2
+        sarr[...] = np.arange(5, dtype='float64')
+
+        np.testing.assert_array_equal(sarr[-2:0].ndarray, [0.0, 1.0])
+        np.testing.assert_array_equal(sarr[:0].ndarray, [0.0, 1.0])
+        np.testing.assert_array_equal(sarr[0:].ndarray, [2.0, 3.0, 4.0])
+        np.testing.assert_array_equal(
+            sarr[...].ndarray, np.arange(5, dtype='float64'))
+
+        body = sarr[0:]
+        self.assertEqual(0, body.nghost)
+        self.assertFalse(body.has_ghost)
+        body[0] = 20.0
+        self.assertEqual(20.0, sarr[0])
+
+    def test_SimpleArray_getitem_slice_ghost_multidimensional(self):
+        sarr = solvcon.SimpleArrayFloat64(shape=(5, 3), value=0.0)
+        sarr.nghost = 2
+        expected = np.arange(15, dtype='float64').reshape((5, 3))
+        sarr[...] = expected
+
+        np.testing.assert_array_equal(sarr[0:, ...].ndarray, expected[2:])
+        np.testing.assert_array_equal(sarr[-2:0, ::2].ndarray,
+                                      expected[0:2, ::2])
+
+    def test_SimpleArray_getitem_slice_of_strided_array(self):
+        base = np.arange(24, dtype='float64').reshape((4, 6))
+        view = base[::2, 1::2]
+        sarr = solvcon.SimpleArrayFloat64(array=view)
+
+        sub = sarr[:, ::-1]
+        np.testing.assert_array_equal(sub.ndarray, view[:, ::-1])
+
+        sub[0, 0] = 300.0
+        self.assertEqual(300.0, base[0, 5])
+
+    def test_SimpleArray_getitem_slice_outlives_source(self):
+        # The view holds the buffer, so releasing the array it was taken
+        # from must not leave it pointing at freed memory.
+        def take_view():
+            sarr = solvcon.SimpleArrayFloat64(
+                array=np.arange(6, dtype='float64'))
+            return sarr[1:4]
+
+        sub = take_view()
+        gc.collect()
+        np.testing.assert_array_equal(
+            sub.ndarray, np.arange(1, 4, dtype='float64'))
+        sub[0] = 42.0
+        self.assertEqual(42.0, sub[0])
+
+    def test_SimpleArray_getitem_unsupported_key(self):
+        sarr = solvcon.SimpleArrayFloat64((2, 3))
+
+        with self.assertRaisesRegex(
+                RuntimeError, r"^syntax error\. dimensions mismatches$"):
+            sarr[:, :, :]
+        with self.assertRaisesRegex(
+                RuntimeError, r"^syntax error\. no more than one ellipsis\.$"):
+            sarr[..., ...]
+        with self.assertRaisesRegex(
+                RuntimeError, r"^unsupported operation\.$"):
+            sarr[0:1, 0]
+        with self.assertRaisesRegex(
+                RuntimeError, r"^unsupported operation\.$"):
+            sarr[None]
+        with self.assertRaisesRegex(ValueError, "slice step cannot be zero"):
+            sarr[::0]
 
     def test_SimpleArray_SimpleArrayPlex_type_switch(self):
         arrayplex_int32 = solvcon.SimpleArray((2, 3, 4), dtype="int32")
@@ -4813,6 +4959,21 @@ class SimpleArrayPlexTC(unittest.TestCase):
         sarr = solvcon.SimpleArray(
             (2, 3, 4), value=magic_number, dtype='float64')
         self.assertEqual(sarr[1, 2, 3], magic_number)
+
+    def test_SimpleArrayPlex_get_item_slice(self):
+        ndarr = np.arange(24, dtype='float64').reshape((2, 3, 4))
+        sarr = solvcon.SimpleArray(array=ndarr)
+
+        sub = sarr[0:1, ::2, ...]
+        self.assertEqual(
+            str(type(sub)), "<class '_solvcon.SimpleArray'>")
+        self.assertEqual((1, 2, 4), sub.shape)
+        np.testing.assert_array_equal(
+            np.array(sub, copy=False), ndarr[0:1, ::2, ...])
+
+        # The dtype-erased read shares memory the same way the typed one does.
+        sub[0, 0, 0] = 400.0
+        self.assertEqual(400.0, ndarr[0, 0, 0])
 
     def test_SimpleArrayPlex_properties(self):
         magic_number = 3.1415


### PR DESCRIPTION
For issue #1292

`PointPad`, `SegmentPad`, and `CurvePad` bind `__getitem__` to a `size_t`, so `pad[-1]` and `pad[0:2]` both raise `TypeError` and a pad reads as less of a container than it is. This branch completes the sequence protocol on the three pads.

Each pad gains a signed integer `__getitem__` that normalizes against `size()` and raises `IndexError` when out of range, plus a slice overload that returns a new pad of the same type and `ndim`. A slice copies rather than views, because a pad owns one `SimpleArray` per axis and carries neither an offset nor a stride. `CurvePad.__setitem__` takes the negative index too. Slice assignment is out of scope, and `get_at` and `set_at` are untouched.