### PR TITLE
Fix lint issue by m_gemm_scratch initialize validity

### DIFF
--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -1026,11 +1026,20 @@ void MatmulExecutor<Array>::execute_gemm_blas(value_type * output, value_type co
 {
     std::optional<matrix_view_type> lhs_view = lhs_matrix_view(lhs_data);
     std::optional<matrix_view_type> rhs_view = rhs_matrix_view(rhs_data);
+    value_type * scratch = nullptr;
+    if (!lhs_view || !rhs_view)
+    {
+        if (!m_gemm_scratch)
+        {
+            throw std::logic_error("MatmulExecutor::execute_gemm_blas(): missing GEMM scratch");
+        }
+        scratch = m_gemm_scratch->data();
+    }
     if (!lhs_view)
     {
         lhs_view = pack_matrix_to_scratch(
             lhs_data,
-            m_gemm_scratch.value().data(),
+            scratch,
             m_cached_lhs_source,
             m_plan.rows(),
             m_plan.inner_size(),
@@ -1041,7 +1050,7 @@ void MatmulExecutor<Array>::execute_gemm_blas(value_type * output, value_type co
     {
         rhs_view = pack_matrix_to_scratch(
             rhs_data,
-            m_gemm_scratch.value().data() + m_lhs_scratch_elements,
+            scratch + m_lhs_scratch_elements,
             m_cached_rhs_source,
             m_plan.inner_size(),
             m_plan.columns(),


### PR DESCRIPTION
In this PR, I fix the lint issue by checking the optional value first.

The error message indicates:

>   /Users/runner/work/solvcon/solvcon/cpp/solvcon/buffer/matmul.hpp:1033:13: error: unchecked access to optional value [bugprone-unchecked-optional-access,-warnings-as-errors]
   1033 |             m_gemm_scratch.value().data(),
        |             ^~~~~~~~~~~~~~
  /Users/runner/work/solvcon/solvcon/cpp/solvcon/buffer/matmul.hpp:1044:13: error: unchecked access to optional value [bugprone-unchecked-optional-access,-warnings-as-errors]
   1044 |             m_gemm_scratch.value().data() + m_lhs_scratch_elements,
        |             ^~~~~~~~~~~~~~

Therefore, I added a check the validity of `m_gemm_scratch` when initialize by `m_gemm_scratch`. The CI should passed.