### PR TITLE
Add Codex-specific project skills

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,1 +1,0 @@
-../.claude/skills

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: code-review
+description: Review a diff, branch, path, commit, or pull request for actionable correctness defects. Use when the user invokes $code-review or asks for a code review. Keep the review read-only unless the user explicitly requests fixes or comments.
+---
+
+# Code Review
+
+Resolve the exact review target first. For current work, include staged,
+unstaged, and untracked changes. For a pull request, inspect its real base,
+head, diff, and relevant discussion.
+
+Use code graph tools to trace changed symbols, callers, and invariants. Read the
+minimum surrounding code and tests needed to prove each finding. Focus on bugs,
+regressions, unsafe behavior, missing validation, and tests that fail to cover
+a material risk. Do not report style preferences or speculative concerns.
+
+Rank findings by severity. For every finding, cite exact file and line evidence,
+describe the failing scenario, and explain the impact. If no actionable issue
+is found, say so explicitly and note any verification gap.
+
+Remain read-only by default. Apply fixes or post review comments only when the
+user explicitly asks, then re-review the resulting live diff.
+
+<!-- vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: -->

--- a/.agents/skills/commit-code
+++ b/.agents/skills/commit-code
@@ -1,0 +1,1 @@
+../../.claude/skills/commit-code

--- a/.agents/skills/cpp-style-review
+++ b/.agents/skills/cpp-style-review
@@ -1,0 +1,1 @@
+../../.claude/skills/cpp-style-review

--- a/.agents/skills/create-pr
+++ b/.agents/skills/create-pr
@@ -1,0 +1,1 @@
+../../.claude/skills/create-pr

--- a/.agents/skills/ide-user-presets
+++ b/.agents/skills/ide-user-presets
@@ -1,0 +1,1 @@
+../../.claude/skills/ide-user-presets

--- a/.agents/skills/prototype-with-devplan
+++ b/.agents/skills/prototype-with-devplan
@@ -1,0 +1,1 @@
+../../.claude/skills/prototype-with-devplan

--- a/.agents/skills/python-style-review
+++ b/.agents/skills/python-style-review
@@ -1,0 +1,1 @@
+../../.claude/skills/python-style-review

--- a/.agents/skills/serve-docs
+++ b/.agents/skills/serve-docs
@@ -1,0 +1,1 @@
+../../.claude/skills/serve-docs

--- a/.agents/skills/simplify/SKILL.md
+++ b/.agents/skills/simplify/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: simplify
+description: Review recently changed code for reuse, simplicity, efficiency, and appropriate abstraction, then apply safe behavior-preserving cleanup. Use when the user invokes $simplify or asks to simplify or refine recent changes. Do not use for correctness review.
+---
+
+# Simplify
+
+Review the target the user names. Otherwise inspect tracked and untracked
+changes with `git status --short --untracked-files=all`, then read the relevant
+diffs and new files. If there is no changed code, report that and stop.
+
+Check four things:
+
+1. Reuse existing helpers instead of duplicating logic.
+2. Reduce unnecessary control flow, state, indirection, and comments.
+3. Remove avoidable work or allocation when the benefit is clear.
+4. Keep behavior at the right abstraction level for the surrounding code.
+
+Use code graph tools for relationships and reuse discovery. Read the diff and
+the minimum surrounding code needed to validate each cleanup. Do not broaden
+the task into bug hunting, feature work, or unrelated refactoring.
+
+Apply only changes that preserve intended behavior and make the code plainly
+simpler. Leave uncertain or subjective suggestions unapplied and report them.
+Keep edits inside changed code unless a directly reused helper requires a
+small adjacent update.
+
+Run focused tests and relevant lint checks after editing. Invoke
+`$cpp-style-review` after C++ changes and `$python-style-review` after Python
+changes. Review the final diff and revert any cleanup that adds complexity or
+changes behavior. Do not commit or open a pull request unless asked.
+
+Report the cleanups applied, verification results, and any suggestions left
+for the user.
+
+<!-- vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: -->

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: verify
+description: Verify that a code change works through the real running application and observable acceptance criteria. Use when the user invokes $verify or asks for end-to-end confirmation beyond unit tests, lint, or type checks.
+---
+
+# Verify
+
+Translate the request and diff into concrete observable acceptance criteria.
+Read repository instructions and a matching `run-*` skill if one exists.
+
+Build and launch the real application using the supported workflow. Exercise
+the changed behavior through its actual user or integration surface and collect
+evidence for every acceptance criterion. Include an important negative or
+boundary case when it is safe and relevant.
+
+Tests, lint, logs, and internal state may support the result, but they do not
+replace direct observation of the running application. Do not claim success
+when an environment limitation prevented the relevant behavior from running.
+
+Stop processes and remove temporary state created for verification. Report each
+criterion as passed, failed, or blocked, with the evidence and commands used.
+Do not fix a failure unless the user also requested implementation.
+
+<!-- vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: -->

--- a/.agents/skills/worktree
+++ b/.agents/skills/worktree
@@ -1,0 +1,1 @@
+../../.claude/skills/worktree


### PR DESCRIPTION
Replace the `.agents/skills` directory-wide link with individual links for shared Claude skills, allowing Codex-only skills to coexist without duplicating shared definitions.

Add lightweight Codex workflows for correctness review, behavior-preserving simplification, and runtime verification.

[skip-ci]
