### PR TITLE
Cache GEMM scratch data pointer

### DIFF
--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -386,6 +386,7 @@ private:
     std::optional<Array> m_packed_lhs;
     std::optional<Array> m_packed_rhs;
     std::optional<Array> m_gemm_scratch;
+    value_type * m_gemm_scratch_data = nullptr;
     size_t m_lhs_scratch_elements = 0;
     value_type const * m_cached_lhs_source = nullptr;
     value_type const * m_cached_rhs_source = nullptr;
@@ -999,6 +1000,7 @@ void MatmulExecutor<Array>::prepare_gemm_scratch()
 {
     if (m_gemm_scratch)
     {
+        m_gemm_scratch_data = m_gemm_scratch->data();
         m_cached_lhs_source = nullptr;
         m_cached_rhs_source = nullptr;
         return;
@@ -1018,7 +1020,7 @@ void MatmulExecutor<Array>::prepare_gemm_scratch()
         throw std::length_error("MatmulExecutor::prepare_gemm_scratch(): scratch size overflows");
     }
     typename Array::shape_type const scratch_shape{static_cast<ssize_t>(m_lhs_scratch_elements + rhs_elements)};
-    m_gemm_scratch.emplace(scratch_shape);
+    m_gemm_scratch_data = m_gemm_scratch.emplace(scratch_shape).data();
 }
 
 template <typename Array>
@@ -1030,7 +1032,7 @@ void MatmulExecutor<Array>::execute_gemm_blas(value_type * output, value_type co
     {
         lhs_view = pack_matrix_to_scratch(
             lhs_data,
-            m_gemm_scratch.value().data(),
+            m_gemm_scratch_data,
             m_cached_lhs_source,
             m_plan.rows(),
             m_plan.inner_size(),
@@ -1041,7 +1043,7 @@ void MatmulExecutor<Array>::execute_gemm_blas(value_type * output, value_type co
     {
         rhs_view = pack_matrix_to_scratch(
             rhs_data,
-            m_gemm_scratch.value().data() + m_lhs_scratch_elements,
+            m_gemm_scratch_data + m_lhs_scratch_elements,
             m_cached_rhs_source,
             m_plan.inner_size(),
             m_plan.columns(),


### PR DESCRIPTION
## Motivation

The scheduled `clang-tidy` job reports `bugprone-unchecked-optional-access` for GEMM scratch storage. The optional is prepared before batched GEMM execution, but that invariant is not visible at each access.

## Approach

Cache the scratch data pointer when storage is prepared and use it while packing incompatible operands. This keeps setup outside the batch loop and removes repeated optional checks.

## Validation

`make lint`, 244 C++ tests, and 106 matrix tests pass.

Related to #1283.