### PR TITLE
Declare Pillow for the documentation fallback

### DIFF
--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -180,7 +180,8 @@ scdv_apt_latex_cmd() {
   # Gotcha: Ubuntu's ImageMagick policy.xml disables the EPS/PS coders, so
   # convert fails on the generated .eps.  The pstake input is locally built
   # and trusted; comment out the rights="none" lines for EPS/PS, or skip
-  # imagemagick and rely on the Ghostscript fallback.
+  # imagemagick and rely on the Ghostscript fallback.  The fallback uses
+  # Pillow, which `doc/requirements.txt` installs.
   cat <<'EOF'
 sudo apt install -y \
   texlive-latex-base texlive-latex-recommended texlive-latex-extra \

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,6 +4,7 @@
 
 sphinx>=7.0
 numpy
+Pillow
 myst-parser>=2.0
 furo>=2024.1
 breathe>=4.35

--- a/doc/source/start/build_dep.md
+++ b/doc/source/start/build_dep.md
@@ -50,10 +50,11 @@ HTML, because the `pstake` extension renders the PSTricks figures through
 Ubuntu that is the `texlive-*` set led by `texlive-pstricks`, plus
 `ghostscript` and `imagemagick`; note that Ubuntu's ImageMagick disables the
 EPS and PS coders in `policy.xml`, so either allow them or drop `imagemagick`
-and let the Ghostscript fallback do the work. On macOS there is no system TeX
-at all, so it is the `mactex-no-gui` cask (a several-gigabyte download) plus
-`ghostscript` and `imagemagick`. The cask installs into `/Library/TeX/texbin`
-and reaches `PATH` through `/etc/paths.d`, so run
+and use the Ghostscript fallback. The fallback uses Pillow, which
+`doc/requirements.txt` installs. On macOS there is no system TeX at all, so it
+is the `mactex-no-gui` cask (a several-gigabyte download) plus `ghostscript`
+and `imagemagick`. The cask installs into `/Library/TeX/texbin` and reaches
+`PATH` through `/etc/paths.d`, so run
 `eval "$(/usr/libexec/path_helper)"` or open a new terminal before building
 the documentation.
 


### PR DESCRIPTION
## Summary

- add Pillow to the Python requirements for documentation builds;
- document that the ImageMagick-free Ghostscript fallback uses Pillow;
- keep the dependency helper guidance consistent with the documented fallback.

## Motivation

The build documentation says Ubuntu users may omit ImageMagick and rely on the Ghostscript fallback. However, `pstake` requires PIL/Pillow to read the generated EPS dimensions before invoking Ghostscript, and the documentation requirements did not install Pillow.

## Testing

- `make -C doc html` in an Ubuntu 24.04 container without ImageMagick (passed)
- `sphinx-build -b linkcheck doc/source doc/build/linkcheck` (reported two existing external HTTP 403 responses)
- `make lint` (passed)
- `bash -n contrib/dependency/build-scdv.sh` (passed)
- `SCDV_OS=ubuntu bash contrib/dependency/build-scdv.sh --print-deps` (passed)
- `git diff --check` (passed)

## Scope

This change only updates documentation build dependencies and related guidance. It does not modify the `pstake` implementation, runtime source code, or core build behavior.