### PR TITLE
Fix plot3d multiblock issues

### DIFF
--- a/cpp/solvcon/inout/plot3d.cpp
+++ b/cpp/solvcon/inout/plot3d.cpp
@@ -27,6 +27,7 @@ Plot3d::Plot3d(const std::string & data)
     m_y_shape.remake(small_vector<ssize_t>{static_cast<ssize_t>(nblocks)}, 0);
     m_z_shape.remake(small_vector<ssize_t>{static_cast<ssize_t>(nblocks)}, 0);
     m_blk_sizes.remake(small_vector<ssize_t>{static_cast<ssize_t>(nblocks)}, 0);
+    m_blk_offsets.remake(small_vector<ssize_t>{static_cast<ssize_t>(nblocks)}, 0);
 
     // parsing xyz dimension of each block
     for (auto i = 0; i < nblocks; ++i)
@@ -37,6 +38,7 @@ Plot3d::Plot3d(const std::string & data)
         m_y_shape(i) = std::stoul(tokens[1]);
         m_z_shape(i) = std::stoul(tokens[2]);
         m_blk_sizes(i) = m_x_shape(i) * m_y_shape(i) * m_z_shape(i);
+        m_blk_offsets(i) = static_cast<uint_type>(total_blk_size);
         total_blk_size += m_blk_sizes(i);
     }
 
@@ -48,7 +50,6 @@ Plot3d::Plot3d(const std::string & data)
 
 void Plot3d::parseCoordinates(const uint_type nblocks)
 {
-    uint_type base_idx = 0;
     std::string line;
     std::queue<real_type> parsing_q;
     const std::regex plot3d_coord_delim(R"(-?\d+(\.\d+)?([eE][+-]?\d+)?|\b\d+\b)");
@@ -56,6 +57,7 @@ void Plot3d::parseCoordinates(const uint_type nblocks)
     // TODO: The nested for-loop needs to be enhanced
     for (auto blk = 0; blk < nblocks; ++blk)
     {
+        const uint_type base_idx = m_blk_offsets(blk);
         for (auto k = 0; k < 3; ++k)
         {
             for (auto j = 0; j < m_blk_sizes(blk); ++j)
@@ -72,7 +74,6 @@ void Plot3d::parseCoordinates(const uint_type nblocks)
                 parsing_q.pop();
             }
         }
-        base_idx += m_blk_sizes(blk);
     }
 }
 

--- a/cpp/solvcon/inout/plot3d.hpp
+++ b/cpp/solvcon/inout/plot3d.hpp
@@ -63,7 +63,7 @@ public:
 private:
     inline uint_type coordinate_to_node_id(uint_type blk, uint_type x, uint_type y, uint_type z)
     {
-        return blk > 0 ? m_blk_sizes(blk - 1) : 0 + x + y * m_x_shape(blk) + z * m_x_shape(blk) * m_y_shape(blk);
+        return m_blk_offsets(blk) + x + y * m_x_shape(blk) + z * m_x_shape(blk) * m_y_shape(blk);
     }
 
     void parseCoordinates(uint_type nblocks);
@@ -76,6 +76,8 @@ private:
     SimpleArray<uint_type> m_y_shape;
     SimpleArray<uint_type> m_z_shape;
     SimpleArray<uint_type> m_blk_sizes;
+    /// Exclusive prefix sum of m_blk_sizes: the node-id base of each block.
+    SimpleArray<uint_type> m_blk_offsets;
 
     std::unordered_map<uint_type, small_vector<uint_type>> m_elems;
 }; /* end class Plot3d */

--- a/tests/test_plot3d.py
+++ b/tests/test_plot3d.py
@@ -41,4 +41,54 @@ class Plot3dTC(unittest.TestCase):
         self.assertEqual(blk.clnds.ndarray[6:, :].tolist(),
                          [[8, 0, 2, 6, 4, 1, 3, 7, 5]])
 
+    def test_multi_block_cells_stay_in_their_block(self):
+        # Three disjoint blocks along x; the first has a different shape
+        # so a per-block size cannot be treated as a cumulative offset.
+        # Per block the file lists x, then y, then z of every node, with
+        # the x grid index running fastest; the node at grid (i, j, k)
+        # sits at that coordinate plus the block's x offset (0, 10, 20).
+        data = """3
+3 2 2
+2 2 2
+2 2 2
+0 1 2 0 1 2 0 1 2 0 1 2
+0 0 0 1 1 1 0 0 0 1 1 1
+0 0 0 0 0 0 1 1 1 1 1 1
+10 11 10 11 10 11 10 11
+0 0 1 1 0 0 1 1
+0 0 0 0 1 1 1 1
+20 21 20 21 20 21 20 21
+0 0 1 1 0 0 1 1
+0 0 0 0 1 1 1 1
+"""
+        blk = solvcon.core.Plot3d(data.encode('utf-8')).to_block()
+
+        self.assertEqual(blk.nnode, 28)
+        self.assertEqual(blk.ncell, 4)
+        # The body rows sit after the ghost rows, as in the test above.
+        ndcrd = blk.ndcrd.ndarray[-28:, :]
+        clnds = blk.clnds.ndarray[-4:, :]
+
+        np.testing.assert_almost_equal(
+            ndcrd.tolist(),
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0],
+             [0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [2.0, 1.0, 0.0],
+             [0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [2.0, 0.0, 1.0],
+             [0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [2.0, 1.0, 1.0],
+             [10.0, 0.0, 0.0], [11.0, 0.0, 0.0],
+             [10.0, 1.0, 0.0], [11.0, 1.0, 0.0],
+             [10.0, 0.0, 1.0], [11.0, 0.0, 1.0],
+             [10.0, 1.0, 1.0], [11.0, 1.0, 1.0],
+             [20.0, 0.0, 0.0], [21.0, 0.0, 0.0],
+             [20.0, 1.0, 0.0], [21.0, 1.0, 0.0],
+             [20.0, 0.0, 1.0], [21.0, 0.0, 1.0],
+             [20.0, 1.0, 1.0], [21.0, 1.0, 1.0]])
+        # Two cells in the 3x2x2 block, then one per 2x2x2 block, whose
+        # ids start at the cumulative node counts 12 and 20.
+        self.assertEqual(clnds.tolist(),
+                         [[8, 0, 3, 9, 6, 1, 4, 10, 7],
+                          [8, 1, 4, 10, 7, 2, 5, 11, 8],
+                          [8, 12, 14, 18, 16, 13, 15, 19, 17],
+                          [8, 20, 22, 26, 24, 21, 23, 27, 25]])
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`coordinate_to_node_id` parsed as `blk > 0 ? m_blk_sizes(blk - 1) : (0 + ...)` because the conditional operator precedence looser than `+`, so every cell in every block after the first collapsed its eight node ids into one constant and the mesh silently degenerated. Parenthesizing alone would still be wrong from the third block on, because `m_blk_sizes` holds per-block sizes, so the helper now reads the base from `m_blk_offsets`, the exclusive prefix sum the constructor accumulates.  A test over three literal Plot3d blocks of unequal shapes pins every node coordinate and every cell's connectivity; on the unfixed reader it fails with the eight node ids of a later block's cell collapsed into one.

Related to #1326 plot3d issue.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
