### PR TITLE
Implement chained function call (fluent API) for `SimpleArray` in-place arithmetic operation

### DIFF
--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -454,37 +454,37 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def(
                 "iadd",
                 [](wrapped_type & self, wrapped_type const & other)
-                { self.iadd(other); })
+                { return py::cast(std::move(self.iadd(other))); })
             .def(
                 "iadd",
                 [](wrapped_type & self, value_type scalar)
-                { self.iadd(scalar); })
+                { return py::cast(std::move(self.iadd(scalar))); })
             .def(
                 "isub",
                 [](wrapped_type & self, wrapped_type const & other)
-                { self.isub(other); })
+                { return py::cast(std::move(self.isub(other))); })
             .def(
                 "isub",
                 [](wrapped_type & self, value_type scalar)
-                { self.isub(scalar); })
+                { return py::cast(std::move(self.isub(scalar))); })
             .def(
                 "imul",
                 [](wrapped_type & self, wrapped_type const & other)
-                { self.imul(other); })
+                { return py::cast(std::move(self.imul(other))); })
             .def(
                 "imul",
                 [](wrapped_type & self, value_type scalar)
-                { self.imul(scalar); })
+                { return py::cast(std::move(self.imul(scalar))); })
             .def("idiv", [](wrapped_type & self, wrapped_type const & other)
-                 { self.idiv(other); })
+                 { return py::cast(std::move(self.idiv(other))); })
             .def(
                 "idiv",
                 [](wrapped_type & self, value_type scalar)
-                { self.idiv(scalar); })
+                { return py::cast(std::move(self.idiv(scalar))); })
             .def("imatmul", [](wrapped_type & self, wrapped_type const & other)
-                 { self.imatmul(other); })
+                 { return py::cast(std::move(self.imatmul(other))); })
             .def("imatmul_blas", [](wrapped_type & self, wrapped_type const & other)
-                 { self.imatmul_blas(other); })
+                 { return py::cast(std::move(self.imatmul_blas(other))); })
             .def(
                 "imatmul_fast",
                 [](wrapped_type & self,
@@ -492,7 +492,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                    ssize_t tile_x,
                    ssize_t tile_y,
                    ssize_t tile_z)
-                { self.imatmul_fast(other, tile_x, tile_y, tile_z); },
+                { return py::cast(std::move(self.imatmul_fast(other, tile_x, tile_y, tile_z))); },
                 py::arg("other"),
                 py::arg("tile_x") = 16,
                 py::arg("tile_y") = 16,
@@ -506,13 +506,13 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def("mul_simd", &wrapped_type::mul_simd)
             .def("div_simd", &wrapped_type::div_simd)
             .def("iadd_simd", [](wrapped_type & self, wrapped_type const & other)
-                 { self.iadd_simd(other); })
+                 { return py::cast(std::move(self.iadd_simd(other))); })
             .def("isub_simd", [](wrapped_type & self, wrapped_type const & other)
-                 { self.isub_simd(other); })
+                 { return py::cast(std::move(self.isub_simd(other))); })
             .def("imul_simd", [](wrapped_type & self, wrapped_type const & other)
-                 { self.imul_simd(other); })
+                 { return py::cast(std::move(self.imul_simd(other))); })
             .def("idiv_simd", [](wrapped_type & self, wrapped_type const & other)
-                 { self.idiv_simd(other); })
+                 { return py::cast(std::move(self.idiv_simd(other))); })
             //
             ;
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -2939,6 +2939,62 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
                         getattr(lhs, operation)(rhs)
                     np.testing.assert_array_equal(expected, lhs.ndarray)
 
+    def test_inplace_arithmetic_returns_self(self):
+        # In-place methods must return the same Python object as the
+        # receiver (not a copy) so that calls can be chained fluently.
+        sarr1 = solvcon.SimpleArrayFloat64((3,), value=4)
+        sarr2 = solvcon.SimpleArrayFloat64((3,), value=2)
+        self.assertIs(sarr1.iadd(sarr2), sarr1)
+
+        sarr1 = solvcon.SimpleArrayFloat64((3,), value=4)
+        sarr2 = solvcon.SimpleArrayFloat64((3,), value=2)
+        self.assertIs(sarr1.isub(sarr2), sarr1)
+
+        sarr1 = solvcon.SimpleArrayFloat64((3,), value=4)
+        sarr2 = solvcon.SimpleArrayFloat64((3,), value=2)
+        self.assertIs(sarr1.imul(sarr2), sarr1)
+
+        sarr1 = solvcon.SimpleArrayFloat64((3,), value=4)
+        sarr2 = solvcon.SimpleArrayFloat64((3,), value=2)
+        self.assertIs(sarr1.idiv(sarr2), sarr1)
+
+        sarr1 = solvcon.SimpleArrayFloat64((3,), value=4)
+        self.assertIs(sarr1.iadd(2.0), sarr1)
+
+        sarr1 = solvcon.SimpleArrayFloat64((3,), value=4)
+        self.assertIs(sarr1.isub(2.0), sarr1)
+
+        sarr1 = solvcon.SimpleArrayFloat64((3,), value=4)
+        self.assertIs(sarr1.imul(2.0), sarr1)
+
+        sarr1 = solvcon.SimpleArrayFloat64((3,), value=4)
+        self.assertIs(sarr1.idiv(2.0), sarr1)
+
+    def test_inplace_arithmetic_fluent_chaining(self):
+        # Chaining relies on each in-place call returning self, so the
+        # chained result must equal applying the operations sequentially.
+        narr1 = np.array([8.0, 12.0, 16.0], dtype='float64')
+        narr2 = np.array([2.0, 3.0, 4.0], dtype='float64')
+        sarr1 = solvcon.SimpleArrayFloat64(array=narr1.copy())
+        sarr2 = solvcon.SimpleArrayFloat64(array=narr2.copy())
+
+        chained = sarr1.iadd(sarr2).isub(sarr2).imul(sarr2).idiv(sarr2)
+
+        expected = narr1.copy()
+        expected = expected + narr2
+        expected = expected - narr2
+        expected = expected * narr2
+        expected = expected / narr2
+
+        self.assertIs(chained, sarr1)
+        np.testing.assert_array_equal(sarr1.ndarray, expected)
+
+        sarr3 = solvcon.SimpleArrayFloat64(array=narr1.copy())
+        chained_scalar = sarr3.iadd(1.0).imul(2.0).isub(3.0)
+        expected_scalar = ((narr1.copy() + 1.0) * 2.0) - 3.0
+        self.assertIs(chained_scalar, sarr3)
+        np.testing.assert_array_equal(sarr3.ndarray, expected_scalar)
+
     def test_add(self):
         # test integer
         def _check_add_type(type):

--- a/tests/test_buffer_simd.py
+++ b/tests/test_buffer_simd.py
@@ -73,4 +73,55 @@ class SimdTransformBinaryTC(unittest.TestCase):
         for i, want in enumerate(expected):
             self.assertEqual(out[i], want)
 
+
+class SimdTransformInplaceBinaryTC(unittest.TestCase):
+    # The in-place SIMD wrappers (iadd_simd, isub_simd, imul_simd,
+    # idiv_simd) must return the receiver itself, not a copy, so that
+    # the fluent (chained) API mutates in place across every call.
+    def test_inplace_simd_returns_self(self):
+        a = solvcon.SimpleArrayFloat32(
+            array=np.array([4.0, 6.0, 8.0], dtype='float32'))
+        b = solvcon.SimpleArrayFloat32(
+            array=np.array([2.0, 2.0, 2.0], dtype='float32'))
+        self.assertIs(a.iadd_simd(b), a)
+
+        a = solvcon.SimpleArrayFloat32(
+            array=np.array([4.0, 6.0, 8.0], dtype='float32'))
+        b = solvcon.SimpleArrayFloat32(
+            array=np.array([2.0, 2.0, 2.0], dtype='float32'))
+        self.assertIs(a.isub_simd(b), a)
+
+        a = solvcon.SimpleArrayFloat32(
+            array=np.array([4.0, 6.0, 8.0], dtype='float32'))
+        b = solvcon.SimpleArrayFloat32(
+            array=np.array([2.0, 2.0, 2.0], dtype='float32'))
+        self.assertIs(a.imul_simd(b), a)
+
+        a = solvcon.SimpleArrayFloat32(
+            array=np.array([4.0, 6.0, 8.0], dtype='float32'))
+        b = solvcon.SimpleArrayFloat32(
+            array=np.array([2.0, 2.0, 2.0], dtype='float32'))
+        self.assertIs(a.idiv_simd(b), a)
+
+    def test_inplace_simd_fluent_chaining(self):
+        n = 17  # four NEON blocks plus a 1-element scalar tail
+        a_vals = np.array(
+            [float(i + 4) for i in range(n)], dtype='float32')
+        b_vals = np.array(
+            [float(i + 1) for i in range(n)], dtype='float32')
+        a = solvcon.SimpleArrayFloat32(array=a_vals.copy())
+        b = solvcon.SimpleArrayFloat32(array=b_vals.copy())
+
+        chained = a.iadd_simd(b).isub_simd(b).imul_simd(b).idiv_simd(b)
+
+        expected = a_vals.copy()
+        expected = expected + b_vals
+        expected = expected - b_vals
+        expected = expected * b_vals
+        expected = expected / b_vals
+
+        self.assertIs(chained, a)
+        for i in range(n):
+            self.assertAlmostEqual(a[i], expected[i], places=5)
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
<!--
solvcon pull request guidelines.

- Subject: concise and informative.
- Description: clear prose.  Write single-line paragraphs separated by blank
  lines; GitHub reflows text to the viewer's width, so hard-wrapping at 79/80
  columns renders as ragged mid-sentence breaks.
- Draft until ready: open the PR as a draft while work is in progress.  When
  the PR is ready for review, post a global PR comment that explicitly asks for
  review.  Pushing the "ready for review" button alone is not a review request,
  because the push cannot be quoted in follow-ups.
- Inline annotations: as the author, add inline annotations on the diff to
  guide the reviewer, unless the diff is one-liner-ish.
- Issue reference: end the description with "Related to #xxx" or "For issue
  #xxx".  Do not use closing keywords (close, closes, closed, fix, fixes,
  fixed, resolve, resolves, resolved) followed by an issue number.  We do not
  let PR or commit text drive issue management.
- Authorship: PR text is treated as human-authored.  Tool assistance is OK, but
  you need to know what you wrote.

Delete this comment block before submitting.
-->

This PR enables chaining function call (fluent API) for `SimpleArray` in-place arithmetic operations in Python. For example `sarr1.iadd(sarr2).isub(sarr3)` is now valid function call syntax in Python. 

Related to #514.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
