### PR TITLE
Store multi-ring polygons in World and expose them as shape_rings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ profiling/results/
 thirdparty/install/
 thirdparty/archive/
 tmp/
+graphify-out/
 setup.mk
 CMakeUserPresets.json
 *.egg-info/

--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -263,6 +263,7 @@ struct ShapeRecord
     size_t curve_count; ///< Number of cubic Beziers this shape occupies.
     size_t ring_offset; ///< First index in the ring registry. Only POLYGON shapes use this.
     size_t ring_count; ///< Number of rings this shape owns. Zero for non-polygon shapes.
+    uint8_t ring_ndim; ///< Dimensionality (2 or 3) of this shape's rings. Zero for non-polygon shapes.
 
     /// OBB corner x's in world coordinates, ordered TL, TR, BR, BL.
     bbox_array_type obb_x;
@@ -323,6 +324,7 @@ public:
     using point_pad_type = PointPad<T>;
     using segment_pad_type = SegmentPad<T>;
     using curve_pad_type = CurvePad<T>;
+    using ring_list_type = RingList<T>;
     using bbox_type = BoundBox3d<T>;
     using rtree_type = RTree<ShapeEntry<T>, bbox_type>;
 
@@ -461,9 +463,10 @@ public:
      * Add a polygon with one outer ring and zero or more hole rings. The
      * first ring in `rings` is the outer boundary; the rest are holes.
      * Each ring needs at least 3 vertices. Rings are stored as one
-     * contiguous segment run, outer ring first.
+     * contiguous segment run, outer ring first. `rings` may be 2- or
+     * 3-dimensional; every ring in one call shares `rings`'s ndim.
      */
-    int32_t add_polygon_rings(std::vector<std::vector<std::array<T, 2>>> const & rings);
+    int32_t add_polygon_rings(ring_list_type const & rings);
 
     /**
      * Add a closed chain of straight segments through the given vertices, with
@@ -507,13 +510,17 @@ public:
         return m_curves->get(rec.curve_offset + i);
     }
 
-    /// One ring of a live shape (0-based within the shape), with vertices
-    /// reconstructed from the segment pad in input order (no repeated
-    /// closing vertex) and its role (outer for ring 0, hole otherwise).
+    /**
+     * One ring of a live shape (0-based within the shape), with vertices
+     * reconstructed from the segment pad in input order (no repeated
+     * closing vertex) and its role (outer for ring 0, hole otherwise).
+     * Each vertex has 2 elements for a 2-dimensional ring, 3 for a
+     * 3-dimensional one.
+     */
     struct RingInfo
     {
         RingRole role;
-        std::vector<std::array<T, 2>> vertices;
+        std::vector<std::vector<T>> vertices;
     }; /* end struct RingInfo */
 
     std::vector<RingInfo> shape_rings(int32_t shape_id) const;
@@ -726,7 +733,8 @@ private:
                            size_t curve_offset = 0,
                            size_t curve_count = 0,
                            size_t ring_offset = 0,
-                           size_t ring_count = 0);
+                           size_t ring_count = 0,
+                           uint8_t ring_ndim = 0);
 
     /**
      * Check if shape_id is valid and not DEAD.
@@ -824,10 +832,11 @@ int32_t World<T>::register_shape(ShapeType type,
                                  size_t curve_offset,
                                  size_t curve_count,
                                  size_t ring_offset,
-                                 size_t ring_count)
+                                 size_t ring_count,
+                                 uint8_t ring_ndim)
 {
     auto shape_id = static_cast<int32_t>(m_shape_registry.size());
-    m_shape_registry.push_back(ShapeRecord{type, segment_offset, segment_count, curve_offset, curve_count, ring_offset, ring_count, {}, {}}); // NOLINT(modernize-use-designated-initializers)
+    m_shape_registry.push_back(ShapeRecord{type, segment_offset, segment_count, curve_offset, curve_count, ring_offset, ring_count, ring_ndim, {}, {}}); // NOLINT(modernize-use-designated-initializers)
     ++m_nshape;
     bbox_type const bb = compute_shape_bbox(m_shape_registry[shape_id]);
 
@@ -973,15 +982,15 @@ int32_t World<T>::add_polyline(std::vector<std::array<T, 2>> const & vertices)
 }
 
 template <typename T>
-int32_t World<T>::add_polygon_rings(std::vector<std::vector<std::array<T, 2>>> const & rings)
+int32_t World<T>::add_polygon_rings(ring_list_type const & rings)
 {
-    if (rings.empty())
+    if (rings.nring() == 0)
     {
         throw std::invalid_argument("World: add_polygon_rings needs at least one ring");
     }
-    for (auto const & ring : rings)
+    for (size_t r = 0; r < rings.nring(); ++r)
     {
-        if (ring.size() < 3)
+        if (rings.ring_size(r) < 3)
         {
             throw std::invalid_argument("World: add_polygon_rings needs at least 3 vertices per ring");
         }
@@ -989,24 +998,23 @@ int32_t World<T>::add_polygon_rings(std::vector<std::vector<std::array<T, 2>>> c
 
     size_t const segment_offset = m_segments->size();
     size_t const ring_offset = m_ring_registry.size();
-    for (size_t r = 0; r < rings.size(); ++r)
+    for (size_t r = 0; r < rings.nring(); ++r)
     {
-        auto const & ring = rings[r];
         size_t const ring_seg_offset = m_segments->size();
-        for (size_t i = 0; i < ring.size(); ++i)
+        size_t const nvert = rings.ring_size(r);
+        for (size_t i = 0; i < nvert; ++i)
         {
-            size_t const j = (i + 1) % ring.size();
-            m_segments->append(
-                point_type(ring[i][0], ring[i][1], 0),
-                point_type(ring[j][0], ring[j][1], 0));
+            size_t const j = (i + 1) % nvert;
+            m_segments->append(rings.vertex(r, i), rings.vertex(r, j));
         }
-        m_ring_registry.push_back(RingEntry{ring_seg_offset, ring.size(), r == 0 ? RingRole::OUTER : RingRole::HOLE});
+        m_ring_registry.push_back(RingEntry{.segment_offset = ring_seg_offset, .segment_count = nvert, .role = r == 0 ? RingRole::OUTER : RingRole::HOLE});
     }
     return register_shape(ShapeType::POLYGON, segment_offset, m_segments->size() - segment_offset,
                           /*curve_offset*/ 0,
                           /*curve_count*/ 0,
                           ring_offset,
-                          rings.size());
+                          rings.nring(),
+                          rings.ndim());
 }
 
 template <typename T>
@@ -1016,7 +1024,13 @@ int32_t World<T>::add_polygon(std::vector<std::array<T, 2>> const & vertices)
     {
         throw std::invalid_argument("World: add_polygon needs at least 3 vertices");
     }
-    return add_polygon_rings({vertices});
+    ring_list_type rings(/* ndim */ 2);
+    rings.begin_ring();
+    for (auto const & v : vertices)
+    {
+        rings.add_vertex(v[0], v[1]);
+    }
+    return add_polygon_rings(rings);
 }
 
 template <typename T>
@@ -1034,7 +1048,14 @@ std::vector<typename World<T>::RingInfo> World<T>::shape_rings(int32_t shape_id)
         for (size_t i = 0; i < ring.segment_count; ++i)
         {
             segment_type const seg = m_segments->get(ring.segment_offset + i);
-            info.vertices.push_back({seg.p0().x(), seg.p0().y()});
+            if (rec.ring_ndim == 3)
+            {
+                info.vertices.push_back({seg.p0().x(), seg.p0().y(), seg.p0().z()});
+            }
+            else
+            {
+                info.vertices.push_back({seg.p0().x(), seg.p0().y()});
+            }
         }
         result.push_back(std::move(info));
     }

--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -765,6 +765,9 @@ private:
     // TODO: Replace std::vector with a custom SoA container and BoundBoxPad
     // auxiliary class. Consider moving the registry into the R-tree.
     std::vector<ShapeRecord> m_shape_registry;
+
+    // TODO: Replace std::vector with SimpleCollector or fold into the same
+    // SoA container as m_shape_registry (see the TODO above).
     std::vector<RingEntry> m_ring_registry; ///< Polygon ring ranges; empty for non-polygon shapes.
 
     size_t m_nshape = 0; ///< Count of live (non-DEAD) shapes.
@@ -993,6 +996,31 @@ int32_t World<T>::add_polygon_rings(ring_list_type const & rings)
         if (rings.ring_size(r) < 3)
         {
             throw std::invalid_argument("World: add_polygon_rings needs at least 3 vertices per ring");
+        }
+    }
+    // Right-hand rule: the outer ring is counter-clockwise (positive signed
+    // area), every hole is clockwise (negative). The XY-projected shoelace
+    // formula would silently misjudge -- or always read as degenerate -- a
+    // 3D ring not aligned with the XY plane (e.g. a vertical wall), so this
+    // check only applies to 2-dimensional rings.
+    if (rings.ndim() == 2)
+    {
+        constexpr T ring_area_eps = std::numeric_limits<T>::epsilon() * 100;
+        for (size_t r = 0; r < rings.nring(); ++r)
+        {
+            auto const [area, scale] = rings.signed_area(r);
+            if (std::abs(area) <= ring_area_eps * std::max(scale, T(1)))
+            {
+                throw std::invalid_argument("World: add_polygon_rings rejects a degenerate (zero-area) ring");
+            }
+            if (r == 0 && area <= 0)
+            {
+                throw std::invalid_argument("World: add_polygon_rings needs the outer ring wound counter-clockwise");
+            }
+            if (r != 0 && area >= 0)
+            {
+                throw std::invalid_argument("World: add_polygon_rings needs hole rings wound clockwise");
+            }
         }
     }
 

--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -220,6 +220,32 @@ private:
 }; /* end class WorldState */
 
 /**
+ * Whether a polygon ring is the outer boundary or a hole. Recorded by
+ * position (the first ring of a shape is OUTER, the rest are HOLE);
+ * winding direction carries no meaning.
+ *
+ * @ingroup group_geometry
+ */
+enum class RingRole : uint8_t
+{
+    OUTER,
+    HOLE,
+}; /* end enum class RingRole */
+
+/**
+ * One ring (outer boundary or hole) of a polygon shape, as a range into
+ * the shape's own segment run.
+ *
+ * @ingroup group_geometry
+ */
+struct RingEntry
+{
+    size_t segment_offset; ///< Absolute first index of this ring's run in SegmentPad.
+    size_t segment_count; ///< Number of segments (== number of vertices) in this ring.
+    RingRole role;
+}; /* end struct RingEntry */
+
+/**
  * Lightweight record mapping a shape ID to the segment and curve ranges
  * it owns in the world's pads. A shape may own segments only
  * (triangle, line, rectangle), curves only (ellipse, circle), or both.
@@ -235,6 +261,8 @@ struct ShapeRecord
     size_t segment_count; ///< Number of segments this shape occupies.
     size_t curve_offset; ///< First index in CurvePad.
     size_t curve_count; ///< Number of cubic Beziers this shape occupies.
+    size_t ring_offset; ///< First index in the ring registry. Only POLYGON shapes use this.
+    size_t ring_count; ///< Number of rings this shape owns. Zero for non-polygon shapes.
 
     /// OBB corner x's in world coordinates, ordered TL, TR, BR, BL.
     bbox_array_type obb_x;
@@ -430,8 +458,17 @@ public:
     int32_t add_polyline(std::vector<std::array<T, 2>> const & vertices);
 
     /**
+     * Add a polygon with one outer ring and zero or more hole rings. The
+     * first ring in `rings` is the outer boundary; the rest are holes.
+     * Each ring needs at least 3 vertices. Rings are stored as one
+     * contiguous segment run, outer ring first.
+     */
+    int32_t add_polygon_rings(std::vector<std::vector<std::array<T, 2>>> const & rings);
+
+    /**
      * Add a closed chain of straight segments through the given vertices, with
      * a final segment back to the first. Needs at least three vertices.
+     * One-ring special case of add_polygon_rings.
      */
     int32_t add_polygon(std::vector<std::array<T, 2>> const & vertices);
 
@@ -469,6 +506,17 @@ public:
         check_size(i, rec.curve_count, "shape curve");
         return m_curves->get(rec.curve_offset + i);
     }
+
+    /// One ring of a live shape (0-based within the shape), with vertices
+    /// reconstructed from the segment pad in input order (no repeated
+    /// closing vertex) and its role (outer for ring 0, hole otherwise).
+    struct RingInfo
+    {
+        RingRole role;
+        std::vector<std::array<T, 2>> vertices;
+    }; /* end struct RingInfo */
+
+    std::vector<RingInfo> shape_rings(int32_t shape_id) const;
 
     /**
      * Undo the most recent change. A change is any shape operation: creation,
@@ -676,7 +724,9 @@ private:
                            size_t segment_offset,
                            size_t segment_count,
                            size_t curve_offset = 0,
-                           size_t curve_count = 0);
+                           size_t curve_count = 0,
+                           size_t ring_offset = 0,
+                           size_t ring_count = 0);
 
     /**
      * Check if shape_id is valid and not DEAD.
@@ -707,6 +757,7 @@ private:
     // TODO: Replace std::vector with a custom SoA container and BoundBoxPad
     // auxiliary class. Consider moving the registry into the R-tree.
     std::vector<ShapeRecord> m_shape_registry;
+    std::vector<RingEntry> m_ring_registry; ///< Polygon ring ranges; empty for non-polygon shapes.
 
     size_t m_nshape = 0; ///< Count of live (non-DEAD) shapes.
     uint64_t m_state_stamp = 0; ///< Moves on every change; see state_stamp().
@@ -771,10 +822,12 @@ int32_t World<T>::register_shape(ShapeType type,
                                  size_t segment_offset,
                                  size_t segment_count,
                                  size_t curve_offset,
-                                 size_t curve_count)
+                                 size_t curve_count,
+                                 size_t ring_offset,
+                                 size_t ring_count)
 {
     auto shape_id = static_cast<int32_t>(m_shape_registry.size());
-    m_shape_registry.push_back(ShapeRecord{type, segment_offset, segment_count, curve_offset, curve_count, {}, {}}); // NOLINT(modernize-use-designated-initializers)
+    m_shape_registry.push_back(ShapeRecord{type, segment_offset, segment_count, curve_offset, curve_count, ring_offset, ring_count, {}, {}}); // NOLINT(modernize-use-designated-initializers)
     ++m_nshape;
     bbox_type const bb = compute_shape_bbox(m_shape_registry[shape_id]);
 
@@ -920,21 +973,72 @@ int32_t World<T>::add_polyline(std::vector<std::array<T, 2>> const & vertices)
 }
 
 template <typename T>
+int32_t World<T>::add_polygon_rings(std::vector<std::vector<std::array<T, 2>>> const & rings)
+{
+    if (rings.empty())
+    {
+        throw std::invalid_argument("World: add_polygon_rings needs at least one ring");
+    }
+    for (auto const & ring : rings)
+    {
+        if (ring.size() < 3)
+        {
+            throw std::invalid_argument("World: add_polygon_rings needs at least 3 vertices per ring");
+        }
+    }
+
+    size_t const segment_offset = m_segments->size();
+    size_t const ring_offset = m_ring_registry.size();
+    for (size_t r = 0; r < rings.size(); ++r)
+    {
+        auto const & ring = rings[r];
+        size_t const ring_seg_offset = m_segments->size();
+        for (size_t i = 0; i < ring.size(); ++i)
+        {
+            size_t const j = (i + 1) % ring.size();
+            m_segments->append(
+                point_type(ring[i][0], ring[i][1], 0),
+                point_type(ring[j][0], ring[j][1], 0));
+        }
+        m_ring_registry.push_back(RingEntry{ring_seg_offset, ring.size(), r == 0 ? RingRole::OUTER : RingRole::HOLE});
+    }
+    return register_shape(ShapeType::POLYGON, segment_offset, m_segments->size() - segment_offset,
+                          /*curve_offset*/ 0,
+                          /*curve_count*/ 0,
+                          ring_offset,
+                          rings.size());
+}
+
+template <typename T>
 int32_t World<T>::add_polygon(std::vector<std::array<T, 2>> const & vertices)
 {
     if (vertices.size() < 3)
     {
         throw std::invalid_argument("World: add_polygon needs at least 3 vertices");
     }
-    size_t const offset = m_segments->size();
-    for (size_t i = 0; i < vertices.size(); ++i)
+    return add_polygon_rings({vertices});
+}
+
+template <typename T>
+std::vector<typename World<T>::RingInfo> World<T>::shape_rings(int32_t shape_id) const
+{
+    ShapeRecord const & rec = find_shape_or_throw(shape_id);
+    std::vector<RingInfo> result;
+    result.reserve(rec.ring_count);
+    for (size_t r = 0; r < rec.ring_count; ++r)
     {
-        size_t const j = (i + 1) % vertices.size();
-        m_segments->append(
-            point_type(vertices[i][0], vertices[i][1], 0),
-            point_type(vertices[j][0], vertices[j][1], 0));
+        RingEntry const & ring = m_ring_registry[rec.ring_offset + r];
+        RingInfo info;
+        info.role = ring.role;
+        info.vertices.reserve(ring.segment_count);
+        for (size_t i = 0; i < ring.segment_count; ++i)
+        {
+            segment_type const seg = m_segments->get(ring.segment_offset + i);
+            info.vertices.push_back({seg.p0().x(), seg.p0().y()});
+        }
+        result.push_back(std::move(info));
     }
-    return register_shape(ShapeType::POLYGON, offset, vertices.size());
+    return result;
 }
 
 template <typename T>
@@ -1379,6 +1483,7 @@ void World<T>::clear()
     m_curves = curve_pad_type::construct(/* ndim */ 3);
     m_bare_segment_indices.clear();
     m_shape_registry.clear();
+    m_ring_registry.clear();
     m_nshape = 0;
     m_rtree = std::make_unique<rtree_type>();
     m_undo_stack.clear();

--- a/cpp/solvcon/universe/coord.hpp
+++ b/cpp/solvcon/universe/coord.hpp
@@ -810,6 +810,38 @@ public:
         return m_points->get(m_ring_offset[r] + i);
     }
 
+    /// Result of signed_area(): the area itself, and a scale to compare it
+    /// against when judging whether it is degenerate (near zero relative
+    /// to the ring's own coordinate magnitude, not to an absolute bound).
+    struct SignedArea
+    {
+        T value; ///< Shoelace signed area: positive CCW, negative CW.
+        T scale; ///< Sum of |shoelace term| magnitudes.
+    }; /* end struct SignedArea */
+
+    /**
+     * Signed area of ring `r` via the shoelace formula, using only x and y
+     * (matches PolygonPad::compute_signed_area()). Positive means
+     * counter-clockwise, negative clockwise; meaningful for a 3D ring only
+     * when it is planar and aligned with the XY plane.
+     */
+    SignedArea signed_area(size_t r) const
+    {
+        size_t const n = ring_size(r);
+        T area = 0;
+        T scale = 0;
+        point_type prev = vertex(r, 0);
+        for (size_t i = 1; i <= n; ++i)
+        {
+            point_type const next = vertex(r, i % n);
+            T const term = prev.x() * next.y() - next.x() * prev.y();
+            area += term;
+            scale += std::abs(term);
+            prev = next;
+        }
+        return {area / 2, scale / 2};
+    }
+
 private:
 
     void check_ring_open(char const * caller) const

--- a/cpp/solvcon/universe/coord.hpp
+++ b/cpp/solvcon/universe/coord.hpp
@@ -731,6 +731,105 @@ private:
 using PointPadFp32 = PointPad<float>;
 using PointPadFp64 = PointPad<double>;
 
+/**
+ * A polygon's rings (one outer boundary plus zero or more holes), stored as
+ * one flat PointPad-backed vertex buffer with a per-ring [offset, size)
+ * index. Avoids the per-ring heap allocation of a vector of vectors. Every
+ * ring in one RingList shares the same ndim, decided at construction.
+ *
+ * @ingroup group_geometry
+ */
+template <typename T>
+class RingList
+{
+
+public:
+
+    using point_type = Point3d<T>;
+    using point_pad_type = PointPad<T>;
+
+    explicit RingList(uint8_t ndim)
+        : m_points(point_pad_type::construct(ndim))
+    {
+    }
+
+    RingList() = delete;
+    RingList(RingList const &) = delete;
+    RingList(RingList &&) = default;
+    RingList & operator=(RingList const &) = delete;
+    RingList & operator=(RingList &&) = default;
+    ~RingList() = default;
+
+    /// Start a new ring; must be followed by add_vertex() calls.
+    void begin_ring()
+    {
+        m_ring_offset.push_back(m_points->size());
+        m_ring_size.push_back(0);
+    }
+
+    void add_vertex(T x, T y)
+    {
+        check_ring_open("add_vertex");
+        m_points->append(x, y);
+        ++m_ring_size.back();
+    }
+
+    void add_vertex(T x, T y, T z)
+    {
+        check_ring_open("add_vertex");
+        m_points->append(x, y, z);
+        ++m_ring_size.back();
+    }
+
+    uint8_t ndim() const { return m_points->ndim(); }
+
+    size_t nring() const { return m_ring_offset.size(); }
+
+    size_t ring_size(size_t r) const
+    {
+        if (r >= m_ring_size.size())
+        {
+            throw std::out_of_range(
+                std::format("RingList::ring_size: ring {} >= nring {}", r, m_ring_size.size()));
+        }
+        return m_ring_size[r];
+    }
+
+    point_type vertex(size_t r, size_t i) const
+    {
+        if (r >= m_ring_offset.size())
+        {
+            throw std::out_of_range(
+                std::format("RingList::vertex: ring {} >= nring {}", r, m_ring_offset.size()));
+        }
+        if (i >= m_ring_size[r])
+        {
+            throw std::out_of_range(
+                std::format("RingList::vertex: index {} >= ring_size {}", i, m_ring_size[r]));
+        }
+        return m_points->get(m_ring_offset[r] + i);
+    }
+
+private:
+
+    void check_ring_open(char const * caller) const
+    {
+        if (m_ring_offset.empty())
+        {
+            throw std::out_of_range(
+                std::format("RingList::{}: no ring started; call begin_ring() first", caller));
+        }
+    }
+
+    std::shared_ptr<point_pad_type> m_points;
+    SimpleCollector<size_t> m_ring_offset;
+    SimpleCollector<size_t> m_ring_size;
+
+}; /* end class RingList */
+
+using RingListFp32 = RingList<float>;
+using RingListFp64 = RingList<double>;
+
 namespace detail
 {
 

--- a/cpp/solvcon/universe/pymod/wrap_World.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_World.cpp
@@ -28,6 +28,7 @@ public:
     using segment_pad_type = typename wrapped_type::segment_pad_type;
     using bezier_type = typename wrapped_type::bezier_type;
     using curve_pad_type = typename wrapped_type::curve_pad_type;
+    using ring_list_type = typename wrapped_type::ring_list_type;
 
     friend typename base_type::root_base_type;
 
@@ -40,6 +41,13 @@ protected:
     WrapWorld & wrap_segment();
     WrapWorld & wrap_bezier();
     WrapWorld & wrap_shape();
+
+private:
+
+    /// Build a RingList from Python's nested [ring][vertex][coordinate]
+    /// lists, inferring ndim from the data and rejecting inconsistent
+    /// per-vertex coordinate counts.
+    static ring_list_type build_ring_list(std::vector<std::vector<std::vector<value_type>>> const & rings);
 }; /* end class WrapWorld */
 
 template <typename T>
@@ -307,6 +315,52 @@ WrapWorld<T> & WrapWorld<T>::wrap_bezier()
 }
 
 template <typename T>
+typename WrapWorld<T>::ring_list_type WrapWorld<T>::build_ring_list(std::vector<std::vector<std::vector<value_type>>> const & rings)
+{
+    uint8_t ndim = 0;
+    for (auto const & ring : rings)
+    {
+        for (auto const & vertex : ring)
+        {
+            if (vertex.size() != 2 && vertex.size() != 3)
+            {
+                throw std::invalid_argument(
+                    "World: add_polygon_rings vertices need 2 or 3 coordinates");
+            }
+            if (ndim == 0)
+            {
+                ndim = static_cast<uint8_t>(vertex.size());
+            }
+            else if (vertex.size() != ndim)
+            {
+                throw std::invalid_argument(
+                    "World: add_polygon_rings needs the same number of "
+                    "coordinates (2 or 3) on every vertex");
+            }
+        }
+    }
+
+    ring_list_type ring_list(ndim == 0 ? 2 : ndim);
+    for (auto const & ring : rings)
+    {
+        ring_list.begin_ring();
+        for (auto const & vertex : ring)
+        {
+            if (ndim == 3)
+            {
+                ring_list.add_vertex(vertex.at(0), vertex.at(1), vertex.at(2));
+            }
+            else
+            {
+                ring_list.add_vertex(vertex.at(0), vertex.at(1));
+            }
+        }
+    }
+
+    return ring_list;
+}
+
+template <typename T>
 WrapWorld<T> & WrapWorld<T>::wrap_shape()
 {
     namespace py = pybind11;
@@ -398,9 +452,9 @@ WrapWorld<T> & WrapWorld<T>::wrap_shape()
             py::arg("vertices"))
         .def(
             "add_polygon_rings",
-            [](wrapped_type & self, std::vector<std::vector<std::array<value_type, 2>>> const & rings)
+            [](wrapped_type & self, std::vector<std::vector<std::vector<value_type>>> const & rings)
             {
-                return self.add_polygon_rings(rings);
+                return self.add_polygon_rings(build_ring_list(rings));
             },
             py::arg("rings"))
         .def(

--- a/cpp/solvcon/universe/pymod/wrap_World.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_World.cpp
@@ -146,6 +146,21 @@ WrapWorld<T> & WrapWorld<T>::wrap_management()
             },
             py::arg("shape_id"))
         .def(
+            "shape_rings",
+            [](wrapped_type const & self, int32_t shape_id)
+            {
+                py::list result;
+                for (auto const & ring : self.shape_rings(shape_id))
+                {
+                    py::dict d;
+                    d["role"] = (ring.role == RingRole::OUTER) ? "outer" : "hole";
+                    d["vertices"] = ring.vertices;
+                    result.append(d);
+                }
+                return result;
+            },
+            py::arg("shape_id"))
+        .def(
             "pick_shape",
             &wrapped_type::pick_shape,
             py::arg("x"),
@@ -381,6 +396,13 @@ WrapWorld<T> & WrapWorld<T>::wrap_shape()
                 return self.add_polyline(vertices);
             },
             py::arg("vertices"))
+        .def(
+            "add_polygon_rings",
+            [](wrapped_type & self, std::vector<std::vector<std::array<value_type, 2>>> const & rings)
+            {
+                return self.add_polygon_rings(rings);
+            },
+            py::arg("rings"))
         .def(
             "add_polygon",
             [](wrapped_type & self, std::vector<std::array<value_type, 2>> const & vertices)

--- a/solvcon/agent/draw/command.py
+++ b/solvcon/agent/draw/command.py
@@ -305,7 +305,8 @@ class AddPolygon(_cmd.Command):
     category = "create"
     summary = "Add a closed polygon through a list of [x, y] vertices."
     arguments = {"vertices": _vertices(
-        3, "The last vertex connects back to the first.")}
+        3, "The last vertex connects back to the first. Vertices must be "
+        "wound counter-clockwise.")}
     returns = {"shape_id": _int("Id of the new shape.")}
 
     def apply(self, world, args, ctx):

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -368,7 +368,7 @@ class WorldPolygonRingsTC(unittest.TestCase):
 
     def test_add_polygon_rings_basic(self):
         outer = [[0, 0], [4, 0], [4, 4], [0, 4]]
-        hole = [[1, 1], [2, 1], [2, 2], [1, 2]]
+        hole = [[1, 2], [2, 2], [2, 1], [1, 1]]
         sid = self.w.add_polygon_rings([outer, hole])
         self.assertEqual(self.w.shape_type_of(sid), "polygon")
         self.assertEqual(self.w.nsegment, len(outer) + len(hole))
@@ -389,6 +389,22 @@ class WorldPolygonRingsTC(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.w.add_polygon_rings([[[0, 0], [1, 1]]])
 
+    def test_add_polygon_rings_rejects_clockwise_outer(self):
+        outer = [[0, 4], [4, 4], [4, 0], [0, 0]]
+        with self.assertRaises(ValueError):
+            self.w.add_polygon_rings([outer])
+
+    def test_add_polygon_rings_rejects_counterclockwise_hole(self):
+        outer = [[0, 0], [4, 0], [4, 4], [0, 4]]
+        hole = [[1, 1], [2, 1], [2, 2], [1, 2]]
+        with self.assertRaises(ValueError):
+            self.w.add_polygon_rings([outer, hole])
+
+    def test_add_polygon_rings_rejects_degenerate_ring(self):
+        collinear = [[0, 0], [1, 0], [2, 0]]
+        with self.assertRaises(ValueError):
+            self.w.add_polygon_rings([collinear])
+
     def test_add_polygon_delegates_to_rings(self):
         vertices = [[0, 0], [2, 0], [2, 2]]
         sid = self.w.add_polygon(vertices)
@@ -398,9 +414,13 @@ class WorldPolygonRingsTC(unittest.TestCase):
         self.assertEqual(
             [list(v) for v in rings[0]["vertices"]], vertices)
 
+    def test_add_polygon_rejects_clockwise_winding(self):
+        with self.assertRaises(ValueError):
+            self.w.add_polygon([[0, 2], [2, 2], [2, 0], [0, 0]])
+
     def test_multi_ring_polygon_translate(self):
         outer = [[0, 0], [4, 0], [4, 4], [0, 4]]
-        hole = [[1, 1], [2, 1], [2, 2], [1, 2]]
+        hole = [[1, 2], [2, 2], [2, 1], [1, 1]]
         sid = self.w.add_polygon_rings([outer, hole])
         self.w.translate_shape(sid, 10, -5)
         rings = self.w.shape_rings(sid)
@@ -413,7 +433,7 @@ class WorldPolygonRingsTC(unittest.TestCase):
 
     def test_multi_ring_polygon_rotate(self):
         outer = [[1, 0], [0, 1], [-1, 0], [0, -1]]
-        hole = [[0.2, 0], [0, 0.2], [-0.2, 0], [0, -0.2]]
+        hole = [[0, -0.2], [-0.2, 0], [0, 0.2], [0.2, 0]]
         sid = self.w.add_polygon_rings([outer, hole])
         # A 90-degree rotation about the origin maps (x, y) -> (-y, x).
         self.w.rotate_shape(sid, math.pi / 2, 0, 0)
@@ -425,7 +445,7 @@ class WorldPolygonRingsTC(unittest.TestCase):
 
     def test_multi_ring_polygon_undo_redo(self):
         outer = [[0, 0], [4, 0], [4, 4], [0, 4]]
-        hole = [[1, 1], [2, 1], [2, 2], [1, 2]]
+        hole = [[1, 2], [2, 2], [2, 1], [1, 1]]
         sid = self.w.add_polygon_rings([outer, hole])
         self.w.undo()
         self.assertFalse(self.w.shape_is_live(sid))
@@ -440,7 +460,7 @@ class WorldPolygonRingsTC(unittest.TestCase):
 
     def test_add_polygon_rings_3d_round_trip(self):
         outer = [[0, 0, 1], [4, 0, 1], [4, 4, 1], [0, 4, 1]]
-        hole = [[1, 1, 1], [2, 1, 1], [2, 2, 1], [1, 2, 1]]
+        hole = [[1, 2, 1], [2, 2, 1], [2, 1, 1], [1, 1, 1]]
         sid = self.w.add_polygon_rings([outer, hole])
         rings = self.w.shape_rings(sid)
         self.assertEqual(
@@ -451,6 +471,16 @@ class WorldPolygonRingsTC(unittest.TestCase):
     def test_add_polygon_rings_rejects_mixed_dimensionality(self):
         with self.assertRaises(ValueError):
             self.w.add_polygon_rings([[[0, 0], [1, 0, 1], [1, 1], [0, 1]]])
+
+    def test_add_polygon_rings_skips_winding_check_for_3d(self):
+        # A vertical wall in the XZ plane: every vertex has y == 0, so the
+        # XY-projected shoelace area is always exactly zero regardless of
+        # winding. Winding/degeneracy validation only applies to 2D rings.
+        wall = [[0, 0, 0], [4, 0, 0], [4, 0, 4], [0, 0, 4]]
+        sid = self.w.add_polygon_rings([wall])
+        rings = self.w.shape_rings(sid)
+        self.assertEqual(
+            [list(v) for v in rings[0]["vertices"]], wall)
 
 
 class WorldStateStampTC(unittest.TestCase):

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -360,6 +360,85 @@ class WorldPrimitivesTC(unittest.TestCase):
             self.w.add_polygon([[0, 0], [1, 1]])
 
 
+class WorldPolygonRingsTC(unittest.TestCase):
+    """Multi-ring polygons: one outer ring plus zero or more holes."""
+
+    def setUp(self):
+        self.w = solvcon.WorldFp64()
+
+    def test_add_polygon_rings_basic(self):
+        outer = [[0, 0], [4, 0], [4, 4], [0, 4]]
+        hole = [[1, 1], [2, 1], [2, 2], [1, 2]]
+        sid = self.w.add_polygon_rings([outer, hole])
+        self.assertEqual(self.w.shape_type_of(sid), "polygon")
+        self.assertEqual(self.w.nsegment, len(outer) + len(hole))
+        rings = self.w.shape_rings(sid)
+        self.assertEqual(len(rings), 2)
+        self.assertEqual(rings[0]["role"], "outer")
+        self.assertEqual(
+            [list(v) for v in rings[0]["vertices"]], outer)
+        self.assertEqual(rings[1]["role"], "hole")
+        self.assertEqual(
+            [list(v) for v in rings[1]["vertices"]], hole)
+
+    def test_add_polygon_rings_needs_one_ring(self):
+        with self.assertRaises(ValueError):
+            self.w.add_polygon_rings([])
+
+    def test_add_polygon_rings_needs_three_vertices_per_ring(self):
+        with self.assertRaises(ValueError):
+            self.w.add_polygon_rings([[[0, 0], [1, 1]]])
+
+    def test_add_polygon_delegates_to_rings(self):
+        vertices = [[0, 0], [2, 0], [2, 2]]
+        sid = self.w.add_polygon(vertices)
+        rings = self.w.shape_rings(sid)
+        self.assertEqual(len(rings), 1)
+        self.assertEqual(rings[0]["role"], "outer")
+        self.assertEqual(
+            [list(v) for v in rings[0]["vertices"]], vertices)
+
+    def test_multi_ring_polygon_translate(self):
+        outer = [[0, 0], [4, 0], [4, 4], [0, 4]]
+        hole = [[1, 1], [2, 1], [2, 2], [1, 2]]
+        sid = self.w.add_polygon_rings([outer, hole])
+        self.w.translate_shape(sid, 10, -5)
+        rings = self.w.shape_rings(sid)
+        self.assertEqual(
+            [list(v) for v in rings[0]["vertices"]],
+            [[x + 10, y - 5] for x, y in outer])
+        self.assertEqual(
+            [list(v) for v in rings[1]["vertices"]],
+            [[x + 10, y - 5] for x, y in hole])
+
+    def test_multi_ring_polygon_rotate(self):
+        outer = [[1, 0], [0, 1], [-1, 0], [0, -1]]
+        hole = [[0.2, 0], [0, 0.2], [-0.2, 0], [0, -0.2]]
+        sid = self.w.add_polygon_rings([outer, hole])
+        # A 90-degree rotation about the origin maps (x, y) -> (-y, x).
+        self.w.rotate_shape(sid, math.pi / 2, 0, 0)
+        rings = self.w.shape_rings(sid)
+        for ring, expected in ((rings[0], outer), (rings[1], hole)):
+            for (x, y), (ex, ey) in zip(ring["vertices"], expected):
+                self.assertAlmostEqual(x, -ey)
+                self.assertAlmostEqual(y, ex)
+
+    def test_multi_ring_polygon_undo_redo(self):
+        outer = [[0, 0], [4, 0], [4, 4], [0, 4]]
+        hole = [[1, 1], [2, 1], [2, 2], [1, 2]]
+        sid = self.w.add_polygon_rings([outer, hole])
+        self.w.undo()
+        self.assertFalse(self.w.shape_is_live(sid))
+        self.w.redo()
+        self.assertTrue(self.w.shape_is_live(sid))
+        rings = self.w.shape_rings(sid)
+        self.assertEqual(len(rings), 2)
+        self.assertEqual(
+            [list(v) for v in rings[0]["vertices"]], outer)
+        self.assertEqual(
+            [list(v) for v in rings[1]["vertices"]], hole)
+
+
 class WorldStateStampTC(unittest.TestCase):
     """The stamp that tells a reader the world has changed."""
 

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -438,6 +438,20 @@ class WorldPolygonRingsTC(unittest.TestCase):
         self.assertEqual(
             [list(v) for v in rings[1]["vertices"]], hole)
 
+    def test_add_polygon_rings_3d_round_trip(self):
+        outer = [[0, 0, 1], [4, 0, 1], [4, 4, 1], [0, 4, 1]]
+        hole = [[1, 1, 1], [2, 1, 1], [2, 2, 1], [1, 2, 1]]
+        sid = self.w.add_polygon_rings([outer, hole])
+        rings = self.w.shape_rings(sid)
+        self.assertEqual(
+            [list(v) for v in rings[0]["vertices"]], outer)
+        self.assertEqual(
+            [list(v) for v in rings[1]["vertices"]], hole)
+
+    def test_add_polygon_rings_rejects_mixed_dimensionality(self):
+        with self.assertRaises(ValueError):
+            self.w.add_polygon_rings([[[0, 0], [1, 0, 1], [1, 1], [0, 1]]])
+
 
 class WorldStateStampTC(unittest.TestCase):
     """The stamp that tells a reader the world has changed."""


### PR DESCRIPTION
This teaches solvcon::World that a polygon is a region rather than a single closed loop: it can now have one outer ring plus zero or more hole rings. A new RingEntry table, parallel to World's existing segment and curve pads, is referenced from ShapeRecord by ring_offset and ring_count, following the same offset-and-count convention the rest of the class already uses.

add_polygon_rings(rings) is the new primitive; the landed add_polygon(vertices) becomes its one-ring special case, with its exact error message and observable behavior preserved. A new shape_rings(shape_id) accessor reconstructs each ring's role and vertices from the segment pad, and is exposed to Python through a new pybind11 binding alongside add_polygon_rings. translate_shape, rotate_shape, undo/redo, and shape removal needed no changes, since every ring of a shape lives in that shape's existing contiguous segment range.

This is Step 1 of the "Shape MVP: Complete the Polygon as a Real Canvas Shape" plan; interior-aware picking, a GUI polygon tool, agent read-back, and degeneracy diagnostics are later steps and are not part of this PR.

Related to #1234.
