### PR TITLE
Clear the MSVC C4458, C4244, C4267 and C4702 backlog in the core libraries

### DIFF
--- a/cpp/solvcon/CMakeLists.txt
+++ b/cpp/solvcon/CMakeLists.txt
@@ -340,14 +340,11 @@ foreach (SOLVCON_LIBRARY IN LISTS SOLVCON_LIBRARIES)
             ${SOLVCON_LIBRARY} PRIVATE
             ${COMMON_COMPILER_OPTIONS}
             /bigobj # C1128: number of sections exceeded object file format limit
-            # TODO: fix the code and drop each of these; see issue #1324. They
-            # come from templates instantiated over every value type, so one
-            # line warns once per instantiation.
+            # This is the last suppression left from issue #1324. It fires in
+            # the SimpleArray<bool> reductions, where clearing it means
+            # deciding what mean, average and variance mean for bool rather
+            # than rewriting an expression. Issue #1332 tracks that.
             /wd4804 # bool in an arithmetic operation, from reductions over SimpleArray<bool>
-            /wd4244 # narrowing conversion
-            /wd4267 # narrowing conversion from size_t
-            /wd4458 # a declaration hides a class member
-            /wd4702 # unreachable code, after the `if constexpr` bool branches that throw
             /external:W0 # do not apply /W4 to a SYSTEM include such as numpy
         )
     else () # MSVC

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -230,6 +230,11 @@ public:
 
 }; /* end class SimpleArrayMixinModifiers */
 
+// SimpleArray<bool> reaches these mixins like any other value type, and the
+// operations that have no boolean meaning have to say so one by one.
+template <typename U>
+inline constexpr bool is_bool_v = std::is_same_v<bool, std::remove_const_t<U>>;
+
 template <typename U>
 struct select_real_t
 {
@@ -551,7 +556,7 @@ public:
         {
             sum += v;
         }
-        return sum / static_cast<value_type>(n);
+        return sum / convert_count(n);
     }
 
     A mean(const shape_type & axis) const
@@ -567,7 +572,7 @@ public:
         {
             throw std::runtime_error("SimpleArray::mean(): empty array");
         }
-        return athis->sum() / static_cast<value_type>(n);
+        return athis->sum() / convert_count(n);
     }
 
     real_type var_op(small_vector<value_type> & sv, size_t ddof) const
@@ -639,14 +644,18 @@ public:
         }
         else
         {
-            acc -= n * mu * mu;
+            // Cast the result, not the count: the compound assignment
+            // already performed this conversion, and narrowing `n` first
+            // would move the product into a signed type that overflows
+            // instead of the defined size_t wrap.
+            acc = static_cast<real_type>(acc - n * mu * mu);
         }
         return acc / static_cast<real_type>(n - ddof);
     }
 
     real_type std_op(small_vector<value_type> & sv, size_t ddof) const
     {
-        return std::sqrt(var_op(sv, ddof));
+        return static_cast<real_type>(std::sqrt(var_op(sv, ddof)));
     }
 
     auto std(const shape_type & axis, size_t ddof) const
@@ -657,7 +666,7 @@ public:
     real_type std(size_t ddof) const
     {
         auto athis = static_cast<A const *>(this);
-        return std::sqrt(athis->var(ddof));
+        return static_cast<real_type>(std::sqrt(athis->var(ddof)));
     }
 
     value_type min() const
@@ -696,7 +705,7 @@ public:
         {
             for (size_t i = 0; i < athis->size(); ++i)
             {
-                ret.data(i) = std::abs(athis->data(i));
+                ret.data(i) = static_cast<value_type>(std::abs(athis->data(i)));
             }
         }
         return ret;
@@ -716,12 +725,26 @@ public:
     A sub(A const & other) const
     {
         validate_same_shape(other, "sub");
-        return A(*static_cast<A const *>(this)).isub(other);
+        if constexpr (is_bool_v<value_type>)
+        {
+            reject_bool_operation("isub");
+        }
+        else
+        {
+            return A(*static_cast<A const *>(this)).isub(other);
+        }
     }
 
     A sub(value_type scalar) const
     {
-        return A(*static_cast<A const *>(this)).isub(scalar);
+        if constexpr (is_bool_v<value_type>)
+        {
+            reject_bool_operation("isub");
+        }
+        else
+        {
+            return A(*static_cast<A const *>(this)).isub(scalar);
+        }
     }
 
     A mul(A const & other) const
@@ -738,15 +761,48 @@ public:
     A div(A const & other) const
     {
         validate_same_shape(other, "div");
-        return A(*static_cast<A const *>(this)).idiv(other);
+        if constexpr (is_bool_v<value_type>)
+        {
+            reject_bool_operation("idiv");
+        }
+        else
+        {
+            return A(*static_cast<A const *>(this)).idiv(other);
+        }
     }
 
     A div(value_type scalar) const
     {
-        return A(*static_cast<A const *>(this)).idiv(scalar);
+        if constexpr (is_bool_v<value_type>)
+        {
+            reject_bool_operation("idiv");
+        }
+        else
+        {
+            return A(*static_cast<A const *>(this)).idiv(scalar);
+        }
     }
 
 private:
+
+    // Subtraction and division have no meaning on bool. Throwing from inside
+    // the `if constexpr` branch, instead of falling through to a shared
+    // `return`, keeps the bool instantiation free of a statement no execution
+    // can reach. The out-of-place `sub()` and `div()` pass the name of the
+    // in-place operation they delegate to, so the thrown message stays the one
+    // callers already see.
+    [[noreturn]] static void reject_bool_operation(char const * op)
+    {
+        throw std::runtime_error(
+            std::format("SimpleArray<bool>::{}(): boolean value doesn't support this operation", op));
+    }
+
+    // An element count is a size_t, and a Complex value_type converts from its
+    // real_type rather than from a size_t, so the conversion needs two steps.
+    static value_type convert_count(size_t count)
+    {
+        return static_cast<value_type>(static_cast<real_type>(count));
+    }
 
     void validate_same_shape(A const & other, char const * op) const;
 
@@ -832,10 +888,10 @@ public:
 
     A & isub(A const & other)
     {
-        auto athis = static_cast<A *>(this);
         validate_same_shape(other, "isub");
         if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
         {
+            auto athis = static_cast<A *>(this);
             const value_type * const end = athis->end();
             value_type * ptr = athis->begin();
             const value_type * other_ptr = other.begin();
@@ -846,20 +902,19 @@ public:
                 ++ptr;
                 ++other_ptr;
             }
+            return *athis;
         }
         else
         {
-            throw std::runtime_error(
-                "SimpleArray<bool>::isub(): boolean value doesn't support this operation");
+            reject_bool_operation("isub");
         }
-        return *athis;
     }
 
     A & isub(value_type scalar)
     {
-        auto athis = static_cast<A *>(this);
         if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
         {
+            auto athis = static_cast<A *>(this);
             const value_type * const end = athis->end();
             value_type * ptr = athis->begin();
 
@@ -868,13 +923,12 @@ public:
                 *ptr -= scalar;
                 ++ptr;
             }
+            return *athis;
         }
         else
         {
-            throw std::runtime_error(
-                "SimpleArray<bool>::isub(): boolean value doesn't support this operation");
+            reject_bool_operation("isub");
         }
-        return *athis;
     }
 
     A & imul(A const & other)
@@ -935,10 +989,10 @@ public:
 
     A & idiv(A const & other)
     {
-        auto athis = static_cast<A *>(this);
         validate_same_shape(other, "idiv");
         if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
         {
+            auto athis = static_cast<A *>(this);
             const value_type * const end = athis->end();
             value_type * ptr = athis->begin();
             const value_type * other_ptr = other.begin();
@@ -949,20 +1003,19 @@ public:
                 ++ptr;
                 ++other_ptr;
             }
+            return *athis;
         }
         else
         {
-            throw std::runtime_error(
-                "SimpleArray<bool>::idiv(): boolean value doesn't support this operation");
+            reject_bool_operation("idiv");
         }
-        return *athis;
     }
 
     A & idiv(value_type scalar)
     {
-        auto athis = static_cast<A *>(this);
         if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>>)
         {
+            auto athis = static_cast<A *>(this);
             const value_type * const end = athis->end();
             value_type * ptr = athis->begin();
 
@@ -971,13 +1024,12 @@ public:
                 *ptr /= scalar;
                 ++ptr;
             }
+            return *athis;
         }
         else
         {
-            throw std::runtime_error(
-                "SimpleArray<bool>::idiv(): boolean value doesn't support this operation");
+            reject_bool_operation("idiv");
         }
-        return *athis;
     }
 
     A add_simd(A const & other) const

--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -32,6 +32,11 @@ inline constexpr bool can_matmul_blas_v = std::is_same_v<T, float> ||
                                           std::is_same_v<T, Complex<float>> ||
                                           std::is_same_v<T, Complex<double>>;
 
+// Whether a matmul over T reaches BLAS at all: the type has to be one BLAS
+// takes and the build has to have a backend behind the wrappers.
+template <typename T>
+inline constexpr bool use_matmul_blas_v = has_blas_backend && can_matmul_blas_v<T>;
+
 /**
  * @brief Identify the contraction kernel fixed before batch traversal.
  */
@@ -601,32 +606,36 @@ void MatmulExecutor<Array>::execute()
         pack(selection.packing);
     }
 
-    switch (selection.kernel)
+    // `select_execution()` names a BLAS kernel only where one exists, so the
+    // dispatch stays uninstantiated for a value type that has none, and the
+    // generic kernel is the one path every instantiation keeps.
+    if constexpr (use_matmul_blas_v<value_type>)
     {
-    case MatmulKernel::Generic:
-        execute_contractions<MatmulKernel::Generic>();
-        return;
-    case MatmulKernel::BlasDot:
-        execute_contractions<MatmulKernel::BlasDot>();
-        return;
-    case MatmulKernel::BlasGevm:
-        execute_contractions<MatmulKernel::BlasGevm>();
-        return;
-    case MatmulKernel::BlasGemv:
-        execute_contractions<MatmulKernel::BlasGemv>();
-        return;
-    case MatmulKernel::BlasGemm:
-        execute_contractions<MatmulKernel::BlasGemm>();
-        return;
+        switch (selection.kernel)
+        {
+        case MatmulKernel::Generic:
+            break;
+        case MatmulKernel::BlasDot:
+            execute_contractions<MatmulKernel::BlasDot>();
+            return;
+        case MatmulKernel::BlasGevm:
+            execute_contractions<MatmulKernel::BlasGevm>();
+            return;
+        case MatmulKernel::BlasGemv:
+            execute_contractions<MatmulKernel::BlasGemv>();
+            return;
+        case MatmulKernel::BlasGemm:
+            execute_contractions<MatmulKernel::BlasGemm>();
+            return;
+        }
     }
-    throw std::logic_error("MatmulExecutor::execute(): invalid kernel");
+    execute_contractions<MatmulKernel::Generic>();
 }
 
 template <typename Array>
 MatmulSelection MatmulExecutor<Array>::select_execution() const
 {
-#if (defined(__APPLE__) && defined(__arm64__)) || defined(SC_HAS_CBLAS)
-    if constexpr (can_matmul_blas_v<value_type>)
+    if constexpr (use_matmul_blas_v<value_type>)
     {
         if (m_plan.lhs_is_vector() && m_plan.rhs_is_vector())
         {
@@ -642,8 +651,10 @@ MatmulSelection MatmulExecutor<Array>::select_execution() const
         }
         return select_gemm();
     }
-#endif
-    return MatmulSelection{};
+    else
+    {
+        return MatmulSelection{};
+    }
 }
 
 template <typename Array>
@@ -855,32 +866,27 @@ void MatmulExecutor<Array>::execute_at(
     }
     else
     {
-#if (defined(__APPLE__) && defined(__arm64__)) || defined(SC_HAS_CBLAS)
-        if constexpr (can_matmul_blas_v<value_type>)
+        static_assert(use_matmul_blas_v<value_type>,
+                      "execute() dispatches a BLAS kernel only where one exists");
+        value_type * output = m_output_data + output_base;
+        value_type const * lhs_data = m_lhs_data + lhs_base;
+        value_type const * rhs_data = m_rhs_data + rhs_base;
+        if constexpr (Kernel == MatmulKernel::BlasDot)
         {
-            value_type * output = m_output_data + output_base;
-            value_type const * lhs_data = m_lhs_data + lhs_base;
-            value_type const * rhs_data = m_rhs_data + rhs_base;
-            if constexpr (Kernel == MatmulKernel::BlasDot)
-            {
-                execute_dot_blas(output, lhs_data, rhs_data);
-            }
-            else if constexpr (Kernel == MatmulKernel::BlasGevm)
-            {
-                execute_gevm_blas(output, lhs_data, rhs_data);
-            }
-            else if constexpr (Kernel == MatmulKernel::BlasGemv)
-            {
-                execute_gemv_blas(output, lhs_data, rhs_data);
-            }
-            else if constexpr (Kernel == MatmulKernel::BlasGemm)
-            {
-                execute_gemm_blas(output, lhs_data, rhs_data);
-            }
-            return;
+            execute_dot_blas(output, lhs_data, rhs_data);
         }
-#endif
-        throw std::logic_error("MatmulExecutor::execute_at(): unavailable BLAS kernel");
+        else if constexpr (Kernel == MatmulKernel::BlasGevm)
+        {
+            execute_gevm_blas(output, lhs_data, rhs_data);
+        }
+        else if constexpr (Kernel == MatmulKernel::BlasGemv)
+        {
+            execute_gemv_blas(output, lhs_data, rhs_data);
+        }
+        else if constexpr (Kernel == MatmulKernel::BlasGemm)
+        {
+            execute_gemm_blas(output, lhs_data, rhs_data);
+        }
     }
 }
 

--- a/cpp/solvcon/buffer/pymod/array_common.hpp
+++ b/cpp/solvcon/buffer/pymod/array_common.hpp
@@ -59,7 +59,7 @@ private:
         return ptr;
     }
 
-    static bool direct_converter(PyObject * obj, void *& value)
+    static bool direct_converter(PyObject * obj, void *& storage)
     {
         auto & api = npy_api::get();
         if (!PyObject_TypeCheck(obj, api.PyVoidArrType_Type_))
@@ -70,7 +70,7 @@ private:
         {
             if (api.PyArray_EquivTypes_(dtype_ptr(), descr.ptr()))
             {
-                value = (reinterpret_cast<PyVoidScalarObject_Proxy *>(obj))->obval; // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                storage = (reinterpret_cast<PyVoidScalarObject_Proxy *>(obj))->obval; // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
                 return true;
             }
         }
@@ -110,7 +110,7 @@ private:
         return ptr;
     }
 
-    static bool direct_converter(PyObject * obj, void *& value)
+    static bool direct_converter(PyObject * obj, void *& storage)
     {
         auto & api = npy_api::get();
         if (!PyObject_TypeCheck(obj, api.PyVoidArrType_Type_))
@@ -122,7 +122,7 @@ private:
             if (api.PyArray_EquivTypes_(dtype_ptr(), descr.ptr()))
             {
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-                value = (reinterpret_cast<PyVoidScalarObject_Proxy *>(obj))->obval;
+                storage = (reinterpret_cast<PyVoidScalarObject_Proxy *>(obj))->obval;
                 return true;
             }
         }

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -9,6 +9,7 @@
 
 #include <solvcon/buffer/pymod/array_common.hpp>
 
+#include <cctype>
 #include <cstdint>
 
 namespace solvcon
@@ -16,6 +17,18 @@ namespace solvcon
 
 namespace python
 {
+
+namespace detail
+{
+
+// std::tolower is specified in terms of unsigned char and returns int; the
+// casts keep a negative char out of it and the result inside char.
+inline char lower_ascii(char ch)
+{
+    return static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+}
+
+} /* end namespace detail */
 
 template <typename T>
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
@@ -566,7 +579,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
         }
 
         py_typename.replace(0, strlen("_solvcon.SimpleArray"), "");
-        py_typename[0] = tolower(py_typename[0]);
+        py_typename[0] = detail::lower_ascii(py_typename[0]);
         const DataType dt(py_typename);
 
 #define SC_DECL_TAKE_ALONG_AXIS_TYPED(IntDataType) \
@@ -601,7 +614,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
         }
 
         py_typename.replace(0, strlen("_solvcon.SimpleArray"), "");
-        py_typename[0] = tolower(py_typename[0]);
+        py_typename[0] = detail::lower_ascii(py_typename[0]);
         const DataType dt(py_typename);
 
 #define SC_DECL_TAKE_ALONG_AXIS_SIMD_TYPED(IntDataType) \
@@ -689,8 +702,8 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
 
         py_typename_x.replace(0, strlen("_solvcon.SimpleArray"), "");
         py_typename_y.replace(0, strlen("_solvcon.SimpleArray"), "");
-        py_typename_x[0] = tolower(py_typename_x[0]);
-        py_typename_y[0] = tolower(py_typename_y[0]);
+        py_typename_x[0] = detail::lower_ascii(py_typename_x[0]);
+        py_typename_y[0] = detail::lower_ascii(py_typename_y[0]);
 
         const DataType dt_x(py_typename_x);
         const DataType dt_y(py_typename_y);

--- a/cpp/solvcon/inout/gmsh.hpp
+++ b/cpp/solvcon/inout/gmsh.hpp
@@ -208,7 +208,7 @@ private:
             auto tokens = tokenize(line, ' ');
 
             // parse element type
-            auto tpn = std::stoul(tokens[1]);
+            auto tpn = static_cast<uint16_t>(std::stoul(tokens[1]));
             auto eldef = GmshElementDef::by_id(tpn);
             // parse element tag
             std::vector<uint_type> tag;
@@ -238,7 +238,7 @@ private:
                 nds_temp[mmcl[i] + 1] = nds[i] - 1;
             }
             usnds.insert(usnds.end(), nds_temp.begin() + 1, nds_temp.end());
-            nds_temp[0] = mmcl.size();
+            nds_temp[0] = static_cast<uint_type>(mmcl.size());
             m_elems.insert(std::pair{idx, nds_temp});
             idx++;
         }
@@ -257,7 +257,7 @@ private:
         m_ndmap.remake(small_vector<ssize_t>{static_cast<ssize_t>(usnds.size())}, -1);
         for (size_t i = 0; i < usnds.size(); ++i)
         {
-            m_ndmap(usnds[i]) = i;
+            m_ndmap(usnds[i]) = static_cast<uint_type>(i);
         }
     }
 

--- a/cpp/solvcon/inout/plot3d.cpp
+++ b/cpp/solvcon/inout/plot3d.cpp
@@ -136,12 +136,13 @@ void Plot3d::build_interior(const std::shared_ptr<StaticMesh> & blk)
     blk->cltpn().swap(m_cltpn);
     blk->ndcrd().swap(m_nds);
 
-    for (size_t i = 0; i < m_elems.size(); ++i)
+    for (uint_type i = 0; i < m_elems.size(); ++i)
     {
-        blk->clnds()(i, 0) = m_elems[i][0];
-        for (size_t j = 1; j <= m_elems[i][0]; ++j)
+        small_vector<uint_type> const & elem = m_elems[i];
+        blk->clnds()(i, 0) = elem[0];
+        for (size_t j = 1; j <= elem[0]; ++j)
         {
-            blk->clnds()(i, j) = m_elems[i][j];
+            blk->clnds()(i, j) = elem[j];
         }
     }
     blk->build_interior(true);

--- a/cpp/solvcon/math/blas_compat.hpp
+++ b/cpp/solvcon/math/blas_compat.hpp
@@ -15,6 +15,20 @@ namespace solvcon
 {
 
 /**
+ * Whether this build has a BLAS backend behind the wrappers below.
+ *
+ * A constant rather than an `#if` at each call site, so a caller can discard
+ * its BLAS branch through `if constexpr` instead of having the preprocessor
+ * delete it. That leaves no unreachable statement behind the branch, which
+ * MSVC reports as C4702 from its code generator.
+ */
+#if (defined(__APPLE__) && defined(__arm64__)) || defined(SC_HAS_CBLAS)
+inline constexpr bool has_blas_backend = true;
+#else
+inline constexpr bool has_blas_backend = false;
+#endif
+
+/**
  * @brief Select whether BLAS reads a matrix descriptor as stored or transposed.
  */
 enum class BlasTranspose : std::uint8_t

--- a/cpp/solvcon/oasis/oasis_device.cpp
+++ b/cpp/solvcon/oasis/oasis_device.cpp
@@ -28,7 +28,7 @@ void OasisDevice::append_unsigned_integer(std::vector<uint8_t> & segment, int va
     while (payload >= 1)
     {
         int const first_bit = payload >= 128 ? 1 : 0;
-        segment.push_back((first_bit << 7) | (payload % 128));
+        segment.push_back(static_cast<uint8_t>((first_bit << 7) | (payload % 128)));
         payload /= 128;
     }
 }
@@ -57,7 +57,7 @@ void OasisDevice::append_signed_integer(std::vector<uint8_t> & segment, int valu
     while (payload >= 1)
     {
         int const first_bit = payload >= 128 ? 1 : 0;
-        segment.push_back((first_bit << 7) | (payload % 128));
+        segment.push_back(static_cast<uint8_t>((first_bit << 7) | (payload % 128)));
         payload /= 128;
     }
 }
@@ -82,7 +82,7 @@ std::vector<uint8_t> OasisRecordRect::to_bytes() const
 
     const int INFO = (S << 7) | (W << 6) | (H << 5) |
                      (X << 4) | (Y << 3) | (R << 2) | (D << 1) | L;
-    segment.push_back(INFO);
+    segment.push_back(static_cast<uint8_t>(INFO));
 
     // Layer-num and datatype-num (0 in default).
     segment.push_back(0x00);
@@ -115,7 +115,7 @@ std::vector<uint8_t> OasisRecordPoly::to_bytes() const
     const int D = 1; // Have Datatype? (1 if yes, 0 if no)
     const int L = 1; // Have Layer? (1 if yes, 0 if no)
     const int INFO = (P << 5) | (X << 4) | (Y << 3) | (R << 2) | (D << 1) | L;
-    segment.push_back(INFO);
+    segment.push_back(static_cast<uint8_t>(INFO));
 
     // Layer-num and datatype-num (0 in default).
     segment.push_back(0x00);
@@ -134,7 +134,7 @@ std::vector<uint8_t> OasisRecordPoly::to_bytes() const
     }
 
     // The vertex count shoud be (vertex - 1)
-    segment.push_back(m_vertices.size() - 1);
+    segment.push_back(static_cast<uint8_t>(m_vertices.size() - 1));
 
     // In this implementation, point-list only support 1-delta format.
     // Please refer Point-list in OASIS draft 7.7.

--- a/cpp/solvcon/pilot/console/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/console/RPythonConsoleDockWidget.cpp
@@ -651,12 +651,12 @@ void RPythonConsoleDockWidget::updateCompletionPrefix()
     }
 }
 
-void RPythonConsoleDockWidget::writeToHistory(const std::string & data) const
+void RPythonConsoleDockWidget::writeToHistory(const std::string & text) const
 {
     QTextCursor cursor = m_history_edit->textCursor();
     cursor.movePosition(QTextCursor::End);
     m_history_edit->setTextCursor(cursor);
-    m_history_edit->insertPlainText(QString::fromStdString(data));
+    m_history_edit->insertPlainText(QString::fromStdString(text));
 }
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/console/RPythonConsoleDockWidget.hpp
+++ b/cpp/solvcon/pilot/console/RPythonConsoleDockWidget.hpp
@@ -143,7 +143,7 @@ public:
         return *this;
     }
 
-    void writeToHistory(std::string const & data) const;
+    void writeToHistory(std::string const & text) const;
 
     /// Point the syntax highlighter and the bracket marker at a theme's syntax
     /// colors. The text itself follows the application palette; these are the

--- a/cpp/solvcon/pilot/console/RPythonTerminalDockWidget.cpp
+++ b/cpp/solvcon/pilot/console/RPythonTerminalDockWidget.cpp
@@ -479,9 +479,9 @@ QWidget * RPythonTerminalDockWidget::textEdit() const
     return m_edit;
 }
 
-void RPythonTerminalDockWidget::writeToHistory(std::string const & data)
+void RPythonTerminalDockWidget::writeToHistory(std::string const & text)
 {
-    m_edit->appendBeforePrompt(QString::fromStdString(data));
+    m_edit->appendBeforePrompt(QString::fromStdString(text));
 }
 
 void RPythonTerminalDockWidget::applyTheme(SyntaxColors const & colors)

--- a/cpp/solvcon/pilot/console/RPythonTerminalDockWidget.hpp
+++ b/cpp/solvcon/pilot/console/RPythonTerminalDockWidget.hpp
@@ -175,7 +175,7 @@ public:
         return *this;
     }
 
-    void writeToHistory(std::string const & data);
+    void writeToHistory(std::string const & text);
 
     /// Point the input highlighter, the bracket marker, and the stderr color
     /// at a theme's syntax table so the terminal follows a light or dark

--- a/cpp/solvcon/pilot/visual/RDrawable.cpp
+++ b/cpp/solvcon/pilot/visual/RDrawable.cpp
@@ -3,7 +3,20 @@
  * BSD 3-Clause License, see COPYING
  */
 
+// Qt's `qnumeric.h` is the only place C4702 still fires, from a dead branch
+// the optimizer finds after inlining `qAddOverflowGeneric`. MSVC raises C4702
+// from the code generator, so `/external:W0` does not reach it and marking the
+// Qt headers SYSTEM does not silence it. The state of a 4700-4999 warning at a
+// function's opening brace governs that function, so disabling it across the
+// include covers Qt's inline bodies and leaves C4702 in force below.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4702) // unreachable code
+#endif
 #include <solvcon/pilot/visual/RDrawable.hpp> // Must be the first include.
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 namespace solvcon
 {

--- a/cpp/solvcon/serialization/SerializableItem.hpp
+++ b/cpp/solvcon/serialization/SerializableItem.hpp
@@ -215,7 +215,7 @@ void JsonHelper::from_json_string(const std::unique_ptr<JsonNode> & node, T & va
         {
             throw std::runtime_error("Invalid JSON format: invalid integer type.");
         }
-        value = std::stoll(std::get<std::string>(node->value));
+        value = static_cast<T>(std::stoll(std::get<std::string>(node->value)));
     }
     else if constexpr (std::is_floating_point_v<T>)
     {

--- a/cpp/solvcon/transform/fourier.hpp
+++ b/cpp/solvcon/transform/fourier.hpp
@@ -38,7 +38,7 @@ void fft_radix_2(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
     for (size_t size = 2; size <= N; size *= 2)
     {
         size_t const half_size = size / 2;
-        T2 angle_inc = -2.0 * pi<T2> / static_cast<T2>(size);
+        auto angle_inc = static_cast<T2>(-2.0 * pi<T2> / static_cast<T2>(size));
 
         for (size_t i = 0; i < N; i += size)
         {
@@ -130,8 +130,8 @@ public:
             out[i] = 0;
             for (size_t j = 0; j < N; ++j)
             {
-                T2 tmp = -2.0 * pi<T2> * i * j / static_cast<T2>(N);
-                T1<T2> const twiddle_factor{std::cos(tmp), std::sin(tmp)};
+                auto const angle = static_cast<T2>(-2.0 * pi<T2> * i * j / static_cast<T2>(N));
+                T1<T2> const twiddle_factor{std::cos(angle), std::sin(angle)};
                 out[i] += in[j] * twiddle_factor;
             }
         }

--- a/cpp/solvcon/universe/bernstein.hpp
+++ b/cpp/solvcon/universe/bernstein.hpp
@@ -18,13 +18,13 @@ template <typename T>
 T calc_bernstein_polynomial_impl(T t, size_t i, size_t n)
 {
     T ret = 1.0;
+    if (i > 0)
     {
-        T const v = (i > 0) ? std::pow(t, i) : 1.0;
-        ret *= v;
+        ret *= static_cast<T>(std::pow(t, i));
     }
+    if (n > i)
     {
-        T const v = (n > i) ? std::pow(1.0 - t, n - i) : 1.0;
-        ret *= v;
+        ret *= static_cast<T>(std::pow(1.0 - t, n - i));
     }
     for (size_t it = n; it > 1; --it)
     {
@@ -47,7 +47,7 @@ T interpolate_bernstein_impl(T t, std::vector<T> const & values, size_t n)
     T ret = 0.0;
     for (size_t it = 0; it <= n; ++it)
     {
-        T v = (it >= values.size()) ? 1.0 : values[it];
+        T v = (it >= values.size()) ? T(1) : values[it];
         v *= calc_bernstein_polynomial_impl(t, it, n);
         ret += v;
     }

--- a/cpp/solvcon/universe/bezier.hpp
+++ b/cpp/solvcon/universe/bezier.hpp
@@ -505,7 +505,7 @@ public:
     using value_type = typename bezier_type::value_type;
 
     explicit CubicBezierSampler(size_t ndim)
-        : m_segments(segment_pad_type::construct(ndim))
+        : m_segments(segment_pad_type::construct(static_cast<uint8_t>(ndim)))
     {
     }
 
@@ -554,8 +554,7 @@ size_t CubicBezierSampler<T>::sample_to(bezier_type const & c, segment_pad_type 
     size_t nseg = 0;
     for (size_t j = 1; j < nlocus - 1; ++j)
     {
-        value_type t = j;
-        t /= nlocus - 1;
+        value_type const t = static_cast<value_type>(j) / static_cast<value_type>(nlocus - 1);
         point_type thisp;
         for (size_t idim = 0; idim < 3; ++idim)
         {


### PR DESCRIPTION
Moving `COMMON_COMPILER_OPTIONS` above the core turned `/W4 /WX` on for the core libraries for the first time, and to keep that move landable the core suppressed five MSVC codes. This clears four of them and drops their `/wd` entries, leaving only `/wd4804`.

C4458 was two parameters that happen to share a name with a member in scope: `direct_converter()`'s `value` against the `value` of the enclosing `npy_format_descriptor`, and `writeToHistory()`'s `data` against `QWidget::data`. They are renamed to `storage` and `text`. C4244 and C4267 are implicit narrowings, mostly in template bodies instantiated over every value type, so a single line reports once per instantiation; each is now spelled out. Two of them were real rather than intended: `CubicBezierSampler` now takes the `uint8_t ndim` that `SegmentPad` wants instead of narrowing a `size_t` at the call, and `Plot3d::build_interior()` binds the element it already looked up instead of rebuilding the map key three times per iteration. C4702 came from two shapes that leave a statement no execution can reach once instantiated: `isub()` and `idiv()` threw from the `bool` branch of an `if constexpr` and then fell through to a `return` shared with the numeric branch, and `MatmulExecutor::execute_at()` guarded its BLAS dispatch with `#if` around an `if constexpr` that returns. The throw now lives inside the branch, and a `has_blas_backend` constant lets `if constexpr` discard the dispatch rather than the preprocessor delete it.

This is meant to be a pure warning fix, so every cast wraps the expression it makes explicit rather than retyping an operand. That distinction is not cosmetic: an earlier attempt wrote `T{1} - t` for `1.0 - t` in `bernstein.hpp`, which moved a float32 intermediate from `double` to `float` and broke `CurvePadFp32TC::test_sample_2d`. For the same reason `var()` keeps its product in the `size_t` the count promotes to, where overflow is defined to wrap, and the `dft()` angle is deduced with `auto` so a `long double` instantiation keeps its precision. No `SimpleArray<bool>` result changes: `sum`, `mean`, `median`, `var`, `std`, `average`, `symmetrize`, `trace`, `matmul`, the elementwise operations and the `*_simd` variants were compared against master and are byte-identical, and the exception type and message text for `sub`/`div`/`isub`/`idiv` are unchanged.

`/wd4702` could not be removed outright. Both remaining reports name Qt's own `qnumeric.h`, where there is no solvcon line to fix, and `/external:W0` cannot reach them because MSVC raises C4702 from the code generator rather than the front end. A full rebuild with every suppression stripped shows exactly one translation unit affected, so the suppression is applied to `RDrawable.cpp` alone. The rest of the pilot keeps C4702 in force, and a second unit reaching the same inlining will fail the build and name itself.

C4804 stays suppressed. It fires only in the `SimpleArray<bool>` reductions, where clearing it means deciding what `mean`, `average` and variance mean for `bool` rather than rewriting an expression, which is an API question rather than a warning fix. Issue #1332 records the measured solvcon-versus-numpy behaviour and tracks that work; the comment on `/wd4804` now points at it.

Verified on a Windows VM with MSVC 19.44: a `/W4 /WX` build of the module, the pilot and the gtest binary compiles with no warnings and no errors, gtest passes 242 of 242, and the pilot's in-binary pytest passes 1800 with none failing. A survey build with `/WX` and every `/wd` removed reports C4458, C4244, C4267 and C4702 at zero across 189 translation units, down from 14, 70, 26 and 32. On Linux the suite is unchanged against master: 1618 passed, with `test_average_with_axis` failing identically before and after in this environment. `make lint` is clean.

Related to #1324.
