### PR TITLE
Refactor the obsrelf app into painter, viewer, and controller

### DIFF
--- a/solvcon/pilot/apps/obsrefl/_app.py
+++ b/solvcon/pilot/apps/obsrefl/_app.py
@@ -11,46 +11,18 @@ callbacks that widget fires build the run session from :mod:`._session`,
 open the domain viewer sub-window, and pump the session into it on a timer.
 """
 
-import collections
-
-import numpy as np
-
-from PySide6.QtCore import Qt, QTimer, QObject, QEvent
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtWidgets import QDockWidget
 
-from .... import core
 from ...base import _gui_common
-from . import _field_render
+from ._field_render import FieldPainter
 from ._panel import SolutionPanel
 from ._session import ReflectionSession
+from ._viewer import DomainViewer
 
 __all__ = [  # noqa: F822
     'ObliqueShockApp',
 ]
-
-
-#: What the viewer needs to recolor one run: the packed triangle vertices, the
-#: indices into them, and how many triangles each cell contributed.  It is cut
-#: from the mesh, so it outlives every frame of the run.
-FrameGeometry = collections.namedtuple('FrameGeometry',
-                                       ['verts', 'indices', 'counts'])
-
-
-class _SubWindowCloseFilter(QObject):
-    """Report a watched sub-window's close synchronously.
-
-    A ``QMdiSubWindow`` has no close signal, so this filter is the only way to
-    stop the march before Qt frees the viewer.
-    """
-
-    def __init__(self, on_close, parent):
-        super().__init__(parent)
-        self._on_close = on_close
-
-    def eventFilter(self, obj, event):
-        if event.type() == QEvent.Type.Close:
-            self._on_close()
-        return False
 
 
 class ObliqueShockApp(_gui_common.PilotFeature):
@@ -67,9 +39,6 @@ class ObliqueShockApp(_gui_common.PilotFeature):
 
     #: Qt timer interval in milliseconds.
     INTERVAL_MS = 50
-    #: Lift the analytic shock overlay off the z = 0 field plane so it is
-    #: not z-fought away by the colored triangles.
-    PATH_LIFT = 0.01
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
@@ -79,16 +48,12 @@ class ObliqueShockApp(_gui_common.PilotFeature):
         self._dock = None
         self._panel = None
         self._session = None
-        self._frame = None
+        self._painter = None
         self._timer = QTimer()
         self._timer.timeout.connect(self._advance)
-        self._viewer = None
-        self._subwin = None
-        self._close_filter = None
-        # Held for the panel's lifetime: a throwaway mdiArea wrapper is
-        # garbage-collected right after use, invalidating any sub-window handle
-        # taken through it.
-        self._mdi = None
+        self._viewer = DomainViewer(self._mgr)
+        self._viewer.closed = self._on_viewer_closed
+        self._viewer.mesh_updated = self._notify_viewer_updated
 
     def populate_menu(self):
         self._action = self.add_action(
@@ -121,45 +86,24 @@ class ObliqueShockApp(_gui_common.PilotFeature):
         if open_:
             self._open_viewer()
         else:
-            self._close_viewer()
+            self._viewer.close()
 
     def _open_viewer(self):
         """Open the domain viewer sub-window if it is not already open."""
-        if self._viewer is not None:
-            return
-        self._viewer = self._mgr.add3DWidget()
-        self._viewer.showAxis(True)
-        # Delete the sub-window on close and watch for that close, so a close
-        # from any source stops the march before Qt frees the viewer.
-        if self._mdi is None:
-            self._mdi = self._mgr.mdiArea
-        self._subwin = self._mdi.activeSubWindow()
-        if self._subwin is not None:
-            self._subwin.setAttribute(Qt.WA_DeleteOnClose, True)
-            self._close_filter = _SubWindowCloseFilter(
-                self._on_viewer_closed, self._subwin)
-            self._subwin.installEventFilter(self._close_filter)
+        self._viewer.open()
         self._panel.set_viewer_open(True)
 
-    def _close_viewer(self):
-        """Close the viewer sub-window; its close event stops the run."""
-        if self._subwin is not None:
-            self._subwin.close()
-        else:
-            self._on_viewer_closed()
-
     def _on_viewer_closed(self):
-        # Reached from the sub-window's close event; stop the run and drop the
-        # viewer before Qt frees it.
+        # Reached from the sub-window's close event; stop the run before Qt
+        # frees the viewer.
         self._stop_timer()
-        self._viewer = None
-        self._subwin = None
-        self._close_filter = None
         self._panel.set_viewer_open(False)
 
-    def _viewer_alive(self):
-        """True while the viewer is open; the close filter clears it."""
-        return self._viewer is not None
+    def _notify_viewer_updated(self):
+        # Fired after a run sets the viewer mesh; the wiring in the outer
+        # controller points it at the inspector's resync.
+        if self.viewer_updated is not None:
+            self.viewer_updated()
 
     def _on_start(self):
         """(Re)build the run session from the controls and march it into the
@@ -168,14 +112,9 @@ class ObliqueShockApp(_gui_common.PilotFeature):
         self._open_viewer()
         self._session = ReflectionSession(**self._panel.params())
         shock = self._session.shock
-        # Set the viewer mesh so the inspector can report it; reusing an open
-        # viewer raises no activation, so nudge the inspector directly.
-        if self._viewer is not None:
-            self._viewer.updateMesh(shock.mesh)
-            self._draw_shock_path(shock)
-            if self.viewer_updated is not None:
-                self.viewer_updated()
-        self._frame = self._build_frame(shock.mesh)
+        self._viewer.update_mesh(shock.mesh)
+        self._viewer.draw_shock_path(shock)
+        self._painter = FieldPainter(shock.mesh)
         self._panel.set_paused(False)
         self._draw_frame()
         self._timer.start(self.INTERVAL_MS)
@@ -185,11 +124,11 @@ class ObliqueShockApp(_gui_common.PilotFeature):
             return
         if paused:
             self._timer.stop()
-        elif self._viewer_alive():
+        elif self._viewer.is_open:
             self._timer.start(self.INTERVAL_MS)
 
     def _on_step(self):
-        if self._session is not None and self._viewer_alive():
+        if self._session is not None and self._viewer.is_open:
             self._march_frame()
 
     def _on_field(self, _name):
@@ -197,7 +136,7 @@ class ObliqueShockApp(_gui_common.PilotFeature):
             self._draw_frame()
 
     def _advance(self):
-        if not self._viewer_alive():
+        if not self._viewer.is_open:
             self._stop_timer()
             return
         if self._session.finished:
@@ -216,35 +155,8 @@ class ObliqueShockApp(_gui_common.PilotFeature):
         self._session.advance()
         self._draw_frame()
 
-    @staticmethod
-    def _build_frame(mesh):
-        """Cut the :class:`FrameGeometry` of a run from its mesh.
-
-        ``updateColorField`` wants an indexed vertex soup; the cell fan
-        already is one, so its vertices are packed once, the geometry being
-        fixed for the run, and indexed sequentially.
-        """
-        fan, counts = _field_render.cell_triangulation(mesh)
-        verts = fan.pack_array().ndarray.reshape(-1, 3)
-        indices = np.arange(verts.shape[0], dtype='uint32').reshape(-1, 3)
-        return FrameGeometry(core.SimpleArrayFloat32(array=verts),
-                             core.SimpleArrayUint32(array=indices), counts)
-
-    def _draw_shock_path(self, shock):
-        """Overlay the analytic shock polyline on the viewer.
-
-        The two-arm measurement draws the incident and the reflected shock
-        as one path with the reflection angle annotated, so the computed
-        field can be judged against where the shocks have to stand.
-        """
-        path = [(x, y, self.PATH_LIFT) for x, y in shock.shock_path()]
-        if 3 == len(path):
-            self._viewer.measureAngle(path[0], path[1], path[2])
-        else:
-            self._viewer.measureDistance(path[0], path[1])
-
     def _draw_frame(self):
-        if not self._viewer_alive():
+        if not self._viewer.is_open:
             return
         session = self._session
         name = self._panel.field()
@@ -256,10 +168,9 @@ class ObliqueShockApp(_gui_common.PilotFeature):
         zones = session.analysis.zone_field(name)
         lo = min(vmin, float(zones.min()))
         hi = max(vmax, float(zones.max()))
-        colors = _field_render.field_colors(field, self._frame.counts, lo, hi)
-        self._viewer.updateColorField(self._frame.verts,
-                                      core.SimpleArrayFloat32(array=colors),
-                                      self._frame.indices)
+        self._viewer.draw_field(self._painter.verts,
+                                self._painter.colors(field, lo, hi),
+                                self._painter.indices)
         self._panel.set_status(session, vmin, vmax)
 
     def _stop_timer(self):

--- a/solvcon/pilot/apps/obsrefl/_app.py
+++ b/solvcon/pilot/apps/obsrefl/_app.py
@@ -5,19 +5,20 @@
 """Pilot feature that runs the 2D Euler oblique-shock reflection and draws a
 selected solution field as a flat color map.
 
-The feature mirrors the mesh information panel: a toggle in the View
-"Panels" submenu owns the control widget from :mod:`._panel`, and the
-callbacks that widget fires build the run session from :mod:`._session`,
-open the domain viewer sub-window, and pump the session into it on a timer.
+The feature is the composition root of the app: a toggle in the View
+"Panels" submenu owns the dock, and building the dock builds the control
+panel from :mod:`._panel`, the domain viewer from :mod:`._viewer`, and the
+:class:`~._control.RunController` that wires the two around the run
+session.  The feature itself holds no run logic; it only composes the
+parts and forwards the inspector nudge to the outer GUI.
 """
 
-from PySide6.QtCore import Qt, QTimer
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QDockWidget
 
 from ...base import _gui_common
-from ._field_render import FieldPainter
+from ._control import RunController
 from ._panel import SolutionPanel
-from ._session import ReflectionSession
 from ._viewer import DomainViewer
 
 __all__ = [  # noqa: F822
@@ -28,17 +29,9 @@ __all__ = [  # noqa: F822
 class ObliqueShockApp(_gui_common.PilotFeature):
     """Euler solver panel, toggled from the View "Panels" submenu.
 
-    The panel owns one domain viewer sub-window and one solver run.  The viewer
-    control opens and closes the sub-window; starting marches the run into it
-    on a timer; closing it stops the march.
-
-    The run itself belongs to :class:`~._session.ReflectionSession`, which
-    decides how far a chunk marches and when the run is over.  This feature
-    only pumps it: one chunk per timer frame, one frame drawn after each.
+    The panel owns one domain viewer sub-window and one solver run; the
+    controller between them starts, pauses, steps, and stops the march.
     """
-
-    #: Qt timer interval in milliseconds.
-    INTERVAL_MS = 50
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
@@ -47,12 +40,8 @@ class ObliqueShockApp(_gui_common.PilotFeature):
         self._action = None
         self._dock = None
         self._panel = None
-        self._session = None
-        self._painter = None
-        self._timer = QTimer()
-        self._timer.timeout.connect(self._advance)
+        self._control = None
         self._viewer = DomainViewer(self._mgr)
-        self._viewer.closed = self._on_viewer_closed
         self._viewer.mesh_updated = self._notify_viewer_updated
 
     def populate_menu(self):
@@ -72,108 +61,14 @@ class ObliqueShockApp(_gui_common.PilotFeature):
         if self._panel is not None:
             return
         self._panel = SolutionPanel()
-        self._panel.viewer_toggled = self._on_viewer
-        self._panel.start_requested = self._on_start
-        self._panel.pause_toggled = self._on_pause
-        self._panel.step_requested = self._on_step
-        self._panel.field_changed = self._on_field
+        self._control = RunController(self._panel, self._viewer)
         self._dock = QDockWidget("euler solver")
         self._dock.setWidget(self._panel)
         self._mgr.mainWindow.addDockWidget(Qt.LeftDockWidgetArea, self._dock)
         self._dock.visibilityChanged.connect(self._action.setChecked)
 
-    def _on_viewer(self, open_):
-        if open_:
-            self._open_viewer()
-        else:
-            self._viewer.close()
-
-    def _open_viewer(self):
-        """Open the domain viewer sub-window if it is not already open."""
-        self._viewer.open()
-        self._panel.set_viewer_open(True)
-
-    def _on_viewer_closed(self):
-        # Reached from the sub-window's close event; stop the run before Qt
-        # frees the viewer.
-        self._stop_timer()
-        self._panel.set_viewer_open(False)
-
     def _notify_viewer_updated(self):
-        # Fired after a run sets the viewer mesh; the wiring in the outer
-        # controller points it at the inspector's resync.
         if self.viewer_updated is not None:
             self.viewer_updated()
-
-    def _on_start(self):
-        """(Re)build the run session from the controls and march it into the
-        viewer, opening the viewer sub-window first if it was closed."""
-        self._stop_timer()
-        self._open_viewer()
-        self._session = ReflectionSession(**self._panel.params())
-        shock = self._session.shock
-        self._viewer.update_mesh(shock.mesh)
-        self._viewer.draw_shock_path(shock)
-        self._painter = FieldPainter(shock.mesh)
-        self._panel.set_paused(False)
-        self._draw_frame()
-        self._timer.start(self.INTERVAL_MS)
-
-    def _on_pause(self, paused):
-        if self._session is None:
-            return
-        if paused:
-            self._timer.stop()
-        elif self._viewer.is_open:
-            self._timer.start(self.INTERVAL_MS)
-
-    def _on_step(self):
-        if self._session is not None and self._viewer.is_open:
-            self._march_frame()
-
-    def _on_field(self, _name):
-        if self._session is not None:
-            self._draw_frame()
-
-    def _advance(self):
-        if not self._viewer.is_open:
-            self._stop_timer()
-            return
-        if self._session.finished:
-            self._stop_timer()
-            self._panel.set_paused(True)
-            return
-        self._march_frame()
-
-    def _march_frame(self):
-        """March one chunk and draw what it left behind.
-
-        The chunk length is read from the control every frame, so turning
-        the dial mid-run takes effect on the next one.
-        """
-        self._session.steps_per_chunk = self._panel.steps_per_frame()
-        self._session.advance()
-        self._draw_frame()
-
-    def _draw_frame(self):
-        if not self._viewer.is_open:
-            return
-        session = self._session
-        name = self._panel.field()
-        field = session.field.field(name)
-        vmin, vmax = float(field.min()), float(field.max())
-        # Scale the colors to the analytic range, not the frame's own, so a
-        # field stuck short of the target looks stuck instead of stretching
-        # to full color every frame.
-        zones = session.analysis.zone_field(name)
-        lo = min(vmin, float(zones.min()))
-        hi = max(vmax, float(zones.max()))
-        self._viewer.draw_field(self._painter.verts,
-                                self._painter.colors(field, lo, hi),
-                                self._painter.indices)
-        self._panel.set_status(session, vmin, vmax)
-
-    def _stop_timer(self):
-        self._timer.stop()
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/apps/obsrefl/_control.py
+++ b/solvcon/pilot/apps/obsrefl/_control.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Drive one reflection run between the control panel and the viewer.
+
+:class:`RunController` is the presenter of the app: the panel and the
+viewer stay passive widgets, the session stays a Qt-free model, and every
+wire between them lands here.  Panel gestures arrive through the callbacks
+the controller plants on the panel, a viewer close arrives through the
+viewer's ``closed``, and everything the widgets show is pushed back into
+them from this side.  No widget ever reaches into a sibling.
+"""
+
+from PySide6.QtCore import QTimer
+
+from ._field_render import FieldPainter
+from ._session import ReflectionSession
+
+__all__ = [  # noqa: F822
+    'RunController',
+]
+
+
+class RunController(object):
+    """March one run into the viewer on the frame timer.
+
+    The run itself belongs to :class:`~._session.ReflectionSession`, which
+    decides how far a chunk marches and when the run is over.  The
+    controller only pumps it: one chunk per timer frame, one frame drawn
+    after each, so however fast the solver is, the widgets update at the
+    frame rate and no march outlives its viewer.
+
+    :ivar session: The running :class:`~._session.ReflectionSession`, or
+        None before the first start.
+    """
+
+    #: Qt timer interval in milliseconds.
+    INTERVAL_MS = 50
+
+    def __init__(self, panel, viewer):
+        self._panel = panel
+        self._viewer = viewer
+        self.session = None
+        self._painter = None
+        self._timer = QTimer()
+        self._timer.timeout.connect(self._advance)
+        panel.viewer_toggled = self._on_viewer
+        panel.start_requested = self.start
+        panel.pause_toggled = self._on_pause
+        panel.step_requested = self._on_step
+        panel.field_changed = self._on_field
+        viewer.closed = self._on_viewer_closed
+
+    def start(self):
+        """(Re)build the run session from the controls and march it into the
+        viewer, opening the viewer sub-window first if it was closed."""
+        self._timer.stop()
+        self._open_viewer()
+        self.session = ReflectionSession(**self._panel.params())
+        shock = self.session.shock
+        self._viewer.update_mesh(shock.mesh)
+        self._viewer.draw_shock_path(shock)
+        self._painter = FieldPainter(shock.mesh)
+        self._panel.set_paused(False)
+        self._draw_frame()
+        self._timer.start(self.INTERVAL_MS)
+
+    def _open_viewer(self):
+        self._viewer.open()
+        self._panel.set_viewer_open(True)
+
+    def _on_viewer(self, open_):
+        if open_:
+            self._open_viewer()
+        else:
+            self._viewer.close()
+
+    def _on_viewer_closed(self):
+        # Reached from the sub-window's close event; stop the run before Qt
+        # frees the viewer.
+        self._timer.stop()
+        self._panel.set_viewer_open(False)
+
+    def _on_pause(self, paused):
+        if self.session is None:
+            return
+        if paused:
+            self._timer.stop()
+        elif self._viewer.is_open:
+            self._timer.start(self.INTERVAL_MS)
+
+    def _on_step(self):
+        if self.session is not None and self._viewer.is_open:
+            self._march_frame()
+
+    def _on_field(self, _name):
+        if self.session is not None:
+            self._draw_frame()
+
+    def _advance(self):
+        if not self._viewer.is_open:
+            self._timer.stop()
+            return
+        if self.session.finished:
+            self._timer.stop()
+            self._panel.set_paused(True)
+            return
+        self._march_frame()
+
+    def _march_frame(self):
+        """March one chunk and draw what it left behind.
+
+        The chunk length is read from the control every frame, so turning
+        the dial mid-run takes effect on the next one.
+        """
+        self.session.steps_per_chunk = self._panel.steps_per_frame()
+        self.session.advance()
+        self._draw_frame()
+
+    def _draw_frame(self):
+        if not self._viewer.is_open:
+            return
+        session = self.session
+        name = self._panel.field()
+        field = session.field.field(name)
+        vmin, vmax = float(field.min()), float(field.max())
+        # Scale the colors to the analytic range, not the frame's own, so a
+        # field stuck short of the target looks stuck instead of stretching
+        # to full color every frame.
+        zones = session.analysis.zone_field(name)
+        lo = min(vmin, float(zones.min()))
+        hi = max(vmax, float(zones.max()))
+        self._viewer.draw_field(self._painter.verts,
+                                self._painter.colors(field, lo, hi),
+                                self._painter.indices)
+        self._panel.set_status(session, vmin, vmax)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/apps/obsrefl/_field_render.py
+++ b/solvcon/pilot/apps/obsrefl/_field_render.py
@@ -5,10 +5,11 @@
 """Turn a per-cell scalar field into the flat colored triangles that
 ``RDomainWidget.updateColorField`` draws.
 
-The mesh cells are triangulated once with :func:`cell_triangulation`; each
-frame then maps the scalar field to vertex colors with :func:`field_colors`
-over that fixed triangulation, so a running solver redraws without
-rebuilding the geometry.  The app in :mod:`._app` is the only caller.
+A run draws through one :class:`FieldPainter`: building it triangulates the
+mesh cells once with :func:`cell_triangulation`, and each frame then maps
+the scalar field to vertex colors with :func:`field_colors` over that fixed
+triangulation, so a running solver redraws without rebuilding the geometry.
+Everything here is numpy in and numpy out; no Qt enters the module.
 """
 
 import numpy as np
@@ -61,5 +62,30 @@ def field_colors(field, counts, vmin, vmax):
     span = vmax - vmin
     t = (field - vmin) / span if span > 0 else np.zeros_like(field)
     return np.repeat(colormap(t), counts, axis=0).astype('float32')
+
+
+class FieldPainter(object):
+    """Hold the fixed triangulation of one run and color its fields.
+
+    ``updateColorField`` wants an indexed vertex soup; the cell fan already
+    is one, so the vertices are packed once when the painter is built, the
+    geometry being fixed for the run, and indexed sequentially.  A frame
+    then costs only the color mapping of :meth:`colors`.
+
+    :ivar verts: The packed triangle vertices of the whole mesh.
+    :ivar indices: The sequential vertex indices, one row per triangle.
+    """
+
+    def __init__(self, mh):
+        fan, self._counts = cell_triangulation(mh)
+        verts = fan.pack_array().ndarray.reshape(-1, 3)
+        indices = np.arange(verts.shape[0], dtype='uint32').reshape(-1, 3)
+        self.verts = core.SimpleArrayFloat32(array=verts)
+        self.indices = core.SimpleArrayUint32(array=indices)
+
+    def colors(self, field, vmin, vmax):
+        """The vertex colors of one frame of ``field`` over the range."""
+        colors = field_colors(field, self._counts, vmin, vmax)
+        return core.SimpleArrayFloat32(array=colors)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/apps/obsrefl/_viewer.py
+++ b/solvcon/pilot/apps/obsrefl/_viewer.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""The domain viewer sub-window a reflection run draws into.
+
+:class:`DomainViewer` wraps the one 3D sub-window of a run: it opens and
+closes the window, watches for a close from any source, and forwards what
+the run wants drawn (the mesh, the analytic shock overlay, the colored
+field).  Every drawing call is a no-op while the window is closed, so the
+owner never draws into a freed widget.  What to draw and when stays with
+the owner, which hears about a close through the :attr:`closed` callback.
+"""
+
+from PySide6.QtCore import Qt, QObject, QEvent
+
+__all__ = [  # noqa: F822
+    'DomainViewer',
+]
+
+
+class _SubWindowCloseFilter(QObject):
+    """Report a watched sub-window's close synchronously.
+
+    A ``QMdiSubWindow`` has no close signal, so this filter is the only way
+    to stop the march before Qt frees the viewer.
+    """
+
+    def __init__(self, on_close, parent):
+        super().__init__(parent)
+        self._on_close = on_close
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Type.Close:
+            self._on_close()
+        return False
+
+
+class DomainViewer(object):
+    """Own the domain sub-window and draw a run into it."""
+
+    #: Lift the analytic shock overlay off the z = 0 field plane so it is
+    #: not z-fought away by the colored triangles.
+    PATH_LIFT = 0.01
+
+    def __init__(self, mgr):
+        self._mgr = mgr
+        # Owner-supplied callbacks: `closed` fires when the sub-window
+        # closes from any source, `mesh_updated` after a run sets the mesh.
+        self.closed = None
+        self.mesh_updated = None
+        self._viewer = None
+        self._subwin = None
+        self._close_filter = None
+        # Held for the viewer's lifetime: a throwaway mdiArea wrapper is
+        # garbage-collected right after use, invalidating any sub-window
+        # handle taken through it.
+        self._mdi = None
+
+    @property
+    def is_open(self):
+        """True while the sub-window is open; the close filter clears it."""
+        return self._viewer is not None
+
+    def open(self):
+        """Open the sub-window if it is not already open."""
+        if self._viewer is not None:
+            return
+        self._viewer = self._mgr.add3DWidget()
+        self._viewer.showAxis(True)
+        # Delete the sub-window on close and watch for that close, so a
+        # close from any source reaches `closed` before Qt frees the widget.
+        if self._mdi is None:
+            self._mdi = self._mgr.mdiArea
+        self._subwin = self._mdi.activeSubWindow()
+        if self._subwin is not None:
+            self._subwin.setAttribute(Qt.WA_DeleteOnClose, True)
+            self._close_filter = _SubWindowCloseFilter(
+                self._on_subwin_closed, self._subwin)
+            self._subwin.installEventFilter(self._close_filter)
+
+    def close(self):
+        """Close the sub-window; its close event fires :attr:`closed`."""
+        if self._subwin is not None:
+            self._subwin.close()
+        else:
+            self._on_subwin_closed()
+
+    def _on_subwin_closed(self):
+        # Reached from the sub-window's close event; drop the widget before
+        # Qt frees it, then tell the owner so it can stop the march.
+        self._viewer = None
+        self._subwin = None
+        self._close_filter = None
+        if self.closed is not None:
+            self.closed()
+
+    def update_mesh(self, mesh):
+        """Set the viewer mesh so the inspector can report the run.
+
+        Reusing an open viewer raises no sub-window activation, so the
+        :attr:`mesh_updated` callback is what nudges the inspector.
+        """
+        if self._viewer is None:
+            return
+        self._viewer.updateMesh(mesh)
+        if self.mesh_updated is not None:
+            self.mesh_updated()
+
+    def draw_shock_path(self, shock):
+        """Overlay the analytic shock polyline on the viewer.
+
+        The two-arm measurement draws the incident and the reflected shock
+        as one path with the reflection angle annotated, so the computed
+        field can be judged against where the shocks have to stand.
+        """
+        if self._viewer is None:
+            return
+        path = [(x, y, self.PATH_LIFT) for x, y in shock.shock_path()]
+        if 3 == len(path):
+            self._viewer.measureAngle(path[0], path[1], path[2])
+        else:
+            self._viewer.measureDistance(path[0], path[1])
+
+    def draw_field(self, verts, colors, indices):
+        """Recolor the field triangles of the current frame."""
+        if self._viewer is None:
+            return
+        self._viewer.updateColorField(verts, colors, indices)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/gui/test_obsrefl.py
+++ b/tests/gui/test_obsrefl.py
@@ -10,7 +10,7 @@ import solvcon
 try:
     from solvcon import pilot
     from solvcon.pilot.base import _gui
-    from solvcon.pilot.apps.obsrefl import _app
+    from solvcon.pilot.apps.obsrefl import ReflectionSession, _app
     from PySide6.QtWidgets import QApplication
 except ImportError:
     pilot = None
@@ -47,26 +47,26 @@ class ObliqueShockAppTC(unittest.TestCase):
     def test_panel_starts_paused_without_session(self):
         feature = self._feature()
         # Before Start there is no run, and the status tree says so.
-        self.assertIsNone(feature._session)
+        self.assertIsNone(feature._control.session)
         root = feature._panel._tree.topLevelItem(0)
         self.assertIn("not started", root.text(0))
 
     def test_start_builds_session_and_viewer(self):
         feature = self._feature()
         feature._panel._mach.setValue(2.5)
-        feature._on_start()
+        feature._control.start()
         # Stop the timer so the heavy march does not run during the test.
-        feature._timer.stop()
-        self.assertIsInstance(feature._session, _app.ReflectionSession)
-        self.assertEqual(feature._session.step, 0)
-        self.assertEqual(feature._session.shock.mach, 2.5)
+        feature._control._timer.stop()
+        self.assertIsInstance(feature._control.session, ReflectionSession)
+        self.assertEqual(feature._control.session.step, 0)
+        self.assertEqual(feature._control.session.shock.mach, 2.5)
         self.assertIsNotNone(self.mgr.currentR3DWidget())
         self.assertEqual("0", self._status(feature)["step"])
 
     def test_start_sets_viewer_mesh_for_inspector(self):
         feature = self._feature()
-        feature._on_start()
-        feature._timer.stop()
+        feature._control.start()
+        feature._control._timer.stop()
         # The inspector reads the active viewer's mesh; the solver viewer must
         # carry the run's mesh so the mesh panel is not empty during a run.
         self.assertIsNotNone(self.mgr.currentR3DWidget().mesh)
@@ -79,54 +79,54 @@ class ObliqueShockAppTC(unittest.TestCase):
         # Opening the viewer first and then starting reuses it, which raises no
         # sub-window activation, so start must notify the inspector itself.
         feature._panel._viewer_btn.setChecked(True)
-        feature._on_start()
-        feature._timer.stop()
+        feature._control.start()
+        feature._control._timer.stop()
         self.assertEqual(len(calls), 1)
         QApplication.processEvents()
 
     def test_step_advances_one_frame(self):
         feature = self._feature()
-        feature._on_start()
-        feature._timer.stop()
+        feature._control.start()
+        feature._control._timer.stop()
         feature._panel.set_paused(True)
         feature._panel._steps.setValue(3)
-        feature._on_step()
-        self.assertEqual(feature._session.step, 3)
+        feature._control._on_step()
+        self.assertEqual(feature._control.session.step, 3)
         status = self._status(feature)
         self.assertEqual("3", status["step"])
         self.assertEqual("running", status["run"])
 
     def test_the_frame_timer_follows_the_session_to_its_end(self):
         feature = self._feature()
-        feature._on_start()
+        feature._control.start()
         # The frame timer stops on the session's decision instead of counting
         # steps of its own.
-        feature._session.stop()
-        feature._advance()
-        self.assertFalse(feature._timer.isActive())
+        feature._control.session.stop()
+        feature._control._advance()
+        self.assertFalse(feature._control._timer.isActive())
         self.assertTrue(feature._panel._pause.isChecked())
-        feature._draw_frame()
+        feature._control._draw_frame()
         self.assertEqual("stopped", self._status(feature)["run"])
         QApplication.processEvents()
 
     def test_pause_toggle_controls_timer(self):
         feature = self._feature()
-        feature._on_start()
+        feature._control.start()
         feature._panel._pause.setChecked(True)
-        self.assertFalse(feature._timer.isActive())
+        self.assertFalse(feature._control._timer.isActive())
         feature._panel._pause.setChecked(False)
-        self.assertTrue(feature._timer.isActive())
-        feature._timer.stop()
+        self.assertTrue(feature._control._timer.isActive())
+        feature._control._timer.stop()
 
     def test_field_change_redraws_without_marching(self):
         feature = self._feature()
-        feature._on_start()
-        feature._timer.stop()
+        feature._control.start()
+        feature._control._timer.stop()
         feature._panel._pause.setChecked(True)
-        step = feature._session.step
+        step = feature._control.session.step
         feature._panel._field.setCurrentText('pressure')
         # Picking a field recolors the current frame; it must not march.
-        self.assertEqual(feature._session.step, step)
+        self.assertEqual(feature._control.session.step, step)
         self.assertEqual("pressure", self._status(feature)["field"])
 
     def test_viewer_button_opens_and_closes_subwindow(self):
@@ -140,26 +140,26 @@ class ObliqueShockAppTC(unittest.TestCase):
 
     def test_closing_viewer_stops_run_without_drawing(self):
         feature = self._feature()
-        feature._on_start()
+        feature._control.start()
         # Closing the domain sub-window while marching must stop the timer,
         # drop the viewer, and leave later frames as no-ops rather than
         # drawing into the freed widget.
         feature._viewer.close()
         self.assertFalse(feature._viewer.is_open)
-        self.assertFalse(feature._timer.isActive())
+        self.assertFalse(feature._control._timer.isActive())
         self.assertFalse(feature._panel._viewer_btn.isChecked())
-        step = feature._session.step
-        feature._advance()
-        feature._draw_frame()
-        self.assertEqual(feature._session.step, step)
+        step = feature._control.session.step
+        feature._control._advance()
+        feature._control._draw_frame()
+        self.assertEqual(feature._control.session.step, step)
         QApplication.processEvents()
 
     def test_start_reopens_a_closed_viewer(self):
         feature = self._feature()
-        feature._on_start()
+        feature._control.start()
         feature._viewer.close()
-        feature._on_start()
-        feature._timer.stop()
+        feature._control.start()
+        feature._control._timer.stop()
         self.assertTrue(feature._viewer.is_open)
         self.assertTrue(feature._panel._viewer_btn.isChecked())
         QApplication.processEvents()
@@ -182,8 +182,8 @@ class SolutionInspectorTC(unittest.TestCase):
         # standing on "No mesh loaded".
         sol._panel._viewer_btn.setChecked(True)
         QApplication.processEvents()
-        sol._on_start()
-        sol._timer.stop()
+        sol._control.start()
+        sol._control._timer.stop()
         QApplication.processEvents()
         root = ctl.tree_panel._mesh_tree._tree.topLevelItem(0)
         self.assertEqual(root.text(0), "StaticMesh (2D)")

--- a/tests/gui/test_obsrefl.py
+++ b/tests/gui/test_obsrefl.py
@@ -132,10 +132,10 @@ class ObliqueShockAppTC(unittest.TestCase):
     def test_viewer_button_opens_and_closes_subwindow(self):
         feature = self._feature()
         feature._panel._viewer_btn.setChecked(True)
-        self.assertIsNotNone(feature._viewer)
+        self.assertTrue(feature._viewer.is_open)
         self.assertIsNotNone(self.mgr.currentR3DWidget())
         feature._panel._viewer_btn.setChecked(False)
-        self.assertIsNone(feature._viewer)
+        self.assertFalse(feature._viewer.is_open)
         QApplication.processEvents()
 
     def test_closing_viewer_stops_run_without_drawing(self):
@@ -144,8 +144,8 @@ class ObliqueShockAppTC(unittest.TestCase):
         # Closing the domain sub-window while marching must stop the timer,
         # drop the viewer, and leave later frames as no-ops rather than
         # drawing into the freed widget.
-        feature._close_viewer()
-        self.assertIsNone(feature._viewer)
+        feature._viewer.close()
+        self.assertFalse(feature._viewer.is_open)
         self.assertFalse(feature._timer.isActive())
         self.assertFalse(feature._panel._viewer_btn.isChecked())
         step = feature._session.step
@@ -157,10 +157,10 @@ class ObliqueShockAppTC(unittest.TestCase):
     def test_start_reopens_a_closed_viewer(self):
         feature = self._feature()
         feature._on_start()
-        feature._close_viewer()
+        feature._viewer.close()
         feature._on_start()
         feature._timer.stop()
-        self.assertIsNotNone(feature._viewer)
+        self.assertTrue(feature._viewer.is_open)
         self.assertTrue(feature._panel._viewer_btn.isChecked())
         QApplication.processEvents()
 


### PR DESCRIPTION
For issue #1270 

Split the oblique-shock reflection GUI feature:
- `FieldPainter` in `_field_render.py` packs the run's fixed triangulation once and colors each frame, numpy in and numpy out with no Qt.
- `DomainViewer` in `_viewer.py` owns the domain sub-window: the open, the close, the close filter, and the drawing calls, each a no-op once the window is closed.
- `RunController` in `_control.py` owns the frame timer, the session, and every wire between the panel and the viewer.

`ObliqueShockApp` in `_app.py` shrinks to the composition root: the menu toggle, the dock, and the inspector nudge. No behavior changes.