### PR TITLE
Use boxed sub-widgets in the reflection panel

### DIFF
--- a/solvcon/pilot/apps/obsrefl/_panel.py
+++ b/solvcon/pilot/apps/obsrefl/_panel.py
@@ -4,13 +4,14 @@
 
 """Control widget for the oblique-shock reflection run.
 
-The controls set the free stream and the mesh, open or close the domain
-viewer sub-window, start / pause / step the march, and pick which derived
-field (density, velocity, pressure, Mach, ...) the viewer colors.  Below
-them the status tree reads out the run: how far it has come, and how far
-each zone stands from the analytic state it has to hold.  The widget only
-reports what its controls hold and calls back into its owner; the solver
-and the viewer belong to the feature in :mod:`._app`.
+The input boxes hold what a run consumes when it starts: the free stream
+and the incident shock in one, the discretization in the other.  The run
+box holds the march controls.  Below them the field selector picks what
+the viewer colors, and the status tree reads out the run.  Each box is a
+passive widget that only reports what its controls hold and calls back
+into its owner; the panel composes the boxes and forwards their surface,
+and the solver and the viewer belong to the controller in
+:mod:`._control`.
 """
 
 import math
@@ -18,7 +19,7 @@ import math
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QFormLayout,
                                QComboBox, QDoubleSpinBox, QSpinBox,
                                QPushButton, QTreeWidget, QTreeWidgetItem,
-                               QFrame)
+                               QFrame, QGroupBox)
 
 from ....multidim.euler import EulerField
 
@@ -27,56 +28,80 @@ __all__ = [  # noqa: F822
 ]
 
 
-class SolutionPanel(QWidget):
-    """Widget with the solver controls and a live solution-field readout."""
+def _spin(value, low, high, step, decimals):
+    box = QDoubleSpinBox()
+    box.setDecimals(decimals)
+    box.setRange(low, high)
+    box.setSingleStep(step)
+    box.setValue(value)
+    return box
 
-    #: Derived scalar fields the viewer can color, in display order.
-    FIELDS = EulerField.FIELDS
-    #: Mesh flavors offered by :mod:`._driver`, the first being the default.
-    CELL_TYPES = ('unstructured', 'quad', 'triangle')
-    #: What a :attr:`ReflectionSession.stop_reason` reads as in the tree.
-    RUN_STATES = {None: "running", 'cap': "step cap", 'stopped': "stopped"}
-    #: Headings of the status tree, whose first column carries the labels.
-    STATUS_COLUMNS = ("", "value", "analytic", "error")
+
+class FreeStreamBox(QGroupBox):
+    """The upstream state and the incident shock; read once at Start."""
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super().__init__("Free stream", parent)
+        self.setFlat(True)
+        self._gamma = _spin(1.4, 1.01, 3.0, 0.01, 3)
+        self._density = _spin(1.0, 1e-3, 1e6, 0.1, 3)
+        self._pressure = _spin(1.0, 1e-3, 1e6, 0.1, 3)
+        self._mach = _spin(3.0, 1.1, 20.0, 0.1, 3)
+        self._angle = _spin(10.0, 0.5, 45.0, 0.5, 2)
+        self._angle.setSuffix(" deg")
+
+        form = QFormLayout(self)
+        form.addRow("gamma", self._gamma)
+        form.addRow("density", self._density)
+        form.addRow("pressure", self._pressure)
+        form.addRow("Mach", self._mach)
+        form.addRow("shock angle", self._angle)
+
+    def params(self):
+        return dict(gamma=self._gamma.value(),
+                    density=self._density.value(),
+                    pressure=self._pressure.value(),
+                    mach=self._mach.value(),
+                    angle=self._angle.value())
+
+
+class NumericsBox(QGroupBox):
+    """The discretization of a run; read once at Start."""
+
+    #: Mesh flavors offered by :mod:`._driver`, the first being the default.
+    CELL_TYPES = ('unstructured', 'quad', 'triangle')
+
+    def __init__(self, parent=None):
+        super().__init__("Numerics", parent)
+        self.setFlat(True)
+        self._dt = _spin(2e-3, 1e-6, 1.0, 1e-3, 6)
+        self._cell_type = QComboBox()
+        self._cell_type.addItems(self.CELL_TYPES)
+
+        form = QFormLayout(self)
+        form.addRow("time step", self._dt)
+        form.addRow("cell type", self._cell_type)
+
+    def params(self):
+        return dict(time_increment=self._dt.value(),
+                    cell_type=self._cell_type.currentText())
+
+
+class RunBox(QGroupBox):
+    """The march controls: the pacing, the viewer, and the run buttons."""
+
+    def __init__(self, parent=None):
+        super().__init__("Run", parent)
+        self.setFlat(True)
         # Owner-supplied callbacks that drive the solver from the controls.
         self.viewer_toggled = None
         self.start_requested = None
         self.pause_toggled = None
         self.step_requested = None
-        self.field_changed = None
-        self._build_controls()
-        self._build_status()
 
-    def _build_controls(self):
-        """Lay out the free-stream / mesh inputs and the run buttons."""
-        self._gamma = self._spin(1.4, 1.01, 3.0, 0.01, 3)
-        self._density = self._spin(1.0, 1e-3, 1e6, 0.1, 3)
-        self._pressure = self._spin(1.0, 1e-3, 1e6, 0.1, 3)
-        self._mach = self._spin(3.0, 1.1, 20.0, 0.1, 3)
-        self._angle = self._spin(10.0, 0.5, 45.0, 0.5, 2)
-        self._dt = self._spin(2e-3, 1e-6, 1.0, 1e-3, 6)
         self._steps = QSpinBox()
         self._steps.setRange(1, 1000)
         self._steps.setValue(5)
-        self._cell_type = QComboBox()
-        self._cell_type.addItems(self.CELL_TYPES)
-        self._field = QComboBox()
-        self._field.addItems(self.FIELDS)
-        self._field.currentTextChanged.connect(self._on_field_changed)
-
-        form = QFormLayout()
-        form.addRow("gamma", self._gamma)
-        form.addRow("density", self._density)
-        form.addRow("pressure", self._pressure)
-        form.addRow("mach", self._mach)
-        form.addRow("angle (deg)", self._angle)
-        form.addRow("dt", self._dt)
-        form.addRow("steps/frame", self._steps)
-        form.addRow("cell type", self._cell_type)
-        form.addRow("field", self._field)
 
         # Opens and closes the one domain viewer the run buttons draw into.
         self._viewer_btn = QPushButton("Open viewer")
@@ -95,46 +120,10 @@ class SolutionPanel(QWidget):
         buttons.addWidget(self._pause)
         buttons.addWidget(self._step)
 
-        self._layout = QVBoxLayout(self)
-        self._layout.setContentsMargins(4, 4, 4, 4)
-        self._layout.addLayout(form)
-        self._layout.addWidget(self._viewer_btn)
-        self._layout.addLayout(buttons)
-
-    def _build_status(self):
-        """Add the read-only run readout below the controls.
-
-        The headings are what keep a zone's three numbers apart; only the
-        zone rows fill the last two columns, and the rest read as a plain
-        label / value list under them.
-        """
-        self._tree = QTreeWidget()
-        self._tree.setHeaderLabels(self.STATUS_COLUMNS)
-        self._tree.setFrameShape(QFrame.NoFrame)
-        self._layout.addWidget(self._tree)
-        self.set_status(None, None, None)
-
-    @staticmethod
-    def _spin(value, low, high, step, decimals):
-        box = QDoubleSpinBox()
-        box.setDecimals(decimals)
-        box.setRange(low, high)
-        box.setSingleStep(step)
-        box.setValue(value)
-        return box
-
-    def params(self):
-        """Collect the current control values for the solver driver."""
-        return dict(gamma=self._gamma.value(),
-                    density=self._density.value(),
-                    pressure=self._pressure.value(),
-                    mach=self._mach.value(),
-                    angle=self._angle.value(),
-                    time_increment=self._dt.value(),
-                    cell_type=self._cell_type.currentText())
-
-    def field(self):
-        return self._field.currentText()
+        form = QFormLayout(self)
+        form.addRow("steps/frame", self._steps)
+        form.addRow(self._viewer_btn)
+        form.addRow(buttons)
 
     def steps_per_frame(self):
         return self._steps.value()
@@ -152,6 +141,123 @@ class SolutionPanel(QWidget):
         self._viewer_btn.setChecked(open_)
         self._viewer_btn.setText("Close viewer" if open_ else "Open viewer")
         self._viewer_btn.blockSignals(False)
+
+    def _on_viewer_toggled(self, open_):
+        self._viewer_btn.setText("Close viewer" if open_ else "Open viewer")
+        if self.viewer_toggled is not None:
+            self.viewer_toggled(open_)
+
+    def _on_start_clicked(self):
+        if self.start_requested is not None:
+            self.start_requested()
+
+    def _on_pause_toggled(self, paused):
+        self._pause.setText("Resume" if paused else "Pause")
+        if self.pause_toggled is not None:
+            self.pause_toggled(paused)
+
+    def _on_step_clicked(self):
+        if self.step_requested is not None:
+            self.step_requested()
+
+
+class SolutionPanel(QWidget):
+    """Widget with the solver controls and a live solution-field readout.
+
+    The panel composes the input and run boxes and forwards their
+    callbacks and accessors as one flat surface, so the controller and
+    the tests see a single widget.  The field selector and the status
+    tree stay on the panel itself until the readout grows boxes of its
+    own.
+    """
+
+    #: Derived scalar fields the viewer can color, in display order.
+    FIELDS = EulerField.FIELDS
+    #: What a :attr:`ReflectionSession.stop_reason` reads as in the tree.
+    RUN_STATES = {None: "running", 'cap': "step cap", 'stopped': "stopped"}
+    #: Headings of the status tree, whose first column carries the labels.
+    STATUS_COLUMNS = ("", "value", "analytic", "error")
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.field_changed = None
+        self._freestream = FreeStreamBox()
+        self._numerics = NumericsBox()
+        self._run = RunBox()
+        self._field = QComboBox()
+        self._field.addItems(self.FIELDS)
+        self._field.currentTextChanged.connect(self._on_field_changed)
+
+        self._layout = QVBoxLayout(self)
+        self._layout.setContentsMargins(4, 4, 4, 4)
+        self._layout.addWidget(self._freestream)
+        self._layout.addWidget(self._numerics)
+        self._layout.addWidget(self._run)
+        form = QFormLayout()
+        form.addRow("field", self._field)
+        self._layout.addLayout(form)
+        self._build_status()
+
+    def _build_status(self):
+        """Add the read-only run readout below the controls.
+
+        The headings are what keep a zone's three numbers apart; only the
+        zone rows fill the last two columns, and the rest read as a plain
+        label / value list under them.
+        """
+        self._tree = QTreeWidget()
+        self._tree.setHeaderLabels(self.STATUS_COLUMNS)
+        self._tree.setFrameShape(QFrame.NoFrame)
+        self._layout.addWidget(self._tree)
+        self.set_status(None, None, None)
+
+    @property
+    def viewer_toggled(self):
+        return self._run.viewer_toggled
+
+    @viewer_toggled.setter
+    def viewer_toggled(self, callback):
+        self._run.viewer_toggled = callback
+
+    @property
+    def start_requested(self):
+        return self._run.start_requested
+
+    @start_requested.setter
+    def start_requested(self, callback):
+        self._run.start_requested = callback
+
+    @property
+    def pause_toggled(self):
+        return self._run.pause_toggled
+
+    @pause_toggled.setter
+    def pause_toggled(self, callback):
+        self._run.pause_toggled = callback
+
+    @property
+    def step_requested(self):
+        return self._run.step_requested
+
+    @step_requested.setter
+    def step_requested(self, callback):
+        self._run.step_requested = callback
+
+    def params(self):
+        """Collect the current control values for the solver driver."""
+        return {**self._freestream.params(), **self._numerics.params()}
+
+    def field(self):
+        return self._field.currentText()
+
+    def steps_per_frame(self):
+        return self._run.steps_per_frame()
+
+    def set_paused(self, paused):
+        self._run.set_paused(paused)
+
+    def set_viewer_open(self, open_):
+        self._run.set_viewer_open(open_)
 
     def set_status(self, session, vmin, vmax):
         """Read one run out into the status tree.
@@ -198,24 +304,6 @@ class SolutionPanel(QWidget):
     def _row(self, label, value, analytic="", error=""):
         """Add one line to the status tree, under its column headings."""
         QTreeWidgetItem(self._tree, [label, value, analytic, error])
-
-    def _on_viewer_toggled(self, open_):
-        self._viewer_btn.setText("Close viewer" if open_ else "Open viewer")
-        if self.viewer_toggled is not None:
-            self.viewer_toggled(open_)
-
-    def _on_start_clicked(self):
-        if self.start_requested is not None:
-            self.start_requested()
-
-    def _on_pause_toggled(self, paused):
-        self._pause.setText("Resume" if paused else "Pause")
-        if self.pause_toggled is not None:
-            self.pause_toggled(paused)
-
-    def _on_step_clicked(self):
-        if self.step_requested is not None:
-            self.step_requested()
 
     def _on_field_changed(self, name):
         if self.field_changed is not None:

--- a/solvcon/pilot/apps/obsrefl/_panel.py
+++ b/solvcon/pilot/apps/obsrefl/_panel.py
@@ -4,22 +4,23 @@
 
 """Control widget for the oblique-shock reflection run.
 
-The input boxes hold what a run consumes when it starts: the free stream
-and the incident shock in one, the discretization in the other.  The run
-box holds the march controls.  Below them the field selector picks what
-the viewer colors, and the status tree reads out the run.  Each box is a
-passive widget that only reports what its controls hold and calls back
-into its owner; the panel composes the boxes and forwards their surface,
-and the solver and the viewer belong to the controller in
+The panel stacks its boxes in the order a run is used: the free-stream and
+numerics inputs consumed when a run starts, the run controls with the live
+march readout, the field the viewer colors with the range it spans, and
+the zone readout that judges the field against the analytic reflection.
+Each box is a passive widget that only reports what its controls hold and
+calls back into its owner; the panel composes the boxes and forwards their
+surface, and the solver and the viewer belong to the controller in
 :mod:`._control`.
 """
 
 import math
 
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QFontDatabase
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QFormLayout,
-                               QComboBox, QDoubleSpinBox, QSpinBox,
-                               QPushButton, QTreeWidget, QTreeWidgetItem,
-                               QFrame, QGroupBox)
+                               QGridLayout, QGroupBox, QLabel, QComboBox,
+                               QDoubleSpinBox, QSpinBox, QPushButton)
 
 from ....multidim.euler import EulerField
 
@@ -35,6 +36,24 @@ def _spin(value, low, high, step, decimals):
     box.setSingleStep(step)
     box.setValue(value)
     return box
+
+
+def _number(value):
+    """Format a readout number to four significant digits.
+
+    The alternate form keeps the trailing zeros a plain ``g`` drops, so a
+    column of values stays a column instead of ragged decimals.
+    """
+    return f"{value:#.4g}"
+
+
+def _value_label():
+    """A live readout cell: right-aligned in a fixed-width font, so a value
+    can update every frame without jittering the column it stands in."""
+    label = QLabel("")
+    label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+    label.setFont(QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont))
+    return label
 
 
 class FreeStreamBox(QGroupBox):
@@ -88,7 +107,15 @@ class NumericsBox(QGroupBox):
 
 
 class RunBox(QGroupBox):
-    """The march controls: the pacing, the viewer, and the run buttons."""
+    """The march controls and the live march readout, kept side by side.
+
+    The readout is the run's own progress: how far the march has come of
+    the steps it may take, what ended it, and the overall mass the domain
+    holds, which the inflow and the outflow move as the flow develops.
+    """
+
+    #: What a :attr:`ReflectionSession.stop_reason` reads as in the readout.
+    RUN_STATES = {None: "running", 'cap': "step cap", 'stopped': "stopped"}
 
     def __init__(self, parent=None):
         super().__init__("Run", parent)
@@ -115,15 +142,25 @@ class RunBox(QGroupBox):
         self._pause.toggled.connect(self._on_pause_toggled)
         self._step = QPushButton("Step")
         self._step.clicked.connect(self._on_step_clicked)
+        # Disabled, not hidden, until a run exists to pause or step.
+        self._pause.setEnabled(False)
+        self._step.setEnabled(False)
         buttons = QHBoxLayout()
         buttons.addWidget(self._start)
         buttons.addWidget(self._pause)
         buttons.addWidget(self._step)
 
+        self._progress = _value_label()
+        self._state = _value_label()
+        self._mass = _value_label()
+
         form = QFormLayout(self)
         form.addRow("steps/frame", self._steps)
         form.addRow(self._viewer_btn)
         form.addRow(buttons)
+        form.addRow("step", self._progress)
+        form.addRow("state", self._state)
+        form.addRow("mass", self._mass)
 
     def steps_per_frame(self):
         return self._steps.value()
@@ -141,6 +178,20 @@ class RunBox(QGroupBox):
         self._viewer_btn.setChecked(open_)
         self._viewer_btn.setText("Close viewer" if open_ else "Open viewer")
         self._viewer_btn.blockSignals(False)
+
+    def show_run(self, session):
+        """Read the march progress of one run, or the lack of a run."""
+        if None is session:
+            self._progress.setText("-")
+            self._state.setText("not started")
+            self._mass.setText("-")
+            return
+        self._progress.setText(f"{session.step} / {session.max_steps}")
+        self._state.setText(self.RUN_STATES[session.stop_reason])
+        last = session.history.last
+        self._mass.setText("-" if last is None else _number(last.mass))
+        self._pause.setEnabled(True)
+        self._step.setEnabled(True)
 
     def _on_viewer_toggled(self, open_):
         self._viewer_btn.setText("Close viewer" if open_ else "Open viewer")
@@ -161,54 +212,108 @@ class RunBox(QGroupBox):
             self.step_requested()
 
 
-class SolutionPanel(QWidget):
-    """Widget with the solver controls and a live solution-field readout.
-
-    The panel composes the input and run boxes and forwards their
-    callbacks and accessors as one flat surface, so the controller and
-    the tests see a single widget.  The field selector and the status
-    tree stay on the panel itself until the readout grows boxes of its
-    own.
-    """
+class FieldBox(QGroupBox):
+    """Which derived field the viewer colors, and the range it spans."""
 
     #: Derived scalar fields the viewer can color, in display order.
     FIELDS = EulerField.FIELDS
-    #: What a :attr:`ReflectionSession.stop_reason` reads as in the tree.
-    RUN_STATES = {None: "running", 'cap': "step cap", 'stopped': "stopped"}
-    #: Headings of the status tree, whose first column carries the labels.
-    STATUS_COLUMNS = ("", "value", "analytic", "error")
+
+    def __init__(self, parent=None):
+        super().__init__("Field", parent)
+        self.setFlat(True)
+        self.field_changed = None
+        self._selector = QComboBox()
+        self._selector.addItems(self.FIELDS)
+        self._selector.currentTextChanged.connect(self._on_field_changed)
+        self._min = _value_label()
+        self._max = _value_label()
+
+        form = QFormLayout(self)
+        form.addRow("field", self._selector)
+        form.addRow("min", self._min)
+        form.addRow("max", self._max)
+
+    def field(self):
+        return self._selector.currentText()
+
+    def show_range(self, vmin, vmax):
+        self._min.setText("-" if vmin is None else _number(vmin))
+        self._max.setText("-" if vmax is None else _number(vmax))
+
+    def _on_field_changed(self, name):
+        if self.field_changed is not None:
+            self.field_changed(name)
+
+
+class ZoneBox(QGroupBox):
+    """The per-zone readout that judges the run.
+
+    Each zone carries its analytic value beside the computed one, so the
+    error in the last column is a reading a user can check rather than take
+    on faith, and the analytic state is the only thing the field is
+    measured against: how far a march has come is the step count, not the
+    size of what it last changed.
+    """
+
+    HEADERS = ("zone", "computed", "analytic", "error")
+
+    def __init__(self, parent=None):
+        super().__init__("Zones", parent)
+        self.setFlat(True)
+        self._grid = QGridLayout(self)
+        for col, text in enumerate(self.HEADERS):
+            label = QLabel(text)
+            font = label.font()
+            font.setBold(True)
+            label.setFont(font)
+            if col:
+                label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+            self._grid.addWidget(label, 0, col)
+        self._rows = []
+
+    def show_zones(self, infos):
+        """Fill one row per zone; a missing run blanks the rows instead of
+        removing them, so the panel does not jump as a run comes and goes."""
+        while len(self._rows) < len(infos):
+            row = tuple(_value_label() for _ in range(len(self.HEADERS)))
+            for col, label in enumerate(row):
+                self._grid.addWidget(label, len(self._rows) + 1, col)
+            self._rows.append(row)
+        for row in self._rows:
+            for label in row:
+                label.setText("")
+        for info, row in zip(infos, self._rows):
+            row[0].setText(f"{info.zone}")
+            row[1].setText(_number(info.computed))
+            row[2].setText(_number(info.analytic))
+            # A zone whose analytic value is zero, as the transverse
+            # velocity is in zones 1 and 3, has no error to be a percent of.
+            error = "" if math.isnan(info.error) else f"{info.error:+.2%}"
+            row[3].setText(error)
+
+
+class SolutionPanel(QWidget):
+    """Widget with the solver controls and a live solution-field readout.
+
+    The panel is pure composition: it stacks the boxes and forwards their
+    callbacks and accessors as one flat surface, so the controller and the
+    tests see a single widget while every box stays its own concern.
+    """
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.field_changed = None
         self._freestream = FreeStreamBox()
         self._numerics = NumericsBox()
         self._run = RunBox()
-        self._field = QComboBox()
-        self._field.addItems(self.FIELDS)
-        self._field.currentTextChanged.connect(self._on_field_changed)
+        self._field = FieldBox()
+        self._zones = ZoneBox()
 
-        self._layout = QVBoxLayout(self)
-        self._layout.setContentsMargins(4, 4, 4, 4)
-        self._layout.addWidget(self._freestream)
-        self._layout.addWidget(self._numerics)
-        self._layout.addWidget(self._run)
-        form = QFormLayout()
-        form.addRow("field", self._field)
-        self._layout.addLayout(form)
-        self._build_status()
-
-    def _build_status(self):
-        """Add the read-only run readout below the controls.
-
-        The headings are what keep a zone's three numbers apart; only the
-        zone rows fill the last two columns, and the rest read as a plain
-        label / value list under them.
-        """
-        self._tree = QTreeWidget()
-        self._tree.setHeaderLabels(self.STATUS_COLUMNS)
-        self._tree.setFrameShape(QFrame.NoFrame)
-        self._layout.addWidget(self._tree)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+        for box in (self._freestream, self._numerics, self._run, self._field,
+                    self._zones):
+            layout.addWidget(box)
+        layout.addStretch(1)
         self.set_status(None, None, None)
 
     @property
@@ -243,12 +348,20 @@ class SolutionPanel(QWidget):
     def step_requested(self, callback):
         self._run.step_requested = callback
 
+    @property
+    def field_changed(self):
+        return self._field.field_changed
+
+    @field_changed.setter
+    def field_changed(self, callback):
+        self._field.field_changed = callback
+
     def params(self):
         """Collect the current control values for the solver driver."""
         return {**self._freestream.params(), **self._numerics.params()}
 
     def field(self):
-        return self._field.currentText()
+        return self._field.field()
 
     def steps_per_frame(self):
         return self._run.steps_per_frame()
@@ -260,53 +373,18 @@ class SolutionPanel(QWidget):
         self._run.set_viewer_open(open_)
 
     def set_status(self, session, vmin, vmax):
-        """Read one run out into the status tree.
+        """Read one run out into the readout boxes.
 
         ``session`` is the :class:`~._session.ReflectionSession` being
         marched, or None before the first run; ``vmin`` and ``vmax`` bound
         the field the viewer is drawing.
-
-        The zone rows are what judge the run.  Each carries its analytic
-        value beside the computed one, so the error in the last column is a
-        reading a user can check rather than take on faith, and the analytic
-        state is the only thing the field is measured against: how far a
-        march has come is the step count, not the size of what it last
-        changed.
         """
-        self._tree.clear()
+        self._run.show_run(session)
         if None is session:
-            QTreeWidgetItem(self._tree, ["not started"])
+            self._field.show_range(None, None)
+            self._zones.show_zones([])
             return
-        name = self.field()
-        self._row("step", f"{session.step}")
-        self._row("run", self.RUN_STATES[session.stop_reason])
-        self._row("field", name)
-        self._row("min", self._number(vmin))
-        self._row("max", self._number(vmax))
-        for info in session.zone_info(name):
-            # A zone whose analytic value is zero, as the transverse
-            # velocity is in zones 1 and 3, has no error to be a percent of.
-            error = "" if math.isnan(info.error) else f"{info.error:+.2%}"
-            self._row(f"zone {info.zone}", self._number(info.computed),
-                      self._number(info.analytic), error)
-        for column in range(self._tree.columnCount() - 1):
-            self._tree.resizeColumnToContents(column)
-
-    @staticmethod
-    def _number(value):
-        """Format a readout number to four significant digits.
-
-        The alternate form keeps the trailing zeros a plain ``g`` drops, so
-        a column of values stays a column instead of ragged decimals.
-        """
-        return f"{value:#.4g}"
-
-    def _row(self, label, value, analytic="", error=""):
-        """Add one line to the status tree, under its column headings."""
-        QTreeWidgetItem(self._tree, [label, value, analytic, error])
-
-    def _on_field_changed(self, name):
-        if self.field_changed is not None:
-            self.field_changed(name)
+        self._field.show_range(vmin, vmax)
+        self._zones.show_zones(session.zone_info(self.field()))
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/apps/obsrefl/test_panel.py
+++ b/tests/apps/obsrefl/test_panel.py
@@ -6,7 +6,7 @@
 
 The panel is a widget, not a window, so the readout is checked here rather
 than in the window lane: a `SolutionPanel` and a coarse session are all it
-takes to fill the tree and read the rows back.
+takes to fill the readout boxes and read the cells back.
 """
 
 import unittest
@@ -16,14 +16,15 @@ import solvcon
 try:
     from solvcon import pilot
     from solvcon.pilot.apps.obsrefl import ReflectionSession
+    from solvcon.pilot.apps.obsrefl import _panel
     from solvcon.pilot.apps.obsrefl._panel import SolutionPanel
 except ImportError:
     pilot = None
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
-class StatusTreeTC(unittest.TestCase):
-    """What `set_status` puts in which column."""
+class StatusReadoutTC(unittest.TestCase):
+    """What `set_status` puts in which readout cell."""
 
     @classmethod
     def setUpClass(cls):
@@ -31,28 +32,49 @@ class StatusTreeTC(unittest.TestCase):
         pilot.RManager.instance.setUp()
 
     def _filled(self, name='density'):
-        """A panel showing one marched chunk of a coarse run."""
+        """A panel showing one marched chunk of a coarse run, with the run
+        and the drawn field range it was filled from."""
         panel = SolutionPanel()
-        panel._field.setCurrentText(name)
+        panel._field._selector.setCurrentText(name)
         sess = ReflectionSession(nx=8, ny=3, steps_per_chunk=3)
         sess.advance()
         field = sess.field.field(name)
-        panel.set_status(sess, float(field.min()), float(field.max()))
-        return panel
+        vmin, vmax = float(field.min()), float(field.max())
+        panel.set_status(sess, vmin, vmax)
+        return panel, sess, vmin, vmax
 
     @staticmethod
-    def _rows(panel):
-        tree = panel._tree
-        return [tuple(tree.topLevelItem(it).text(col) for col in range(4))
-                for it in range(tree.topLevelItemCount())]
+    def _zone_rows(panel):
+        grid = panel._zones._grid
+        rows = [tuple(grid.itemAtPosition(irow, col).widget().text()
+                      for col in range(len(panel._zones.HEADERS)))
+                for irow in range(1, grid.rowCount())]
+        return [row for row in rows if any(row)]
 
     def test_an_unstarted_panel_says_so(self):
         panel = SolutionPanel()
-        self.assertEqual("not started", panel._tree.topLevelItem(0).text(0))
+        self.assertEqual("not started", panel._run._state.text())
+        self.assertEqual("-", panel._run._progress.text())
+        self.assertEqual("-", panel._field._min.text())
+        self.assertEqual([], self._zone_rows(panel))
+
+    def test_the_run_box_reads_the_march(self):
+        panel, sess, _, _ = self._filled()
+        self.assertEqual(f"3 / {sess.max_steps}",
+                         panel._run._progress.text())
+        self.assertEqual("running", panel._run._state.text())
+        # One chunk is recorded, so the mass cell carries its measurement.
+        self.assertEqual(_panel._number(sess.history.last.mass),
+                         panel._run._mass.text())
+
+    def test_the_field_box_shows_the_drawn_range(self):
+        panel, _, vmin, vmax = self._filled()
+        self.assertEqual(_panel._number(vmin), panel._field._min.text())
+        self.assertEqual(_panel._number(vmax), panel._field._max.text())
 
     def test_the_zone_rows_carry_the_computed_analytic_and_error(self):
-        zones = [row for row in self._rows(self._filled())
-                 if row[0].startswith("zone")]
+        panel, _, _, _ = self._filled()
+        zones = self._zone_rows(panel)
         self.assertEqual(3, len(zones))
         # The density rises across each shock, so the analytic column has to
         # carry three ascending values rather than one repeated.
@@ -68,8 +90,8 @@ class StatusTreeTC(unittest.TestCase):
     def test_a_zone_with_no_analytic_value_shows_no_percent(self):
         # The transverse velocity is zero outside the wedge, and an error
         # relative to zero is not a percent of anything.
-        zones = [row for row in self._rows(self._filled('vely'))
-                 if row[0].startswith("zone")]
+        panel, _, _, _ = self._filled('vely')
+        zones = self._zone_rows(panel)
         self.assertEqual(["", ""], [zones[0][3], zones[2][3]])
         self.assertTrue(zones[1][3].endswith('%'))
 

--- a/tests/gui/test_obsrefl.py
+++ b/tests/gui/test_obsrefl.py
@@ -53,7 +53,7 @@ class ObliqueShockAppTC(unittest.TestCase):
 
     def test_start_builds_session_and_viewer(self):
         feature = self._feature()
-        feature._panel._mach.setValue(2.5)
+        feature._panel._freestream._mach.setValue(2.5)
         feature._control.start()
         # Stop the timer so the heavy march does not run during the test.
         feature._control._timer.stop()
@@ -78,7 +78,7 @@ class ObliqueShockAppTC(unittest.TestCase):
         feature.viewer_updated = lambda: calls.append(1)
         # Opening the viewer first and then starting reuses it, which raises no
         # sub-window activation, so start must notify the inspector itself.
-        feature._panel._viewer_btn.setChecked(True)
+        feature._panel._run._viewer_btn.setChecked(True)
         feature._control.start()
         feature._control._timer.stop()
         self.assertEqual(len(calls), 1)
@@ -89,7 +89,7 @@ class ObliqueShockAppTC(unittest.TestCase):
         feature._control.start()
         feature._control._timer.stop()
         feature._panel.set_paused(True)
-        feature._panel._steps.setValue(3)
+        feature._panel._run._steps.setValue(3)
         feature._control._on_step()
         self.assertEqual(feature._control.session.step, 3)
         status = self._status(feature)
@@ -104,7 +104,7 @@ class ObliqueShockAppTC(unittest.TestCase):
         feature._control.session.stop()
         feature._control._advance()
         self.assertFalse(feature._control._timer.isActive())
-        self.assertTrue(feature._panel._pause.isChecked())
+        self.assertTrue(feature._panel._run._pause.isChecked())
         feature._control._draw_frame()
         self.assertEqual("stopped", self._status(feature)["run"])
         QApplication.processEvents()
@@ -112,9 +112,9 @@ class ObliqueShockAppTC(unittest.TestCase):
     def test_pause_toggle_controls_timer(self):
         feature = self._feature()
         feature._control.start()
-        feature._panel._pause.setChecked(True)
+        feature._panel._run._pause.setChecked(True)
         self.assertFalse(feature._control._timer.isActive())
-        feature._panel._pause.setChecked(False)
+        feature._panel._run._pause.setChecked(False)
         self.assertTrue(feature._control._timer.isActive())
         feature._control._timer.stop()
 
@@ -122,7 +122,7 @@ class ObliqueShockAppTC(unittest.TestCase):
         feature = self._feature()
         feature._control.start()
         feature._control._timer.stop()
-        feature._panel._pause.setChecked(True)
+        feature._panel._run._pause.setChecked(True)
         step = feature._control.session.step
         feature._panel._field.setCurrentText('pressure')
         # Picking a field recolors the current frame; it must not march.
@@ -131,10 +131,10 @@ class ObliqueShockAppTC(unittest.TestCase):
 
     def test_viewer_button_opens_and_closes_subwindow(self):
         feature = self._feature()
-        feature._panel._viewer_btn.setChecked(True)
+        feature._panel._run._viewer_btn.setChecked(True)
         self.assertTrue(feature._viewer.is_open)
         self.assertIsNotNone(self.mgr.currentR3DWidget())
-        feature._panel._viewer_btn.setChecked(False)
+        feature._panel._run._viewer_btn.setChecked(False)
         self.assertFalse(feature._viewer.is_open)
         QApplication.processEvents()
 
@@ -147,7 +147,7 @@ class ObliqueShockAppTC(unittest.TestCase):
         feature._viewer.close()
         self.assertFalse(feature._viewer.is_open)
         self.assertFalse(feature._control._timer.isActive())
-        self.assertFalse(feature._panel._viewer_btn.isChecked())
+        self.assertFalse(feature._panel._run._viewer_btn.isChecked())
         step = feature._control.session.step
         feature._control._advance()
         feature._control._draw_frame()
@@ -161,7 +161,7 @@ class ObliqueShockAppTC(unittest.TestCase):
         feature._control.start()
         feature._control._timer.stop()
         self.assertTrue(feature._viewer.is_open)
-        self.assertTrue(feature._panel._viewer_btn.isChecked())
+        self.assertTrue(feature._panel._run._viewer_btn.isChecked())
         QApplication.processEvents()
 
 
@@ -180,7 +180,7 @@ class SolutionInspectorTC(unittest.TestCase):
         # Open the viewer first, then start: the reused viewer raises no
         # activation, so only the wired refresh keeps the inspector from
         # standing on "No mesh loaded".
-        sol._panel._viewer_btn.setChecked(True)
+        sol._panel._run._viewer_btn.setChecked(True)
         QApplication.processEvents()
         sol._control.start()
         sol._control._timer.stop()

--- a/tests/gui/test_obsrefl.py
+++ b/tests/gui/test_obsrefl.py
@@ -34,22 +34,16 @@ class ObliqueShockAppTC(unittest.TestCase):
         return feature
 
     @staticmethod
-    def _items(feature):
-        tree = feature._panel._tree
-        return [tree.topLevelItem(it)
-                for it in range(tree.topLevelItemCount())]
-
-    @classmethod
-    def _status(cls, feature):
-        """The status tree's value column, as ``{label: value}``."""
-        return {item.text(0): item.text(1) for item in cls._items(feature)}
+    def _status(feature):
+        """The run readout of the panel, as ``{label: text}``."""
+        run = feature._panel._run
+        return {"step": run._progress.text(), "state": run._state.text()}
 
     def test_panel_starts_paused_without_session(self):
         feature = self._feature()
-        # Before Start there is no run, and the status tree says so.
+        # Before Start there is no run, and the readout says so.
         self.assertIsNone(feature._control.session)
-        root = feature._panel._tree.topLevelItem(0)
-        self.assertIn("not started", root.text(0))
+        self.assertEqual("not started", self._status(feature)["state"])
 
     def test_start_builds_session_and_viewer(self):
         feature = self._feature()
@@ -61,7 +55,8 @@ class ObliqueShockAppTC(unittest.TestCase):
         self.assertEqual(feature._control.session.step, 0)
         self.assertEqual(feature._control.session.shock.mach, 2.5)
         self.assertIsNotNone(self.mgr.currentR3DWidget())
-        self.assertEqual("0", self._status(feature)["step"])
+        self.assertEqual(f"0 / {feature._control.session.max_steps}",
+                         self._status(feature)["step"])
 
     def test_start_sets_viewer_mesh_for_inspector(self):
         feature = self._feature()
@@ -93,8 +88,9 @@ class ObliqueShockAppTC(unittest.TestCase):
         feature._control._on_step()
         self.assertEqual(feature._control.session.step, 3)
         status = self._status(feature)
-        self.assertEqual("3", status["step"])
-        self.assertEqual("running", status["run"])
+        self.assertEqual(f"3 / {feature._control.session.max_steps}",
+                         status["step"])
+        self.assertEqual("running", status["state"])
 
     def test_the_frame_timer_follows_the_session_to_its_end(self):
         feature = self._feature()
@@ -106,7 +102,7 @@ class ObliqueShockAppTC(unittest.TestCase):
         self.assertFalse(feature._control._timer.isActive())
         self.assertTrue(feature._panel._run._pause.isChecked())
         feature._control._draw_frame()
-        self.assertEqual("stopped", self._status(feature)["run"])
+        self.assertEqual("stopped", self._status(feature)["state"])
         QApplication.processEvents()
 
     def test_pause_toggle_controls_timer(self):
@@ -124,10 +120,10 @@ class ObliqueShockAppTC(unittest.TestCase):
         feature._control._timer.stop()
         feature._panel._run._pause.setChecked(True)
         step = feature._control.session.step
-        feature._panel._field.setCurrentText('pressure')
+        feature._panel._field._selector.setCurrentText('pressure')
         # Picking a field recolors the current frame; it must not march.
         self.assertEqual(feature._control.session.step, step)
-        self.assertEqual("pressure", self._status(feature)["field"])
+        self.assertEqual("pressure", feature._panel.field())
 
     def test_viewer_button_opens_and_closes_subwindow(self):
         feature = self._feature()


### PR DESCRIPTION
For issue #1270 

Rebuild `SolutionPanel` from one flat widget into five boxes stacked in the order a run is used:

- `FreeStreamBox` and `NumericsBox` hold the inputs consumed at Start
- `RunBox` pairs the march controls with the march readout
- `FieldBox` picks what the viewer colors and shows the drawn range
- `ZoneBox` judges the field against the analytic states

The readout now shows progress against the known step cap, what ended the run, and the recorded overall mass, in right-aligned fixed-width cells that update without jitter (I think; if you find jittering, we fix again).

The shock angle carries its unit as a spin-box suffix, and Pause and Step are disabled until a run exists. The panel forwards the boxes' callbacks and accessors as one flat surface, so the controller is untouched.