### PR TITLE
Spell the sort partition point as a pointer

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -1439,8 +1439,8 @@ void SimpleArrayMixinSort<A, T>::sort()
     else if constexpr (std::is_floating_point_v<value_type>)
     {
         // Partition the array into two parts: non-NaN values and NaN values.
-        auto const mid = std::partition(athis->begin(), athis->end(), [](value_type const & v)
-                                        { return !std::isnan(v); });
+        auto * const mid = std::partition(athis->begin(), athis->end(), [](value_type const & v)
+                                          { return !std::isnan(v); });
         std::sort(athis->begin(), mid);
     }
     else


### PR DESCRIPTION
The master lint workflow has been failing since #1328 landed. `make pilot` runs clang-tidy as a compiler launcher with `-warnings-as-errors=*`, and the NaN partition added to `SimpleArrayMixinSort::sort()` tripped `readability-qualified-auto`: `begin()` returns `value_type *`, so `auto const mid` deduces a pointer, and the check wants a deduced pointer spelled with a `*`. One warning failed `wrap_SimpleArray_float.cpp.o` and took the whole pilot build down on both the ubuntu-24.04 and the macos-26 job.

`auto * const mid` names exactly the type `auto const mid` already deduced, `value_type * const`, so this is a spelling change and the ordering behavior is untouched.

The failing build stopped at the first error, so most translation units were never checked. To confirm nothing else is waiting behind it, I ran clang-tidy over all 133 translation units from a generated compile database using the repository `.clang-tidy` and CI's header filter, and it reported nothing. `make pilot` and `make lint` both pass locally, and the sort tests pass.

Related to #1328.
