### PR TITLE
Order `sort()` and `argsort()` the way numpy does

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -25,8 +25,8 @@
 
 #include <algorithm>
 #include <array>
-#include <concepts>
 #include <cmath>
+#include <concepts>
 #include <format>
 #include <functional>
 #include <limits>
@@ -1323,6 +1323,68 @@ void SimpleArrayMixinCalculators<A, T>::find_two_bins(const uint32_t * freq, siz
     }
 }
 
+/**
+ * Order one value the way numpy sorts and searches it: a NaN goes after every
+ * number and counts equal to another NaN, which the built-in comparison cannot
+ * express because it answers false in both directions for a NaN. A complex
+ * value carrying a NaN in either component goes past all the others as one
+ * group, whatever its other component holds, and orders within that group
+ * lexicographically like any other pair.
+ */
+template <typename V>
+bool nan_aware_less(V const & lhs, V const & rhs)
+{
+    if constexpr (is_complex_v<V>)
+    {
+        bool const lhs_nan = std::isnan(lhs.real()) || std::isnan(lhs.imag());
+        bool const rhs_nan = std::isnan(rhs.real()) || std::isnan(rhs.imag());
+        if (lhs_nan != rhs_nan)
+        {
+            return rhs_nan;
+        }
+        if (!lhs_nan)
+        {
+            return lhs < rhs;
+        }
+
+        if (nan_aware_less(lhs.real(), rhs.real()))
+        {
+            return true;
+        }
+        if (nan_aware_less(rhs.real(), lhs.real()))
+        {
+            return false;
+        }
+        return nan_aware_less(lhs.imag(), rhs.imag());
+    }
+    else if constexpr (std::is_floating_point_v<V>)
+    {
+        if (std::isnan(rhs))
+        {
+            return !std::isnan(lhs);
+        }
+        if (std::isnan(lhs))
+        {
+            return false;
+        }
+        return lhs < rhs;
+    }
+    else
+    {
+        return lhs < rhs;
+    }
+}
+
+struct NanAwareLess
+{
+    template <typename V>
+    bool operator()(V const & lhs, V const & rhs) const { return nan_aware_less(lhs, rhs); }
+}; /* end struct NanAwareLess */
+
+// TODO: every member here walks begin() to end() and so reads the buffer in
+// storage order, ignoring stride(). A strided one-dimensional view is accepted
+// and then sorted as the wrong span. Reject a non-contiguous receiver the way
+// argmin() already does, in a change that covers the whole mixin at once.
 template <typename A, typename T>
 class SimpleArrayMixinSort
 {
@@ -1342,20 +1404,50 @@ public:
     template <IntegralType I>
     A take_along_axis_simd(SimpleArray<I> const & indices);
 
+private:
+
+    void validate_1d(char const * op, char const * what = "array") const;
+
 }; /* end class SimpleArrayMixinSort */
+
+template <typename A, typename T>
+void SimpleArrayMixinSort<A, T>::validate_1d(char const * op, char const * what) const
+{
+    auto const * athis = static_cast<A const *>(this);
+    if (athis->ndim() != 1)
+    {
+        throw std::runtime_error(
+            std::format("SimpleArray::{}(): "
+                        "currently only support 1D array but the {} is {} dimension",
+                        op,
+                        what,
+                        athis->ndim()));
+    }
+}
 
 template <typename A, typename T>
 void SimpleArrayMixinSort<A, T>::sort()
 {
+    validate_1d("sort");
     auto athis = static_cast<A *>(this);
-    if (athis->ndim() != 1)
-    {
-        throw std::runtime_error(
-            std::format(
-                "SimpleArray::sort(): currently only support 1D array but the array is {} dimension", athis->ndim()));
-    }
 
-    std::sort(athis->begin(), athis->end());
+    if constexpr (is_complex_v<value_type>)
+    {
+        // Complex numbers are sorted lexicographically by real and then imaginary parts.
+        std::sort(athis->begin(), athis->end(), NanAwareLess{});
+    }
+    else if constexpr (std::is_floating_point_v<value_type>)
+    {
+        // Partition the array into two parts: non-NaN values and NaN values.
+        auto const mid = std::partition(athis->begin(), athis->end(), [](value_type const & v)
+                                        { return !std::isnan(v); });
+        std::sort(athis->begin(), mid);
+    }
+    else
+    {
+        // For integral types, we can use the default sort.
+        std::sort(athis->begin(), athis->end());
+    }
 }
 
 template <typename T, IntegralType I>
@@ -2913,14 +3005,8 @@ void SimpleArray<T>::copy_logical_into(SimpleArray & out) const
 template <typename A, typename T>
 SimpleArray<uint64_t> detail::SimpleArrayMixinSort<A, T>::argsort()
 {
+    validate_1d("argsort");
     auto athis = static_cast<A *>(this);
-    if (athis->ndim() != 1)
-    {
-        throw std::runtime_error(
-            std::format("SimpleArray::argsort(): "
-                        "currently only support 1D array but the array is {} dimension",
-                        athis->ndim()));
-    }
 
     SimpleArray<uint64_t> ret(athis->shape());
 
@@ -2930,10 +3016,22 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSort<A, T>::argsort()
                       { v = cnt++; });
     }
 
-    value_type const * buf = athis->body();
+    // Index from begin(), the range that sort() and take_along_axis() work on.
+    // body() skips the ghost part while the indices in ret do not, so a ghosted
+    // array would run past the buffer.
+    value_type const * buf = athis->begin();
+    // Break ties by position to keep the order of equal values deterministic.
     auto cmp = [buf](uint64_t a, uint64_t b)
     {
-        return buf[a] < buf[b];
+        if (nan_aware_less(buf[a], buf[b]))
+        {
+            return true;
+        }
+        if (nan_aware_less(buf[b], buf[a]))
+        {
+            return false;
+        }
+        return a < b;
     };
     std::sort(ret.begin(), ret.end(), cmp);
     return ret;
@@ -2943,14 +3041,8 @@ template <typename A, typename T>
 template <IntegralType I>
 A detail::SimpleArrayMixinSort<A, T>::take_along_axis(SimpleArray<I> const & indices)
 {
+    validate_1d("take_along_axis");
     auto athis = static_cast<A *>(this);
-    if (athis->ndim() != 1)
-    {
-        throw std::runtime_error(
-            std::format("SimpleArray::take_along_axis(): "
-                        "currently only support 1D array but the array is {} dimension",
-                        athis->ndim()));
-    }
 
     ssize_t const max_idx = athis->shape()[0];
     I const * src = indices.begin();
@@ -3446,14 +3538,8 @@ template <typename A, typename T>
 template <IntegralType I>
 A detail::SimpleArrayMixinSort<A, T>::take_along_axis_simd(SimpleArray<I> const & indices)
 {
+    validate_1d("take_along_axis_simd");
     auto athis = static_cast<A *>(this);
-    if (athis->ndim() != 1)
-    {
-        const auto err = std::format("SimpleArray::take_along_axis(): "
-                                     "currently only support 1D array but the array is {} dimension",
-                                     athis->ndim());
-        throw std::runtime_error(err);
-    }
 
     if (indices.size() == 0)
     {

--- a/cpp/solvcon/math/Complex.hpp
+++ b/cpp/solvcon/math/Complex.hpp
@@ -143,9 +143,9 @@ bool operator<(const ComplexImpl<T> & lhs, const ComplexImpl<T> & rhs)
 {
     if (lhs.real_v == rhs.real_v)
     {
-        return lhs.imag_v <= rhs.imag_v;
+        return lhs.imag_v < rhs.imag_v;
     }
-    return lhs.real_v <= rhs.real_v;
+    return lhs.real_v < rhs.real_v;
 }
 
 template <typename T>

--- a/doc/source/compute/buffer/reduce.md
+++ b/doc/source/compute/buffer/reduce.md
@@ -164,6 +164,25 @@ sarr.sort()
 assert sarr.ndarray.tolist() == [1.0, 2.0, 3.0]
 ```
 
+NaN sorts last, as numpy sorts it: after every number, and equal to another
+NaN. `sort()` and `argsort()` share this order; the reductions and
+`argmin`/`argmax` do not, and still skip a NaN where numpy propagates it.
+
+A complex value compares by its real part, and by its imaginary part only when
+the real parts are equal. `2-1j` therefore sorts before `2+1j`, and both sort
+after every value with a smaller real part:
+
+```python
+narr = np.array([2 + 1j, 1 + 5j, 2 - 1j, 0 + 0j], dtype='complex128')
+sarr = solvcon.SimpleArrayComplex128(array=narr)
+sarr.sort()
+assert sarr.ndarray.tolist() == [0j, 1 + 5j, 2 - 1j, 2 + 1j]
+```
+
+A complex value carrying a NaN in either component sorts after all of them as
+one group, whatever its other component holds, so `nan+0j` and `0+nanj` both
+land at the end rather than where their finite component would put them.
+
 ### The `argsort` Method
 
 `argsort()` returns the indices that sort the receiver, under the same
@@ -177,6 +196,14 @@ args = sarr.argsort()
 assert type(args) is solvcon.SimpleArrayUint64
 assert args.ndarray.tolist() == [1, 2, 0]
 ```
+
+Equal values keep the order they were already in, matching
+`numpy.argsort(kind='stable')`.
+
+On an array carrying {ref}`a ghost region <ghost-region>` the indices count
+from the first ghost element, where a subscript counts from the first body
+element, so pass them to `take_along_axis()` rather than subscripting with
+them.
 
 ### The `take_along_axis` Method
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1430,6 +1430,85 @@ class SimpleArrayBasicTC(unittest.TestCase):
         _check(test_data[3])
         _check(test_data[4], True)
 
+    def test_argsort_breaks_ties_by_position(self):
+        # Long enough to reach the unstable branch of std::sort; a handful of
+        # elements would be insertion-sorted and tie-break by accident.
+        data = np.array([i % 5 for i in range(300)], dtype='int32')
+        sarr = solvcon.SimpleArrayInt32(array=data)
+
+        args = sarr.argsort()
+        np.testing.assert_array_equal(args.ndarray,
+                                      np.argsort(data, kind='stable'))
+
+    def test_argsort_with_ghost(self):
+        data = np.array([40, 30, 20, 10], dtype='int32')
+        sarr = solvcon.SimpleArrayInt32(array=data)
+        sarr.nghost = 1
+
+        # The indices span the whole buffer, as they do for `sort()` and
+        # `take_along_axis()`. A basis that skips the ghost part instead reads
+        # past the end of the buffer and returns a different order every run.
+        np.testing.assert_array_equal(sarr.argsort().ndarray, [3, 2, 1, 0])
+
+    def test_sort_nan_goes_last(self):
+        # The built-in `<` answers false in both directions for a NaN, which
+        # is not a strict ordering and leaves std::sort undefined. sort() and
+        # argsort() order through the NaN-aware comparison instead.
+        nan = float('nan')
+        data = np.array([3.0, nan, 1.0, nan, 2.0], dtype='float64')
+
+        sarr = solvcon.SimpleArrayFloat64(array=data.copy())
+        sarr.sort()
+        np.testing.assert_array_equal(sarr.ndarray, np.sort(data))
+
+        sarr = solvcon.SimpleArrayFloat64(array=data.copy())
+        np.testing.assert_array_equal(sarr.argsort().ndarray,
+                                      np.argsort(data, kind='stable'))
+
+    def test_sort_complex_nan_goes_last(self):
+        nan = float('nan')
+        data = np.array([2 + 1j, complex(nan, 0), 1 + 5j,
+                         complex(0, nan), 0 + 0j], dtype='complex128')
+
+        sarr = solvcon.SimpleArrayComplex128(array=data.copy())
+        sarr.sort()
+        np.testing.assert_array_equal(sarr.ndarray, np.sort(data))
+
+        sarr = solvcon.SimpleArrayComplex128(array=data.copy())
+        np.testing.assert_array_equal(sarr.argsort().ndarray,
+                                      np.argsort(data, kind='stable'))
+
+    def test_sort_complex_is_lexicographic(self):
+        # sort() and argsort() both rest on ordering complex values, and
+        # neither is defined unless that order is strict.
+        data = np.array([2 + 1j, 1 + 5j, 2 - 1j, 1 + 5j, 0 + 0j],
+                        dtype='complex128')
+
+        sarr = solvcon.SimpleArrayComplex128(array=data.copy())
+        sarr.sort()
+        np.testing.assert_array_equal(sarr.ndarray, np.sort(data))
+
+        sarr = solvcon.SimpleArrayComplex128(array=data.copy())
+        np.testing.assert_array_equal(sarr.argsort().ndarray,
+                                      np.argsort(data, kind='stable'))
+
+    def test_complex_comparison_is_strict(self):
+        # `<` and `>` are bound on the complex scalar, so making the ordering
+        # strict changes what Python sees: a value used to compare less than
+        # itself. Ties in the reductions resolve to the first occurrence as a
+        # result, which is what numpy does.
+        value = solvcon.complex128(1.0, 2.0)
+        same = solvcon.complex128(1.0, 2.0)
+
+        self.assertFalse(value < same)
+        self.assertFalse(value > same)
+        self.assertTrue(value == same)
+
+        data = np.array([1 + 1j, 3 + 0j, 1 + 1j], dtype='complex128')
+        sarr = solvcon.SimpleArrayComplex128(array=data)
+        self.assertEqual(sarr.argmin(), np.argmin(data))
+        self.assertEqual(sarr.argmax(), np.argmax(data))
+
     def test_take_along_axis(self):
         data = [1, 5, 10, 2, 6, 9, 7, 8, 4, 3]
         narr = np.array(data, dtype='int32')

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -143,11 +143,25 @@ class ComplexTB(sc.testing.TestBase):
         # details:
         # 1. https://github.com/numpy/numpy/issues/12943
         # 2. https://stackoverflow.com/questions/52481376
-        def compare():
-            if self.real1 == self.real2:
-                return self.imag1 <= self.imag2
-            return self.real1 <= self.real2
-        self.assertEqual(cplx1 < cplx2, compare())
+        self.assertTrue(cplx1 < cplx2)
+        self.assertFalse(cplx2 < cplx1)
+        self.assertTrue(cplx2 > cplx1)
+        self.assertFalse(cplx1 > cplx2)
+
+        # The imaginary part decides only when the real parts are equal.
+        higher = self.sc_complex(self.real1, self.imag1 + 1)
+        self.assertTrue(cplx1 < higher)
+        self.assertFalse(higher < cplx1)
+
+        # Both relations are strict, so a value is neither less nor greater
+        # than an equal one. Spelling the expectation out rather than
+        # recomputing it here is what catches a `<=` written in place of `<`:
+        # the operands above never share a real part, so a mirrored comparison
+        # would agree with either relation.
+        same = self.sc_complex(self.real1, self.imag1)
+        self.assertFalse(cplx1 < same)
+        self.assertFalse(cplx1 > same)
+        self.assertTrue(cplx1 == same)
 
     def test_norm(self):
         cplx = self.sc_complex(self.real1, self.imag1)


### PR DESCRIPTION
`sort()` and `argsort()` ordered through the built-in `<`, which is not a strict weak ordering once a NaN is present, so `std::sort()` was undefined over such an array. It showed: `sort()` of `[3, nan, 1, nan, 2]` answered `[1, nan, nan, 2, 3]` and `argsort()` answered the identity, where numpy answers `[1, 2, 3, nan, nan]` and `[2, 4, 0, 1, 3]`.

`nan_aware_less()` puts a NaN after every number and holds it equal to another NaN, which is numpy's rule and the one `<` cannot express because it answers false in both directions. A complex value carrying a NaN in either component goes past all the others as one group, ordered lexicographically within it.

`ComplexImpl::operator<()` answered true for equal values, which is the `<=` relation rather than the `<` that the lexicographic ordering documented above it calls for. A comparison that holds `a < a` is not a strict weak ordering either, so `std::sort()` was undefined over repeated complex values. The operator becomes strict only where no NaN is present, which is why the ordering algorithms use `nan_aware_less()` rather than these operators.

Two Python-visible changes follow from that operator, both tested here. `<` and `>` are bound on the complex scalar, so `complex128(1, 2) < complex128(1, 2)` now answers false where it answered true. Complex `argmin()` and `argmax()` resolve a tie to the first occurrence rather than the last, which is what numpy does.

`argsort()` now breaks ties by position, so equal values keep a deterministic order instead of the arbitrary one `std::sort()` left. While adding it I found that `argsort()` indexed from `body()` while numbering the whole array, so an array with ghost read past the end of its buffer and returned a different order on every run. It now indexes from `begin()`, the range that `sort()` and `take_along_axis()` already work on, and a test pins the order for a ghosted array.

The repeated one-dimension check in the sort mixin moves into a `validate_1d()` helper, which also fixes `take_along_axis_simd()` reporting the wrong function name in its error message.

## The NaN order is free on the real types

Apple M-series (arm64), macOS, Apple clang `-O3`, libc++. Figures come from a standalone microbenchmark that reproduces the code path in isolation; best of N runs, variants interleaved.

Passing any comparator to `std::sort()` costs 2.5x to 3.1x on every dtype. libc++ gates its branchless sorting-network path on `__desugars_to_v<__less_tag, _Compare>`, which only `std::less` and the no-comparator form satisfy; a lambda never does, however trivially it inlines. Partitioning NaN to the tail and sorting the rest comparator-free keeps that path, and costs nothing because every NaN is equal to every other, so the tail needs no ordering.

| 5e6 elements, shuffled | `int32` | `float64` |
| --- | --- | --- |
| no comparator (before this branch) | 98.6 ms | 99.8 ms |
| NaN-aware comparator passed to `std::sort` | 244.5 ms | 305.8 ms |
| partition NaN to tail, then comparator-free sort (this branch) | n/a | 101.0 ms |

Through the binding on 5e6 elements this branch measures 97 ms for `int32` and 106 ms for `float64`. This is a libc++ property; libstdc++ has no equivalent specialization, so the gap on a Linux build is expected to be smaller.

## Why `argsort()` does not use `std::stable_sort`

The positional tie-break calls the comparator up to twice per comparison where `std::stable_sort` would call it once, which argues for the latter. Measured across six data patterns it goes the other way: `std::sort` has adaptive paths for already-sorted and reversed input that `stable_sort` does not, and `stable_sort` still pays its merge. Both forms produced identical permutations in all 36 configurations tested, so this is purely about cost.

| n = 2e7 | tie-break `int32` | `stable_sort` `int32` | tie-break `float64` | `stable_sort` `float64` |
| --- | --- | --- | --- | --- |
| already sorted | **16.7 ms** | 303.2 ms | **22.8 ms** | 142.0 ms |
| reversed | **23.9 ms** | 598.6 ms | **30.2 ms** | 671.4 ms |
| all equal | **17.6 ms** | 141.6 ms | **23.0 ms** | 141.8 ms |
| random, all distinct | **1919.9 ms** | 5764.2 ms | **2203.7 ms** | 2351.6 ms |
| ties, n/100 distinct | **3134.6 ms** | 6096.8 ms | 2341.0 ms | **2009.3 ms** |
| ties, 8 distinct | 1375.6 ms | **797.5 ms** | 1832.8 ms | **656.1 ms** |

`stable_sort` wins only where a huge array holds a handful of distinct values. An already-sorted time index is the input `argsort()` sees in the case this series is for, and that is where it loses by 6x to 18x.

This is the first of two stacked pull requests. `SimpleArray::searchsorted()` builds on this ordering and follows in #1252.

Related to #1250 and #1285.
