### PR TITLE
Add scalar constructors for Segment3d and document 2D convention

### DIFF
--- a/cpp/solvcon/universe/coord.hpp
+++ b/cpp/solvcon/universe/coord.hpp
@@ -34,6 +34,10 @@ enum class Axis : uint8_t
 /**
  * Point in three-dimensional space.
  *
+ * A pad of ndim 2 stores and reports z as zero, and a segment or point read
+ * back from it carries that zero. 2-dimensional code is meant to ignore it, not
+ * to work around it.
+ *
  * @tparam T floating-point type
  *
  * @ingroup group_geometry
@@ -271,6 +275,10 @@ using Point3dFp64 = Point3d<double>;
  * Coordinates are stored as separate per-axis arrays (x, y, and, for
  * three dimensions, z), so the layout is structure-of-arrays. The
  * dimensionality (2 or 3) is fixed at construction and cannot change.
+ *
+ * A pad of ndim 2 stores and reports z as zero, and a segment or point read
+ * back from it carries that zero. 2-dimensional code is meant to ignore it, not
+ * to work around it.
  *
  * @tparam T floating-point type
  *
@@ -752,6 +760,10 @@ union Segment3dData
 /**
  * Segment in three-dimensional space.
  *
+ * A pad of ndim 2 stores and reports z as zero, and a segment or point read
+ * back from it carries that zero. 2-dimensional code is meant to ignore it, not
+ * to work around it.
+ *
  * @tparam T floating-point type
  *
  * @ingroup group_geometry
@@ -770,6 +782,16 @@ public:
 
     Segment3d(point_type const & p0, point_type const & p1)
         : m_data{{p0.x(), p1.x(), p0.y(), p1.y(), p0.z(), p1.z()}}
+    {
+    }
+
+    Segment3d(T x0, T y0, T x1, T y1)
+        : m_data{{x0, x1, y0, y1, /*z0*/ 0.0, /*z1*/ 0.0}}
+    {
+    }
+
+    Segment3d(T x0, T y0, T z0, T x1, T y1, T z1)
+        : m_data{{x0, x1, y0, y1, z0, z1}}
     {
     }
 
@@ -907,6 +929,10 @@ using Segment3dFp64 = Segment3d<double>;
  * Each segment is stored as a pair of endpoints, held in two PointPad
  * objects (one for each endpoint). The dimensionality (2 or 3) comes
  * from the underlying point pads.
+ *
+ * A pad of ndim 2 stores and reports z as zero, and a segment or point read
+ * back from it carries that zero. 2-dimensional code is meant to ignore it, not
+ * to work around it.
  *
  * @tparam T floating-point type
  *

--- a/cpp/solvcon/universe/pymod/wrap_shape1d.cpp
+++ b/cpp/solvcon/universe/pymod/wrap_shape1d.cpp
@@ -62,6 +62,18 @@ WrapSegment3d<T> & WrapSegment3d<T>::wrap_management()
         .def(py::init<point_type const &, point_type const &>(),
              py::arg("p0"),
              py::arg("p1"))
+        .def(py::init<value_type, value_type, value_type, value_type>(),
+             py::arg("x0"),
+             py::arg("y0"),
+             py::arg("x1"),
+             py::arg("y1"))
+        .def(py::init<value_type, value_type, value_type, value_type, value_type, value_type>(),
+             py::arg("x0"),
+             py::arg("y0"),
+             py::arg("z0"),
+             py::arg("x1"),
+             py::arg("y1"),
+             py::arg("z1"))
         //
         ;
 

--- a/solvcon/pilot/apps/obsrefl/_analytic.py
+++ b/solvcon/pilot/apps/obsrefl/_analytic.py
@@ -165,18 +165,10 @@ class Reflection(object):
         self.margin = margin
         # The analytic path is fixed once the mesh is built, so its corners
         # are walked once into the segments the measurements read.
-        # TODO: SegmentPad takes a Segment3d built from two Point3d, unlike
-        # PointPad, which appends loose coordinates.  An append(x0, y0, x1,
-        # y1) overload would drop the two constructions per arm.
         self.arms = core.SegmentPadFp64(ndim=2)
         path = shock.shock_path()
         for head, tail in zip(path[:-1], path[1:]):
-            # TODO: the endpoints are 3D even on a 2D pad, so a plane user
-            # pins z twice per segment.  A Segment2d, or a pad that carries
-            # only ndim coordinates per point, would take the zeros away.
-            self.arms.append(core.Segment3dFp64(
-                core.Point3dFp64(head[0], head[1], 0.0),
-                core.Point3dFp64(tail[0], tail[1], 0.0)))
+            self.arms.append(head[0], head[1], tail[0], tail[1])
 
     @property
     def incident(self):

--- a/tests/test_universe_shape1d.py
+++ b/tests/test_universe_shape1d.py
@@ -21,6 +21,20 @@ class Segment3dTB(testing.TestBase):
         self.assertEqual(tuple(s.p0), (0.0, 0.0, 0.0))
         self.assertEqual(tuple(s.p1), (1.0, 1.0, 1.0))
 
+        # Test six-scalar construcotr
+        s = Segment(p0=Point(x=1, y=2, z=3), p1=Point(x=4, y=5, z=6))
+        s_6scalar = Segment(x0=1, y0=2, z0=3, x1=4, y1=5, z1=6)
+        self.assertEqual(s_6scalar, s)
+        s_6scalar = Segment(1, 2, 3, 4, 5, 6)
+        self.assertEqual(s_6scalar, s)
+
+        # Test four-scalar construcotr
+        s = Segment(p0=Point(x=1, y=2), p1=Point(x=4, y=5))
+        s_4scalar = Segment(x0=1, y0=2, x1=4, y1=5)
+        self.assertEqual(s_4scalar, s)
+        s_4scalar = Segment(1, 2, 4, 5)
+        self.assertEqual(s_4scalar, s)
+
         s.p0 = Point(x=3, y=7, z=0)
         s.p1 = Point(x=-1, y=-4, z=9)
         self.assertEqual(s.x0, 3)


### PR DESCRIPTION
Add two scalar constructors (four-scalar and six-scalar) for `Segment3d` and bind them into Python. The two constructors enable `Segment3d` to be constructed without costing two point constructors outside a pad. They are tested against the same segment built from a point pair in `tests/test_universe_shape1d.py`. 

Also, the plane code convention is added in the class docstrings of `Point3d`, `PointPad`, `Segment3d`, and `SegmentPad`.

Related to #1293.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
