### PR TITLE
Add a Codex CLI backend for Agent

### DIFF
--- a/solvcon/agent/__init__.py
+++ b/solvcon/agent/__init__.py
@@ -55,6 +55,7 @@ list_of_backends_impl = [
     'SubprocessBackend',
     'CancellableBackend',
     'ClaudeCliBackend',
+    'CodexCliBackend',
     'OpenAIHttpBackend',
     'ToolCallParser',
     'ParsedReply',

--- a/solvcon/agent/_backends_impl.py
+++ b/solvcon/agent/_backends_impl.py
@@ -10,7 +10,7 @@ OpenAI-compatible HTTP server, plus the shared plumbing they need:
 :class:`SubprocessBackend` (PATH discovery and a cancellable child process),
 :class:`OpenAIHttpBackend` (stdlib ``http.client``, no SDK), and
 :class:`ToolCallParser` (turn a model reply into Agent Draw command dicts).
-The Codex CLI backend is a follow-up that reuses :class:`SubprocessBackend`.
+The Claude Code and Codex CLI backends reuse :class:`SubprocessBackend`.
 
 The module imports no Qt and makes no network call at import time.  A backend
 registers itself only as a class instance in the shared registry, so a caller
@@ -214,12 +214,10 @@ class SubprocessBackend(CancellableBackend, _backend.AgentBackend):
     #: The selector label a subclass names itself with.
     name = None
 
-    #: The only environment variables the agent CLI receives: the process
-    #: basics it needs to run, plus the credentials of the supported
-    #: authentication modes (see the class docstring).
+    #: The process basics every agent CLI receives.  A subclass extends this
+    #: with only its own authentication variables.
     env_passthrough = (
-        "HOME", "USER", "LOGNAME", "PATH", "TMPDIR",
-        "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CONFIG_DIR")
+        "HOME", "USER", "LOGNAME", "PATH", "TMPDIR")
 
     def __init__(self, timeout=120):
         super().__init__()
@@ -292,8 +290,8 @@ class SubprocessBackend(CancellableBackend, _backend.AgentBackend):
         workdir = tempfile.mkdtemp(prefix="solvcon-agent-")
         try:
             proc = subprocess.Popen(
-                argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                text=True, cwd=workdir, env=env)
+                argv, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, text=True, cwd=workdir, env=env)
             self._proc = proc
             if self._cancelled:
                 # A cancel between spawning the child and publishing it here
@@ -328,6 +326,8 @@ class ClaudeCliBackend(SubprocessBackend):
 
     command = "claude"
     name = "Claude Code"
+    env_passthrough = SubprocessBackend.env_passthrough + (
+        "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CONFIG_DIR")
 
     DEFAULT_CHOICE = "default"
 
@@ -383,6 +383,71 @@ class ClaudeCliBackend(SubprocessBackend):
 
 
 _backend.BackendRegistry.register(ClaudeCliBackend())
+
+
+class CodexCliBackend(SubprocessBackend):
+    """Backend over OpenAI's ``codex`` command-line tool.
+
+    ``codex exec`` runs non-interactively in a fresh read-only workspace.  It
+    receives no user configuration, rules, shell, apps, or web-search tool,
+    and saves no session.  Authentication remains the CLI's concern: a stored
+    login comes through ``HOME`` or ``CODEX_HOME``, and automation can provide
+    ``CODEX_API_KEY`` for this child alone.
+
+    The user may leave the model and reasoning effort on the moving CLI
+    default or pin either setting.  The system prompt reaches Codex as
+    developer instructions, separate from the composed user prompt.
+    """
+
+    command = "codex"
+    name = "Codex"
+    env_passthrough = SubprocessBackend.env_passthrough + (
+        "CODEX_HOME", "CODEX_API_KEY")
+
+    DEFAULT_CHOICE = "default"
+
+    SETTINGS = (
+        _backend.BackendSetting(
+            name="model", label="Model",
+            choices=(DEFAULT_CHOICE, "gpt-5.6-sol", "gpt-5.6-terra",
+                     "gpt-5.6-luna"),
+            default=DEFAULT_CHOICE,
+            tooltip="Model passed to the CLI as --model."),
+        _backend.BackendSetting(
+            name="effort", label="Effort",
+            choices=(DEFAULT_CHOICE, "low", "medium", "high", "xhigh", "max"),
+            default=DEFAULT_CHOICE,
+            tooltip="Reasoning effort passed as model_reasoning_effort."),
+    )
+
+    def settings_spec(self):
+        return self.SETTINGS
+
+    @staticmethod
+    def _config(name, value):
+        """One joined ``--config`` override with a TOML string value."""
+        return "--config=%s=%s" % (name, json.dumps(value))
+
+    def _build_argv(self, exe, user_prompt, system_prompt):
+        argv = [
+            exe, "exec", "--sandbox=read-only", "--skip-git-repo-check",
+            "--ephemeral", "--ignore-user-config", "--ignore-rules",
+            "--strict-config", "--color=never", "--disable=shell_tool",
+            "--disable=apps",
+            self._config("web_search", "disabled"),
+            self._config("developer_instructions", system_prompt),
+        ]
+        model = self.get_setting("model")
+        if model and model != self.DEFAULT_CHOICE:
+            argv.append("--model=%s" % model)
+        effort = self.get_setting("effort")
+        if effort and effort != self.DEFAULT_CHOICE:
+            argv.append(self._config("model_reasoning_effort", effort))
+        argv.append(user_prompt)
+        return argv
+
+
+_backend.BackendRegistry.register(CodexCliBackend())
 
 
 class OpenAIHttpBackend(CancellableBackend, _backend.AgentBackend):

--- a/tests/gui/test_agent.py
+++ b/tests/gui/test_agent.py
@@ -302,5 +302,15 @@ class AgentPanelTC(unittest.TestCase):
         self.assertIn("--model=opus", argv)
         self.assertIn("--effort=high", argv)
 
+    def test_codex_backend_settings_reach_the_cli(self):
+        backend = agent.CodexCliBackend()
+        dialog = _agent_settings.AgentBackendSettingsDialog(backend)
+        dialog._editors["model"].setCurrentText("gpt-5.6-sol")
+        dialog._editors["effort"].setCurrentText("high")
+        dialog.accept()
+        argv = backend._build_argv("/usr/bin/codex", "draw", "system")
+        self.assertIn("--model=gpt-5.6-sol", argv)
+        self.assertIn('--config=model_reasoning_effort="high"', argv)
+
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_backend.py
+++ b/tests/test_agent_backend.py
@@ -577,5 +577,20 @@ class BackendSettingsConfigTC(unittest.TestCase):
         self.assertEqual(self.backend.get_setting("effort"),
                          agent.ClaudeCliBackend.DEFAULT_CHOICE)
 
+    def test_codex_settings_survive_a_config_round_trip(self):
+        backend = agent.BackendRegistry.get(agent.CodexCliBackend().name)
+        for knob, value in backend.settings().items():
+            self.addCleanup(backend.set_setting, knob, value)
+        backend.set_setting("model", "gpt-5.6-terra")
+        backend.set_setting("effort", "high")
+        config = Config(self.path)
+        agent.BackendRegistry.save_settings(config)
+        config.save()
+        backend.set_setting("model", agent.CodexCliBackend.DEFAULT_CHOICE)
+        backend.set_setting("effort", agent.CodexCliBackend.DEFAULT_CHOICE)
+        agent.BackendRegistry.load_settings(Config(self.path).load())
+        self.assertEqual(backend.get_setting("model"), "gpt-5.6-terra")
+        self.assertEqual(backend.get_setting("effort"), "high")
+
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_backends_impl.py
+++ b/tests/test_agent_backends_impl.py
@@ -5,7 +5,7 @@
 """Tests for the concrete CLI/HTTP backends and tool-call parsing.
 
 GUI-free by default: PATH discovery is patched, the child process is replaced,
-and HTTP posts are stubbed, so no real ``claude`` CLI or network call runs.
+and HTTP posts are stubbed, so no real AI CLI or network call runs.
 These exercise the parsing contract, availability checks, and the ``send``
 pipeline.  Opt-in classes hit a live CLI or OpenAI-compatible server.
 """
@@ -132,6 +132,12 @@ class SubprocessBackendDiscoveryTC(unittest.TestCase):
         backend = agent.ClaudeCliBackend()
         with mock.patch(_WHICH, lambda name: None):
             self.assertFalse(backend.available())
+
+    def test_codex_resolves_its_own_executable(self):
+        backend = agent.CodexCliBackend()
+        with mock.patch(_WHICH, lambda name: "/usr/bin/" + name):
+            self.assertTrue(backend.available())
+            self.assertEqual(backend.executable(), "/usr/bin/codex")
 
     def test_command_none_never_resolves(self):
         # A subclass that names no executable is never available even though
@@ -284,6 +290,64 @@ class ClaudeCliSendTC(unittest.TestCase):
         self.assertNotIn("drive a 2D drawing canvas", prompt)
 
 
+class CodexCliSendTC(unittest.TestCase):
+    def setUp(self):
+        self.backend = agent.CodexCliBackend()
+        patcher = mock.patch(_WHICH, lambda name: "/usr/bin/" + name)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_send_parses_commands(self):
+        reply = '[{"op": "add_circle", "r": 2.0}]'
+        self.backend._communicate = lambda argv: (0, reply, "")
+        response = self.backend.send(
+            "draw a circle", "empty world", _TOOLS)
+        self.assertIsNone(response.error)
+        self.assertEqual(response.commands, [{"op": "add_circle", "r": 2.0}])
+
+    def test_send_passes_prompt_and_pins_the_cli(self):
+        seen = {}
+
+        def _capture(argv):
+            seen["argv"] = argv
+            return 0, "[]", ""
+
+        self.backend._communicate = _capture
+        self.backend.send("hello", "one shape", _TOOLS)
+        argv = seen["argv"]
+        self.assertEqual(argv[:2], ["/usr/bin/codex", "exec"])
+        for flag in ("--sandbox=read-only", "--skip-git-repo-check",
+                     "--ephemeral", "--ignore-user-config", "--ignore-rules",
+                     "--strict-config", "--color=never",
+                     "--disable=shell_tool", "--disable=apps"):
+            self.assertIn(flag, argv)
+        self.assertIn('--config=web_search="disabled"', argv)
+        prompt = argv[-1]
+        self.assertIn("hello", prompt)
+        self.assertIn("one shape", prompt)
+        self.assertIn("add_circle", prompt)
+        system_arg = next(
+            arg for arg in argv
+            if arg.startswith("--config=developer_instructions="))
+        system = json.loads(system_arg.split("=", 2)[2])
+        self.assertIn("drive a 2D drawing canvas", system)
+        self.assertNotIn("drive a 2D drawing canvas", prompt)
+
+    def test_settings_reach_the_cli(self):
+        self.backend.set_setting("model", "gpt-5.6-sol")
+        self.backend.set_setting("effort", "high")
+        argv = self.backend._build_argv(
+            "/usr/bin/codex", "draw", "system")
+        self.assertIn("--model=gpt-5.6-sol", argv)
+        self.assertIn('--config=model_reasoning_effort="high"', argv)
+
+    def test_default_settings_leave_the_cli_defaults_alone(self):
+        argv = self.backend._build_argv(
+            "/usr/bin/codex", "draw", "system")
+        self.assertFalse(any(arg.startswith("--model=") for arg in argv))
+        self.assertFalse(any("model_reasoning_effort" in arg for arg in argv))
+
+
 class _FakeProc:
     """Stand-in for the CLI child: records nothing, answers an empty batch."""
 
@@ -366,6 +430,10 @@ class SubprocessBackendPinningTC(unittest.TestCase):
         self.assertIn("solvcon-agent-", os.path.basename(workdir))
         self.assertFalse(os.path.exists(workdir))
 
+    def test_child_cannot_read_the_parent_stdin(self):
+        seen = self._run({"PATH": "/bin"})
+        self.assertEqual(seen["stdin"], subprocess.DEVNULL)
+
     def test_argv_pins_the_cli_sandbox(self):
         argv = self._run({"PATH": "/bin"})["argv"]
         self.assertEqual(argv[argv.index("--tools") + 1], "")
@@ -374,6 +442,31 @@ class SubprocessBackendPinningTC(unittest.TestCase):
                      "--no-session-persistence"):
             self.assertIn(flag, argv)
         self.assertEqual(argv[argv.index("--permission-mode") + 1], "dontAsk")
+
+
+class CodexCliPinningTC(unittest.TestCase):
+    def test_child_receives_only_codex_auth(self):
+        backend = agent.CodexCliBackend()
+        seen = {}
+
+        def _popen(argv, **kwargs):
+            seen.update(kwargs)
+            return _FakeProc("[]")
+
+        environ = {
+            "HOME": "/home/u", "PATH": "/bin",
+            "CODEX_HOME": "/home/u/.codex", "CODEX_API_KEY": "codex",
+            "ANTHROPIC_API_KEY": "anthropic", "GITHUB_TOKEN": "github",
+        }
+        with mock.patch(_WHICH, lambda name: "/usr/bin/" + name):
+            with mock.patch.dict(os.environ, environ, clear=True):
+                with mock.patch("subprocess.Popen", _popen):
+                    response = backend.send("draw", "scene", _TOOLS)
+        self.assertIsNone(response.error)
+        self.assertEqual(seen["env"], {
+            "HOME": "/home/u", "PATH": "/bin",
+            "CODEX_HOME": "/home/u/.codex", "CODEX_API_KEY": "codex",
+        })
 
 
 class RegistrationTC(unittest.TestCase):
@@ -386,6 +479,11 @@ class RegistrationTC(unittest.TestCase):
         backend = agent.BackendRegistry.get("openai (http)")
         self.assertIsNotNone(backend)
         self.assertIsInstance(backend, agent.OpenAIHttpBackend)
+
+    def test_codex_registers_on_import(self):
+        backend = agent.BackendRegistry.get("Codex")
+        self.assertIsNotNone(backend)
+        self.assertIsInstance(backend, agent.CodexCliBackend)
 
 
 class OpenAIHttpBackendTC(unittest.TestCase):
@@ -625,6 +723,32 @@ class ClaudeCliRealTC(unittest.TestCase):
         # A real reply must parse cleanly into circle-drawing commands; a
         # broken flag, envelope, or parser would surface as an error or an
         # empty batch here.
+        self.assertIsNone(response.error)
+        self.assertTrue(response.commands)
+        ops = {tool["name"] for tool in _TOOLS}
+        for command in response.commands:
+            self.assertIn(command.get("op"), ops)
+        self.assertIn("add_circle",
+                      [command["op"] for command in response.commands])
+
+
+_REAL_CODEX = "SOLVCON_TEST_REAL_CODEX"
+
+
+@unittest.skipUnless(os.environ.get(_REAL_CODEX) == "1",
+                     "set %s=1 to hit the installed codex CLI" % _REAL_CODEX)
+class CodexCliRealTC(unittest.TestCase):
+    """Opt-in end-to-end test against the installed Codex CLI."""
+
+    def setUp(self):
+        self.backend = agent.CodexCliBackend()
+        if not self.backend.available():
+            self.skipTest("codex CLI not found on PATH")
+
+    def test_draws_a_circle_end_to_end(self):
+        response = self.backend.send(
+            "Add exactly one circle of radius 1 at the origin.",
+            "empty world with 0 shapes", _TOOLS)
         self.assertIsNone(response.error)
         self.assertTrue(response.commands)
         ops = {tool["name"] for tool in _TOOLS}


### PR DESCRIPTION
Add a Codex CLI backend alongside the existing Claude Code backend. It runs `codex exec` in a pinned, read-only, ephemeral subprocess, isolates authentication and standard input, and exposes model and reasoning-effort settings through the existing Agent settings UI.

Tests cover CLI discovery and arguments, settings persistence, GUI propagation, subprocess isolation, and opt-in end-to-end execution. The focused backend suite passed with 114 tests and 3 opt-in tests skipped, the Agent GUI suite passed with 19 tests, and `make lint` passed.

Related to #1137.
