### PR TITLE
Implement geometry helper functions for segment type

### DIFF
--- a/cpp/solvcon/universe/coord.hpp
+++ b/cpp/solvcon/universe/coord.hpp
@@ -16,6 +16,9 @@
 #include <solvcon/base.hpp>
 #include <solvcon/buffer/buffer.hpp>
 
+#include <cmath>
+#include <limits>
+
 namespace solvcon
 {
 
@@ -871,6 +874,50 @@ public:
 
     size_t size() const { return 2; }
 
+    value_type calc_length2() const;
+    value_type calc_length() const { return std::sqrt(calc_length2()); }
+
+    /**
+     * The unit vector from p0 to p1 for every non-zero segment, and the
+     * zero vector for a zero-length segment, without a branch that would
+     * diverge under SIMD or SIMT execution. Scaling by the largest
+     * coordinate difference first keeps the result a unit vector at any
+     * coordinate magnitude, from the subnormal range up to where the
+     * squared length would overflow.
+     */
+    point_type direction() const;
+
+    /**
+     * The unit normal perpendicular to both the segment and the reference
+     * axis: the direction crossed with the reference, normalized, so the
+     * normal, the direction, and the reference form a right-handed frame
+     * and the normal points outward on a counterclockwise polygon. With
+     * the default z reference a plane segment gets the direction turned a
+     * quarter turn clockwise. A segment parallel to the reference axis has
+     * no such normal and throws.
+     */
+    point_type normal_by_axis(Axis axis = Axis::Z) const;
+
+    /**
+     * The signed perpendicular distance from the line to the point,
+     * positive on the side the axis-referenced normal points to, the right
+     * of the direction. Normalizing the direction instead of dividing a
+     * slope keeps every segment with a length finite, vertical and
+     * horizontal alike.
+     */
+    value_type offset_by_axis(point_type const & p, Axis axis = Axis::Z) const
+    {
+        point_type const nml = normal_by_axis(axis);
+        return (p.x() - m_data.f.x0) * nml.x() + (p.y() - m_data.f.y0) * nml.y() + (p.z() - m_data.f.z0) * nml.z();
+    }
+
+    /**
+     * The point on the segment's line where the named axis reaches the
+     * value. Throws when the direction has no component along that axis,
+     * since the line then reaches the value nowhere or everywhere.
+     */
+    point_type point_along_axis(value_type value, Axis axis = Axis::Z) const;
+
     void mirror_x()
     {
         m_data.f.y0 = -m_data.f.y0;
@@ -919,6 +966,108 @@ private:
     detail::Segment3dData<T> m_data;
 
 }; /* end class Segment3d */
+
+template <typename T>
+typename Segment3d<T>::value_type Segment3d<T>::calc_length2() const
+{
+    value_type const dx = m_data.f.x1 - m_data.f.x0;
+    value_type const dy = m_data.f.y1 - m_data.f.y0;
+    value_type const dz = m_data.f.z1 - m_data.f.z0;
+    return dx * dx + dy * dy + dz * dz;
+}
+
+template <typename T>
+typename Segment3d<T>::point_type Segment3d<T>::direction() const
+{
+    value_type const tiny = std::numeric_limits<value_type>::min();
+    value_type const dx = m_data.f.x1 - m_data.f.x0;
+    value_type const dy = m_data.f.y1 - m_data.f.y0;
+    value_type const dz = m_data.f.z1 - m_data.f.z0;
+    // Scaling by the largest difference bounds the squared sum away from
+    // overflow and underflow at any coordinate magnitude; the smallest
+    // normal keeps the divisor non-zero and perturbs no physical length.
+    value_type const amax = std::max(std::abs(dx), std::max(std::abs(dy), std::abs(dz)));
+    value_type const scale = 1 / (amax + tiny);
+    value_type const ux = dx * scale;
+    value_type const uy = dy * scale;
+    value_type const uz = dz * scale;
+    // The scaled length sits far above the regularizer for every non-zero
+    // segment, so the factor is 1 / len there and exactly 0 at zero length.
+    value_type const len = std::sqrt(ux * ux + uy * uy + uz * uz);
+    value_type const fac = len / (len * len + tiny);
+    return point_type(ux * fac, uy * fac, uz * fac);
+}
+
+template <typename T>
+typename Segment3d<T>::point_type Segment3d<T>::normal_by_axis(Axis axis) const
+{
+    point_type const dir = direction();
+    value_type nx;
+    value_type ny;
+    value_type nz;
+    switch (axis)
+    {
+    case Axis::X:
+        nx = 0;
+        ny = dir.z();
+        nz = -dir.y();
+        break;
+    case Axis::Y:
+        nx = -dir.z();
+        ny = 0;
+        nz = dir.x();
+        break;
+    case Axis::Z:
+        nx = dir.y();
+        ny = -dir.x();
+        nz = 0;
+        break;
+    default: throw std::invalid_argument("Segment3d::normal_by_axis: invalid axis");
+    }
+
+    value_type const len = std::sqrt(nx * nx + ny * ny + nz * nz);
+    if (len == 0)
+    {
+        throw std::invalid_argument("Segment3d::normal_by_axis: segment is parallel to the reference axis");
+    }
+    return point_type(nx / len, ny / len, nz / len);
+}
+
+template <typename T>
+typename Segment3d<T>::point_type Segment3d<T>::point_along_axis(value_type value, Axis axis) const
+{
+    // The raw differences walk the same line as the unit direction with
+    // two fewer roundings, so an exactly representable crossing stays
+    // exact, and a component keeps its sign bit even where normalizing
+    // would flush it to zero.
+    value_type const dx = m_data.f.x1 - m_data.f.x0;
+    value_type const dy = m_data.f.y1 - m_data.f.y0;
+    value_type const dz = m_data.f.z1 - m_data.f.z0;
+    value_type origin;
+    value_type along;
+    switch (axis)
+    {
+    case Axis::X:
+        origin = m_data.f.x0;
+        along = dx;
+        break;
+    case Axis::Y:
+        origin = m_data.f.y0;
+        along = dy;
+        break;
+    case Axis::Z:
+        origin = m_data.f.z0;
+        along = dz;
+        break;
+    default: throw std::invalid_argument("Segment3d::point_along_axis: invalid axis");
+    }
+    if (along == 0)
+    {
+        throw std::invalid_argument("Segment3d::point_along_axis: the direction has no component along the axis");
+    }
+    value_type const t = (value - origin) / along;
+    return point_type(m_data.f.x0 + t * dx, m_data.f.y0 + t * dy, m_data.f.z0 + t * dz);
+}
 
 using Segment3dFp32 = Segment3d<float>;
 using Segment3dFp64 = Segment3d<double>;
@@ -1371,6 +1520,14 @@ public:
         }
     }
 
+    /**
+     * The signed perpendicular distances from the line of the indexed
+     * segment to every point (xs[i], ys[i], 0), positive on the side the
+     * axis-referenced normal points to. The loop stays here so the caller
+     * can keep its mask arithmetic in numpy.
+     */
+    SimpleArray<T> offset_by_axis(size_t index, SimpleArray<T> const & xs, SimpleArray<T> const & ys, Axis axis = Axis::Z) const;
+
 private:
 
     void check_constructor_point_size(point_pad_type const & p0, point_pad_type const & p1)
@@ -1388,6 +1545,40 @@ private:
     std::shared_ptr<point_pad_type> m_p1;
 
 }; /* end class SegmentPad */
+
+template <typename T>
+SimpleArray<T> SegmentPad<T>::offset_by_axis(size_t index, SimpleArray<T> const & xs, SimpleArray<T> const & ys, Axis axis) const
+{
+    if (index >= size())
+    {
+        throw std::out_of_range(
+            std::format("SegmentPad::offset_by_axis: index {} is out of bounds with size {}", index, size()));
+    }
+    if (xs.ndim() != 1 || ys.ndim() != 1 || xs.shape(0) != ys.shape(0))
+    {
+        throw std::invalid_argument(
+            std::format("SegmentPad::offset_by_axis: xs and ys must be 1-dimensional and equally long, "
+                        "but their ndims are {} and {} and shapes {} and {}",
+                        xs.ndim(),
+                        ys.ndim(),
+                        xs.shape(0),
+                        ys.shape(0)));
+    }
+
+    segment_type const seg = get_at(index);
+    point_type const nml = seg.normal_by_axis(axis);
+    value_type const x0 = seg.x0();
+    value_type const y0 = seg.y0();
+    // The query points sit at z = 0, the plane of a two-dimensional pad.
+    value_type const zterm = (0 - seg.z0()) * nml.z();
+    ssize_t const npoint = xs.shape(0);
+    SimpleArray<T> result(small_vector<ssize_t>{npoint});
+    for (ssize_t i = 0; i < npoint; ++i)
+    {
+        result(i) = (xs(i) - x0) * nml.x() + (ys(i) - y0) * nml.y() + zterm;
+    }
+    return result;
+}
 
 using SegmentPadFp32 = SegmentPad<float>;
 using SegmentPadFp64 = SegmentPad<double>;

--- a/cpp/solvcon/universe/pymod/wrap_shape0d.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_shape0d.cpp
@@ -173,6 +173,8 @@ WrapPoint3d<T> & WrapPoint3d<T>::wrap_geometry()
                 }
             },
             py::arg("axis"))
+        .def("calc_length2", &wrapped_type::calc_length2)
+        .def("calc_length", &wrapped_type::calc_length)
         //
         ;
 

--- a/cpp/solvcon/universe/pymod/wrap_shape1d.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_shape1d.cpp
@@ -12,6 +12,24 @@ namespace solvcon
 namespace python
 {
 
+/// Map the lower-case axis name to the Axis enum; anything else throws.
+static Axis parse_axis(std::string const & axis, char const * what)
+{
+    if (axis == "x")
+    {
+        return Axis::X;
+    }
+    if (axis == "y")
+    {
+        return Axis::Y;
+    }
+    if (axis == "z")
+    {
+        return Axis::Z;
+    }
+    throw std::invalid_argument(std::format("{}: axis must be 'x', 'y', or 'z'", what));
+}
+
 template <typename T>
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSegment3d
     : public WrapBase<WrapSegment3d<T>, Segment3d<T>>
@@ -202,6 +220,26 @@ WrapSegment3d<T> & WrapSegment3d<T>::wrap_geometry()
                 }
             },
             py::arg("axis"))
+        .def("calc_length2", &wrapped_type::calc_length2)
+        .def("calc_length", &wrapped_type::calc_length)
+        .def("direction", &wrapped_type::direction)
+        .def(
+            "normal_by_axis",
+            [](wrapped_type const & self, std::string const & axis)
+            { return self.normal_by_axis(parse_axis(axis, "Segment3d::normal_by_axis")); },
+            py::arg("axis") = "z")
+        .def(
+            "offset_by_axis",
+            [](wrapped_type const & self, point_type const & point, std::string const & axis)
+            { return self.offset_by_axis(point, parse_axis(axis, "Segment3d::offset_by_axis")); },
+            py::arg("point"),
+            py::arg("axis") = "z")
+        .def(
+            "point_along_axis",
+            [](wrapped_type const & self, value_type value, std::string const & axis)
+            { return self.point_along_axis(value, parse_axis(axis, "Segment3d::point_along_axis")); },
+            py::arg("value"),
+            py::arg("axis") = "z")
         //
         ;
 
@@ -502,6 +540,18 @@ WrapSegmentPad<T> & WrapSegmentPad<T>::wrap_geometry()
                 }
             },
             py::arg("axis"))
+        .def(
+            "offset_by_axis",
+            [](wrapped_type const & self,
+               size_t index,
+               SimpleArray<T> const & xs,
+               SimpleArray<T> const & ys,
+               std::string const & axis)
+            { return self.offset_by_axis(index, xs, ys, parse_axis(axis, "SegmentPad::offset_by_axis")); },
+            py::arg("index"),
+            py::arg("xs"),
+            py::arg("ys"),
+            py::arg("axis") = "z")
         //
         ;
 

--- a/solvcon/pilot/apps/obsrefl/_analytic.py
+++ b/solvcon/pilot/apps/obsrefl/_analytic.py
@@ -185,28 +185,6 @@ class Reflection(object):
         """Return the error of ``value`` relative to ``target``."""
         return (value - target) / target if target else float('nan')
 
-    # TODO: the three helpers below are the plane geometry of a segment, not
-    # of this problem, and every user of Segment3d has to write them again.
-    # Slope, direction, and normal belong on the class, and the offset wants
-    # to stay vectorised: a point-to-line distance taking arrays.
-
-    @staticmethod
-    def _slope(seg):
-        """Return the slope of the line ``seg`` lies on."""
-        return (seg.y1 - seg.y0) / (seg.x1 - seg.x0)
-
-    @classmethod
-    def _offset(cls, seg, xs, ys):
-        """Return the perpendicular distance from ``seg``, positive above
-        it."""
-        slope = cls._slope(seg)
-        return (ys - seg.y0 - slope * (xs - seg.x0)) / math.hypot(1.0, slope)
-
-    @classmethod
-    def _abscissa(cls, seg, height):
-        """Return where the line of ``seg`` reaches ``height``."""
-        return seg.x0 + (height - seg.y0) / cls._slope(seg)
-
     @property
     def has_reflection(self):
         """Whether the incident shock reflects inside the domain.
@@ -231,16 +209,18 @@ class Reflection(object):
         gap = margin * (mesher.y1 - mesher.y0)
         cnd = self.field.centroid
         xs, ys = cnd[:, 0], cnd[:, 1]
-        incident = self._offset(self.incident, xs, ys)
+        xs_arr = core.SimpleArrayFloat64(array=xs)
+        ys_arr = core.SimpleArrayFloat64(array=ys)
+        incident = self.arms.offset_by_axis(0, xs_arr, ys_arr).ndarray
         # The reflected shock runs up from the wall, so the line it lies on
         # passes below the domain floor upstream of the reflection point and
         # cuts zone 3 out on its own.
-        reflected = (self._offset(self.reflected, xs, ys)
+        reflected = (self.arms.offset_by_axis(1, xs_arr, ys_arr).ndarray
                      if self.has_reflection
-                     else np.full(xs.shape, np.inf, dtype='float64'))
-        return [incident < -gap,
-                (incident > gap) & (reflected > gap),
-                reflected < -gap]
+                     else np.full(xs.shape, -np.inf, dtype='float64'))
+        return [incident > gap,
+                (incident < -gap) & (reflected < -gap),
+                reflected > gap]
 
     def zone_fields(self):
         """Return the flow-state value of zones 1, 2, and 3, by field name.
@@ -426,11 +406,11 @@ class Reflection(object):
         """
         zones = self.zone_field(name)
         xs = np.asarray(xs)
-        out = np.where(xs < self._abscissa(self.incident, height),
+        out = np.where(xs < self.incident.point_along_axis(height, 'y').x,
                        zones[0], zones[1])
         if self.has_reflection:
-            out = np.where(xs >= self._abscissa(self.reflected, height),
-                           zones[2], out)
+            turn = self.reflected.point_along_axis(height, 'y').x
+            out = np.where(xs >= turn, zones[2], out)
         return out
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_universe_shape0d.py
+++ b/tests/test_universe_shape0d.py
@@ -215,6 +215,14 @@ class Point3dTB(testing.TestBase):
                 ValueError, "Point3d::mirror: axis must be 'x', 'y', or 'z'"):
             Point(1, 2, 3).mirror('w')
 
+    def test_calc_length(self):
+        Point = self.Point
+
+        self.assertEqual(Point(3, 4, 0).calc_length2(), 25.0)
+        self.assertEqual(Point(3, 4, 0).calc_length(), 5.0)
+        self.assertEqual(Point(1, 2, 2).calc_length(), 3.0)
+        self.assertEqual(Point(0, 0, 0).calc_length(), 0.0)
+
 
 class Point3dFp32TC(Point3dTB, unittest.TestCase):
 

--- a/tests/test_universe_shape1d.py
+++ b/tests/test_universe_shape1d.py
@@ -77,6 +77,171 @@ class Segment3dTB(testing.TestBase):
                 "Segment3d::mirror: axis must be 'x', 'y', or 'z'"):
             Segment(Point(1, 2, 3), Point(4, 5, 6)).mirror('w')
 
+    def test_calc_length(self):
+        Point = self.Point
+        Segment = self.Segment
+
+        s = Segment(Point(1, 2, 3), Point(4, 6, 3))
+        self.assertEqual(s.calc_length2(), 25.0)
+        self.assertEqual(s.calc_length(), 5.0)
+        self.assertEqual(
+            Segment(Point(1, 2, 3), Point(1, 2, 3)).calc_length(), 0.0)
+
+    def test_direction(self):
+        Point = self.Point
+        Segment = self.Segment
+
+        s = Segment(Point(1, 2, 0), Point(4, 6, 0))
+        self.assert_allclose(tuple(s.direction()), (0.6, 0.8, 0.0))
+        # A vertical and a horizontal segment stay finite: the direction
+        # is normalized instead of dividing a slope.
+        vertical = Segment(Point(2, -1, 0), Point(2, 9, 0))
+        self.assertEqual(tuple(vertical.direction()), (0.0, 1.0, 0.0))
+        horizontal = Segment(Point(3, 5, 0), Point(-7, 5, 0))
+        self.assertEqual(tuple(horizontal.direction()), (-1.0, 0.0, 0.0))
+        # A zero-length segment regularizes to the zero vector.
+        zero = Segment(Point(1, 2, 3), Point(1, 2, 3))
+        self.assertEqual(tuple(zero.direction()), (0.0, 0.0, 0.0))
+
+    def test_direction_is_unit_at_any_scale(self):
+        Point = self.Point
+        Segment = self.Segment
+
+        # Scaling by the largest difference keeps the direction a unit
+        # vector at any magnitude; the unscaled factor degraded from
+        # around 1e-4 down in single precision and overflowed to nan for
+        # a length beyond around 2e19.
+        for length in (1e-8, 1e-6, 1e-4, 1.0, 1e4, 1e20):
+            with self.subTest(length=length):
+                s = Segment(Point(0, 0, 0), Point(length, 0, 0))
+                self.assertEqual(tuple(s.direction()), (1.0, 0.0, 0.0))
+        # A mixed huge segment must not overflow the squared sum.
+        wide = Segment(Point(0, 0, 0), Point(1e20, 1e20, 0))
+        self.assert_allclose(tuple(wide.direction()),
+                             (2.0 ** -0.5, 2.0 ** -0.5, 0.0))
+
+    def test_normal_by_axis(self):
+        Point = self.Point
+        Segment = self.Segment
+
+        s = Segment(Point(0, 0, 0), Point(10, 0, 0))
+        self.assertEqual(tuple(s.normal_by_axis()), (0.0, -1.0, 0.0))
+        vertical = Segment(Point(0, 0, 0), Point(0, 10, 0))
+        self.assertEqual(tuple(vertical.normal_by_axis()), (1.0, 0.0, 0.0))
+        slanted = Segment(Point(0, 0, 5), Point(3, 4, 5))
+        self.assert_allclose(tuple(slanted.normal_by_axis()),
+                             (0.8, -0.6, 0.0))
+
+        # The reference axis picks the plane the normal lies in: the
+        # normal is the direction crossed with the reference.
+        along_y = Segment(Point(0, 0, 0), Point(0, 10, 0))
+        self.assertEqual(tuple(along_y.normal_by_axis('x')),
+                         (0.0, 0.0, -1.0))
+        along_z = Segment(Point(0, 0, 0), Point(0, 0, 10))
+        self.assertEqual(tuple(along_z.normal_by_axis('y')),
+                         (-1.0, 0.0, 0.0))
+        risen = Segment(Point(0, 0, 0), Point(3, 4, 5))
+        self.assert_allclose(tuple(risen.normal_by_axis('z')),
+                             (0.8, -0.6, 0.0))
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "Segment3d::normal_by_axis: "
+                "segment is parallel to the reference axis"):
+            along_z.normal_by_axis()
+        # A zero-length segment has the zero direction, so its cross
+        # product with any reference vanishes the same way.
+        with self.assertRaisesRegex(
+                ValueError,
+                "Segment3d::normal_by_axis: "
+                "segment is parallel to the reference axis"):
+            Segment(Point(1, 2, 3), Point(1, 2, 3)).normal_by_axis()
+        with self.assertRaisesRegex(
+                ValueError,
+                "Segment3d::normal_by_axis: axis must be 'x', 'y', or 'z'"):
+            s.normal_by_axis('Z')
+
+    def test_normal_by_axis_right_hand_rule(self):
+        Point = self.Point
+        Segment = self.Segment
+
+        # The normal n, the direction t, and the reference a form a
+        # right-handed frame: n x t = a, t x a = n, and a x n = t. A
+        # length-2 segment keeps the direction exact, so the products are.
+        axes = {'x': (1.0, 0.0, 0.0), 'y': (0.0, 1.0, 0.0),
+                'z': (0.0, 0.0, 1.0)}
+        cases = [('x', Point(0, 2, 0)), ('y', Point(0, 0, 2)),
+                 ('z', Point(2, 0, 0))]
+        for axis, endpoint in cases:
+            with self.subTest(axis=axis):
+                segment = Segment(Point(0, 0, 0), endpoint)
+                n = tuple(segment.normal_by_axis(axis))
+                t = tuple(segment.direction())
+                a = axes[axis]
+                self.assertEqual(tuple(np.cross(n, t)), a)
+                self.assertEqual(tuple(np.cross(t, a)), n)
+                self.assertEqual(tuple(np.cross(a, n)), t)
+
+        # A slanted segment goes through the same rule; its direction is
+        # rounded, so the products are compared to tolerance.
+        slanted = Segment(Point(0, 0, 0), Point(3, 4, 0))
+        n = tuple(slanted.normal_by_axis('z'))
+        t = tuple(slanted.direction())
+        self.assert_allclose(np.cross(n, t), (0.0, 0.0, 1.0), atol=1e-6)
+        self.assert_allclose(np.cross(t, (0.0, 0.0, 1.0)), n, atol=1e-6)
+        self.assert_allclose(np.cross((0.0, 0.0, 1.0), n), t, atol=1e-6)
+
+    def test_offset_by_axis(self):
+        Point = self.Point
+        Segment = self.Segment
+
+        # Positive on the side the normal points to, the right of the
+        # direction: below a left-to-right segment.
+        s = Segment(Point(0, 0, 0), Point(10, 0, 0))
+        self.assertEqual(s.offset_by_axis(Point(5, 3, 0)), -3.0)
+        self.assertEqual(s.offset_by_axis(Point(5, -2, 0)), 2.0)
+        vertical = Segment(Point(0, 0, 0), Point(0, 10, 0))
+        self.assertEqual(vertical.offset_by_axis(Point(2, 5, 0)), 2.0)
+        slanted = Segment(Point(0, 0, 0), Point(3, 4, 0))
+        self.assert_allclose(slanted.offset_by_axis(Point(0, 5, 0)), -3.0)
+        self.assert_allclose(slanted.offset_by_axis(Point(3, 4, 0)), 0.0,
+                             atol=1e-6)
+        # A non-default reference axis reaches the internal normal: with
+        # the x reference the offset of a y-running segment measures -z.
+        along_y = Segment(Point(0, 0, 0), Point(0, 10, 0))
+        self.assertEqual(along_y.offset_by_axis(Point(5, 3, 2), 'x'), -2.0)
+
+    def test_point_along_axis(self):
+        Point = self.Point
+        Segment = self.Segment
+
+        s = Segment(Point(0, 0, 0), Point(2, 4, 6))
+        self.assertEqual(tuple(s.point_along_axis(2, 'y')), (1.0, 2.0, 3.0))
+        self.assertEqual(tuple(s.point_along_axis(1, 'x')), (1.0, 2.0, 3.0))
+        self.assertEqual(tuple(s.point_along_axis(3)), (1.0, 2.0, 3.0))
+        # The value may sit outside the segment: the line reaches it.
+        self.assertEqual(tuple(s.point_along_axis(-4, 'y')),
+                         (-2.0, -4.0, -6.0))
+        horizontal = Segment(Point(0, 5, 0), Point(10, 5, 0))
+        with self.assertRaisesRegex(
+                ValueError,
+                "Segment3d::point_along_axis: "
+                "the direction has no component along the axis"):
+            horizontal.point_along_axis(7, 'y')
+        # A zero-length segment has no component along any axis.
+        with self.assertRaisesRegex(
+                ValueError,
+                "Segment3d::point_along_axis: "
+                "the direction has no component along the axis"):
+            Segment(Point(1, 2, 3), Point(1, 2, 3)).point_along_axis(7, 'y')
+        # The axis is named in lower case only.
+        for axis in ('w', 'Z'):
+            with self.assertRaisesRegex(
+                    ValueError,
+                    "Segment3d::point_along_axis: "
+                    "axis must be 'x', 'y', or 'z'"):
+                horizontal.point_along_axis(7, axis)
+
 
 class Segment3dFp32TC(Segment3dTB, unittest.TestCase):
 
@@ -722,6 +887,47 @@ class SegmentPadTB(testing.TestBase):
                 ValueError,
                 "SegmentPad::mirror: axis must be 'x', 'y', or 'z'"):
             sp.mirror('w')
+
+    def test_offset_by_axis(self):
+        SegmentPad = self.SegmentPad
+        SimpleArray = self.SimpleArray
+
+        sp = SegmentPad(ndim=2)
+        sp.append(0.0, 0.0, 10.0, 0.0)
+        sp.append(0.0, 0.0, 0.0, 10.0)
+
+        def wrap(values):
+            return SimpleArray(array=np.array(values, dtype=self.dtype))
+
+        xs = wrap([5.0, 5.0, 0.0])
+        ys = wrap([3.0, -2.0, 0.0])
+        # Against the horizontal arm: positive below, matching
+        # Segment3d.offset_by_axis on the same points.
+        np.testing.assert_array_equal(
+            sp.offset_by_axis(0, xs, ys).ndarray, [-3.0, 2.0, 0.0])
+        # Against the vertical arm the normal points to +x.
+        np.testing.assert_array_equal(
+            sp.offset_by_axis(1, xs, ys).ndarray, [5.0, 5.0, 0.0])
+        # The pad queries sit at z = 0: with the x reference the normal
+        # of the vertical arm points along -z, so every offset is zero.
+        np.testing.assert_array_equal(
+            sp.offset_by_axis(1, xs, ys, 'x').ndarray, [0.0, 0.0, 0.0])
+
+        # A strided view is read through its stride, not densely.
+        pts = np.array([[5.0, 3.0], [5.0, -2.0]], dtype=self.dtype)
+        np.testing.assert_array_equal(
+            sp.offset_by_axis(0, SimpleArray(array=pts[:, 0]),
+                              SimpleArray(array=pts[:, 1])).ndarray,
+            [-3.0, 2.0])
+
+        with self.assertRaisesRegex(
+                IndexError,
+                "SegmentPad::offset_by_axis: "
+                "index 2 is out of bounds with size 2"):
+            sp.offset_by_axis(2, xs, ys)
+        with self.assertRaisesRegex(
+                ValueError, "must be 1-dimensional and equally long"):
+            sp.offset_by_axis(0, xs, wrap([1.0, 2.0]))
 
 
 class SegmentPadFp32TC(SegmentPadTB, unittest.TestCase):


### PR DESCRIPTION
Slope, direction, and normal were the plane geometry of a segment, yet they lived as private helpers of the reflection analysis, so every consumer of Segment3d had to write them again.  Segment3d now carries `calc_length` and `calc_length2` (with the Point3d pair finally bound), `direction`, `normal`, `offset`, and `point_at`, and SegmentPad answers the vectorised form: `offset` of one arm against arrays of coordinates, with the loop in C++ and the mask arithmetic left to numpy.

`normal` takes the reference axis (default z) and returns the reference crossed with the direction, normalized, so the only segment without one is a segment parallel to the reference.  The implementation normalizes the direction instead of dividing a slope, so a vertical or a horizontal segment stays finite and the remaining honest error is the zero-length segment.  The reflection analysis drops its three private helpers and reads the geometry from the segment types.


Related to #1294

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
