### PR TITLE
Discard the Winograd fallback with `if constexpr`

### DIFF
--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -994,8 +994,7 @@ void MatmulExecutor<Array>::execute_gemm_blas(value_type * output, value_type co
 template <typename Array>
 void MatmulExecutor<Array>::execute_winograd()
 {
-#if (defined(__APPLE__) && defined(__arm64__)) || defined(SC_HAS_CBLAS)
-    if constexpr (can_matmul_blas_v<value_type>)
+    if constexpr (use_matmul_blas_v<value_type>)
     {
         BlasOutputView<value_type> const output{
             .m_data = m_output_data,
@@ -1008,10 +1007,11 @@ void MatmulExecutor<Array>::execute_winograd()
             require_matrix_view(lhs_matrix_view(m_lhs_data)),
             require_matrix_view(rhs_matrix_view(m_rhs_data)),
             output);
-        return;
     }
-#endif
-    throw std::logic_error("MatmulExecutor::execute_winograd(): unavailable Winograd kernel");
+    else
+    {
+        throw std::logic_error("MatmulExecutor::execute_winograd(): unavailable Winograd kernel");
+    }
 }
 
 template <typename Array>


### PR DESCRIPTION
For issue #1353

The issue is that the Windows compiler encountered unreachable code and issued error code [C4702](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4702) in `MatmulExecutor::execute_winograd()`.

Use `use_matmul_blas_v` and put the `throw` in the `else` to fix it.
