### PR TITLE
fix: remove redundant comment from plot3d.hpp

### DIFF
--- a/cpp/solvcon/inout/plot3d.hpp
+++ b/cpp/solvcon/inout/plot3d.hpp
@@ -76,7 +76,6 @@ private:
     SimpleArray<uint_type> m_y_shape;
     SimpleArray<uint_type> m_z_shape;
     SimpleArray<uint_type> m_blk_sizes;
-    /// Exclusive prefix sum of m_blk_sizes: the node-id base of each block.
     SimpleArray<uint_type> m_blk_offsets;
 
     std::unordered_map<uint_type, small_vector<uint_type>> m_elems;


### PR DESCRIPTION
This PR is to follow-up the #1327  to remove the redundant comment from `plot3d.hpp`.

Related to #1326 

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
