### PR TITLE
Fix `OasisRecordPoly` and throw an exception for insufficient vertices

### DIFF
--- a/cpp/solvcon/oasis/oasis_device.cpp
+++ b/cpp/solvcon/oasis/oasis_device.cpp
@@ -11,6 +11,19 @@ namespace solvcon
 {
 
 /*
+ * OasisRecordPoly constructor to move vertices parameter to m_vertices.
+ * Point and line is unsupport.
+ */
+OasisRecordPoly::OasisRecordPoly(std::vector<std::pair<int, int>> vertices)
+    : m_vertices(std::move(vertices))
+{
+    if (m_vertices.size() < 3)
+    {
+        throw std::runtime_error("Not enough vertices");
+    }
+}
+
+/*
  * Convert value to OASIS unsigned integer bytes and append to segment array.
  * Encodes payload as a base-128 variable-length sequence, emitting 7 data
  * bits per byte and using the MSB as a continuation flag.
@@ -128,7 +141,7 @@ std::vector<uint8_t> OasisRecordPoly::to_bytes() const
     {
         segment.push_back(0x00);
     }
-    else if (m_vertices[0].first == m_vertices[0].first)
+    else if (m_vertices[0].first == m_vertices[1].first)
     {
         segment.push_back(0x01);
     }

--- a/cpp/solvcon/oasis/oasis_device.hpp
+++ b/cpp/solvcon/oasis/oasis_device.hpp
@@ -15,6 +15,7 @@
 #include <solvcon/base.hpp>
 
 #include <cstdint>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -75,8 +76,7 @@ class OasisRecordPoly
 {
 
 public:
-    explicit OasisRecordPoly(std::vector<std::pair<int, int>> vertices)
-        : m_vertices(std::move(vertices)) {};
+    explicit OasisRecordPoly(std::vector<std::pair<int, int>>);
     OasisRecordPoly() = delete;
     OasisRecordPoly(OasisRecordPoly const &) = default;
     OasisRecordPoly(OasisRecordPoly &&) = default;

--- a/tests/test_oasis_device.py
+++ b/tests/test_oasis_device.py
@@ -45,6 +45,14 @@ class OasisRecordPolyTC(unittest.TestCase):
 
         self.assertEqual(record_bytes, list(map(ord, expected_record_bytes)))
 
+    def test_empty_vertex_to_byte(self):
+        with self.assertRaisesRegex(RuntimeError, "Not enough vertices"):
+            solvcon.OasisRecordPoly([])
+
+    def test_one_vertex_to_byte(self):
+        with self.assertRaisesRegex(RuntimeError, "Not enough vertices"):
+            solvcon.OasisRecordPoly([[0, 0]])
+
 
 # For OASIS format, refer solvcon::OasisDevice comment in oasis_device.cpp
 class OasisDeviceTC(unittest.TestCase):


### PR DESCRIPTION
In this PR, I fix `OasisRecordPoly` when handling type-1 case.
 - The condition for the type-1 case is incorrect because it compares the same points.
 - Point and line geometries are unsupported by OasisRecordPoly, but no exception is thrown when they are encountered.

Therefore, this PR fix the above issues. I added the tests on point or empty vertices list to check it work properly.

Related to #1326.
