### PR TITLE
Build the core libraries with the common warning flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,12 +371,9 @@ if(BUILD_QT AND "${PYSIDE6_LIBFILE}" STREQUAL "")
         "configure with BUILD_QT=OFF.")
 endif()
 
-add_subdirectory(cpp/solvcon)
-
-include(GNUInstallDirs)
-
-set(SOLVCON_PY_DIR "${PROJECT_SOURCE_DIR}/solvcon")
-
+# add_subdirectory() copies this scope's variables into the subdirectory as it
+# is called, so this must stay above every add_subdirectory() that consumes it.
+# Set it below one and the subdirectory sees nothing, with no diagnostic.
 if(MSVC)
     set(COMMON_COMPILER_OPTIONS /W4 /bigobj /WX)
 else()
@@ -388,6 +385,12 @@ else()
         message(STATUS "Enable -Werror because clang-tidy (with lint as errors) is disabled")
     endif()
 endif()
+
+add_subdirectory(cpp/solvcon)
+
+include(GNUInstallDirs)
+
+set(SOLVCON_PY_DIR "${PROJECT_SOURCE_DIR}/solvcon")
 
 add_subdirectory(cpp/binary/pymod_solvcon)
 if(BUILD_QT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,9 @@ include_directories(${pybind11_INCLUDE_DIRS})
 
 set(NUMPY_INCLUDE_DIR "${Python_NumPy_INCLUDE_DIRS}")
 message(STATUS "NUMPY_INCLUDE_DIR: ${NUMPY_INCLUDE_DIR}")
-include_directories(${NUMPY_INCLUDE_DIR})
+# SYSTEM keeps the core's warning flags off numpy's own headers, which do not
+# build clean under `/W4` and are not ours to fix.
+include_directories(SYSTEM ${NUMPY_INCLUDE_DIR})
 
 set(SOLVCON_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/cpp" CACHE INTERNAL "")
 

--- a/cpp/solvcon/CMakeLists.txt
+++ b/cpp/solvcon/CMakeLists.txt
@@ -340,6 +340,15 @@ foreach (SOLVCON_LIBRARY IN LISTS SOLVCON_LIBRARIES)
             ${SOLVCON_LIBRARY} PRIVATE
             ${COMMON_COMPILER_OPTIONS}
             /bigobj # C1128: number of sections exceeded object file format limit
+            # TODO: fix the code and drop each of these; see issue #1324. They
+            # come from templates instantiated over every value type, so one
+            # line warns once per instantiation.
+            /wd4804 # bool in an arithmetic operation, from reductions over SimpleArray<bool>
+            /wd4244 # narrowing conversion
+            /wd4267 # narrowing conversion from size_t
+            /wd4458 # a declaration hides a class member
+            /wd4702 # unreachable code, after the `if constexpr` bool branches that throw
+            /external:W0 # do not apply /W4 to a SYSTEM include such as numpy
         )
     else () # MSVC
         target_compile_options(

--- a/cpp/solvcon/buffer/SimpleArray.cpp
+++ b/cpp/solvcon/buffer/SimpleArray.cpp
@@ -463,8 +463,8 @@ DataType DataType::from<Complex<double>>()
         break;
 
 SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const DataType data_type)
-    : m_data_type(data_type)
-    , m_has_instance_ownership(true)
+    : m_has_instance_ownership(true)
+    , m_data_type(data_type)
 {
     switch (data_type)
     {
@@ -487,8 +487,8 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const DataType data_t
 }
 
 SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const std::shared_ptr<ConcreteBuffer> & buffer, const DataType data_type)
-    : m_data_type(data_type)
-    , m_has_instance_ownership(true)
+    : m_has_instance_ownership(true)
+    , m_data_type(data_type)
 {
     switch (data_type)
     {
@@ -513,8 +513,8 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const std::shared_ptr
 #undef SC_DECL_CREATE_SIMPLE_ARRAY
 
 SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const DataType data_type, size_t alignment)
-    : m_data_type(data_type)
-    , m_has_instance_ownership(true)
+    : m_has_instance_ownership(true)
+    , m_data_type(data_type)
 {
 #define SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType, ArrayType)                            \
     case DataType:                                                                                 \

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -135,7 +135,7 @@ public:
         : m_lower(array.ndim(), 0)
         , m_upper(array.ndim(), 0)
     {
-        for (size_t dim = 0; dim < array.ndim(); ++dim)
+        for (ssize_t dim = 0; dim < array.ndim(); ++dim)
         {
             m_lower[dim] = lower_bound(array, dim);
             m_upper[dim] = upper_bound(array, dim);

--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -568,7 +568,7 @@ template <typename Array>
 std::string MatmulPlan::shape_string(Array const & array)
 {
     std::string result = "(";
-    for (size_t axis = 0; axis < array.ndim(); ++axis)
+    for (ssize_t axis = 0; axis < array.ndim(); ++axis)
     {
         if (axis > 0)
         {
@@ -1183,7 +1183,7 @@ std::string SimpleArrayMatmulHelper<A, T>::shape_str(A const & arr)
     }
 
     std::string result = "(";
-    for (size_t i = 0; i < arr.ndim(); ++i)
+    for (ssize_t i = 0; i < arr.ndim(); ++i)
     {
         if (i > 0)
         {
@@ -1474,3 +1474,5 @@ A SimpleArrayMatmulHelper<A, T>::matmul_mat_mat_tiled()
 } /* end namespace detail */
 
 } /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -163,7 +163,7 @@ static pybind11::object get_typed_array(const SimpleArrayPlex & array_plex)
     case DataType:                                                                      \
     {                                                                                   \
         const auto * array = static_cast<const ArrayType *>(array_plex.instance_ptr()); \
-        return pybind11::cast(std::move(ArrayType(*array)));                            \
+        return pybind11::cast(ArrayType(*array));                                       \
     }
 
     switch (array_plex.data_type())

--- a/cpp/solvcon/inout/gmsh.hpp
+++ b/cpp/solvcon/inout/gmsh.hpp
@@ -271,7 +271,6 @@ private:
 
     uint_type msh_file_type = 0;
     uint_type msh_data_size = 0;
-    uint_type nnodes = 0;
 
     SimpleArray<int_type> m_cltpn;
 

--- a/cpp/solvcon/inout/plot3d.cpp
+++ b/cpp/solvcon/inout/plot3d.cpp
@@ -29,7 +29,7 @@ Plot3d::Plot3d(const std::string & data)
     m_blk_sizes.remake(small_vector<ssize_t>{static_cast<ssize_t>(nblocks)}, 0);
 
     // parsing xyz dimension of each block
-    for (auto i = 0; i < nblocks; ++i)
+    for (uint_type i = 0; i < nblocks; ++i)
     {
         std::getline(stream, line);
         auto tokens = tokenize(line, plot3d_block_delim);
@@ -54,11 +54,11 @@ void Plot3d::parseCoordinates(const uint_type nblocks)
     const std::regex plot3d_coord_delim(R"(-?\d+(\.\d+)?([eE][+-]?\d+)?|\b\d+\b)");
 
     // TODO: The nested for-loop needs to be enhanced
-    for (auto blk = 0; blk < nblocks; ++blk)
+    for (uint_type blk = 0; blk < nblocks; ++blk)
     {
         for (auto k = 0; k < 3; ++k)
         {
-            for (auto j = 0; j < m_blk_sizes(blk); ++j)
+            for (uint_type j = 0; j < m_blk_sizes(blk); ++j)
             {
                 if (parsing_q.empty())
                 {
@@ -96,13 +96,13 @@ void Plot3d::buildHexahedronElements(const uint_type nblocks)
 
     // TODO: The nested for-loop needs to be enhanced
     // build the hexahedron element from nodes
-    for (auto blk = 0; blk < nblocks; ++blk)
+    for (uint_type blk = 0; blk < nblocks; ++blk)
     {
-        for (auto k = 1; k < m_z_shape(blk); ++k)
+        for (uint_type k = 1; k < m_z_shape(blk); ++k)
         {
-            for (auto j = 1; j < m_y_shape(blk); ++j)
+            for (uint_type j = 1; j < m_y_shape(blk); ++j)
             {
-                for (auto i = 1; i < m_x_shape(blk); ++i)
+                for (uint_type i = 1; i < m_x_shape(blk); ++i)
                 {
                     nds_temp[0] = 8;
                     for (auto ii = 1; ii <= 8; ++ii)

--- a/cpp/solvcon/mesh/StaticMesh_boundary.cpp
+++ b/cpp/solvcon/mesh/StaticMesh_boundary.cpp
@@ -35,13 +35,13 @@ void StaticMesh::add_bc(std::shared_ptr<StaticMeshBc> const & bnd)
     for (auto const & prev : m_bcs)
     {
         auto const & pfacn = prev->facn();
-        for (size_t bfit = 0; bfit < pfacn.nbody(); ++bfit)
+        for (ssize_t bfit = 0; bfit < pfacn.nbody(); ++bfit)
         {
             claimed[pfacn(bfit, 0)] = true;
         }
     }
     auto const & bfacn = bnd->facn();
-    for (size_t bfit = 0; bfit < bfacn.nbody(); ++bfit)
+    for (ssize_t bfit = 0; bfit < bfacn.nbody(); ++bfit)
     {
         int_type const ifc = bfacn(bfit, 0);
         if (ifc < 0 || ifc >= static_cast<int_type>(nface()))
@@ -136,7 +136,7 @@ void StaticMesh::build_boundary()
     for (size_t ibnd = 0; ibnd < m_bcs.size(); ++ibnd)
     {
         auto & bfacn = m_bcs[ibnd]->facn();
-        for (size_t bfit = 0; bfit < bfacn.nbody(); ++bfit)
+        for (ssize_t bfit = 0; bfit < bfacn.nbody(); ++bfit)
         {
             /**
              * First column is the face index in block.  The second column is the face

--- a/cpp/solvcon/multidim/euler_march.cpp
+++ b/cpp/solvcon/multidim/euler_march.cpp
@@ -162,7 +162,6 @@ template <size_t NDIM>
 void calc_solt_impl(EulerCore & ec)
 {
     constexpr size_t neq = NDIM + 2;
-    auto const & msh = *ec.mesh();
     SimpleArray<double> & so0c = ec.so0c();
     SimpleArray<double> & so0t = ec.so0t();
     SimpleArray<double> & so1c = ec.so1c();

--- a/cpp/solvcon/oasis/oasis_device.cpp
+++ b/cpp/solvcon/oasis/oasis_device.cpp
@@ -140,7 +140,7 @@ std::vector<uint8_t> OasisRecordPoly::to_bytes() const
     // Please refer Point-list in OASIS draft 7.7.
     std::vector<uint8_t> point_list;
 
-    for (int i = 0; i < m_vertices.size() - 1; i++)
+    for (size_t i = 0; i + 1 < m_vertices.size(); i++)
     {
         std::pair<int, int> const curr_v = m_vertices[i];
         std::pair<int, int> const next_v = m_vertices[i + 1];

--- a/cpp/solvcon/pilot/console/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/console/RPythonConsoleDockWidget.cpp
@@ -21,7 +21,7 @@
 namespace solvcon
 {
 
-void RPythonHistoryTextEdit::mouseDoubleClickEvent(QMouseEvent * mouse_event)
+void RPythonHistoryTextEdit::mouseDoubleClickEvent(QMouseEvent *)
 {
     // TODO: currently, it will select the whole content, could change the behavior
     QTextCursor cursor = textCursor();

--- a/cpp/solvcon/pilot/visual/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/visual/RDomainWidget.cpp
@@ -539,7 +539,7 @@ void RDomainWidget::colorByCellType()
     {
         SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
         category.reserve(bndfcs.shape(0));
-        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        for (ssize_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
         {
             category.push_back(mh.cltpn(mh.fcicl(bndfcs(ibnd, 0))));
         }
@@ -567,7 +567,7 @@ void RDomainWidget::colorByCellGroup()
     {
         SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
         category.reserve(bndfcs.shape(0));
-        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        for (ssize_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
         {
             category.push_back(mh.clgrp(mh.fcicl(bndfcs(ibnd, 0))));
         }
@@ -597,7 +597,7 @@ void RDomainWidget::colorByBoundary()
         // The 3D surface is the boundary shell, one primitive per boundary
         // face, so the boundary set is the face's own set.
         category.reserve(bndfcs.shape(0));
-        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        for (ssize_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
         {
             category.push_back(bndfcs(ibnd, 1));
         }
@@ -607,12 +607,12 @@ void RDomainWidget::colorByBoundary()
         // The 2D surface is the cells, so color each cell by a boundary set it
         // owns; interior cells share one extra "none" category past the top set.
         int32_t max_bc = -1;
-        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        for (ssize_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
         {
             max_bc = std::max(max_bc, bndfcs(ibnd, 1));
         }
         category.assign(mh.ncell(), max_bc + 1);
-        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        for (ssize_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
         {
             int32_t const icl = mh.fcicl(bndfcs(ibnd, 0));
             if (icl >= 0 && static_cast<size_t>(icl) < category.size())
@@ -651,7 +651,7 @@ void RDomainWidget::colorByQuality(std::string const & metric)
     {
         SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
         primitive.reserve(bndfcs.shape(0));
-        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        for (ssize_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
         {
             primitive.push_back(cellval[mh.fcicl(bndfcs(ibnd, 0))]);
         }
@@ -1046,7 +1046,7 @@ RDomainWidget::PickResult RDomainWidget::pickCell(int x, int y)
     {
         SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
         float best = std::numeric_limits<float>::max();
-        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        for (ssize_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
         {
             int32_t const ifc = bndfcs(ibnd, 0);
             int32_t const nnd = mh.fcnds(ifc, 0);
@@ -1193,7 +1193,7 @@ RDomainWidget::PickResult RDomainWidget::pickFace(int x, int y)
     SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
     float best = std::numeric_limits<float>::max();
     int32_t hit_face = -1;
-    for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+    for (ssize_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
     {
         int32_t const ifc = bndfcs(ibnd, 0);
         int32_t const nnd = mh.fcnds(ifc, 0);
@@ -1270,7 +1270,7 @@ void RDomainWidget::setSelection(
         if (3 == ndim)
         {
             SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
-            for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+            for (ssize_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
             {
                 int32_t const ifc = bndfcs(ibnd, 0);
                 if (mh.fcicl(ifc) == id)
@@ -1425,7 +1425,7 @@ int RDomainWidget::addClip(QVector3D const & origin, QVector3D const & normal)
     if (3 == ndim)
     {
         SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
-        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        for (ssize_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
         {
             int32_t const ifc = bndfcs(ibnd, 0);
             QVector3D const centroid(

--- a/cpp/solvcon/pilot/visual/RFeatureEdges.cpp
+++ b/cpp/solvcon/pilot/visual/RFeatureEdges.cpp
@@ -31,7 +31,7 @@ void RFeatureEdges::build(StaticMesh const & mh)
     // Every boundary face, across all sets, contributes its rim edges.
     SimpleCollector<uint32_t> ends;
     SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
-    for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+    for (ssize_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
     {
         append_face_edges(mh, bndfcs(ibnd, 0), ends);
     }

--- a/cpp/solvcon/pilot/visual/RMeshFrame.cpp
+++ b/cpp/solvcon/pilot/visual/RMeshFrame.cpp
@@ -89,7 +89,7 @@ void RMeshFrame::buildSurface(StaticMesh const & mh)
         // The visible surface of a 3D domain is its boundary shell; each
         // boundary face carries an outward normal from the metric.
         SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
-        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        for (ssize_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
         {
             int32_t const ifc = bndfcs(ibnd, 0);
             int32_t const nnd = mh.fcnds(ifc, 0);

--- a/cpp/solvcon/profiling/SerializableProfiler.hpp
+++ b/cpp/solvcon/profiling/SerializableProfiler.hpp
@@ -140,8 +140,6 @@ public:
     // It returns the json format of the CallProfiler.
     static std::string serialize(const CallProfiler & profiler)
     {
-        auto * radix_tree_curent_node = profiler.radix_tree().get_current_node();
-        auto * radix_tree_root = profiler.radix_tree().get_root();
         SerializableRadixTree const serializable_radix_tree(profiler.radix_tree());
         return serializable_radix_tree.to_json();
     }

--- a/cpp/solvcon/serialization/SerializableItem.cpp
+++ b/cpp/solvcon/serialization/SerializableItem.cpp
@@ -277,9 +277,9 @@ JsonArray JsonNode::parse_array(const std::string & json)
                 else
                 {
                     bool is_number = true;
-                    for (const char c : value_expression)
+                    for (const char digit : value_expression)
                     {
-                        if (!is_json_number(c))
+                        if (!is_json_number(digit))
                         {
                             is_number = false;
                             break;
@@ -516,9 +516,9 @@ JsonMap JsonNode::parse_object(const std::string & json)
                 else
                 {
                     bool is_number = true;
-                    for (const char c : value_expression)
+                    for (const char digit : value_expression)
                     {
-                        if (!is_json_number(c))
+                        if (!is_json_number(digit))
                         {
                             is_number = false;
                             break;

--- a/cpp/solvcon/serialization/SerializableItem.hpp
+++ b/cpp/solvcon/serialization/SerializableItem.hpp
@@ -100,11 +100,11 @@ private:
     {
         if (type == JsonType::Object)
         {
-            value = std::move(parse_object(expression));
+            value = parse_object(expression);
         }
         else if (type == JsonType::Array)
         {
-            value = std::move(parse_array(expression));
+            value = parse_array(expression);
         }
         else
         {

--- a/cpp/solvcon/transform/fourier.cpp
+++ b/cpp/solvcon/transform/fourier.cpp
@@ -11,9 +11,9 @@ size_t bit_reverse(size_t n, const size_t bits)
     size_t reversed = 0;
     for (size_t i = 0; i < bits; i++)
     {
-        if (n & (1 << i))
+        if (n & (size_t{1} << i))
         {
-            reversed |= 1 << (bits - 1 - i);
+            reversed |= size_t{1} << (bits - 1 - i);
         }
     }
     return reversed;
@@ -32,3 +32,5 @@ size_t next_power_of_two(size_t n)
 } /* end namespace detail */
 
 } /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -774,7 +774,7 @@ int32_t World<T>::register_shape(ShapeType type,
                                  size_t curve_count)
 {
     auto shape_id = static_cast<int32_t>(m_shape_registry.size());
-    m_shape_registry.push_back(ShapeRecord{type, segment_offset, segment_count, curve_offset, curve_count}); // NOLINT(modernize-use-designated-initializers)
+    m_shape_registry.push_back(ShapeRecord{type, segment_offset, segment_count, curve_offset, curve_count, {}, {}}); // NOLINT(modernize-use-designated-initializers)
     ++m_nshape;
     bbox_type const bb = compute_shape_bbox(m_shape_registry[shape_id]);
 

--- a/cpp/solvcon/universe/bezier.hpp
+++ b/cpp/solvcon/universe/bezier.hpp
@@ -61,7 +61,7 @@ public:
              point_type const & p1,
              point_type const & p2,
              point_type const & p3)
-        : m_data{p0.x(), p1.x(), p2.x(), p3.x(), p0.y(), p1.y(), p2.y(), p3.y(), p0.z(), p1.z(), p2.z(), p3.z()}
+        : m_data{{p0.x(), p1.x(), p2.x(), p3.x(), p0.y(), p1.y(), p2.y(), p3.y(), p0.z(), p1.z(), p2.z(), p3.z()}}
     {
     }
 

--- a/cpp/solvcon/universe/coord.hpp
+++ b/cpp/solvcon/universe/coord.hpp
@@ -769,7 +769,7 @@ public:
     using value_type = typename point_type::value_type;
 
     Segment3d(point_type const & p0, point_type const & p1)
-        : m_data{p0.x(), p1.x(), p0.y(), p1.y(), p0.z(), p1.z()}
+        : m_data{{p0.x(), p1.x(), p0.y(), p1.y(), p0.z(), p1.z()}}
     {
     }
 

--- a/cpp/solvcon/universe/polygon.hpp
+++ b/cpp/solvcon/universe/polygon.hpp
@@ -83,7 +83,7 @@ public:
     using value_type = typename point_type::value_type;
 
     Trapezoid3d(point_type const & p0, point_type const & p1, point_type const & p2, point_type const & p3)
-        : m_data{p0.x(), p1.x(), p2.x(), p3.x(), p0.y(), p1.y(), p2.y(), p3.y(), p0.z(), p1.z(), p2.z(), p3.z()}
+        : m_data{{p0.x(), p1.x(), p2.x(), p3.x(), p0.y(), p1.y(), p2.y(), p3.y(), p0.z(), p1.z(), p2.z(), p3.z()}}
     {
     }
 
@@ -1324,7 +1324,7 @@ public:
     using value_type = typename point_type::value_type;
 
     Triangle3d(point_type const & p0, point_type const & p1, point_type const & p2)
-        : m_data{p0.x(), p1.x(), p2.x(), p0.y(), p1.y(), p2.y(), p0.z(), p1.z(), p2.z()}
+        : m_data{{p0.x(), p1.x(), p2.x(), p0.y(), p1.y(), p2.y(), p0.z(), p1.z(), p2.z()}}
     {
     }
 


### PR DESCRIPTION
Related to #1310.

`COMMON_COMPILER_OPTIONS` was set after `add_subdirectory(cpp/solvcon)`. `add_subdirectory()` copies the calling scope's variables into the subdirectory as it is called, so a variable set afterwards is not visible there at all: the two expansions in `cpp/solvcon/CMakeLists.txt` produced nothing, and the core libraries were built with no warning flags. No `-Wall -Wextra -Werror` on Clang and GCC, and no `/W4 /WX` on MSVC. Only the literal `-Wno-*` suppressions and `/bigobj` written next to the expansion reached the core. The first commit moves the block above the core so both expansions carry the flags.

Turning the flags on exposed 30 sites across 19 files on Clang and GCC. The second commit fixes each one rather than suppressing it. Most are `-Wsign-compare` from a loop counter typed `size_t` against `ndim()`, `nbody()`, or `shape(0)`, which all return `ssize_t`, and against the `uint_type` shapes in the Plot3d reader. The rest are `-Wpessimizing-move` on a returned temporary, `-Wmissing-braces` on the union aggregate initializers in `bezier.hpp`, `coord.hpp`, and `polygon.hpp`, `-Wreorder-ctor` in the `SimpleArrayPlex` constructors, `-Wmissing-field-initializers` on `ShapeRecord`, and a few dead variables, one dead private field, and one unused parameter.

MSVC reported a separate and larger set that reproduces on no other compiler, and it came in layers, because MSVC stops a translation unit at its first error. Three of those turned out to be worth fixing rather than silencing:

- `bit_reverse()` in `transform/fourier.cpp` shifted an `int` literal (`1 << i`) while taking and returning `size_t`, so the shift was undefined for more than 32 bits (C4334). It now shifts `size_t{1}`.
- Two loops in `serialization/SerializableItem.cpp` declared a `c` that shadowed the enclosing `const char c = json[index]` (C4456). The inner variable is now `digit`.
- `include_directories()` added the numpy headers as a normal include, so `/W4 /WX` applied to numpy's own code (C4127). They are a `SYSTEM` include now, which also makes them `-isystem` on Clang and GCC, and the core passes `/external:W0` so MSVC honors it.

What remains is C4804, C4244, C4267, C4458, and C4702, which come from template bodies instantiated over every value type, including `SimpleArray<bool>`. Those are suppressed in the core for now and #1324 tracks fixing the code and removing them one code at a time.

Two changes go past the diagnostic that reported them. `OasisRecordPoly::to_bytes()` compared against `m_vertices.size() - 1`, which wraps on an empty vector, so the guard is now `i + 1 < m_vertices.size()`. `Trapezoid3d` has the same brace defect as the three that warned but is not instantiated in this build, and is fixed alongside them.

The commits are split so the warning fixes are reviewable on their own, but only the pair builds: the first commit alone turns the flags on before the sources are clean.

This restores the flags but keeps the shape of the original trap, since an empty expansion is still silent. #1325 proposes carrying the flags on an `INTERFACE` target instead, which turns the same ordering mistake into a configure-time error, and covers the `gtests` target, which never referenced the variable and still compiles roughly thirty core sources with no warning flags under a different preprocessor configuration.

Reviewing this branch also turned up three defects that are not warnings and that these flags do not catch, including a Python-reachable segfault. They are unrelated to the flag work and are filed separately as #1326.

Verified locally on Clang 20, arm64 macOS: `make` builds clean with `-Werror` active on the core, `make gtest` passes 242 tests, `make pytest` passes 2107 tests, and `make lint` is clean.
