### PR TITLE
Suppress deprecated warnings with pybind11 and upgrade to 3.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,9 @@ endif()
 option(pybind11_path "pybind11 path")
 find_package(pybind11 2.12.0 REQUIRED PATHS ${pybind11_path})
 message(STATUS "pybind11_INCLUDE_DIRS: ${pybind11_INCLUDE_DIRS}")
-include_directories(${pybind11_INCLUDE_DIRS})
+# SYSTEM keeps the core's warning flags off pybind11's own headers, the same
+# reason numpy gets it below.
+include_directories(SYSTEM ${pybind11_INCLUDE_DIRS})
 
 set(NUMPY_INCLUDE_DIR "${Python_NumPy_INCLUDE_DIRS}")
 message(STATUS "NUMPY_INCLUDE_DIR: ${NUMPY_INCLUDE_DIR}")

--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -293,9 +293,9 @@ EOF
 
 plat_scipy_install() {
   # Runs in the unpacked scipy source directory (the caller has pushd'd).
-  # Ubuntu's pybind11-dev (2.11) at /usr/include shadows our 2.13.6 and
-  # rejects scipy's 3-arg PYBIND11_MODULE. -isystem orders our headers ahead
-  # of /usr/include so scipy compiles against the right pybind11.
+  # Ubuntu's pybind11-dev (2.11) at /usr/include shadows ours and rejects
+  # scipy's 3-arg PYBIND11_MODULE. -isystem orders our headers ahead of
+  # /usr/include so scipy compiles against the right pybind11.
   local saved_cxxflags=${CXXFLAGS:-}
   export CXXFLAGS="-isystem ${SCDV_USRDIR}/include ${saved_cxxflags}"
   with_log install.log "${PY}" -m pip install . --no-build-isolation
@@ -1277,11 +1277,11 @@ build_python() {
 
 build_pybind11() {
   scdv_skip_p pybind11 && { echo "skip: pybind11" ; return 0 ; }
-  local ver=2.13.6 full fn
+  local ver=3.1.0 full fn
   full=pybind11-${ver} ; fn=${full}.tar.gz
   download_md5 "${fn}" \
     "https://github.com/pybind/pybind11/archive/refs/tags/v${ver}.tar.gz" \
-    a04dead9c83edae6d84e2e343da7feeb
+    235664b4673257b80a9ab79f9b208e94
   unpack "${fn}" "${full}"
   mkdir -p "${SCDV_SRCDIR}/${full}/build"
   pushd "${SCDV_SRCDIR}/${full}/build" > /dev/null

--- a/contrib/dependency/windows/build-scdv-windows.ps1
+++ b/contrib/dependency/windows/build-scdv-windows.ps1
@@ -917,10 +917,10 @@ function Build-Python {
 
 function Build-Pybind11 {
     if (Test-Skip 'pybind11') { Write-Host 'skip: pybind11'; return }
-    $ver = '2.13.6'; $full = "pybind11-$ver"; $fn = "$full.tar.gz"
+    $ver = '3.1.0'; $full = "pybind11-$ver"; $fn = "$full.tar.gz"
     Get-Download $fn `
         "https://github.com/pybind/pybind11/archive/refs/tags/v$ver.tar.gz" `
-        'a04dead9c83edae6d84e2e343da7feeb'
+        '235664b4673257b80a9ab79f9b208e94'
     Expand-Source $fn $full
     $bld = Join-Path $ScdvSrcDir "$full\build"
     New-Item -ItemType Directory -Force -Path $bld | Out-Null


### PR DESCRIPTION
Building with `-Werror` on Python 3.14 fails inside the third-party pybind11 2.13.6 header, which calls the deprecated `_Py_fopen_obj` at [`include/pybind11/eval.h#L136`](https://github.com/pybind/pybind11/blob/v2.13.6/include/pybind11/eval.h#L136), and CPython 3.14 keeps that entry point only as a `Py_DEPRECATED(3.14)` shim over the new `Py_fopen`, at [`Include/cpython/fileutils.h#L5-L14`](https://github.com/python/cpython/blob/v3.14.0/Include/cpython/fileutils.h#L5-L14).

The core's warning flags reached that header because `include_directories()` adds a plain include path, so it becames our build failure.  GCC 16.0.1 on Ubuntu 24.04 with Python 3.14.5 reports it this way:

```
.../pybind11-2.13.6/include/pybind11/eval.h: In function 'pybind11::object pybind11::eval_file(str, object, object)':
.../pybind11-2.13.6/include/pybind11/eval.h:136:28: error: 'FILE* _Py_fopen_obj(PyObject*, const char*)' is deprecated [-Werror=deprecated-declarations]
  136 |     FILE *f = _Py_fopen_obj(fname.ptr(), "r");
      |               ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
.../include/python3.14/cpython/fileutils.h:11:1: note: declared here
   11 | _Py_fopen_obj(PyObject *path, const char *mode)
      | ^~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

The fix marks `SYSTEM` for the pybind11 include directory, and keeps `-Werror` to stay meaningful on our own deprecated uses.  The scdv development environment is updated to use the latest pybind11 3.1.0 too.