### PR TITLE
Stop a gcc false positive in pybind11 from failing the default build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,6 +380,13 @@ if(MSVC)
     set(COMMON_COMPILER_OPTIONS /W4 /bigobj /WX)
 else()
     set(COMMON_COMPILER_OPTIONS -Wall -Wextra)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        # gcc computes -Wmaybe-uninitialized after inlining, so at -O3 -g it
+        # fires inside pybind11 on a tuple that is in fact initialized, and
+        # -O3 -g is what a bare `make` configures. Demote rather than disable,
+        # so a real uninitialized use still reaches the log.
+        set(COMMON_COMPILER_OPTIONS ${COMMON_COMPILER_OPTIONS} -Wno-error=maybe-uninitialized)
+    endif()
     if(USE_CLANG_TIDY AND LINT_AS_ERRORS)
         message(STATUS "Disable -Werror because clang-tidy (with lint as errors) is enabled")
     else()


### PR DESCRIPTION
A bare `make` configures RelWithDebInfo, which this project compiles at `-O3 -g`. At that flag pair gcc 16 reports `may be used uninitialized` against `tuple result(size)` in pybind11's `cast.h`, and `-Werror` turns it into an error, so every default local build on Linux stops at `cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp`. The report is wrong, because pybind11 fills that tuple.

gcc computes `-Wmaybe-uninitialized` after inlining, so what it sees depends on how the code was optimized, and only `-O3 -g` produces the shape it misreads. `-O3` alone, `-O2 -g`, and `-O1 -g` all compile the same file clean. That is why no CI job reports it: the ubuntu build job configures Release, and the RelWithDebInfo job runs on macOS, where clang has no such warning. Every ingredient is in CI, but that combination is not.

The change adds `-Wno-error=maybe-uninitialized` to `COMMON_COMPILER_OPTIONS` for gcc only. The `-Wno-error=` form rather than `-Wno-` keeps a real uninitialized use in the log and drops only the escalation to an error. The guard on the compiler id is required rather than defensive: clang has no `-Wmaybe-uninitialized` group and rejects the flag under `-Werror`, so an unguarded option would break every clang and AppleClang build on its first file.

Marking the pybind11 headers SYSTEM was tried first and does not work. The diagnostic does point into `cast.h`, but gcc's late warnings are emitted past the point where system-header suppression applies, and `-isystem` leaves the error unchanged.

One caveat for the reviewer, which is why this references #1325: the suppression is tree-wide, and #1325 argues for scoping such suppressions down rather than widening them. Wrapping the pybind11 include in a `#pragma GCC diagnostic` region confines the relaxation to that header and was verified to work, but doing it robustly wants a choke-point header for the 55 pybind11 includes spread across 32 files, so it belongs with that issue rather than here.

With the change, `make pilot` completes and prints the warning once, and `make lint` passes.

Related to #1325.
