### PR TITLE
Add the plot model

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     # plot/
     ${CMAKE_CURRENT_SOURCE_DIR}/plot/plot_style.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/plot/RPlotSeries.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/plot/RPlotModel.hpp
     # app/
     ${CMAKE_CURRENT_SOURCE_DIR}/app/RManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/app/RMenuModel.hpp
@@ -94,6 +95,7 @@ set(SOLVCON_PILOT_PYMODSOURCES
     # plot/
     ${CMAKE_CURRENT_SOURCE_DIR}/plot/plot_style.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/plot/RPlotSeries.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/plot/RPlotModel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/plot/wrap_plot.cpp
     # app/
     ${CMAKE_CURRENT_SOURCE_DIR}/app/RManager.cpp

--- a/cpp/solvcon/pilot/plot/RPlotModel.cpp
+++ b/cpp/solvcon/pilot/plot/RPlotModel.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/plot/RPlotModel.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <format>
+#include <stdexcept>
+#include <utility>
+
+namespace solvcon
+{
+
+namespace
+{
+
+/**
+ * The nonsingular guard, then the autoscale margin: a degenerate span is
+ * first opened around its value so the margin has a span to scale.
+ */
+std::pair<double, double> expand_axis(double lo, double hi, double margin)
+{
+    if (lo == hi)
+    {
+        double const half = (lo == 0.0) ? 0.5 : std::abs(lo) * 0.05;
+        lo -= half;
+        hi += half;
+    }
+
+    double const pad = (hi - lo) * margin;
+    return {lo - pad, hi + pad};
+}
+
+void validate_axis_limits(double lo, double hi, char const * axis)
+{
+    if (!std::isfinite(lo) || !std::isfinite(hi) || !(lo < hi))
+    {
+        throw std::invalid_argument(
+            std::format(
+                "RPlotModel::set_view_limits: {} limits must be finite and increasing, but they are {} and {}",
+                axis,
+                lo,
+                hi));
+    }
+}
+
+} /* end namespace */
+
+std::shared_ptr<RPlotSeries> RPlotModel::add_series(std::shared_ptr<RPlotSeries> const & series)
+{
+    if (!series)
+    {
+        throw std::invalid_argument("RPlotModel::add_series: series must not be None");
+    }
+
+    if (!series->color_is_set())
+    {
+        series->set_color(plot_cycle_color(m_cycle_index++));
+    }
+    m_series.push_back(series);
+    return m_series.back();
+}
+
+std::shared_ptr<RPlotSeries> const & RPlotModel::series(std::size_t it) const
+{
+    if (it >= m_series.size())
+    {
+        throw std::out_of_range(
+            std::format("RPlotModel::series: index {} is out of bounds with size {}", it, m_series.size()));
+    }
+    return m_series[it];
+}
+
+std::optional<std::array<double, 4>> RPlotModel::data_limits() const
+{
+    std::optional<std::array<double, 4>> limits;
+    for (std::shared_ptr<RPlotSeries> const & ser : m_series)
+    {
+        std::optional<std::array<double, 4>> const serlim = ser->data_limits();
+        if (!serlim.has_value())
+        {
+            continue;
+        }
+        if (!limits.has_value())
+        {
+            limits = serlim;
+            continue;
+        }
+        std::array<double, 4> & lim = *limits;
+        lim[0] = std::min(lim[0], (*serlim)[0]);
+        lim[1] = std::max(lim[1], (*serlim)[1]);
+        lim[2] = std::min(lim[2], (*serlim)[2]);
+        lim[3] = std::max(lim[3], (*serlim)[3]);
+    }
+    return limits;
+}
+
+void RPlotModel::set_margin(double margin)
+{
+    if (!std::isfinite(margin) || margin < 0.0)
+    {
+        throw std::invalid_argument(
+            std::format("RPlotModel::set_margin: margin must be finite and non-negative, but it is {}", margin));
+    }
+    m_margin = margin;
+}
+
+void RPlotModel::set_view_limits(double xmin, double xmax, double ymin, double ymax)
+{
+    validate_axis_limits(xmin, xmax, "x");
+    validate_axis_limits(ymin, ymax, "y");
+    m_view_limits = {xmin, xmax, ymin, ymax};
+}
+
+void RPlotModel::autoscale()
+{
+    std::optional<std::array<double, 4>> const limits = data_limits();
+    if (!limits.has_value())
+    {
+        m_view_limits = {0.0, 1.0, 0.0, 1.0};
+        return;
+    }
+
+    auto const [xmin, xmax] = expand_axis((*limits)[0], (*limits)[1], m_margin);
+    auto const [ymin, ymax] = expand_axis((*limits)[2], (*limits)[3], m_margin);
+    m_view_limits = {xmin, xmax, ymin, ymax};
+}
+
+ViewTransform2dFp64 RPlotModel::view(double width, double height) const
+{
+    if (!std::isfinite(width) || !(width > 0.0) || !std::isfinite(height) || !(height > 0.0))
+    {
+        throw std::invalid_argument(
+            std::format(
+                "RPlotModel::view: width and height must be finite and positive, but they are {} and {}",
+                width,
+                height));
+    }
+
+    double const zoom = std::min(width / (m_view_limits[1] - m_view_limits[0]),
+                                 height / (m_view_limits[3] - m_view_limits[2]));
+    double const center_x = 0.5 * (m_view_limits[0] + m_view_limits[1]);
+    double const center_y = 0.5 * (m_view_limits[2] + m_view_limits[3]);
+
+    ViewTransform2dFp64 transform;
+    transform.set_zoom(zoom);
+    transform.set_pan_x(0.5 * width - zoom * center_x);
+    transform.set_pan_y(0.5 * height + zoom * center_y);
+    return transform;
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/plot/RPlotModel.hpp
+++ b/cpp/solvcon/pilot/plot/RPlotModel.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * The series list of one xy plot: the color cycle a new series draws from,
+ * the aggregate data limits, and the view limits that autoscale derives and
+ * view() maps onto the screen. Qt-free, so it compiles into the no-GUI test
+ * target.
+ *
+ * @ingroup group_domain
+ */
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <solvcon/universe/ViewTransform2d.hpp>
+
+#include <solvcon/pilot/plot/plot_style.hpp>
+#include <solvcon/pilot/plot/RPlotSeries.hpp>
+
+namespace solvcon
+{
+
+/**
+ * The model of naive xy plot: it owns the series list, colors a new
+ * series from the matplotlib color cycle, unions the per-series data limits,
+ * and autoscales the view limits that view() maps onto the screen.
+ */
+class RPlotModel
+{
+public:
+
+    RPlotModel() = default;
+    RPlotModel(RPlotModel const &) = default;
+    RPlotModel(RPlotModel &&) = default;
+    RPlotModel & operator=(RPlotModel const &) = default;
+    RPlotModel & operator=(RPlotModel &&) = default;
+    ~RPlotModel() = default;
+
+    /**
+     * Register a series, coloring it from the cycle when it carries no
+     * explicit color, and return it. An explicitly colored series does not
+     * consume a cycle slot.
+     */
+    std::shared_ptr<RPlotSeries> add_series(std::shared_ptr<RPlotSeries> const & series);
+
+    std::shared_ptr<RPlotSeries> add_series() { return add_series(std::make_shared<RPlotSeries>()); }
+
+    std::size_t size() const { return m_series.size(); }
+
+    std::shared_ptr<RPlotSeries> const & series(std::size_t it) const;
+
+    /**
+     * The union of every series' data limits as {xmin, xmax, ymin, ymax};
+     * nullopt when no series holds a finite sample.
+     */
+    std::optional<std::array<double, 4>> data_limits() const;
+
+    double margin() const { return m_margin; }
+
+    void set_margin(double margin);
+
+    std::array<double, 4> view_limits() const { return m_view_limits; }
+
+    void set_view_limits(double xmin, double xmax, double ymin, double ymax);
+
+    /**
+     * Set the view limits to the data limits opened by the margin, guarding
+     * a singular span first so the margin has a span to scale. Without any
+     * finite sample the view falls back to the unit square.
+     */
+    void autoscale();
+
+    /**
+     * The transform that maps the view limits onto a width-by-height
+     * screen. ViewTransform2d carries a single zoom, so the view box fits
+     * inside the screen and is centered; a per-axis stretch is the
+     * widget's later concern.
+     */
+    ViewTransform2dFp64 view(double width, double height) const;
+
+private:
+
+    std::vector<std::shared_ptr<RPlotSeries>> m_series;
+    std::size_t m_cycle_index = 0;
+    double m_margin = PLOT_DEFAULT_MARGIN;
+    std::array<double, 4> m_view_limits = {0.0, 1.0, 0.0, 1.0};
+}; /* end class RPlotModel */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/plot/plot_style.hpp
+++ b/cpp/solvcon/pilot/plot/plot_style.hpp
@@ -49,6 +49,12 @@ struct PlotColor
 inline constexpr double PLOT_DEFAULT_LINE_WIDTH = 1.5;
 
 /**
+ * Default autoscale margin as a fraction of the data span on each side;
+ * matplotlib's axes.xmargin and axes.ymargin.
+ */
+inline constexpr double PLOT_DEFAULT_MARGIN = 0.05;
+
+/**
  * The matplotlib C0-C9 categorical cycle, in order. Exactly ten entries over
  * storage of static lifetime, so the span outlives any caller.
  */

--- a/cpp/solvcon/pilot/plot/wrap_plot.cpp
+++ b/cpp/solvcon/pilot/plot/wrap_plot.cpp
@@ -13,6 +13,7 @@
 #include <solvcon/buffer/pymod/SimpleArrayCaster.hpp>
 
 #include <solvcon/pilot/plot/plot_style.hpp>
+#include <solvcon/pilot/plot/RPlotModel.hpp>
 #include <solvcon/pilot/plot/RPlotSeries.hpp>
 
 #include <array>
@@ -164,6 +165,66 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRPlotSeries
 
 }; /* end class WrapRPlotSeries */
 
+class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRPlotModel
+    : public WrapBase<WrapRPlotModel, RPlotModel, std::shared_ptr<RPlotModel>>
+{
+
+    friend root_base_type;
+
+    WrapRPlotModel(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : root_base_type(mod, pyname, pydoc)
+    {
+        namespace py = pybind11;
+
+        (*this)
+            .def(py::init<>())
+            //
+            ;
+
+        (*this)
+            .def(
+                "add_series",
+                [](wrapped_type & self)
+                { return self.add_series(); })
+            .def(
+                "add_series",
+                [](wrapped_type & self, std::shared_ptr<RPlotSeries> const & series)
+                { return self.add_series(series); },
+                py::arg("series"))
+            .def_property_readonly("size", &wrapped_type::size)
+            .def("__len__", &wrapped_type::size)
+            .def(
+                "series",
+                [](wrapped_type const & self, std::int64_t index)
+                { return self.series(checked_index(index, self.size(), "RPlotModel::series", "size")); },
+                py::arg("index"))
+            .def(
+                "data_limits",
+                [](wrapped_type const & self)
+                { return limits_to_python(self.data_limits()); })
+            .def_property("margin", &wrapped_type::margin, &wrapped_type::set_margin)
+            .def(
+                "view_limits",
+                [](wrapped_type const & self)
+                {
+                    std::array<double, 4> const lim = self.view_limits();
+                    return py::make_tuple(lim[0], lim[1], lim[2], lim[3]);
+                })
+            .def(
+                "set_view_limits",
+                &wrapped_type::set_view_limits,
+                py::arg("xmin"),
+                py::arg("xmax"),
+                py::arg("ymin"),
+                py::arg("ymax"))
+            .def("autoscale", &wrapped_type::autoscale)
+            .def("view", &wrapped_type::view, py::arg("width"), py::arg("height"))
+            //
+            ;
+    }
+
+}; /* end class WrapRPlotModel */
+
 void wrap_plot(pybind11::module & mod)
 {
     namespace py = pybind11;
@@ -179,6 +240,13 @@ void wrap_plot(pybind11::module & mod)
         "One xy data series: a copy of a contiguous SimpleArrayFloat64 pair "
         "plus the style used to stroke it. Samples are read through "
         "size / x / y.");
+    WrapRPlotModel::commit(
+        mod,
+        "RPlotModel",
+        "The series list of one xy plot: the color cycle a new series draws "
+        "from, the aggregate data limits, and the view limits that "
+        "autoscale derives and view(width, height) maps onto the screen as "
+        "a ViewTransform2dFp64.");
 
     mod.def(
         "plot_color_cycle",

--- a/solvcon/pilot/__init__.py
+++ b/solvcon/pilot/__init__.py
@@ -21,6 +21,7 @@ from ._pilot_core import (  # noqa: F401
     RManager,
     PlotColor,
     RPlotSeries,
+    RPlotModel,
     plot_color_cycle,
     plot_cycle_color,
 )

--- a/solvcon/pilot/_pilot_core.py
+++ b/solvcon/pilot/_pilot_core.py
@@ -65,6 +65,11 @@ list_of_rplotseries = [
     'RPlotSeries',
 ]
 
+# RPlotModel.hpp/.cpp
+list_of_rplotmodel = [
+    'RPlotModel',
+]
+
 
 _from_impl = (  # noqa: F822
     list_of_rdomainwidget +
@@ -74,7 +79,8 @@ _from_impl = (  # noqa: F822
     list_of_rpythonterminal +
     list_of_drawtool +
     list_of_plot_style +
-    list_of_rplotseries
+    list_of_rplotseries +
+    list_of_rplotmodel
 )
 
 __all__ = _from_impl + [  # noqa: F822
@@ -99,6 +105,7 @@ _load(list_of_rpythonterminal)
 _load(list_of_drawtool)
 _load(list_of_plot_style)
 _load(list_of_rplotseries)
+_load(list_of_rplotmodel)
 
 del _load
 

--- a/tests/test_pilot_plot.py
+++ b/tests/test_pilot_plot.py
@@ -189,4 +189,104 @@ class PilotPlotTC(unittest.TestCase):
         self.assertEqual(1.5, ser.line_width)
 
 
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class PilotPlotModelTC(unittest.TestCase):
+    """The series list of one plot and the view derived from it."""
+
+    def test_add_series_walks_the_color_cycle(self):
+        model = pilot.RPlotModel()
+        self.assertEqual(pilot.plot_cycle_color(0), model.add_series().color)
+        self.assertEqual(pilot.plot_cycle_color(1), model.add_series().color)
+        colored = pilot.RPlotSeries()
+        colored.color = pilot.PlotColor(9, 9, 9)
+        self.assertEqual(pilot.PlotColor(9, 9, 9),
+                         model.add_series(colored).color)
+        self.assertEqual(pilot.plot_cycle_color(2), model.add_series().color)
+
+    def test_added_series_is_shared_not_copied(self):
+        model = pilot.RPlotModel()
+        ser = pilot.RPlotSeries()
+        model.add_series(ser)
+        ser.label = 'pressure'
+        ser.set_data(_array([0.0, 1.0]), _array([2.0, 3.0]))
+        self.assertEqual('pressure', model.series(0).label)
+        self.assertEqual((0.0, 1.0, 2.0, 3.0), model.series(0).data_limits())
+        self.assertEqual(1, model.size)
+        self.assertEqual(1, len(model))
+
+    def test_add_series_rejects_none(self):
+        model = pilot.RPlotModel()
+        with self.assertRaisesRegex(ValueError, 'must not be None'):
+            model.add_series(None)
+        self.assertEqual(0, model.size)
+
+    def test_series_index_out_of_range_raises_index_error(self):
+        model = pilot.RPlotModel()
+        model.add_series()
+        for index in (1, -1):
+            message = 'index %d is out of bounds with size 1' % index
+            with self.assertRaisesRegex(IndexError, re.escape(message)):
+                model.series(index)
+
+    def test_data_limits_union_all_series(self):
+        model = pilot.RPlotModel()
+        self.assertIsNone(model.data_limits())
+        model.add_series().set_data(_array([0.0, 1.0]), _array([5.0, 6.0]))
+        model.add_series()
+        self.assertEqual((0.0, 1.0, 5.0, 6.0), model.data_limits())
+        model.add_series().set_data(_array([-3.0, 0.5]), _array([7.0, 8.0]))
+        self.assertEqual((-3.0, 1.0, 5.0, 8.0), model.data_limits())
+
+    def test_autoscale_margins_the_data(self):
+        model = pilot.RPlotModel()
+        self.assertEqual((0.0, 1.0, 0.0, 1.0), model.view_limits())
+        model.autoscale()
+        self.assertEqual((0.0, 1.0, 0.0, 1.0), model.view_limits())
+        model.add_series().set_data(_array([0.0, 10.0]),
+                                    _array([0.0, 100.0]))
+        self.assertEqual(0.05, model.margin)
+        model.autoscale()
+        for expected, actual in zip((-0.5, 10.5, -5.0, 105.0),
+                                    model.view_limits()):
+            self.assertAlmostEqual(expected, actual, places=12)
+
+    def test_autoscale_guards_a_singular_span(self):
+        model = pilot.RPlotModel()
+        model.add_series().set_data(_array([3.0]), _array([0.0]))
+        model.autoscale()
+        # x: opened to 3 +- 0.15, then the 5% margin of the 0.3 span.
+        # y: opened to +-0.5 around zero, then the margin of the 1.0 span.
+        for expected, actual in zip((2.835, 3.165, -0.55, 0.55),
+                                    model.view_limits()):
+            self.assertAlmostEqual(expected, actual, places=12)
+
+    def test_margin_and_view_limits_are_validated(self):
+        model = pilot.RPlotModel()
+        for margin in (-0.1, float('nan')):
+            with self.assertRaises(ValueError):
+                model.margin = margin
+        model.margin = 0.0
+        model.add_series().set_data(_array([0.0, 10.0]), _array([1.0, 2.0]))
+        model.autoscale()
+        self.assertEqual((0.0, 10.0, 1.0, 2.0), model.view_limits())
+        for bad in ((1.0, 1.0, 0.0, 1.0), (0.0, 1.0, 2.0, 1.0),
+                    (float('nan'), 1.0, 0.0, 1.0)):
+            with self.assertRaises(ValueError):
+                model.set_view_limits(*bad)
+        model.set_view_limits(-2.0, 2.0, -4.0, 4.0)
+        self.assertEqual((-2.0, 2.0, -4.0, 4.0), model.view_limits())
+
+    def test_view_fits_and_centers_the_limits(self):
+        model = pilot.RPlotModel()
+        model.set_view_limits(0.0, 10.0, 0.0, 10.0)
+        transform = model.view(200.0, 100.0)
+        self.assertEqual(10.0, transform.zoom)
+        self.assertEqual((100.0, 50.0), transform.screen_from_world(5.0, 5.0))
+        self.assertEqual((50.0, 100.0), transform.screen_from_world(0.0, 0.0))
+        for width, height in ((0.0, 100.0), (200.0, -1.0),
+                              (float('nan'), 100.0)):
+            with self.assertRaises(ValueError):
+                model.view(width, height)
+
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:


### PR DESCRIPTION
`RPlotModel` completes the series-and-model half of the native xy plot core: it keeps the series list in shared ownership with the Python side, colors an uncolored series from the `matplotlib` cycle without spending a slot on an explicitly colored one, unions the per-series NaN-safe data limits, and autoscales the view limits by opening a singular span before applying the margin.  `view()` maps the view limits onto a screen as a `ViewTransform2dFp64`, reusing the existing affine instead of adding one; the single zoom fits the view box inside the screen and centers it, leaving a per-axis stretch to the widget.

Related to #1049 step 1

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
