### PR TITLE
Clarify the Doxygen documentation requirement

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,8 +1,7 @@
 # Minimal documentation build for solvcon.
 #
 # Quick start:
-#   pip install -r requirements.txt   # plus a system Doxygen for C++ docs
-#   make doxygen                      # C++ API XML (optional, run first)
+#   pip install -r requirements.txt   # plus a system Doxygen
 #   make html                         # site -> build/html/index.html
 
 SPHINXBUILD ?= sphinx-build

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -15,7 +15,7 @@ FORCE_BUILD ?=
 .PHONY: help html doxygen serve clean
 
 help:
-	@echo "make doxygen   generate C++ API XML (run before html for C++)"
+	@echo "make doxygen   generate C++ API XML (also run by html)"
 	@echo "make html      build the HTML site into $(BUILDDIR)/html"
 	@echo "make serve     build, then serve at http://localhost:$(PORT)/"
 	@echo "make clean     remove built docs and Doxygen output"

--- a/doc/README.md
+++ b/doc/README.md
@@ -7,11 +7,11 @@ the Sphinx-based documentation.
 
 ```sh
 pip install -r requirements.txt   # Python deps
-make doxygen                      # optional: C++ API XML (needs doxygen)
-make html                         # -> build/html/index.html
+make html                         # needs Doxygen; -> build/html/index.html
 ```
 
-`make html` works without `make doxygen`; the C++ API page simply renders
-empty (a warning, not an error) until the XML exists.
+`make html` runs `make doxygen` first so that the C++ API is current. Install
+Doxygen before building. Run `make doxygen` by itself only to regenerate the
+XML under `build/doxygen` without rebuilding the HTML site.
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->


### PR DESCRIPTION
## Summary

- clarify that `make html` runs Doxygen before Sphinx;
- remove wording that describes the Doxygen step as optional;
- explain that `make doxygen` may be run separately to regenerate the C++ API XML without rebuilding the HTML site.

## Motivation

`doc/README.md` currently says that `make html` works without Doxygen. However, `doc/Makefile` defines `html: doxygen`, so every HTML build runs Doxygen first and requires it to be installed.

This change updates the documentation to match the existing build behavior.

## Testing

- `make -C doc -n html`
- `make -C doc clean`
- `make -C doc html`
- `make lint`
- `git diff --check`
- `sphinx-build -b linkcheck doc/source doc/build/linkcheck` — completed with existing HTTP 403 failures from Annual Reviews and Stack Overflow

The HTML build completed successfully. It reported an existing unresolved Doxygen link warning in `RMenuModel.hpp` that is unrelated to this documentation-only change.

## Scope

This is documentation-only. It does not modify source code, Make targets, Sphinx configuration, or build behavior. No generated documentation output is included.
