### PR TITLE
Configure the Codex TUI status line

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,15 @@
+#:schema https://developers.openai.com/codex/config-schema.json
+
+[tui]
+status_line = [
+    "model-with-reasoning",
+    "project-name",
+    "git-branch",
+    "context-used",
+    "total-input-tokens",
+    "total-output-tokens",
+    "five-hour-limit",
+    "weekly-limit",
+]
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ This section indexes the tools.
 - `AGENTS.md` at the repository root is a symlink to `CLAUDE.md`.
 - `.agents/skills/` is a symlink to `.claude/skills/`, the repository skill
   location recognized by Codex.
+- `.codex/config.toml` configures the Codex TUI status line with the model,
+  project, branch, context, token, and subscription-usage fields.
 - `.codex/hooks.json` wires Codex `PreToolUse` and `PostToolUse` events to the
   shared hook scripts.
 - `.codex/hooks/` is a symlink to `.claude/hooks/`.


### PR DESCRIPTION
Add a project-local Codex TUI status line that reports the active model, project and branch, context consumption, token counts, and available subscription usage windows. Document the setting alongside the repository's other Codex tooling.

[skip-ci]
