### PR TITLE
Enable slicing for geometry pads

### DIFF
--- a/cpp/solvcon/universe/pymod/universe_pymod.hpp
+++ b/cpp/solvcon/universe/pymod/universe_pymod.hpp
@@ -11,11 +11,66 @@
 #include <solvcon/python/common.hpp>
 #include <solvcon/universe/universe.hpp>
 
+#include <format>
+#include <stdexcept>
+
 namespace solvcon
 {
 
 namespace python
 {
+
+/**
+ * Turn a Python index into a pad offset, counting a negative index from the
+ * end of the pad.
+ *
+ * @param index the index as Python spells it
+ * @param size the number of elements in the pad
+ * @param name the pad type name the error message carries
+ *
+ * @throw std::out_of_range if the normalized index falls outside the pad
+ */
+inline size_t normalize_pad_index(ssize_t index, size_t size, char const * name)
+{
+    auto const nelem = static_cast<ssize_t>(size);
+    ssize_t const it = index < 0 ? index + nelem : index;
+    if (it < 0 || it >= nelem)
+    {
+        throw std::out_of_range(
+            std::format("{}: index {} is out of bounds with size {}", name, index, size));
+    }
+    return static_cast<size_t>(it);
+}
+
+/**
+ * Copy the elements a Python slice selects into a new pad of the same type
+ * and dimensionality.
+ *
+ * A pad owns one array per axis and carries neither an offset nor a stride,
+ * so the result copies the selected elements instead of viewing them. The
+ * result is unaligned, because an alignment the slice length does not divide
+ * cannot be honored.
+ *
+ * @param self the pad to read
+ * @param key the Python slice to apply
+ */
+template <typename Pad>
+std::shared_ptr<Pad> copy_pad_slice(Pad const & self, pybind11::slice const & key)
+{
+    ssize_t start = 0, stop = 0, step = 0, slicelength = 0;
+    if (!key.compute(static_cast<ssize_t>(self.size()), &start, &stop, &step, &slicelength))
+    {
+        throw pybind11::error_already_set();
+    }
+
+    std::shared_ptr<Pad> ret = Pad::construct(self.ndim(), static_cast<size_t>(slicelength));
+    for (ssize_t i = 0; i < slicelength; ++i)
+    {
+        ret->set_at(static_cast<size_t>(i), self.get_at(static_cast<size_t>(start)));
+        start += step;
+    }
+    return ret;
+}
 
 void initialize_universe(pybind11::module & mod);
 void wrap_shape0d(pybind11::module & mod);

--- a/cpp/solvcon/universe/pymod/wrap_shape0d.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_shape0d.cpp
@@ -300,11 +300,21 @@ WrapPointPad<T> & WrapPointPad<T>::wrap_accessor_point()
     // Python dunder accessor.
     (*this)
         .def("__len__", &wrapped_type::size)
-        .def("__getitem__",
-             [](wrapped_type const & self, size_t it)
-             {
-                 return self.get_at(it);
-             })
+        .def(
+            "__getitem__",
+            [](wrapped_type const & self, ssize_t it)
+            {
+                return self.get_at(normalize_pad_index(it, self.size(), "PointPad"));
+            },
+            "Return the point at the index. A negative index counts from the end of the pad.")
+        .def(
+            "__getitem__",
+            [](wrapped_type const & self, py::slice const & key)
+            {
+                return copy_pad_slice(self, key);
+            },
+            "Return a new pad of the same ndim holding a copy of the selected points. "
+            "A write to the result does not reach the pad it was sliced from.")
         //
         ;
 

--- a/cpp/solvcon/universe/pymod/wrap_shape1d.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_shape1d.cpp
@@ -309,11 +309,21 @@ WrapSegmentPad<T> & WrapSegmentPad<T>::wrap_accessor_segment()
     // Python dunder accessor.
     (*this)
         .def("__len__", &wrapped_type::size)
-        .def("__getitem__",
-             [](wrapped_type const & self, size_t it)
-             {
-                 return self.get_at(it);
-             })
+        .def(
+            "__getitem__",
+            [](wrapped_type const & self, ssize_t it)
+            {
+                return self.get_at(normalize_pad_index(it, self.size(), "SegmentPad"));
+            },
+            "Return the segment at the index. A negative index counts from the end of the pad.")
+        .def(
+            "__getitem__",
+            [](wrapped_type const & self, py::slice const & key)
+            {
+                return copy_pad_slice(self, key);
+            },
+            "Return a new pad of the same ndim holding a copy of the selected segments. "
+            "A write to the result does not reach the pad it was sliced from.")
         //
         ;
 

--- a/cpp/solvcon/universe/pymod/wrap_shape1d.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_shape1d.cpp
@@ -742,8 +742,28 @@ WrapCurvePad<T> & WrapCurvePad<T>::wrap_accessor_bezier()
     // Python dunder accessor.
     (*this)
         .def("__len__", &wrapped_type::size)
-        .def("__getitem__", &wrapped_type::get_at)
-        .def("__setitem__", &wrapped_type::set_at)
+        .def(
+            "__getitem__",
+            [](wrapped_type const & self, ssize_t it)
+            {
+                return self.get_at(normalize_pad_index(it, self.size(), "CurvePad"));
+            },
+            "Return the curve at the index. A negative index counts from the end of the pad.")
+        .def(
+            "__getitem__",
+            [](wrapped_type const & self, py::slice const & key)
+            {
+                return copy_pad_slice(self, key);
+            },
+            "Return a new pad of the same ndim holding a copy of the selected curves. "
+            "A write to the result does not reach the pad it was sliced from.")
+        .def(
+            "__setitem__",
+            [](wrapped_type & self, ssize_t it, bezier_type const & c)
+            {
+                self.set_at(normalize_pad_index(it, self.size(), "CurvePad"), c);
+            },
+            "Write the curve at the index. A negative index counts from the end of the pad.")
         //
         ;
 

--- a/solvcon/pilot/apps/obsrefl/_analytic.py
+++ b/solvcon/pilot/apps/obsrefl/_analytic.py
@@ -178,19 +178,15 @@ class Reflection(object):
                 core.Point3dFp64(head[0], head[1], 0.0),
                 core.Point3dFp64(tail[0], tail[1], 0.0)))
 
-    # TODO: SegmentPad has no __getitem__, so an arm is taken with get_at.
-    # Indexing would read as the container it is, and a slice would hand a
-    # plot the arms it wants without a loop.
-
     @property
     def incident(self):
         """The segment the incident shock runs along."""
-        return self.arms.get_at(0)
+        return self.arms[0]
 
     @property
     def reflected(self):
         """The segment the reflected shock runs along, or None."""
-        return self.arms.get_at(1) if self.has_reflection else None
+        return self.arms[1] if self.has_reflection else None
 
     @staticmethod
     def _relative(value, target):

--- a/tests/test_universe_shape0d.py
+++ b/tests/test_universe_shape0d.py
@@ -454,6 +454,71 @@ class PointPadTB(testing.TestBase):
         self.assert_allclose(pp.z_at(1), 8.23)
         self.assert_allclose(pp.z_at(2), 3.3 * 5.1)
 
+    def test_getitem_index(self):
+        pp = self.PointPad(ndim=2)
+        for it in range(4):
+            pp.append(float(it), float(it) * 10)
+
+        self.assert_allclose(list(pp[0]), (0, 0, 0))
+        self.assert_allclose(list(pp[-1]), (3, 30, 0))
+        self.assert_allclose(list(pp[-4]), (0, 0, 0))
+
+        with self.assertRaisesRegex(
+                IndexError, "PointPad: index 4 is out of bounds with size 4"):
+            pp[4]
+        with self.assertRaisesRegex(
+                IndexError, "PointPad: index -5 is out of bounds with size 4"):
+            pp[-5]
+
+        empty = self.PointPad(ndim=3)
+        with self.assertRaisesRegex(
+                IndexError, "PointPad: index 0 is out of bounds with size 0"):
+            empty[0]
+        with self.assertRaisesRegex(
+                IndexError, "PointPad: index -1 is out of bounds with size 0"):
+            empty[-1]
+
+    def test_getitem_slice(self):
+        pp = self.PointPad(ndim=3)
+        for it in range(4):
+            pp.append(float(it), float(it) * 10, float(it) * 100)
+
+        full = pp[:]
+        self.assertIsInstance(full, type(pp))
+        self.assertEqual(full.ndim, 3)
+        self.assertEqual(len(full), 4)
+        self.assert_allclose(full.x, [0, 1, 2, 3])
+        self.assert_allclose(full.y, [0, 10, 20, 30])
+        self.assert_allclose(full.z, [0, 100, 200, 300])
+
+        strided = pp[1::2]
+        self.assertEqual(strided.ndim, 3)
+        self.assert_allclose(strided.x, [1, 3])
+        self.assert_allclose(strided.y, [10, 30])
+        self.assert_allclose(strided.z, [100, 300])
+
+        flipped = pp[::-1]
+        self.assert_allclose(flipped.x, [3, 2, 1, 0])
+
+        # A slice copies, so writing to it leaves the source alone.
+        part = pp[1:3]
+        part.set_at(0, -1.0, -2.0, -3.0)
+        self.assert_allclose(list(part[0]), (-1, -2, -3))
+        self.assert_allclose(list(pp[1]), (1, 10, 100))
+
+        # A 2D pad keeps its dimensionality and its empty z array.
+        pp2d = self.PointPad(ndim=2)
+        pp2d.append(1.0, 2.0)
+        sliced2d = pp2d[:]
+        self.assertEqual(sliced2d.ndim, 2)
+        self.assertEqual(len(sliced2d.z), 0)
+        self.assert_allclose(list(sliced2d[0]), (1, 2, 0))
+
+        empty = self.PointPad(ndim=3)
+        self.assertEqual(len(empty[:]), 0)
+        self.assertEqual(empty[:].ndim, 3)
+        self.assertEqual(len(pp[3:1]), 0)
+
     def test_mirror_2d(self):
         PointPad = self.PointPad
 

--- a/tests/test_universe_shape1d.py
+++ b/tests/test_universe_shape1d.py
@@ -580,6 +580,74 @@ class SegmentPadTB(testing.TestBase):
         self.assert_allclose(list(sp.y1), list(sp.p1.y))
         self.assert_allclose(list(sp.z1), list(sp.p1.z))
 
+    def test_getitem_index(self):
+        sp = self.SegmentPad(ndim=2)
+        for it in range(4):
+            sp.append(float(it), 0.0, float(it) + 1, 1.0)
+
+        self.assert_allclose(list(sp[0]), [[0, 0, 0], [1, 1, 0]])
+        self.assertEqual(sp[-1], sp[3])
+        self.assertEqual(sp[-4], sp[0])
+
+        with self.assertRaisesRegex(
+                IndexError,
+                "SegmentPad: index 4 is out of bounds with size 4"):
+            sp[4]
+        with self.assertRaisesRegex(
+                IndexError,
+                "SegmentPad: index -5 is out of bounds with size 4"):
+            sp[-5]
+
+        empty = self.SegmentPad(ndim=3)
+        with self.assertRaisesRegex(
+                IndexError,
+                "SegmentPad: index 0 is out of bounds with size 0"):
+            empty[0]
+        with self.assertRaisesRegex(
+                IndexError,
+                "SegmentPad: index -1 is out of bounds with size 0"):
+            empty[-1]
+
+    def test_getitem_slice(self):
+        sp = self.SegmentPad(ndim=3)
+        for it in range(4):
+            sp.append(float(it), 0.0, 0.0, float(it) + 1, 1.0, 1.0)
+
+        full = sp[:]
+        self.assertIsInstance(full, type(sp))
+        self.assertEqual(full.ndim, 3)
+        self.assertEqual(len(full), 4)
+        for it in range(4):
+            self.assertEqual(full[it], sp[it])
+
+        strided = sp[1::2]
+        self.assertEqual(strided.ndim, 3)
+        self.assertEqual(len(strided), 2)
+        self.assertEqual(strided[0], sp[1])
+        self.assertEqual(strided[1], sp[3])
+
+        flipped = sp[::-1]
+        self.assert_allclose(list(flipped.x0), [3, 2, 1, 0])
+
+        # A slice copies, so writing to it leaves the source alone.
+        part = sp[1:3]
+        part.set_at(0, -1.0, -2.0, -3.0, -4.0, -5.0, -6.0)
+        self.assert_allclose(part.x0_at(0), -1.0)
+        self.assert_allclose(sp.x0_at(1), 1.0)
+
+        # A 2D pad keeps its dimensionality and its empty z arrays.
+        sp2d = self.SegmentPad(ndim=2)
+        sp2d.append(1.0, 2.0, 3.0, 4.0)
+        sliced2d = sp2d[:]
+        self.assertEqual(sliced2d.ndim, 2)
+        self.assertEqual(len(sliced2d.z0), 0)
+        self.assertEqual(sliced2d[0], sp2d[0])
+
+        empty = self.SegmentPad(ndim=3)
+        self.assertEqual(len(empty[:]), 0)
+        self.assertEqual(empty[:].ndim, 3)
+        self.assertEqual(len(sp[3:1]), 0)
+
     def test_mirror_2d(self):
         SegmentPad = self.SegmentPad
 

--- a/tests/test_universe_shape1d.py
+++ b/tests/test_universe_shape1d.py
@@ -979,6 +979,85 @@ class CurvePadTB(testing.TestBase):
         self.assert_allclose(list(sp[9].p1),
                              [7.0, 0.0, 0.0])
 
+    def _make_curve_pad(self, ndim, ncurve):
+        cp = self.CurvePad(ndim=ndim)
+        for it in range(ncurve):
+            cp.append(self.Point(it, 0, 0), self.Point(it, 1, 0),
+                      self.Point(it, 2, 0), self.Point(it, 3, 0))
+        return cp
+
+    def test_getitem_index(self):
+        cp = self._make_curve_pad(2, 4)
+
+        self.assert_allclose(list(cp[0][0]), [0, 0, 0])
+        self.assertEqual(cp[-1], cp[3])
+        self.assertEqual(cp[-4], cp[0])
+
+        with self.assertRaisesRegex(
+                IndexError, "CurvePad: index 4 is out of bounds with size 4"):
+            cp[4]
+        with self.assertRaisesRegex(
+                IndexError, "CurvePad: index -5 is out of bounds with size 4"):
+            cp[-5]
+
+        empty = self.CurvePad(ndim=3)
+        with self.assertRaisesRegex(
+                IndexError, "CurvePad: index 0 is out of bounds with size 0"):
+            empty[0]
+        with self.assertRaisesRegex(
+                IndexError, "CurvePad: index -1 is out of bounds with size 0"):
+            empty[-1]
+
+    def test_setitem_index(self):
+        Point = self.Point
+        cp = self._make_curve_pad(3, 4)
+
+        c = self.Bezier(Point(9, 0, 0), Point(9, 1, 0),
+                        Point(9, 2, 0), Point(9, 3, 0))
+        cp[-1] = c
+        self.assertEqual(cp[3], c)
+
+        with self.assertRaisesRegex(
+                IndexError, "CurvePad: index -5 is out of bounds with size 4"):
+            cp[-5] = c
+
+    def test_getitem_slice(self):
+        cp = self._make_curve_pad(3, 4)
+
+        full = cp[:]
+        self.assertIsInstance(full, type(cp))
+        self.assertEqual(full.ndim, 3)
+        self.assertEqual(len(full), 4)
+        for it in range(4):
+            self.assertEqual(full[it], cp[it])
+
+        strided = cp[1::2]
+        self.assertEqual(strided.ndim, 3)
+        self.assertEqual(len(strided), 2)
+        self.assertEqual(strided[0], cp[1])
+        self.assertEqual(strided[1], cp[3])
+
+        flipped = cp[::-1]
+        self.assert_allclose(list(flipped.x0), [3, 2, 1, 0])
+
+        # A slice copies, so writing to it leaves the source alone.
+        part = cp[1:3]
+        part[0] = cp[0]
+        self.assertEqual(part[0], cp[0])
+        self.assert_allclose(cp.x0_at(1), 1.0)
+
+        # A 2D pad keeps its dimensionality and its empty z arrays.
+        cp2d = self._make_curve_pad(2, 1)
+        sliced2d = cp2d[:]
+        self.assertEqual(sliced2d.ndim, 2)
+        self.assertEqual(len(sliced2d.z0), 0)
+        self.assertEqual(sliced2d[0], cp2d[0])
+
+        empty = self.CurvePad(ndim=3)
+        self.assertEqual(len(empty[:]), 0)
+        self.assertEqual(empty[:].ndim, 3)
+        self.assertEqual(len(cp[3:1]), 0)
+
     def test_mirror(self):
         CurvePad = self.CurvePad
         Point = self.Point


### PR DESCRIPTION
`PointPad`, `SegmentPad`, and `CurvePad` bind `__getitem__` to a `size_t`, so `pad[-1]` and `pad[0:2]` both raise `TypeError` and a pad reads as less of a container than it is. This branch completes the sequence protocol on the three pads.

Each pad gains a signed integer `__getitem__` that normalizes against `size()` and raises `IndexError` when out of range, plus a slice overload that returns a new pad of the same type and `ndim`. A slice copies rather than views, because a pad owns one `SimpleArray` per axis and carries neither an offset nor a stride. `CurvePad.__setitem__` takes the negative index too. Slice assignment is out of scope, and `get_at` and `set_at` are untouched.