### PR TITLE
Add `SimpleArray::diff()` and `cumsum()`

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -222,6 +222,24 @@ private:
 std::string format_shape(shape_type const & shape);
 std::string format_flat_index(shape_type const & shape, ssize_t offset);
 
+/**
+ * Reject an array that is not one-dimensional. `op` names the calling
+ * operation and `what` the role the array plays in it, both for the message.
+ */
+template <typename A>
+void validate_1d(A const & array, char const * op, char const * what = "array")
+{
+    if (array.ndim() != 1)
+    {
+        throw std::runtime_error(
+            std::format("SimpleArray::{}(): "
+                        "currently only support 1D array but the {} is {} dimension",
+                        op,
+                        what,
+                        array.ndim()));
+    }
+}
+
 template <typename T>
 struct SimpleArrayInternalTypes
 {
@@ -732,6 +750,12 @@ public:
         return ret;
     }
 
+    /// Subtract every element of a one-dimensional receiver from the element after it.
+    A diff() const;
+
+    /// Accumulate a one-dimensional receiver into its running total.
+    A cumsum() const;
+
     A add(A const & other) const
     {
         validate_same_shape(other, "add");
@@ -824,6 +848,12 @@ private:
     {
         return static_cast<value_type>(static_cast<real_type>(count));
     }
+
+    static value_type wrapping_sub(value_type lhs, value_type rhs) { return wrapping_op(lhs, rhs, std::minus<>{}); }
+    static value_type wrapping_add(value_type lhs, value_type rhs) { return wrapping_op(lhs, rhs, std::plus<>{}); }
+
+    template <typename Op>
+    static value_type wrapping_op(value_type lhs, value_type rhs, Op op);
 
     void validate_same_shape(A const & other, char const * op) const;
 
@@ -1164,6 +1194,88 @@ private:
     static void find_two_bins(const uint32_t * freq, size_t n, int & bin1, int & bin2);
 }; /* end class SimpleArrayMixinCalculators */
 
+/**
+ * Signed overflow is undefined, so integer arithmetic goes through the unsigned
+ * counterpart, whose overflow wraps. Both conversions are modular, not magnitude:
+ * -1 converts to 2^N - 1, subtracting there carries the borrow the same way, and a
+ * result that fits the element type converts back unchanged. Only a boundary
+ * crossing wraps. The conversion back is defined since C++20; before that it was
+ * implementation-defined.
+ */
+template <typename A, typename T>
+template <typename Op>
+typename detail::SimpleArrayMixinCalculators<A, T>::value_type
+detail::SimpleArrayMixinCalculators<A, T>::wrapping_op(value_type lhs, value_type rhs, Op op)
+{
+    if constexpr (std::is_integral_v<value_type> && !is_bool_v<value_type>)
+    {
+        using unsigned_type = std::make_unsigned_t<value_type>;
+        return static_cast<value_type>(op(static_cast<unsigned_type>(lhs), static_cast<unsigned_type>(rhs)));
+    }
+    else
+    {
+        return static_cast<value_type>(op(lhs, rhs));
+    }
+}
+
+template <typename A, typename T>
+A detail::SimpleArrayMixinCalculators<A, T>::diff() const
+{
+    if constexpr (is_bool_v<value_type>)
+    {
+        reject_bool_operation("diff");
+    }
+    else
+    {
+        auto const * athis = static_cast<A const *>(this);
+        detail::validate_1d(*athis, "diff");
+
+        ssize_t const nelem = athis->shape(0);
+        shape_type const out_shape{std::max<ssize_t>(nelem - 1, 0)};
+        A ret(out_shape);
+
+        value_type const * const src = athis->logical_data();
+        ssize_t const step = athis->stride(0);
+        value_type * const dst = ret.begin();
+        for (ssize_t i = 1; i < nelem; ++i)
+        {
+            dst[i - 1] = wrapping_sub(src[i * step], src[(i - 1) * step]);
+        }
+
+        return ret;
+    }
+}
+
+template <typename A, typename T>
+A detail::SimpleArrayMixinCalculators<A, T>::cumsum() const
+{
+    auto const * athis = static_cast<A const *>(this);
+    detail::validate_1d(*athis, "cumsum");
+
+    ssize_t const nelem = athis->shape(0);
+    shape_type const out_shape{nelem};
+    A ret(out_shape);
+
+    value_type const * const src = athis->logical_data();
+    ssize_t const step = athis->stride(0);
+    value_type * const dst = ret.begin();
+    value_type acc{};
+    for (ssize_t i = 0; i < nelem; ++i)
+    {
+        if constexpr (is_bool_v<value_type>)
+        {
+            acc = acc | src[i * step];
+        }
+        else
+        {
+            acc = wrapping_add(acc, src[i * step]);
+        }
+        dst[i] = acc;
+    }
+
+    return ret;
+}
+
 template <typename A, typename T>
 typename detail::SimpleArrayMixinCalculators<A, T>::value_type
 detail::SimpleArrayMixinCalculators<A, T>::median_op(small_vector<value_type> & sv) const
@@ -1461,32 +1573,13 @@ public:
     template <IntegralType I>
     A take_along_axis_simd(SimpleArray<I> const & indices);
 
-private:
-
-    void validate_1d(char const * op, char const * what = "array") const;
-
 }; /* end class SimpleArrayMixinSort */
-
-template <typename A, typename T>
-void SimpleArrayMixinSort<A, T>::validate_1d(char const * op, char const * what) const
-{
-    auto const * athis = static_cast<A const *>(this);
-    if (athis->ndim() != 1)
-    {
-        throw std::runtime_error(
-            std::format("SimpleArray::{}(): "
-                        "currently only support 1D array but the {} is {} dimension",
-                        op,
-                        what,
-                        athis->ndim()));
-    }
-}
 
 template <typename A, typename T>
 void SimpleArrayMixinSort<A, T>::sort()
 {
-    validate_1d("sort");
     auto athis = static_cast<A *>(this);
+    detail::validate_1d(*athis, "sort");
 
     if constexpr (is_complex_v<value_type>)
     {
@@ -3062,8 +3155,8 @@ void SimpleArray<T>::copy_logical_into(SimpleArray & out) const
 template <typename A, typename T>
 SimpleArray<uint64_t> detail::SimpleArrayMixinSort<A, T>::argsort()
 {
-    validate_1d("argsort");
     auto athis = static_cast<A *>(this);
+    detail::validate_1d(*athis, "argsort");
 
     SimpleArray<uint64_t> ret(athis->shape());
 
@@ -3097,19 +3190,20 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSort<A, T>::argsort()
 template <typename A, typename T>
 size_t detail::SimpleArrayMixinSort<A, T>::searchsorted(value_type const & value, SearchSide side) const
 {
-    validate_1d("searchsorted");
     auto const * athis = static_cast<A const *>(this);
+    detail::validate_1d(*athis, "searchsorted");
     return search_bound(athis->begin(), athis->end(), value, side);
 }
 
 template <typename A, typename T>
 SimpleArray<uint64_t> detail::SimpleArrayMixinSort<A, T>::searchsorted(A const & values, SearchSide side) const
 {
-    validate_1d("searchsorted");
-    values.validate_1d("searchsorted", "value array");
+    auto const * athis = static_cast<A const *>(this);
+    detail::validate_1d(*athis, "searchsorted");
+    detail::validate_1d(values, "searchsorted", "value array");
 
-    value_type const * const first = static_cast<A const *>(this)->begin();
-    value_type const * const last = static_cast<A const *>(this)->end();
+    value_type const * const first = athis->begin();
+    value_type const * const last = athis->end();
     SimpleArray<uint64_t> ret(values.shape());
     value_type const * src = values.begin();
     uint64_t * dst = ret.begin();
@@ -3139,8 +3233,8 @@ template <typename A, typename T>
 template <IntegralType I>
 A detail::SimpleArrayMixinSort<A, T>::take_along_axis(SimpleArray<I> const & indices)
 {
-    validate_1d("take_along_axis");
     auto athis = static_cast<A *>(this);
+    detail::validate_1d(*athis, "take_along_axis");
 
     ssize_t const max_idx = athis->shape()[0];
     I const * src = indices.begin();
@@ -3636,8 +3730,8 @@ template <typename A, typename T>
 template <IntegralType I>
 A detail::SimpleArrayMixinSort<A, T>::take_along_axis_simd(SimpleArray<I> const & indices)
 {
-    validate_1d("take_along_axis_simd");
     auto athis = static_cast<A *>(this);
+    detail::validate_1d(*athis, "take_along_axis_simd");
 
     if (indices.size() == 0)
     {

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -276,6 +276,8 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def("max", &wrapped_type::max)
             .def("sum", &wrapped_type::sum)
             .def("abs", &wrapped_type::abs)
+            .def("diff", &wrapped_type::diff)
+            .def("cumsum", &wrapped_type::cumsum)
             .def(
                 "add",
                 [](wrapped_type const & self, wrapped_type const & other)

--- a/doc/source/compute/buffer/reduce.md
+++ b/doc/source/compute/buffer/reduce.md
@@ -1,9 +1,9 @@
-# Reductions, Statistics, Sorting, and Searching
+# Reductions, Statistics, Scans, Sorting, and Searching
 
 SimpleArray provides the reductions `min`, `max`, and `sum`, the statistics
-`mean`, `average`, `median`, `var`, and `std`, the sorting group `sort`,
-`argsort`, `searchsorted`, and `take_along_axis`, and the searching group
-`argmin`, `argmax`, and `argwhere`.
+`mean`, `average`, `median`, `var`, and `std`, the sequential scans `diff` and
+`cumsum`, the sorting group `sort`, `argsort`, `searchsorted`, and
+`take_along_axis`, and the searching group `argmin`, `argmax`, and `argwhere`.
 
 ## Whole-Array Reductions
 
@@ -149,6 +149,78 @@ classes, plus the boolean and 8-bit median; the integer truncation is
 established from the kernel source and the bound signatures. Whether the
 integer statistics should promote to a floating-point result as numpy does is
 an open decision; this page records the truncating behavior as fact.
+
+## Sequential Scans
+
+`diff()` and `cumsum()` scan a one-dimensional array from its first element to
+its last. Both take no argument. Both return a new array of the receiver's
+class and leave the receiver unchanged.
+
+An array of any other rank raises `RuntimeError`, as the sorting group does.
+For a two-dimensional receiver the message is `SimpleArray::diff(): currently
+only support 1D array but the array is 2 dimension`.
+
+Both scans compute in the element type, as the statistics do. Integer
+arithmetic wraps at the numeric boundary instead of overflowing. The kernels
+take a signed class through its unsigned counterpart, because C++ defines the
+wrap only for the unsigned types.
+
+### The `diff` Method
+
+`diff()` subtracts each element from the element after it. The result is one
+element shorter than the receiver. An empty receiver and a one-element
+receiver both give an empty result:
+
+```python
+sarr = solvcon.SimpleArrayFloat64(array=np.array([1.5, 2.5, 2.0, 7.0]))
+assert sarr.diff().ndarray.tolist() == [1.0, -0.5, 5.0]
+```
+
+A difference on an unsigned class wraps where the signal falls, and
+`numpy.diff` wraps in the same way.
+
+Subtraction has no meaning on bool. `SimpleArrayBool` raises `RuntimeError`
+with the message `SimpleArray<bool>::diff(): boolean value doesn't support
+this operation`, as `sub()` refuses the same class.
+
+### The `cumsum` Method
+
+`cumsum()` accumulates the running total and keeps the length of the receiver:
+
+```python
+sarr = solvcon.SimpleArrayFloat64(array=np.array([1.5, 2.5, 2.0, 7.0]))
+assert sarr.cumsum().ndarray.tolist() == [1.5, 4.0, 6.0, 13.0]
+```
+
+The total wraps where it exceeds the element type. numpy diverges here,
+because it promotes a narrow integer array to the platform integer:
+
+```python
+sarr = solvcon.SimpleArrayUint8(array=np.array([200, 100], dtype='uint8'))
+assert sarr.cumsum().ndarray.tolist() == [200, 44]   # numpy: [200, 300]
+```
+
+On `SimpleArrayBool` the accumulation is a logical or, as `sum()` accumulates.
+The result answers whether any element up to this position is true. numpy
+counts the true elements instead:
+
+```python
+sarr = solvcon.SimpleArrayBool(array=np.array([False, True, False]))
+assert sarr.cumsum().ndarray.tolist() == [False, True, True]
+```
+
+`cumsum()` inverts `diff()`. The expression
+`sarr.diff().cumsum().add(sarr[0])` gives the receiver without its first
+element.
+
+### Scans Read the Logical Elements
+
+Both methods read the logical elements. They therefore read a strided view in
+array order, not in buffer order.
+
+A {ref}`ghost region <ghost-region>` belongs to the array that a scan reads.
+The first difference is the difference between the first two ghost elements,
+and the running total starts at the first ghost element.
 
 ## Sorting and Gathering
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -10,6 +10,21 @@ import numpy as np
 import solvcon
 
 
+def dtype_sample(rng, dtype, size):
+    """Draw values small enough to be exact in every dtype, with ties."""
+    if dtype == 'bool':
+        return rng.integers(0, 2, size).astype(dtype)
+    elif dtype.startswith('uint'):
+        return rng.integers(0, 30, size).astype(dtype)
+    elif dtype.startswith('int'):
+        return rng.integers(-15, 15, size).astype(dtype)
+    elif dtype.startswith('float'):
+        return (rng.integers(-15, 15, size) / 2).astype(dtype)
+    else:
+        return (rng.integers(-4, 4, size)
+                + 1j * rng.integers(-4, 4, size)).astype(dtype)
+
+
 class ConcreteBufferBasicTC(unittest.TestCase):
 
     def test_ConcreteBuffer(self):
@@ -1637,21 +1652,6 @@ class SimpleArrayBasicTC(unittest.TestCase):
     )
 
     @staticmethod
-    def _searchsorted_sample(rng, dtype, size):
-        # Ties are the only place where the two sides differ.
-        if dtype == 'bool':
-            return rng.integers(0, 2, size).astype(dtype)
-        elif dtype.startswith('uint'):
-            return rng.integers(0, 30, size).astype(dtype)
-        elif dtype.startswith('int'):
-            return rng.integers(-15, 15, size).astype(dtype)
-        elif dtype.startswith('float'):
-            return (rng.integers(-15, 15, size) / 2).astype(dtype)
-        else:
-            return (rng.integers(-4, 4, size)
-                    + 1j * rng.integers(-4, 4, size)).astype(dtype)
-
-    @staticmethod
     def _searchsorted_scalar(dtype, value):
         if dtype.startswith('complex'):
             return getattr(solvcon, dtype)(value.real, value.imag)
@@ -1662,8 +1662,8 @@ class SimpleArrayBasicTC(unittest.TestCase):
 
         for dtype in self.SEARCHSORTED_DTYPES:
             cls = getattr(solvcon, 'SimpleArray' + dtype.capitalize())
-            ndata = np.sort(self._searchsorted_sample(rng, dtype, 40))
-            nvalues = self._searchsorted_sample(rng, dtype, 25)
+            ndata = np.sort(dtype_sample(rng, dtype, 40))
+            nvalues = dtype_sample(rng, dtype, 25)
             sarr = cls(array=ndata)
             varr = cls(array=nvalues)
 
@@ -2235,6 +2235,148 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         self.assertEqual(sarr.sum(), True)
         sarr = sarr.abs()
         self.assertEqual(sarr.sum(), True)
+
+    SCAN_DTYPES = (
+        'int8', 'int16', 'int32', 'int64',
+        'uint8', 'uint16', 'uint32', 'uint64',
+        'float32', 'float64', 'complex64', 'complex128',
+    )
+
+    def test_diff_every_dtype(self):
+        rng = np.random.default_rng(20260811)
+
+        for dtype in self.SCAN_DTYPES:
+            cls = getattr(solvcon, 'SimpleArray' + dtype.capitalize())
+            ndata = dtype_sample(rng, dtype, 40)
+            sarr = cls(array=ndata)
+            sres = sarr.diff()
+
+            self.assertIs(type(sres), cls)
+            np.testing.assert_array_equal(sres.ndarray, np.diff(ndata),
+                                          err_msg=dtype)
+
+    def test_cumsum_every_dtype(self):
+        rng = np.random.default_rng(20260811)
+
+        for dtype in self.SCAN_DTYPES:
+            cls = getattr(solvcon, 'SimpleArray' + dtype.capitalize())
+            ndata = dtype_sample(rng, dtype, 40)
+            sarr = cls(array=ndata)
+            sres = sarr.cumsum()
+
+            self.assertIs(type(sres), cls)
+            # numpy accumulates a narrow integer array in the platform
+            # integer, so it is asked for the element type kept here.
+            np.testing.assert_array_equal(sres.ndarray,
+                                          np.cumsum(ndata, dtype=dtype),
+                                          err_msg=dtype)
+
+    def test_diff_length_edges(self):
+        for data in ([], [3.0], [3.0, 5.0]):
+            ndata = np.array(data, dtype='float64')
+            sarr = solvcon.SimpleArrayFloat64(array=ndata)
+            np.testing.assert_array_equal(sarr.diff().ndarray,
+                                          np.diff(ndata))
+
+    def test_cumsum_length_edges(self):
+        for data in ([], [3.0], [3.0, 5.0]):
+            ndata = np.array(data, dtype='float64')
+            sarr = solvcon.SimpleArrayFloat64(array=ndata)
+            np.testing.assert_array_equal(sarr.cumsum().ndarray,
+                                          np.cumsum(ndata))
+
+    def test_diff_unsigned_wraps(self):
+        # A difference is taken in the element type, so a falling unsigned
+        # signal wraps instead of going negative, as numpy wraps it. A
+        # difference that must stay negative needs a signed receiver.
+        ndata = np.array([5, 3, 9], dtype='uint64')
+        sarr = solvcon.SimpleArrayUint64(array=ndata)
+        self.assertEqual(sarr.diff().ndarray.tolist(), [2**64 - 2, 6])
+        np.testing.assert_array_equal(sarr.diff().ndarray, np.diff(ndata))
+
+    def test_diff_signed_wraps_at_the_boundary(self):
+        # The difference of the two extremes does not fit the element type.
+        # It is taken through the unsigned counterpart, where the wrap is
+        # defined, instead of overflowing a signed integer, which C++ leaves
+        # undefined.
+        ndata = np.array([-2**63, 2**63 - 1], dtype='int64')
+        sarr = solvcon.SimpleArrayInt64(array=ndata)
+        self.assertEqual(sarr.diff().ndarray.tolist(), [-1])
+
+    def test_cumsum_signed_wraps_at_the_boundary(self):
+        ndata = np.array([2**63 - 1, 1], dtype='int64')
+        sarr = solvcon.SimpleArrayInt64(array=ndata)
+        self.assertEqual(sarr.cumsum().ndarray.tolist(),
+                         [2**63 - 1, -2**63])
+
+    def test_cumsum_unsigned_wraps(self):
+        # The running total is accumulated in the element type and wraps
+        # where it exceeds the type. numpy would promote a narrow integer
+        # array to the platform integer and answer 300 here.
+        ndata = np.array([200, 100], dtype='uint8')
+        sarr = solvcon.SimpleArrayUint8(array=ndata)
+        self.assertEqual(sarr.cumsum().ndarray.tolist(), [200, 44])
+        np.testing.assert_array_equal(sarr.cumsum().ndarray,
+                                      np.cumsum(ndata, dtype='uint8'))
+
+    def test_diff_bool_raises(self):
+        sarr = solvcon.SimpleArrayBool(
+            array=np.array([False, True], dtype='bool'))
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"SimpleArray<bool>::diff\(\): "
+            "boolean value doesn't support this operation"
+        ):
+            sarr.diff()
+
+    def test_cumsum_bool_accumulates_with_or(self):
+        # sum() on SimpleArrayBool accumulates with logical or, so the
+        # running total answers whether any element up to here is true.
+        # numpy would count the true elements instead.
+        ndata = np.array([False, True, False, False], dtype='bool')
+        sarr = solvcon.SimpleArrayBool(array=ndata)
+        self.assertEqual(sarr.cumsum().ndarray.tolist(),
+                         [False, True, True, True])
+
+    def test_diff_cumsum_reject_multi_dimension(self):
+        sarr = solvcon.SimpleArrayFloat64(
+            array=np.arange(6, dtype='float64').reshape((2, 3)))
+
+        for op in ('diff', 'cumsum'):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"SimpleArray::%s\(\): currently only support 1D "
+                "array but the array is 2 dimension" % op
+            ):
+                getattr(sarr, op)()
+
+    def test_diff_cumsum_strided(self):
+        # A strided view is read in array order, so the result follows the
+        # logical elements and not the buffer they sit in.
+        ndata = np.arange(10, dtype='float64')[::3]
+        sarr = solvcon.SimpleArrayFloat64(array=ndata)
+        np.testing.assert_array_equal(sarr.diff().ndarray, np.diff(ndata))
+        np.testing.assert_array_equal(sarr.cumsum().ndarray,
+                                      np.cumsum(ndata))
+
+    def test_diff_cumsum_ghost(self):
+        # The ghost part is read too, as argsort() and searchsorted() read
+        # it, so the result counts from the first ghost element.
+        ndata = np.array([1.0, 2.0, 4.0, 8.0], dtype='float64')
+        sarr = solvcon.SimpleArrayFloat64(array=ndata)
+        sarr.nghost = 2
+        self.assertEqual(sarr.diff().ndarray.tolist(), [1.0, 2.0, 4.0])
+        self.assertEqual(sarr.cumsum().ndarray.tolist(),
+                         [1.0, 3.0, 7.0, 15.0])
+
+    def test_cumsum_of_diff_rebuilds_the_signal(self):
+        # The two are inverse, which is what lets a time-series kernel
+        # difference a signal and integrate it back.
+        ndata = np.array([1.5, 2.5, 2.0, 7.0], dtype='float64')
+        sarr = solvcon.SimpleArrayFloat64(array=ndata)
+        rebuilt = sarr.diff().cumsum().add(ndata[0])
+        np.testing.assert_array_equal(rebuilt.ndarray, ndata[1:])
 
     def test_median(self):
         nparr = np.arange(24, dtype='float64')


### PR DESCRIPTION
`diff()` subtracts each element of a one-dimensional array from the element after it, and `cumsum()` accumulates the running total. Both return a new array of the receiver's class. Issue #1285 needs them for its time-series kernels. `validate_1d()` becomes a free function template, so both mixins share one check.

Both compute in the element type and wrap at the numeric boundary, through the unsigned counterpart where C++ defines the wrap. `numpy.diff` wraps the same way, but `numpy.cumsum` promotes a narrow integer array: `uint8` `[200, 100]` gives `[200, 300]` there and `[200, 44]` here. `SimpleArrayBool::diff()` refuses as `sub()` refuses, and `cumsum()` there accumulates with logical or, as `sum()` does.

The tests compare twelve dtypes against numpy and cover the length edges, both wraps, the bool cases, a strided view, and a ghosted receiver. `make lint` is clean, `make pytest` passes with 2197 tests, and `make gtest` with 244.

Related to #1285.
