### PR TITLE
Agent MVP 4a: pump the turn loop from the console panel

### DIFF
--- a/solvcon/agent/_backend.py
+++ b/solvcon/agent/_backend.py
@@ -356,6 +356,22 @@ class TurnRequest:
         return backend.send(self.prompt, self.scene_context,
                             self.tool_surface, self.history)
 
+    def send_safely(self, backend):
+        """:meth:`send_to` with a raising backend folded into a transport
+        outcome.
+
+        Neither driver has anywhere to put the exception: headless it would
+        escape to the caller, and under a GUI it would be raised on a worker
+        thread.  Both want the failure as the reply their loop already knows
+        how to stop on.
+        """
+        try:
+            return self.send_to(backend)
+        except Exception as exc:
+            return BackendResponse(
+                error="%s: %s" % (type(exc).__name__, exc),
+                outcome=TransportOutcome.TRANSPORT)
+
 
 class TransportOutcome(enum.Enum):
     """How the exchange that carried a request ended.

--- a/solvcon/agent/_turn.py
+++ b/solvcon/agent/_turn.py
@@ -101,8 +101,15 @@ class Turn:
         Exhausting a multi-step budget records a marker so the transcript does
         not look like the model went silent; a one-shot budget of one records
         nothing, because a single step is the whole turn.
+
+        A session with no backend ends here rather than in each driver, so a
+        prompt typed with nothing selected is recorded and answered the same
+        way whoever is pumping the turn.
         """
         if self.done:
+            return None
+        if self._session.backend is None:
+            self._finish(StopReason.NO_BACKEND, None)
             return None
         if self._steps >= self._budget:
             note = ("step budget of %d reached; turn ended with work still "
@@ -178,20 +185,11 @@ def run_turn(session, prompt, budget=2, scene=None, token=None):
     is recorded and ``None`` comes back.
     """
     turn = Turn(session, prompt, budget=budget, scene=scene, token=token)
-    if session.backend is None:
-        turn.stop(StopReason.NO_BACKEND)
-        return None
     recorded = None
     while True:
         request = turn.next_request()
         if request is None:
             return recorded
-        try:
-            response = request.send_to(session.backend)
-        except Exception as exc:
-            response = _backend.BackendResponse(
-                error="%s: %s" % (type(exc).__name__, exc),
-                outcome=_backend.TransportOutcome.TRANSPORT)
-        recorded = turn.feed(response) or recorded
+        recorded = turn.feed(request.send_safely(session.backend)) or recorded
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/agent/_agent_control.py
+++ b/solvcon/pilot/agent/_agent_control.py
@@ -27,6 +27,7 @@ __all__ = [
     'LiveViewExecutor',
     'build_control_dispatcher',
     'pilot_scene_context',
+    'PilotTurnSeams',
 ]
 
 
@@ -36,17 +37,27 @@ class PilotWindowManager:
 
     Presents the surface the window command family calls: ``new_canvas``,
     ``list_windows``, ``activate_window``, ``close_window``, and
-    ``save_image``.  Each open sub-window carries a stable integer id keyed on
-    the MDI sub-window, whose identity Qt keeps stable across calls; ids for
-    windows that have closed are dropped.  ``save_image`` briefly activates the
-    target window so it can be grabbed through the current canvas, then
-    restores the previously active one.
+    ``save_image``.  Each open sub-window carries a stable integer id, which
+    dies with the window it names.  ``save_image`` briefly activates the target
+    window so it can be grabbed through the current canvas, then restores the
+    previously active one.
     """
+
+    #: Dynamic property holding a sub-window's id.  The id rides on the C++
+    #: object because PySide hands back a fresh Python sub-window for the same
+    #: window from one listing to the next: held in a table keyed on that
+    #: object, every listing would rename the windows under an agent that was
+    #: shown the ids before it.
+    ID_PROPERTY = "solvconAgentWindowId"
+
+    #: Dynamic property holding the next id to hand out.  It sits on the MDI
+    #: area, beside the ids themselves, so a second manager over the same area
+    #: keeps counting rather than restarting at 1 over windows that already
+    #: carry those ids.
+    COUNTER_PROPERTY = "solvconAgentNextWindowId"
 
     def __init__(self, mgr):
         self._mgr = mgr
-        self._ids = {}  # sub-window -> stable id
-        self._next_id = 1
 
     def _area(self):
         return self._mgr.mdiArea
@@ -54,17 +65,22 @@ class PilotWindowManager:
     def _open_subwindows(self):
         return [s for s in self._area().subWindowList() if s.isVisible()]
 
+    def _mint_id(self):
+        area = self._area()
+        window_id = area.property(self.COUNTER_PROPERTY) or 1
+        area.setProperty(self.COUNTER_PROPERTY, window_id + 1)
+        return window_id
+
     def _id_of(self, subwin):
-        window_id = self._ids.get(subwin)
+        window_id = subwin.property(self.ID_PROPERTY)
         if window_id is None:
-            window_id = self._next_id
-            self._next_id += 1
-            self._ids[subwin] = window_id
+            window_id = self._mint_id()
+            subwin.setProperty(self.ID_PROPERTY, window_id)
         return window_id
 
     def _subwindow_of(self, window_id):
         for subwin in self._open_subwindows():
-            if self._ids.get(subwin) == window_id:
+            if subwin.property(self.ID_PROPERTY) == window_id:
                 return subwin
         return None
 
@@ -81,8 +97,6 @@ class PilotWindowManager:
     def list_windows(self):
         active = self._area().activeSubWindow()
         subwins = self._open_subwindows()
-        live = set(subwins)
-        self._ids = {s: i for s, i in self._ids.items() if s in live}
         return [{"id": self._id_of(s),
                  "title": s.windowTitle() or "window",
                  "active": s is active}
@@ -231,5 +245,37 @@ def pilot_scene_context(dispatcher, base):
         lines.append("view: pan (%g, %g), zoom %g" % (
             transform["pan_x"], transform["pan_y"], transform["zoom"]))
     return "\n".join(lines)
+
+
+class PilotTurnSeams:
+    """The scene a pilot turn is composed against, and with it the state the
+    turn is guarded by.
+
+    :class:`~solvcon.agent.Turn` calls :meth:`scene` once per step, on the
+    thread that owns the canvas, and hands what it returns to its token.  The
+    step starts from the canvas that is active *now*: a batch of the turn's
+    own may have opened or activated one, and the executors above retarget on
+    the spot, so a session left bound to the canvas the prompt started on
+    would go on showing the model that world's shapes while the commands
+    landed on another.
+
+    Rebinding here is also what lets the turn keep the core's own
+    :func:`~solvcon.agent.default_token`.  That token is the active canvas's
+    world plus a digest of this scene, and this scene names every open window
+    with its id, marks the active one, and prints the view, so a canvas
+    switched, a window closed, or a pan or zoom the user made while the model
+    was thinking all move it.  The tests in ``tests/gui/test_agent_control.py``
+    pin that sensitivity, because it rests on what this scene carries.
+    """
+
+    def __init__(self, mgr):
+        self._mgr = mgr
+
+    def scene(self, session):
+        """Point the session at the active canvas and describe it: the world's
+        summary, then the live windows and view."""
+        widget = self._mgr.currentR2DWidget()
+        session.bind_world(None if widget is None else widget.world)
+        return pilot_scene_context(session.runner, session.scene_context())
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/agent/_agent_gui.py
+++ b/solvcon/pilot/agent/_agent_gui.py
@@ -5,11 +5,12 @@
 """Agent Console: a dock that drives the 2D world from natural language.
 
 The console sits at the bottom-right, beside the Python console, and runs the
-selected AI backend on the active canvas world for one request at a time.  It
-reuses the headless :class:`~solvcon.agent.AgentSession`, so the drawing logic
-stays Qt-free and testable.  The session keeps the conversation, so each
-request replays the turns before it; driving several backend steps within one
-request is a later addition.
+selected AI backend on the active canvas world.  It reuses the headless
+:class:`~solvcon.agent.AgentSession`, so the drawing logic stays Qt-free and
+testable.  The session keeps the conversation, so each request replays the
+turns before it, and one request may spend several backend steps: the panel
+pumps a :class:`~solvcon.agent.Turn`, composing and applying on the Qt thread
+and running only the call itself on a worker.
 """
 
 from itertools import zip_longest
@@ -19,7 +20,8 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QDockWidget,
                                QLabel, QComboBox, QTextEdit, QLineEdit,
                                QPushButton)
 
-from ...agent import AgentBackend, AgentSession, BackendRegistry, op_of
+from ...agent import (AgentBackend, AgentSession, BackendRegistry, StopReason,
+                      Turn, op_of)
 from ...config import Config
 from . import _agent_control
 from ._agent_settings import AgentBackendSettingsDialog
@@ -37,46 +39,37 @@ class AgentBackendWorker(QThread):
 
     Only the backend call runs here, the slow subprocess or HTTP round trip;
     it reads neither Qt nor the world, so it is safe off the main thread.  The
-    turns it replays are snapshotted on the main thread at construction, so a
-    turn recorded meanwhile cannot land in the request being composed.  The
-    reply returns through :attr:`succeeded` (a ``BackendResponse``) or
-    :attr:`failed` (an error string); the owning panel applies the commands and
-    repaints on the main thread, where the connected slots run.
+    request was frozen on the main thread before the thread started, so a
+    canvas edited meanwhile cannot reach the call in flight.  The reply lands
+    on :attr:`response` and the thread's own ``finished`` announces it, which
+    orders the reply before the release of the worker that carried it.  The
+    send goes through :meth:`~solvcon.agent.TurnRequest.send_safely`, so a
+    backend that raises arrives as a transport outcome the turn can stop on
+    rather than as an exception on a worker thread.
     """
 
-    succeeded = Signal(object)
-    failed = Signal(str)
-
-    def __init__(self, backend, prompt, scene_context, tool_surface,
-                 history=(), parent=None):
+    def __init__(self, backend, request, parent=None):
         super().__init__(parent)
         self._backend = backend
-        self._prompt = prompt
-        self._scene_context = scene_context
-        self._tool_surface = tool_surface
-        self._history = list(history)
+        self._request = request
+        self.response = None
 
     def run(self):
-        try:
-            response = self._backend.send(
-                self._prompt, self._scene_context, self._tool_surface,
-                self._history)
-        except Exception as exc:
-            self.failed.emit("%s: %s" % (type(exc).__name__, exc))
-        else:
-            self.succeeded.emit(response)
+        self.response = self._request.send_safely(self._backend)
 
 
 class AgentConsoleWidget(QWidget):
     """The console body: a backend selector, a transcript, and a prompt box.
 
-    Display-only.  It emits :attr:`submitted` with the typed prompt and
+    Display-only.  It emits :attr:`submitted` with the typed prompt,
+    :attr:`stop_requested` when the user asks to halt the running turn, and
     :attr:`settings_requested` when the user asks to configure the selected
     backend, and exposes the chosen backend; the owning feature runs the turn
     and calls back to append the reply.
     """
 
     submitted = Signal(str)
+    stop_requested = Signal()
     settings_requested = Signal()
 
     def __init__(self, backends=(), parent=None):
@@ -96,6 +89,9 @@ class AgentConsoleWidget(QWidget):
         self._input.setPlaceholderText(
             "Ask the agent to draw, arrange windows, or aim the view...")
         self._send = QPushButton("Send")
+        self._stop = QPushButton("Stop")
+        self._stop.setEnabled(False)
+        self._stop.setToolTip("Stop the agent after the running step")
 
         selector = QHBoxLayout()
         selector.setContentsMargins(4, 2, 4, 2)
@@ -107,6 +103,7 @@ class AgentConsoleWidget(QWidget):
         entry.setContentsMargins(4, 2, 4, 4)
         entry.addWidget(self._input, 1)
         entry.addWidget(self._send)
+        entry.addWidget(self._stop)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -122,6 +119,7 @@ class AgentConsoleWidget(QWidget):
 
         self._input.returnPressed.connect(self._emit)
         self._send.clicked.connect(self._emit)
+        self._stop.clicked.connect(self.stop_requested)
         self._settings.clicked.connect(self.settings_requested)
 
     def _emit(self):
@@ -140,10 +138,12 @@ class AgentConsoleWidget(QWidget):
     def set_busy(self, busy):
         """Lock the prompt and the settings button while a turn runs, so a
         second turn cannot overlap and an edit cannot look like it reaches the
-        in-flight call, which already holds its configuration."""
+        in-flight call, which already holds its configuration.  Stop is the one
+        control that works only while busy."""
         self._input.setEnabled(not busy)
         self._send.setEnabled(not busy)
         self._settings.setEnabled(not busy)
+        self._stop.setEnabled(busy)
 
     def start_working(self):
         """Show an animated ``working ...`` line while a turn runs, so a slow
@@ -178,7 +178,28 @@ class AgentPanel(_gui_common.PilotFeature):
     backend on each turn.  The session runs a dispatcher over the Agent Draw,
     Agent Window, and Agent View families, so a prompt can draw on the canvas,
     open or arrange windows, and aim the view through one tool surface.
+
+    One prompt is a :class:`~solvcon.agent.Turn` this panel pumps a step at a
+    time: :meth:`_pump` composes the request and starts a worker,
+    :meth:`_on_step_finished` applies the reply and pumps the next step.  Only
+    the backend call leaves the Qt thread, so reading the canvas and writing
+    to it both stay where Qt allows them.
     """
+
+    #: Backend calls one prompt may spend.  Enough for a plan, a repair after
+    #: an error, and the empty batch that says the work is done, while a model
+    #: that keeps proposing work still stops after four real calls.
+    TURN_BUDGET = 4
+
+    #: What to tell the user for a stop the transcript does not already
+    #: explain by itself.  A turn the model ended (an empty batch or prose)
+    #: needs no note: its own reply is the ending.
+    _STOP_NOTES = {
+        StopReason.NO_BACKEND: "(no backend selected)",
+        StopReason.STOPPED: "(stopped)",
+        StopReason.STATE: "(the canvas changed; the agent stopped)",
+        StopReason.BUDGET: "(step budget reached; send again to continue)",
+    }
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
@@ -187,17 +208,25 @@ class AgentPanel(_gui_common.PilotFeature):
         self._panel = None
         self._session = AgentSession(
             runner=_agent_control.build_control_dispatcher(self._mgr))
+        self._seams = _agent_control.PilotTurnSeams(self._mgr)
         self._config = Config.instance()
         BackendRegistry.load_settings(self._config)
         self._worker = None
-        self._active_widget = None
+        self._turn = None
+        self._logged_payload = False
         # Make sure the worker thread is joined before the main thread exits.
         app = QCoreApplication.instance()
         if app is not None:
             app.aboutToQuit.connect(self._join_worker)
 
     def _join_worker(self):
-        """Wait for the worker to finish before the main thread exits."""
+        """Halt the turn and wait for the worker before the main thread exits.
+
+        Halting first cancels the call in flight, so quitting does not wait a
+        slow CLI out, and keeps a reply delivered during shutdown from pumping
+        the step after it.
+        """
+        self._halt_turn()
         if self._worker is not None:
             self._worker.wait()
 
@@ -233,6 +262,7 @@ class AgentPanel(_gui_common.PilotFeature):
             return
         self._panel = AgentConsoleWidget(backends=BackendRegistry.available())
         self._panel.submitted.connect(self._on_submitted)
+        self._panel.stop_requested.connect(self._halt_turn)
         self._panel.settings_requested.connect(self._on_settings_requested)
         self._dock = QDockWidget("Agent")
         self._dock.setWidget(self._panel)
@@ -263,69 +293,88 @@ class AgentPanel(_gui_common.PilotFeature):
 
     def _on_submitted(self, prompt):
         """Start one turn on the active canvas without blocking the GUI."""
-        if self._worker is not None:
+        if self._turn is not None:
             return
         widget = self._mgr.currentR2DWidget()
         session = self._session
         session.backend = self._panel.selected_backend()
-        # The draw, window, and view executors resolve the active canvas on
-        # their own; bind_world only keeps scene_context pointed at it.
+        # Each step rebinds through the scene seam anyway; binding here as
+        # well puts the marker for a canvas switched since the last prompt
+        # before that prompt in the transcript rather than after it.
         session.bind_world(None if widget is None else widget.world)
         self._panel.append_message("user", prompt)
         self._panel.clear_input()
-        session.record_prompt(prompt)
-        if session.backend is None:
-            self._panel.append_message("agent", self._format_turn(None))
-            return
-        self._active_widget = widget
+        self._turn = Turn(session, prompt, budget=self.TURN_BUDGET,
+                          scene=self._seams.scene)
+        self._logged_payload = False
         self._panel.set_busy(True)
         self._panel.start_working()
-        history = session.history()
-        scene = _agent_control.pilot_scene_context(
-            session.runner, session.scene_context())
-        tool_surface = session.tool_surface()
-        self._write_history_payload(session.backend, prompt, scene,
-                                    tool_surface, history)
+        self._pump()
+
+    def _pump(self):
+        """Send the turn's next step, or finish the turn when it has none.
+
+        Composing the request reads the canvas and the windows, so it stays
+        here on the Qt thread; only the call crosses to the worker.
+        """
+        request = self._turn.next_request()
+        if request is None:
+            self._finish_turn()
+            return
+        if not self._logged_payload:
+            # Only the first step is logged: every later one replays the same
+            # conversation with the steps between appended, so logging each
+            # would reprint the turn from the top once per step.
+            self._logged_payload = True
+            self._write_history_payload(self._session.backend, request)
         self._worker = AgentBackendWorker(
-            session.backend, prompt, scene, tool_surface,
-            history, parent=self._panel)
-        self._worker.succeeded.connect(self._on_backend_succeeded)
-        self._worker.failed.connect(self._on_backend_failed)
-        self._worker.finished.connect(self._on_worker_finished)
+            self._session.backend, request, parent=self._panel)
+        self._worker.finished.connect(self._on_step_finished)
         self._worker.start()
 
-    def _on_backend_succeeded(self, response):
-        """Apply the backend's commands to the world and repaint the canvas.
+    def _on_step_finished(self):
+        """Apply one step's reply and pump the next.
+
+        The worker is released before the turn is fed, so the step this may go
+        on to start is never the one being torn down.  The turn itself decides
+        whether the reply is applied at all: a canvas that changed under the
+        call, or a Stop the user hit meanwhile, drops it here.
         """
-        # TODO(#966): potential race condition here. capture a world revision
-        # at submit and skip by-id commands when the world advanced.
-        turn = self._session.complete_turn(response)
-        self._panel.append_message("agent", self._format_turn(turn))
-        widget = self._active_widget
-        if widget is not None:
-            try:
-                widget.requestRepaint()
-            except RuntimeError:
-                # TODO: the widget may have been deleted while the backend was
-                # running, so the repaint request fails. Need a better way to
-                # track the widget's lifetime and avoid this.
-                pass
+        worker, self._worker = self._worker, None
+        response = worker.response
+        worker.deleteLater()
+        turn = self._turn.feed(response)
+        if turn is not None:
+            self._panel.append_message("agent", self._format_turn(turn))
+        self._pump()
 
-    def _on_backend_failed(self, error):
-        """Record a backend that raised as a failed agent turn."""
-        turn = self._session.fail_turn(error)
-        self._panel.append_message("agent", self._format_turn(turn))
+    def _halt_turn(self):
+        """Halt the turn between steps and cancel the call in flight.
 
-    def _on_worker_finished(self):
-        """Release the worker and re-enable the prompt for the next turn."""
-        self._worker.deleteLater()
-        self._worker = None
-        self._active_widget = None
+        The turn is ended first, so a reply landing after the cancel is dropped
+        rather than applied; a backend with no cancel of its own simply runs
+        its last call out, and its reply meets an ended turn.  Both the Stop
+        button and application shutdown come through here.
+        """
+        if self._turn is None:
+            return
+        self._turn.stop()
+        cancel = getattr(self._session.backend, "cancel", None)
+        if cancel is not None:
+            cancel()
+        if self._worker is None:
+            self._finish_turn()
+
+    def _finish_turn(self):
+        """Release the turn and re-enable the prompt for the next one."""
+        turn, self._turn = self._turn, None
+        note = self._STOP_NOTES.get(turn.stop_reason)
+        if note:
+            self._panel.append_message("agent", note)
         self._panel.stop_working()
         self._panel.set_busy(False)
 
-    def _write_history_payload(self, backend, prompt, scene, tool_surface,
-                               history):
+    def _write_history_payload(self, backend, request):
         """Log the conversation about to be replayed to the backend.
 
         It goes to the Python console rather than the panel, whose transcript
@@ -336,7 +385,8 @@ class AgentPanel(_gui_common.PilotFeature):
         """
         compose = getattr(backend, "history_section",
                           AgentBackend.history_section)
-        formatted = compose(prompt, scene, tool_surface, history)
+        formatted = compose(request.prompt, request.scene_context,
+                            request.tool_surface, request.history)
         if not formatted:
             return
         self._pycon.writeToHistory(
@@ -378,8 +428,6 @@ class AgentPanel(_gui_common.PilotFeature):
         """The user-facing reply: the ``log`` messages that ran (else backend
         prose), followed by a line per command that did not succeed, so a turn
         whose commands all failed cannot read as a turn that worked."""
-        if turn is None:
-            return "(no backend selected)"
         logs = AgentPanel._turn_log_messages(turn)
         lines = logs if logs else [turn.text or "(no reply)"]
         return "\n".join(lines + AgentPanel._turn_error_lines(turn))

--- a/tests/gui/test_agent.py
+++ b/tests/gui/test_agent.py
@@ -22,39 +22,36 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
-class _CircleBackend:
-    """Test backend that emits one real Agent Draw command without a CLI."""
-
-    name = "circle (test)"
-
-    def available(self):
-        return True
-
-    def send(self, prompt, scene_context, tool_surface, history=()):
-        return agent.BackendResponse(text="circle added", commands=[
-            {"op": "log", "message": "Add a unit circle at the origin"},
-            {"op": "add_circle", "cx": 0.0, "cy": 0.0, "r": 1.0}])
+def _circle_batch(message, cx=0.0):
+    return [{"op": "log", "message": message},
+            {"op": "add_circle", "cx": cx, "cy": 0.0, "r": 1.0}]
 
 
-class _TranslateBackend:
-    """Test backend that asks to translate a fixed shape id, so a GUI test can
-    drive a by-id command whose target may have been removed meanwhile.  It
-    uses an update op, not a delete, so the session's destructive gating does
-    not intercept it before the shape-liveness check."""
+class _ScriptedBackend:
+    """Test backend replaying one canned command batch per step.
 
-    name = "translate (test)"
+    It stands in for a CLI: the panel's pump asks it once per step, and an
+    exhausted script answers with the empty batch a model ends a turn with, so
+    a test never has to count the steps its turn will take.  Every request is
+    kept, which is how a test reads what a step was composed against.
+    """
 
-    def __init__(self, shape_id):
-        self._shape_id = shape_id
+    name = "scripted (test)"
+
+    def __init__(self, *batches):
+        self.batches = list(batches)
+        self.requests = []
 
     def available(self):
         return True
 
     def send(self, prompt, scene_context, tool_surface, history=()):
-        return agent.BackendResponse(
-            text="translating", commands=[
-                {"op": "translate_shape", "shape_id": self._shape_id,
-                 "dx": 1.0, "dy": 0.0}])
+        self.requests.append(agent.TurnRequest(
+            prompt=prompt, scene_context=scene_context,
+            tool_surface=list(tool_surface or ()), history=list(history)))
+        if not self.batches:
+            return agent.BackendResponse(commands=[])
+        return agent.BackendResponse(commands=self.batches.pop(0))
 
 
 @unittest.skipIf(not solvcon.HAS_PILOT, "pilot is not built")
@@ -128,6 +125,32 @@ class AgentTurnFormatTC(unittest.TestCase):
 class AgentPanelTC(unittest.TestCase):
     def setUp(self):
         self.mgr = pilot.RManager.instance.setUp()
+        self._close_canvases()
+
+    def tearDown(self):
+        self._close_canvases()
+
+    def _close_canvases(self):
+        """Start and leave each test with an empty MDI area.  A turn is guarded
+        by a token that watches the open windows, so a canvas another test left
+        behind is enough to end a turn that never touched it."""
+        self.mgr.mdiArea.closeAllSubWindows()
+        QCoreApplication.processEvents()
+
+    def _open_canvas(self):
+        """Open a 2D canvas on a fresh world and let it settle.
+
+        The window is mapped through queued events, and until they run the
+        canvas is not in the window list the scene and the token read.
+        Settling it here keeps what a turn is composed against and what it is
+        fed against the same, the way a user opening a canvas and then typing
+        does.
+        """
+        widget = self.mgr.add2DWidget()
+        world = solvcon.WorldFp64()
+        widget.updateWorld(world)
+        QCoreApplication.processEvents()
+        return world
 
     def _panel_on(self):
         feature = _agent_gui.AgentPanel(mgr=self.mgr)
@@ -145,13 +168,19 @@ class AgentPanelTC(unittest.TestCase):
         panel._backend_combo.setCurrentIndex(panel._backend_combo.count() - 1)
 
     def _finish_turn(self, feature):
-        """Drive the pending async turn to completion: wait for the backend
-        worker, then pump the event loop so its queued reply reaches the main
-        thread and finishes the turn."""
-        worker = feature._worker
-        if worker is not None:
+        """Drive the pending async turn to completion: wait for each step's
+        backend worker, then pump the event loop so its queued reply reaches
+        the main thread and the panel starts the step after it.  The loop is
+        bounded by the turn budget, so a pump that never finishes fails the
+        test instead of hanging it."""
+        for _ in range(feature.TURN_BUDGET + 1):
+            worker = feature._worker
+            if worker is None:
+                break
             self.assertTrue(worker.wait(5000))
-        QCoreApplication.processEvents()
+            QCoreApplication.processEvents()
+        self.assertIsNone(feature._worker)
+        self.assertIsNone(feature._turn)
 
     def test_toggle_is_placed_under_view_panels(self):
         feature = _agent_gui.AgentPanel(mgr=self.mgr)
@@ -190,11 +219,10 @@ class AgentPanelTC(unittest.TestCase):
         # A real draw command pins active-world binding and command dispatch,
         # which the echo round-trip does not exercise.
         feature = self._panel_on()
-        widget = self.mgr.add2DWidget()
-        world = solvcon.WorldFp64()
-        widget.updateWorld(world)
+        world = self._open_canvas()
         panel = feature._panel
-        self._select_backend(panel, _CircleBackend())
+        self._select_backend(panel, _ScriptedBackend(
+            _circle_batch("Add a unit circle at the origin")))
         panel._input.setText("draw a circle")
         panel._emit()
         self.assertIs(feature._session.world, world)
@@ -269,11 +297,13 @@ class AgentPanelTC(unittest.TestCase):
         # while the model was thinking fails as a not-live shape rather than
         # crashing the turn.  The empty world stands in for that removal.
         feature = self._panel_on()
-        widget = self.mgr.add2DWidget()
-        world = solvcon.WorldFp64()
-        widget.updateWorld(world)
+        self._open_canvas()
         panel = feature._panel
-        self._select_backend(panel, _TranslateBackend(4242))
+        # An update op, not a delete, so the session's destructive gating does
+        # not intercept it before the shape-liveness check.
+        self._select_backend(panel, _ScriptedBackend(
+            [{"op": "translate_shape", "shape_id": 4242,
+              "dx": 1.0, "dy": 0.0}]))
         panel._input.setText("move shape 4242 right")
         panel._emit()
         self._finish_turn(feature)
@@ -281,6 +311,101 @@ class AgentPanelTC(unittest.TestCase):
         self.assertIn("- translate_shape:", text)
         self.assertIn("4242", text)
         self.assertTrue(panel._input.isEnabled())
+
+    def test_two_prompts_share_one_conversation(self):
+        # The panel keeps one session across Sends, and rebinding the same
+        # world does not cut the conversation the second prompt builds on.
+        feature = self._panel_on()
+        self._open_canvas()
+        panel = feature._panel
+        backend = _ScriptedBackend()
+        self._select_backend(panel, backend)
+        for prompt in ("draw a truck", "move it right"):
+            panel._input.setText(prompt)
+            panel._emit()
+            self._finish_turn(feature)
+        replayed = agent.format_history(backend.requests[-1].history)
+        self.assertIn("draw a truck", replayed)
+        self.assertNotIn("canvas switched", replayed)
+
+    def test_a_multi_step_turn_applies_each_step_in_order(self):
+        feature = self._panel_on()
+        world = self._open_canvas()
+        panel = feature._panel
+        backend = _ScriptedBackend(_circle_batch("left", cx=-2.0),
+                                   _circle_batch("middle"),
+                                   _circle_batch("right", cx=2.0))
+        self._select_backend(panel, backend)
+        panel._input.setText("draw circles")
+        panel._emit()
+        self._finish_turn(feature)
+        self.assertEqual(world.nshape, 3)
+        text = panel._transcript.toPlainText()
+        self.assertLess(text.index("left"), text.index("middle"))
+        self.assertLess(text.index("middle"), text.index("right"))
+        # Each step saw what the step before it did, which is what makes the
+        # extra calls worth their cost.
+        self.assertIn("add_circle",
+                      agent.format_history(backend.requests[1].history))
+
+    def test_stop_mid_turn_leaves_a_clean_transcript(self):
+        feature = self._panel_on()
+        world = self._open_canvas()
+        panel = feature._panel
+        self.assertFalse(panel._stop.isEnabled())
+        self._select_backend(panel, _ScriptedBackend(
+            _circle_batch("left", cx=-2.0), _circle_batch("right", cx=2.0)))
+        panel._input.setText("draw circles")
+        panel._emit()
+        self.assertTrue(panel._stop.isEnabled())
+        panel.stop_requested.emit()
+        self._finish_turn(feature)
+        text = panel._transcript.toPlainText()
+        self.assertIn("(stopped)", text)
+        # The reply of the step in flight is dropped, not applied.
+        self.assertNotIn("left", text)
+        self.assertEqual(world.nshape, 0)
+        self.assertTrue(panel._input.isEnabled())
+        self.assertFalse(panel._stop.isEnabled())
+
+    def test_a_canvas_opened_mid_turn_is_what_the_next_step_sees(self):
+        # The executors retarget the moment a batch opens a canvas, so the
+        # step after it has to be composed against the canvas the agent just
+        # opened, not the one the prompt started on.
+        feature = self._panel_on()
+        self.mgr.show()
+        QCoreApplication.processEvents()
+        started_on = self._open_canvas()
+        panel = feature._panel
+        backend = _ScriptedBackend(
+            [{"op": "new_canvas"}] + _circle_batch("on the new canvas"),
+            _circle_batch("and another"))
+        self._select_backend(panel, backend)
+        panel._input.setText("open a canvas and draw on it")
+        panel._emit()
+        self._finish_turn(feature)
+        self.assertEqual(started_on.nshape, 0)
+        opened = self.mgr.currentR2DWidget().world
+        self.assertEqual(opened.nshape, 2)
+        # The model was shown the canvas its own command had just opened.
+        self.assertIn("world with 1 shapes", backend.requests[1].scene_context)
+
+    def test_switching_the_canvas_mid_turn_ends_the_turn(self):
+        # A step is composed against the canvas that was active when it was
+        # sent, so a canvas activated meanwhile must not receive its commands.
+        # The windows have to be mapped for the token to see them at all.
+        feature = self._panel_on()
+        self.mgr.show()
+        QCoreApplication.processEvents()
+        world = self._open_canvas()
+        panel = feature._panel
+        self._select_backend(panel, _ScriptedBackend(_circle_batch("left")))
+        panel._input.setText("draw a circle")
+        panel._emit()
+        self._open_canvas()
+        self._finish_turn(feature)
+        self.assertEqual(world.nshape, 0)
+        self.assertIn("the canvas changed", panel._transcript.toPlainText())
 
     def test_blank_prompt_is_ignored(self):
         feature = self._panel_on()

--- a/tests/gui/test_agent_control.py
+++ b/tests/gui/test_agent_control.py
@@ -18,7 +18,7 @@ try:
     from solvcon.pilot.agent import _agent_gui
     from solvcon.pilot.agent._agent_control import (
         PilotWindowManager, LiveViewExecutor, build_control_dispatcher,
-        pilot_scene_context)
+        pilot_scene_context, PilotTurnSeams)
     from solvcon.agent import window
     from PySide6 import QtWidgets
 except ImportError:
@@ -103,6 +103,21 @@ class PilotWindowManagerTC(_PilotTC):
             self.assertTrue(res.ok, res.error)
             self.assertTrue(os.path.exists(path))
             self.assertGreater(os.path.getsize(path), 0)
+
+    def test_an_id_belongs_to_the_window_not_to_the_manager(self):
+        # A second manager reading the same ids is what says the id belongs to
+        # the window rather than to a table the manager keeps, which is what a
+        # rebuilt Python sub-window would lose.
+        first = self.ex.run({"op": "new_canvas"}).value["window_id"]
+        self.ex.run({"op": "close_window", "window_id": first})
+        QtWidgets.QApplication.processEvents()
+        opened = [self.ex.run({"op": "new_canvas"}).value["window_id"],
+                  self.ex.run({"op": "new_canvas"}).value["window_id"]]
+        other = window.Executor(PilotWindowManager(self.mgr))
+        listed = other.run({"op": "list_windows"}).value["windows"]
+        self.assertEqual([w["id"] for w in listed], opened)
+        self.assertTrue(other.run(
+            {"op": "activate_window", "window_id": opened[0]}).ok)
 
     def test_by_id_commands_fail_cleanly_on_a_missing_window(self):
         self.ex.run({"op": "new_canvas"})
@@ -216,6 +231,68 @@ class DispatcherIntegrationTC(_PilotTC):
         names = {tool["name"] for tool in session.tool_surface()}
         self.assertLessEqual(
             {"close_window", "clear", "remove_shape"}, names)
+
+
+class PilotTurnSeamsTC(_PilotTC):
+    """The scene a pilot turn is composed against, and the guard it carries.
+
+    The turn keeps the core's own token, so what moves that token is decided
+    entirely by what this scene names.  These pin it: drop the window list or
+    the view line from the scene and the guard stops seeing a canvas switched
+    or a view panned under a running turn.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.dispatcher = build_control_dispatcher(self.mgr)
+        self.session = agent.AgentSession(runner=self.dispatcher)
+        self.seams = PilotTurnSeams(self.mgr)
+
+    def _token(self):
+        return agent.default_token(self.session,
+                                   self.seams.scene(self.session))
+
+    def test_the_scene_follows_a_canvas_opened_under_the_turn(self):
+        # The executors retarget the moment a batch opens a canvas, so the
+        # session has to follow rather than describe the canvas it started on.
+        self.dispatcher.run({"op": "new_canvas"})
+        first = self.mgr.currentR2DWidget().world
+        self.seams.scene(self.session)
+        self.assertIs(self.session.world, first)
+        self.dispatcher.run({"op": "new_canvas"})
+        self.dispatcher.run({"op": "add_circle", "cx": 0.0, "cy": 0.0,
+                             "r": 1.0})
+        scene = self.seams.scene(self.session)
+        self.assertIsNot(self.session.world, first)
+        self.assertIn("world with 1 shapes", scene)
+
+    def test_it_holds_still_while_nothing_moves(self):
+        self.dispatcher.run({"op": "new_canvas"})
+        self.assertEqual(self._token(), self._token())
+
+    def test_a_canvas_activated_meanwhile_changes_it(self):
+        self.dispatcher.run({"op": "new_canvas"})
+        before = self._token()
+        self.dispatcher.run({"op": "new_canvas"})
+        self.assertNotEqual(before, self._token())
+
+    def test_a_pan_the_user_made_changes_it(self):
+        self.dispatcher.run({"op": "new_canvas"})
+        before = self._token()
+        self.dispatcher.run(
+            {"op": "pan", "dx_screen": 30.0, "dy_screen": 0.0})
+        self.assertNotEqual(before, self._token())
+
+    def test_a_shape_added_meanwhile_changes_it(self):
+        self.dispatcher.run({"op": "new_canvas"})
+        before = self._token()
+        self.dispatcher.run({"op": "add_circle", "cx": 0.0, "cy": 0.0,
+                             "r": 1.0})
+        self.assertNotEqual(before, self._token())
+
+    def test_it_reads_cleanly_with_no_canvas_at_all(self):
+        self.assertIn("windows: none open", self.seams.scene(self.session))
+        self.assertEqual(self._token(), self._token())
 
 
 class AgentPanelControlTC(_PilotTC):


### PR DESCRIPTION
The Agent Console sent one backend call for each prompt. The model never saw what its own commands did, so it could not repair a command that failed. This change makes one prompt a `Turn` that the panel drives one step at a time, up to four backend calls.

The panel composes each request and applies each reply on the Qt thread. Only the backend call runs on a worker. A new Stop button ends the turn between steps and cancels the call in flight. Shutdown takes the same path, so the pilot neither waits for a slow backend nor starts another step as it closes.

Several steps need a guard on the canvas that the commands reach, because a batch of the turn itself can open one. `PilotTurnSeams.scene` binds the session to the active canvas and then describes it. The turn therefore keeps the core `default_token`. That token holds the world of the active canvas, plus a digest of a scene that names every open window and the current view. A canvas switch, a window close, or a pan by the user now ends the turn. The commands never reach a target the model did not see.

Two smaller pieces belong to the same mechanism. `TurnRequest.send_safely` turns a backend exception into a transport outcome, for the headless loop and for the worker alike. `Turn` itself now stops a session that has no backend. Neither rule lives in two places any more. The panel also drops its own repaint and its stored widget. The live executors repaint after each command, and the guard covers the race that the stored widget tried to avoid.

The first commit fixes a defect that the pump depends on. `PilotWindowManager` held the window ids in a dictionary keyed on the Python `QMdiSubWindow`. PySide returns a fresh object for the same window between two listings. The lookup therefore missed, and every listing renamed the windows under an agent that just read the old ids. The id now rides on the window as a dynamic property, and the counter that mints ids sits on the `QMdiArea` beside them.

`make lint` is clean. `make run_pilot_pytest` passes 2162 tests, with 14 skipped and 3 xfailed. `make pytest-fast` passes 1955 tests. The two tests for the canvas rebind fail without the rebind, and the window-id test fails against the old dictionary.

Related to #1206. Related to #1136.
