### PR TITLE
Qualify detail:: calls instead of using namespace detail in simd.hpp

### DIFF
--- a/cpp/solvcon/simd/simd.hpp
+++ b/cpp/solvcon/simd/simd.hpp
@@ -34,10 +34,9 @@ const T * check_between(T const * start, T const * end, T const & min_val, T con
 template <typename T>
 void add(T * dest, T const * dest_end, T const * src1, T const * src2)
 {
-    using namespace detail; // FIXME: NOLINT(google-build-using-namespace)
-    switch (detect_simd())
+    switch (detail::detect_simd())
     {
-    case SIMD_NEON:
+    case detail::SIMD_NEON:
         return neon::add<T>(dest, dest_end, src1, src2);
         break;
 
@@ -49,10 +48,9 @@ void add(T * dest, T const * dest_end, T const * src1, T const * src2)
 template <typename T>
 void sub(T * dest, T const * dest_end, T const * src1, T const * src2)
 {
-    using namespace detail; // FIXME: NOLINT(google-build-using-namespace)
-    switch (detect_simd())
+    switch (detail::detect_simd())
     {
-    case SIMD_NEON:
+    case detail::SIMD_NEON:
         return neon::sub<T>(dest, dest_end, src1, src2);
         break;
 
@@ -64,10 +62,9 @@ void sub(T * dest, T const * dest_end, T const * src1, T const * src2)
 template <typename T>
 void mul(T * dest, T const * dest_end, T const * src1, T const * src2)
 {
-    using namespace detail; // FIXME: NOLINT(google-build-using-namespace)
-    switch (detect_simd())
+    switch (detail::detect_simd())
     {
-    case SIMD_NEON:
+    case detail::SIMD_NEON:
         return neon::mul<T>(dest, dest_end, src1, src2);
         break;
 
@@ -79,10 +76,9 @@ void mul(T * dest, T const * dest_end, T const * src1, T const * src2)
 template <typename T>
 void div(T * dest, T const * dest_end, T const * src1, T const * src2)
 {
-    using namespace detail; // FIXME: NOLINT(google-build-using-namespace)
-    switch (detect_simd())
+    switch (detail::detect_simd())
     {
-    case SIMD_NEON:
+    case detail::SIMD_NEON:
         return neon::div<T>(dest, dest_end, src1, src2);
         break;
 
@@ -100,3 +96,5 @@ T max(T const * start, T const * end)
 } /* end namespace simd */
 
 } /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`cpp/solvcon/simd/simd.hpp` defined add, sub, mul, and div, each opening a function-local using namespace detail; to reach `detect_simd()` and `SIMD_NEON` from the `solvcon::simd::detail namespace`.

A local using-directive hides which symbols are pulled in from detail, making it harder for a maintainer to tell at a glance which names are implementation details versus local declarations, which is why each occurrence carried a FIXME comment.

This PR removes the four using namespace detail; directives and qualifies the calls explicitly as `detail::detect_simd()` and `detail::SIMD_NEON`, matching the pattern check_between in the same file already used.

Related to #631.