### PR TITLE
Add resolution, run-ending, and CFL controls to the reflection panel

### DIFF
--- a/cpp/solvcon/pilot/app/RManager.cpp
+++ b/cpp/solvcon/pilot/app/RManager.cpp
@@ -12,8 +12,13 @@
 #include <QAction>
 #include <QActionGroup>
 #include <QColor>
+#include <QEvent>
+#include <QLayout>
+#include <QMdiSubWindow>
 #include <QMenu>
 #include <QMenuBar>
+#include <QSize>
+#include <QSizeGrip>
 #include <QVBoxLayout>
 #include <QWidget>
 #include <Qt>
@@ -26,6 +31,74 @@
 
 namespace solvcon
 {
+
+namespace
+{
+
+/**
+ * A size grip over the bottom-right corner of an MDI sub-window.
+ *
+ * QMdiSubWindow adopts a QSizeGrip child into the layout that holds its
+ * hosted widget, where the grip would claim a row of the height. Removing it
+ * from that layout leaves the whole height to the widget, and placing the
+ * grip becomes this class's job. The grip stays a child of the sub-window
+ * because the macOS style draws one only there.
+ */
+class SubWindowGrip : public QObject
+{
+
+public:
+
+    explicit SubWindowGrip(QMdiSubWindow * subwin);
+
+protected:
+
+    bool eventFilter(QObject * watched, QEvent * event) override;
+
+private:
+
+    void place();
+
+    QMdiSubWindow * m_subwin;
+    QSizeGrip * m_grip;
+
+}; /* end class SubWindowGrip */
+
+SubWindowGrip::SubWindowGrip(QMdiSubWindow * subwin)
+    : QObject(subwin)
+    , m_subwin(subwin)
+    , m_grip(new QSizeGrip(subwin))
+{
+    // Adoption happens on polish, so force it before removing the grip.
+    m_grip->ensurePolished();
+    if (QLayout * layout = m_subwin->layout())
+    {
+        layout->removeWidget(m_grip);
+    }
+    m_grip->show();
+    place();
+    m_subwin->installEventFilter(this);
+}
+
+bool SubWindowGrip::eventFilter(QObject * watched, QEvent * event)
+{
+    if (QEvent::Resize == event->type())
+    {
+        place();
+    }
+    return QObject::eventFilter(watched, event);
+}
+
+void SubWindowGrip::place()
+{
+    QSize const hint = m_grip->sizeHint();
+    m_grip->resize(hint);
+    m_grip->move(m_subwin->width() - hint.width(), m_subwin->height() - hint.height());
+    // Stay above the hosted widget, which spans the corner.
+    m_grip->raise();
+}
+
+} /* end namespace */
 
 RManager & RManager::instance()
 {
@@ -150,6 +223,9 @@ RDomainWidget * RManager::add3DWidget()
         }
         auto * subwin = this->addSubWindow(host);
         subwin->resize(400, 300);
+        // The sub-window frame is a few pixels wide, too little to aim a drag
+        // at.
+        new SubWindowGrip(subwin);
     }
     return viewer;
 }

--- a/cpp/solvcon/pilot/visual/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/visual/RDomainWidget.cpp
@@ -236,6 +236,13 @@ void RDomainWidget::updateMesh(std::shared_ptr<StaticMesh> const & mesh)
         lo = QVector3D(std::min(lo.x(), x), std::min(lo.y(), y), std::min(lo.z(), z));
         hi = QVector3D(std::max(hi.x(), x), std::max(hi.y(), y), std::max(hi.z(), z));
     }
+    // Remember the framed box. A mesh spanning the same domain is the same
+    // subject at another resolution, and reframing it would throw away the
+    // pan and zoom the user set.
+    bool const framed = m_scene.hasBoundingBox();
+    QVector3D const framed_lo = m_scene.boundingBoxLo();
+    QVector3D const framed_hi = m_scene.boundingBoxHi();
+
     m_scene.resetBoundingBox();
     if (mh.nnode() > 0)
     {
@@ -247,7 +254,13 @@ void RDomainWidget::updateMesh(std::shared_ptr<StaticMesh> const & mesh)
         m_scene.extendBoundingBox(m_field_lo, m_field_hi);
     }
 
-    m_scene.fitCameraToScene(viewportAspect());
+    QVector3D const box_lo = m_scene.boundingBoxLo();
+    QVector3D const box_hi = m_scene.boundingBoxHi();
+    bool const same_box = framed && m_scene.hasBoundingBox() && framed_lo == box_lo && framed_hi == box_hi;
+    if (!same_box)
+    {
+        m_scene.fitCameraToScene(viewportAspect());
+    }
     update();
 }
 

--- a/cpp/solvcon/pilot/visual/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/visual/RDomainWidget.hpp
@@ -63,7 +63,10 @@ public:
     explicit RDomainWidget(QWidget * parent = nullptr);
     ~RDomainWidget() override;
 
-    /// Replace the rendered mesh with the wireframe of @p mesh.
+    /**
+     * Replace the rendered mesh with the wireframe of @p mesh. The camera is
+     * reframed only when the new mesh spans a different domain.
+     */
     void updateMesh(std::shared_ptr<StaticMesh> const & mesh);
 
     // A scene of several named mesh objects, each with its own model transform

--- a/solvcon/multidim/euler/_field.py
+++ b/solvcon/multidim/euler/_field.py
@@ -26,7 +26,7 @@ class EulerField(object):
     """
 
     FIELDS = ('density', 'velx', 'vely', 'speed', 'pressure', 'mach',
-              'total_energy')
+              'total_energy', 'cfl')
 
     #: Momentum components in axis order; the solution table carries the
     #: first ``ndim`` of them.
@@ -113,6 +113,17 @@ class EulerField(object):
         """The Mach number against the local speed of sound, ``[ncell]``."""
         return self.speed / np.sqrt(self.gamma * self.pressure / self.density)
 
+    @property
+    def cfl(self):
+        """The CFL number the last step ran at, ``[ncell]``.
+
+        The solver's unclamped ``cflo``: the wave speed over half a step
+        against the shortest distance out of the cell.  Above 1 a cell
+        marched past its own domain of dependence.
+        """
+        arr = self.svr.cflo
+        return arr.ndarray[arr.nghost:]
+
     def field(self, name):
         """Return the scalar field named by one of :attr:`FIELDS`.
 
@@ -127,5 +138,13 @@ class EulerField(object):
     def calc_overall_mass(self):
         """Return the density integrated over the whole domain."""
         return float(np.sum(self.density * self.volume))
+
+    def calc_cfl_range(self):
+        """Return the smallest and the largest CFL number in the domain.
+
+        A mean would hide the one cell that outran the stable step.
+        """
+        cfl = self.cfl
+        return float(cfl.min()), float(cfl.max())
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/apps/obsrefl/_analytic.py
+++ b/solvcon/pilot/apps/obsrefl/_analytic.py
@@ -251,12 +251,15 @@ class Reflection(object):
                 reflected < -gap]
 
     def zone_fields(self):
-        """Return every :attr:`EulerField.FIELDS` value of zones 1, 2, and 3.
+        """Return the flow-state value of zones 1, 2, and 3, by field name.
 
         The states of :meth:`ObliqueShock.zone_states` are primitives, so
         the four they carry need no work and the other three follow from
         the same ideal-gas relations the field reader applies to the
         computed solution.
+
+        The CFL number belongs to the discretization and not to the flow, so
+        it is not among them.
         """
         gamma = self.shock.gamma
         rho, velx, vely, pressure = np.array(
@@ -273,6 +276,19 @@ class Reflection(object):
         if name not in fields:
             raise ValueError(f"unknown field '{name}'")
         return fields[name]
+
+    def color_range(self, name, vmin, vmax):
+        """Widen ``(vmin, vmax)`` to cover the analytic zone values.
+
+        The color then says how far the field has come, instead of every
+        frame stretching to the full scale.  A field with no analytic value
+        keeps the range it came with.
+        """
+        fields = self.zone_fields()
+        if name not in fields:
+            return vmin, vmax
+        zones = fields[name]
+        return min(vmin, float(zones.min())), max(vmax, float(zones.max()))
 
     def zone_conserved(self):
         """Return the analytic zone states as conserved rows, ``[3, neq]``.
@@ -291,10 +307,16 @@ class Reflection(object):
 
         Each :class:`ZoneInfo` holds the mean of the computed field over
         the zone's cells against the analytic value the steady solution has
-        to reach.  A zone the margin leaves empty reports ``nan``.
+        to reach.  A zone the margin leaves empty reports ``nan``; a field
+        with no analytic value reports no zones.
         """
+        # Read the field first: an unknown name is an error, a known one
+        # without an analytic value is not.
         values = self.field.field(name)
-        analytic = self.zone_field(name)
+        fields = self.zone_fields()
+        if name not in fields:
+            return []
+        analytic = fields[name]
         report = []
         for it, mask in enumerate(self.zone_masks()):
             count = int(mask.sum())

--- a/solvcon/pilot/apps/obsrefl/_app.py
+++ b/solvcon/pilot/apps/obsrefl/_app.py
@@ -30,7 +30,7 @@ class ObliqueShockApp(_gui_common.PilotFeature):
     """Euler solver panel, toggled from the View "Panels" submenu.
 
     The panel owns one domain viewer sub-window and one solver run; the
-    controller between them starts, pauses, steps, and stops the march.
+    controller between them starts, pauses, steps, and ends the march.
     """
 
     def __init__(self, *args, **kw):

--- a/solvcon/pilot/apps/obsrefl/_control.py
+++ b/solvcon/pilot/apps/obsrefl/_control.py
@@ -49,6 +49,8 @@ class RunController(object):
         panel.start_requested = self.start
         panel.pause_toggled = self._on_pause
         panel.step_requested = self._on_step
+        panel.stop_requested = self.stop
+        panel.reset_requested = self.reset
         panel.remesh_requested = self.remesh
         panel.field_changed = self._on_field
         viewer.closed = self._on_viewer_closed
@@ -78,20 +80,42 @@ class RunController(object):
         """
         self.preview()
 
-    def _build(self):
-        """Halt any march, then build and draw the configured run."""
+    def stop(self):
+        """End the run where it stands, leaving its field on screen."""
         self._timer.stop()
-        self._open_viewer()
-        self.session = ReflectionSession(**self._panel.params())
-        shock = self.session.shock
-        self._viewer.update_mesh(shock.mesh)
-        self._viewer.draw_shock_path(shock)
-        self._painter = FieldPainter(shock.mesh)
+        if self.session is not None:
+            self.session.stop()
+            self._draw_frame()
+
+    def reset(self):
+        """Drop the run and its viewer, back to where the panel started."""
+        self._timer.stop()
+        self.session = None
+        self._painter = None
+        self._viewer.close()
+        self._panel.set_paused(False)
         self._draw_frame()
 
+    def _build(self):
+        """Halt any march, then build the configured run and draw it."""
+        self._timer.stop()
+        self.session = ReflectionSession(**self._panel.params())
+        self._painter = FieldPainter(self.session.shock.mesh)
+        self._open_viewer()
+
     def _open_viewer(self):
+        """Open the sub-window and draw the standing run into it.
+
+        Closing deletes the sub-window, so what opens is always an empty
+        viewer and every layer of the run has to go in again.
+        """
         self._viewer.open()
         self._panel.set_viewer_open(True)
+        if self.session is not None:
+            shock = self.session.shock
+            self._viewer.update_mesh(shock.mesh)
+            self._viewer.draw_shock_path(shock)
+        self._draw_frame()
 
     def _on_viewer(self, open_):
         if open_:
@@ -142,21 +166,29 @@ class RunController(object):
         self._draw_frame()
 
     def _draw_frame(self):
-        if not self._viewer.is_open:
-            return
+        """Read the run out into the panel, and into the viewer if it is
+        open.
+
+        The readout belongs to the run, so a closed viewer leaves the panel
+        current rather than stale.
+        """
         session = self.session
+        if None is session:
+            self._panel.set_status(None, None, None)
+            return
         name = self._panel.field()
         field = session.field.field(name)
         vmin, vmax = float(field.min()), float(field.max())
-        # Scale the colors to the analytic range, not the frame's own, so a
-        # field stuck short of the target looks stuck instead of stretching
-        # to full color every frame.
-        zones = session.analysis.zone_field(name)
-        lo = min(vmin, float(zones.min()))
-        hi = max(vmax, float(zones.max()))
-        self._viewer.draw_field(self._painter.verts,
-                                self._painter.colors(field, lo, hi),
-                                self._painter.indices)
+        if self._viewer.is_open:
+            # Scale the colors to the analytic range, not the frame's own, so
+            # a field stuck short of the target looks stuck instead of
+            # stretching to full color every frame.
+            zones = session.analysis.zone_field(name)
+            lo = min(vmin, float(zones.min()))
+            hi = max(vmax, float(zones.max()))
+            self._viewer.draw_field(self._painter.verts,
+                                    self._painter.colors(field, lo, hi),
+                                    self._painter.indices)
         self._panel.set_status(session, vmin, vmax)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/apps/obsrefl/_control.py
+++ b/solvcon/pilot/apps/obsrefl/_control.py
@@ -49,6 +49,7 @@ class RunController(object):
         panel.start_requested = self.start
         panel.pause_toggled = self._on_pause
         panel.step_requested = self._on_step
+        panel.remesh_requested = self.remesh
         panel.field_changed = self._on_field
         viewer.closed = self._on_viewer_closed
 
@@ -68,6 +69,14 @@ class RunController(object):
         self._build()
         self._panel.set_paused(False)
         self._timer.start(self.INTERVAL_MS)
+
+    def remesh(self):
+        """Rebuild the run at the resolution the controls now hold.
+
+        A session owns its mesh, so a new resolution means a new session and
+        a march that starts over, waiting on its initial state.
+        """
+        self.preview()
 
     def _build(self):
         """Halt any march, then build and draw the configured run."""

--- a/solvcon/pilot/apps/obsrefl/_control.py
+++ b/solvcon/pilot/apps/obsrefl/_control.py
@@ -158,8 +158,8 @@ class RunController(object):
     def _march_frame(self):
         """March one chunk and draw what it left behind.
 
-        The chunk length is read from the control every frame, so turning
-        the dial mid-run takes effect on the next one.
+        The chunk length is read every frame, so changing it mid-run takes
+        effect on the next one.
         """
         self.session.steps_per_chunk = self._panel.steps_per_frame()
         self.session.advance()
@@ -180,12 +180,7 @@ class RunController(object):
         field = session.field.field(name)
         vmin, vmax = float(field.min()), float(field.max())
         if self._viewer.is_open:
-            # Scale the colors to the analytic range, not the frame's own, so
-            # a field stuck short of the target looks stuck instead of
-            # stretching to full color every frame.
-            zones = session.analysis.zone_field(name)
-            lo = min(vmin, float(zones.min()))
-            hi = max(vmax, float(zones.max()))
+            lo, hi = session.analysis.color_range(name, vmin, vmax)
             self._viewer.draw_field(self._painter.verts,
                                     self._painter.colors(field, lo, hi),
                                     self._painter.indices)

--- a/solvcon/pilot/apps/obsrefl/_panel.py
+++ b/solvcon/pilot/apps/obsrefl/_panel.py
@@ -39,6 +39,13 @@ def _spin(value, low, high, step, decimals):
     return box
 
 
+def _count(value, low, high):
+    box = QSpinBox()
+    box.setRange(low, high)
+    box.setValue(value)
+    return box
+
+
 def _number(value):
     """Format a readout number to four significant digits.
 
@@ -156,24 +163,45 @@ class FreeStreamBox(FoldBox):
 
 
 class NumericsBox(FoldBox):
-    """The discretization of a run; read once at Start."""
+    """The discretization of a run: how finely the domain is cut and how far
+    a step carries it; read at Start and at Remesh.
+
+    The mesh is ``nx`` by ``ny`` boxes over a domain four units long and one
+    tall, so ``nx = 4 * ny`` keeps the cells square.  A finer mesh also holds
+    a shorter stable step, which the time step has to follow.
+    """
 
     #: Mesh flavors offered by :mod:`._driver`, the first being the default.
     CELL_TYPES = ('unstructured', 'quad', 'triangle')
 
     def __init__(self, parent=None):
         super().__init__("Numerics", parent)
+        # Owner-supplied callback that rebuilds the run.
+        self.remesh_requested = None
+        self._nx = _count(64, 4, 1024)
+        self._ny = _count(16, 2, 256)
         self._dt = _spin(2e-3, 1e-6, 1.0, 1e-3, 6)
         self._cell_type = QComboBox()
         self._cell_type.addItems(self.CELL_TYPES)
+        # Apply a new resolution without marching it.
+        self._remesh = QPushButton("Remesh")
+        self._remesh.clicked.connect(self._on_remesh_clicked)
 
         form = QFormLayout(self._content)
+        form.addRow("nx", self._nx)
+        form.addRow("ny", self._ny)
         form.addRow("time step", self._dt)
         form.addRow("cell type", self._cell_type)
+        form.addRow(self._remesh)
 
     def params(self):
-        return dict(time_increment=self._dt.value(),
+        return dict(nx=self._nx.value(), ny=self._ny.value(),
+                    time_increment=self._dt.value(),
                     cell_type=self._cell_type.currentText())
+
+    def _on_remesh_clicked(self):
+        if self.remesh_requested is not None:
+            self.remesh_requested()
 
 
 class RunBox(FoldBox):
@@ -444,6 +472,14 @@ class SolutionPanel(QScrollArea):
     @step_requested.setter
     def step_requested(self, callback):
         self._run.step_requested = callback
+
+    @property
+    def remesh_requested(self):
+        return self._numerics.remesh_requested
+
+    @remesh_requested.setter
+    def remesh_requested(self, callback):
+        self._numerics.remesh_requested = callback
 
     @property
     def field_changed(self):

--- a/solvcon/pilot/apps/obsrefl/_panel.py
+++ b/solvcon/pilot/apps/obsrefl/_panel.py
@@ -209,8 +209,8 @@ class RunBox(FoldBox):
 
     The buttons stand in the order a run is used: started, held (paused,
     stepped), and ended (stopped where it stands, or dropped).  The readout
-    beneath them carries the step count, what ended the run, and the mass
-    the domain holds.
+    beneath them carries the step count, what ended the run, the mass the
+    domain holds, and the CFL bounds of the last chunk.
     """
 
     #: What ended a run reads as in the state cell; a live run reads as
@@ -260,6 +260,7 @@ class RunBox(FoldBox):
         self._progress = _value_label()
         self._state = _value_label()
         self._mass = _value_label()
+        self._cfl = _value_label()
 
         form = QFormLayout(self._content)
         form.addRow("steps/frame", self._steps)
@@ -269,6 +270,7 @@ class RunBox(FoldBox):
         form.addRow("step", self._progress)
         form.addRow("state", self._state)
         form.addRow("mass", self._mass)
+        form.addRow("cfl min/max", self._cfl)
         self.show_run(None)
 
     def steps_per_frame(self):
@@ -308,6 +310,7 @@ class RunBox(FoldBox):
             self._progress.setText("-")
             self._state.setText("not started")
             self._mass.setText("-")
+            self._cfl.setText("-")
             return
         if self._live:
             state = "paused" if self._paused else "running"
@@ -317,6 +320,9 @@ class RunBox(FoldBox):
         self._state.setText(state)
         last = session.history.last
         self._mass.setText("-" if last is None else _number(last.mass))
+        self._cfl.setText("-" if last is None else
+                          f"{_number(last.cfl_min)} / "
+                          f"{_number(last.cfl_max)}")
 
     def _on_viewer_toggled(self, open_):
         self._viewer_btn.setText("Close viewer" if open_ else "Open viewer")

--- a/solvcon/pilot/apps/obsrefl/_panel.py
+++ b/solvcon/pilot/apps/obsrefl/_panel.py
@@ -20,8 +20,8 @@ from PySide6.QtCore import Qt, QSize
 from PySide6.QtGui import QFontDatabase
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QFormLayout,
                                QGridLayout, QLabel, QComboBox, QDoubleSpinBox,
-                               QSpinBox, QPushButton, QToolButton, QSizePolicy,
-                               QScrollArea, QFrame)
+                               QSpinBox, QPushButton, QToolButton,
+                               QSizePolicy, QScrollArea, QFrame)
 
 from ....multidim.euler import EulerField
 
@@ -84,6 +84,12 @@ class FoldBox(QWidget):
     section gives its room back to the boxes below it.
     """
 
+    #: Room around the content pane, as (left, top, right, bottom).  The
+    #: left inset indents the rows under their header, the small top keeps
+    #: the header reading as their label, and the bottom holds one box off
+    #: the next.
+    CONTENT_MARGINS = (12, 3, 12, 12)
+
     def __init__(self, title, parent=None):
         super().__init__(parent)
         self._head = QToolButton()
@@ -110,8 +116,18 @@ class FoldBox(QWidget):
 
         box = QVBoxLayout(self)
         box.setContentsMargins(0, 0, 0, 0)
+        box.setSpacing(0)
         box.addWidget(self._head)
         box.addWidget(self._content)
+
+    def set_content_layout(self, layout):
+        """Fill the content pane with ``layout``.
+
+        The padding belongs to the section rather than to what it holds, so
+        every box takes it from here instead of from the style.
+        """
+        layout.setContentsMargins(*self.CONTENT_MARGINS)
+        self._content.setLayout(layout)
 
     def _on_head_clicked(self):
         self._open = not self._open
@@ -147,12 +163,13 @@ class FreeStreamBox(FoldBox):
         self._angle = _spin(10.0, 0.5, 45.0, 0.5, 2)
         self._angle.setSuffix(" deg")
 
-        form = QFormLayout(self._content)
+        form = QFormLayout()
         form.addRow("gamma", self._gamma)
         form.addRow("density", self._density)
         form.addRow("pressure", self._pressure)
         form.addRow("Mach", self._mach)
         form.addRow("shock angle", self._angle)
+        self.set_content_layout(form)
 
     def params(self):
         return dict(gamma=self._gamma.value(),
@@ -187,12 +204,13 @@ class NumericsBox(FoldBox):
         self._remesh = QPushButton("Remesh")
         self._remesh.clicked.connect(self._on_remesh_clicked)
 
-        form = QFormLayout(self._content)
+        form = QFormLayout()
         form.addRow("nx", self._nx)
         form.addRow("ny", self._ny)
         form.addRow("time step", self._dt)
         form.addRow("cell type", self._cell_type)
         form.addRow(self._remesh)
+        self.set_content_layout(form)
 
     def params(self):
         return dict(nx=self._nx.value(), ny=self._ny.value(),
@@ -262,7 +280,7 @@ class RunBox(FoldBox):
         self._mass = _value_label()
         self._cfl = _value_label()
 
-        form = QFormLayout(self._content)
+        form = QFormLayout()
         form.addRow("steps/frame", self._steps)
         form.addRow(self._viewer_btn)
         form.addRow(marching)
@@ -271,6 +289,7 @@ class RunBox(FoldBox):
         form.addRow("state", self._state)
         form.addRow("mass", self._mass)
         form.addRow("cfl min/max", self._cfl)
+        self.set_content_layout(form)
         self.show_run(None)
 
     def steps_per_frame(self):
@@ -366,10 +385,11 @@ class FieldBox(FoldBox):
         self._min = _value_label()
         self._max = _value_label()
 
-        form = QFormLayout(self._content)
+        form = QFormLayout()
         form.addRow("field", self._selector)
         form.addRow("min", self._min)
         form.addRow("max", self._max)
+        self.set_content_layout(form)
 
     def field(self):
         return self._selector.currentText()
@@ -397,7 +417,7 @@ class ZoneBox(FoldBox):
 
     def __init__(self, parent=None):
         super().__init__("Zones", parent)
-        self._grid = QGridLayout(self._content)
+        self._grid = QGridLayout()
         for col, text in enumerate(self.HEADERS):
             label = QLabel(text)
             font = label.font()
@@ -406,6 +426,7 @@ class ZoneBox(FoldBox):
             if col:
                 label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
             self._grid.addWidget(label, 0, col)
+        self.set_content_layout(self._grid)
         self._rows = []
 
     def show_zones(self, infos):

--- a/solvcon/pilot/apps/obsrefl/_panel.py
+++ b/solvcon/pilot/apps/obsrefl/_panel.py
@@ -207,9 +207,10 @@ class NumericsBox(FoldBox):
 class RunBox(FoldBox):
     """The march controls and the live march readout, kept side by side.
 
-    The readout is the run's own progress: how far the march has come of
-    the steps it may take, what ended it, and the overall mass the domain
-    holds, which the inflow and the outflow move as the flow develops.
+    The buttons stand in the order a run is used: started, held (paused,
+    stepped), and ended (stopped where it stands, or dropped).  The readout
+    beneath them carries the step count, what ended the run, and the mass
+    the domain holds.
     """
 
     #: What ended a run reads as in the state cell; a live run reads as
@@ -223,12 +224,12 @@ class RunBox(FoldBox):
         self.start_requested = None
         self.pause_toggled = None
         self.step_requested = None
+        self.stop_requested = None
+        self.reset_requested = None
         self._paused = False
         self._live = False
 
-        self._steps = QSpinBox()
-        self._steps.setRange(1, 1000)
-        self._steps.setValue(5)
+        self._steps = _count(5, 1, 1000)
 
         # Opens and closes the one domain viewer the run buttons draw into.
         self._viewer_btn = QPushButton("Open viewer")
@@ -244,13 +245,17 @@ class RunBox(FoldBox):
         self._step = QPushButton("Step")
         self._step.clicked.connect(self._on_step_clicked)
         _reserve_width(self._pause, ("Pause", "Resume"))
-        # Disabled, not hidden, until a run exists to pause or step.
-        self._pause.setEnabled(False)
-        self._step.setEnabled(False)
-        buttons = QHBoxLayout()
-        buttons.addWidget(self._start)
-        buttons.addWidget(self._pause)
-        buttons.addWidget(self._step)
+        self._stop = QPushButton("Stop")
+        self._stop.clicked.connect(self._on_stop_clicked)
+        self._reset = QPushButton("Reset")
+        self._reset.clicked.connect(self._on_reset_clicked)
+        marching = QHBoxLayout()
+        marching.addWidget(self._start)
+        marching.addWidget(self._pause)
+        marching.addWidget(self._step)
+        ending = QHBoxLayout()
+        ending.addWidget(self._stop)
+        ending.addWidget(self._reset)
 
         self._progress = _value_label()
         self._state = _value_label()
@@ -259,10 +264,12 @@ class RunBox(FoldBox):
         form = QFormLayout(self._content)
         form.addRow("steps/frame", self._steps)
         form.addRow(self._viewer_btn)
-        form.addRow(buttons)
+        form.addRow(marching)
+        form.addRow(ending)
         form.addRow("step", self._progress)
         form.addRow("state", self._state)
         form.addRow("mass", self._mass)
+        self.show_run(None)
 
     def steps_per_frame(self):
         return self._steps.value()
@@ -292,13 +299,16 @@ class RunBox(FoldBox):
 
     def show_run(self, session):
         """Read the march progress of one run, or the lack of a run."""
+        self._live = session is not None and session.stop_reason is None
+        # A run that has ended can still be dropped, but not marched.
+        for button in (self._pause, self._step, self._stop):
+            button.setEnabled(self._live)
+        self._reset.setEnabled(session is not None)
         if None is session:
-            self._live = False
             self._progress.setText("-")
             self._state.setText("not started")
             self._mass.setText("-")
             return
-        self._live = session.stop_reason is None
         if self._live:
             state = "paused" if self._paused else "running"
         else:
@@ -307,8 +317,6 @@ class RunBox(FoldBox):
         self._state.setText(state)
         last = session.history.last
         self._mass.setText("-" if last is None else _number(last.mass))
-        self._pause.setEnabled(True)
-        self._step.setEnabled(True)
 
     def _on_viewer_toggled(self, open_):
         self._viewer_btn.setText("Close viewer" if open_ else "Open viewer")
@@ -327,6 +335,14 @@ class RunBox(FoldBox):
     def _on_step_clicked(self):
         if self.step_requested is not None:
             self.step_requested()
+
+    def _on_stop_clicked(self):
+        if self.stop_requested is not None:
+            self.stop_requested()
+
+    def _on_reset_clicked(self):
+        if self.reset_requested is not None:
+            self.reset_requested()
 
 
 class FieldBox(FoldBox):
@@ -472,6 +488,22 @@ class SolutionPanel(QScrollArea):
     @step_requested.setter
     def step_requested(self, callback):
         self._run.step_requested = callback
+
+    @property
+    def stop_requested(self):
+        return self._run.stop_requested
+
+    @stop_requested.setter
+    def stop_requested(self, callback):
+        self._run.stop_requested = callback
+
+    @property
+    def reset_requested(self):
+        return self._run.reset_requested
+
+    @reset_requested.setter
+    def reset_requested(self, callback):
+        self._run.reset_requested = callback
 
     @property
     def remesh_requested(self):

--- a/solvcon/pilot/apps/obsrefl/_session.py
+++ b/solvcon/pilot/apps/obsrefl/_session.py
@@ -34,10 +34,10 @@ __all__ = [
 ]
 
 
-#: What one marched chunk leaves behind: the step it ended on and the mass the
-#: domain held there, which the inflow and the outflow move as the flow
-#: develops.
-RunRecord = collections.namedtuple('RunRecord', ['step', 'mass'])
+#: What one marched chunk leaves behind: the step it ended on, the mass the
+#: domain held there, and the CFL numbers it ran at.
+RunRecord = collections.namedtuple('RunRecord',
+                                   ['step', 'mass', 'cfl_min', 'cfl_max'])
 
 
 class RunHistory(object):
@@ -54,9 +54,9 @@ class RunHistory(object):
     def __len__(self):
         return len(self.records)
 
-    def append(self, step, mass):
+    def append(self, step, mass, cfl_min, cfl_max):
         """Record one chunk; returns the new :class:`RunRecord`."""
-        record = RunRecord(step, mass)
+        record = RunRecord(step, mass, cfl_min, cfl_max)
         self.records.append(record)
         return record
 
@@ -131,8 +131,10 @@ class ReflectionSession(object):
         steps = min(self.steps_per_chunk, self.max_steps - self.step)
         self.shock.march(steps)
         self.step += steps
+        cfl_min, cfl_max = self.field.calc_cfl_range()
         record = self.history.append(self.step,
-                                     self.field.calc_overall_mass())
+                                     self.field.calc_overall_mass(),
+                                     cfl_min, cfl_max)
         if self.step >= self.max_steps:
             self.stop_reason = 'cap'
         return record

--- a/tests/apps/obsrefl/test_analytic.py
+++ b/tests/apps/obsrefl/test_analytic.py
@@ -100,17 +100,33 @@ class AnalyticFieldTC(unittest.TestCase):
     def test_zone_info_recovers_every_analytic_state(self):
         # The seeded field is the analytic answer, so each zone average has
         # to reproduce its state to the last bit for every derived field.
-        for name in EulerField.FIELDS:
+        for name in self.analysis.zone_fields():
             for record in self.analysis.zone_info(name):
                 self.assertGreater(record.count, 0)
                 assert_almost_equal(record.computed, record.analytic,
                                     decimal=12)
 
-    def test_the_analytic_side_answers_every_field(self):
+    def test_a_field_with_no_analytic_value_reports_no_zones(self):
+        # A CFL number has no analytic value to be held against.
+        self.assertEqual([], self.analysis.zone_info('cfl'))
+        with self.assertRaises(ValueError):
+            self.analysis.zone_info('nonesuch')
+
+    def test_the_color_range_reaches_the_analytic_values(self):
+        # A field short of its analytic range still colors against that
+        # range; one the reflection cannot answer for keeps its own.
+        rho = self.analysis.zone_field('density')
+        self.assertEqual((float(rho.min()), float(rho.max())),
+                         self.analysis.color_range('density', 1e9, -1e9))
+        self.assertEqual((0.2, 0.7),
+                         self.analysis.color_range('cfl', 0.2, 0.7))
+
+    def test_the_analytic_side_answers_every_flow_field(self):
         # The computed and the analytic side are compared field by field, so
-        # the analysis has to derive everything the field reader does, and
-        # the primitives have to come back as the driver states them.
-        self.assertEqual(set(EulerField.FIELDS),
+        # the analysis has to derive every flow quantity the field reader
+        # does, and the primitives have to come back as the driver states
+        # them.  The CFL number is the one field it answers nothing for.
+        self.assertEqual(set(EulerField.FIELDS) - {'cfl'},
                          set(self.analysis.zone_fields()))
         states = self.shock.zone_states()
         assert_almost_equal(self.analysis.zone_field('density'),

--- a/tests/apps/obsrefl/test_panel.py
+++ b/tests/apps/obsrefl/test_panel.py
@@ -51,18 +51,18 @@ class StatusReadoutTC(unittest.TestCase):
                 for irow in range(1, grid.rowCount())]
         return [row for row in rows if any(row)]
 
+    @staticmethod
+    def _enabled(panel):
+        run = panel._run
+        return dict(pause=run._pause.isEnabled(), step=run._step.isEnabled(),
+                    stop=run._stop.isEnabled(), reset=run._reset.isEnabled())
+
     def test_an_unstarted_panel_says_so(self):
         panel = SolutionPanel()
         self.assertEqual("not started", panel._run._state.text())
         self.assertEqual("-", panel._run._progress.text())
         self.assertEqual("-", panel._field._min.text())
         self.assertEqual([], self._zone_rows(panel))
-
-    @staticmethod
-    def _enabled(panel):
-        run = panel._run
-        return dict(pause=run._pause.isEnabled(), step=run._step.isEnabled(),
-                    stop=run._stop.isEnabled(), reset=run._reset.isEnabled())
 
     def test_the_buttons_follow_what_the_run_can_still_do(self):
         panel = SolutionPanel()
@@ -129,6 +129,18 @@ class StatusReadoutTC(unittest.TestCase):
         panel.set_status(sess, vmin, vmax)
         panel.set_paused(True)
         self.assertEqual("stopped", panel._run._state.text())
+
+    def test_every_box_pads_its_content_the_same(self):
+        # A layout built on the content pane directly takes the style's
+        # dialog margins instead, which are meant for a whole dialog.
+        panel = SolutionPanel()
+        for box in panel._boxes:
+            margins = box._content.layout().contentsMargins()
+            self.assertEqual(_panel.FoldBox.CONTENT_MARGINS,
+                             (margins.left(), margins.top(),
+                              margins.right(), margins.bottom()))
+            # The gap over the content is the top margin and nothing else.
+            self.assertEqual(0, box.layout().spacing())
 
     def test_folding_keeps_the_box_width(self):
         # Folding gives back height only; a fold that narrowed the box

--- a/tests/apps/obsrefl/test_panel.py
+++ b/tests/apps/obsrefl/test_panel.py
@@ -58,6 +58,25 @@ class StatusReadoutTC(unittest.TestCase):
         self.assertEqual("-", panel._field._min.text())
         self.assertEqual([], self._zone_rows(panel))
 
+    @staticmethod
+    def _enabled(panel):
+        run = panel._run
+        return dict(pause=run._pause.isEnabled(), step=run._step.isEnabled(),
+                    stop=run._stop.isEnabled(), reset=run._reset.isEnabled())
+
+    def test_the_buttons_follow_what_the_run_can_still_do(self):
+        panel = SolutionPanel()
+        self.assertEqual(dict(pause=False, step=False, stop=False,
+                              reset=False), self._enabled(panel))
+        panel, sess, vmin, vmax = self._filled()
+        self.assertEqual(dict(pause=True, step=True, stop=True, reset=True),
+                         self._enabled(panel))
+        sess.stop()
+        panel.set_status(sess, vmin, vmax)
+        # An ended run can still be dropped, but not marched.
+        self.assertEqual(dict(pause=False, step=False, stop=False,
+                              reset=True), self._enabled(panel))
+
     def test_the_run_box_reads_the_march(self):
         panel, sess, _, _ = self._filled()
         self.assertEqual(f"3 / {sess.max_steps}",

--- a/tests/apps/obsrefl/test_panel.py
+++ b/tests/apps/obsrefl/test_panel.py
@@ -74,6 +74,15 @@ class StatusReadoutTC(unittest.TestCase):
         panel.set_paused(False)
         self.assertEqual("running", panel._run._state.text())
 
+    def test_remesh_asks_its_owner_to_cut_the_domain_again(self):
+        # The button belongs to the numerics box whose values it applies.
+        panel = SolutionPanel()
+        asked = []
+        panel.remesh_requested = lambda: asked.append(panel.params())
+        panel._numerics._nx.setValue(21)
+        panel._numerics._remesh.click()
+        self.assertEqual([21], [params['nx'] for params in asked])
+
     def test_pausing_does_not_rename_a_finished_state(self):
         # What ended a run outranks the Pause button, which the controller
         # checks when the march reaches its end.

--- a/tests/apps/obsrefl/test_panel.py
+++ b/tests/apps/obsrefl/test_panel.py
@@ -93,6 +93,25 @@ class StatusReadoutTC(unittest.TestCase):
         panel.set_paused(False)
         self.assertEqual("running", panel._run._state.text())
 
+    def test_the_cfl_readout_bounds_the_last_chunk(self):
+        # Read off the chunk record beside the mass, so the panel says what
+        # the march ran at.
+        panel, sess, _, _ = self._filled()
+        last = sess.history.last
+        self.assertEqual(f"{_panel._number(last.cfl_min)} / "
+                         f"{_panel._number(last.cfl_max)}",
+                         panel._run._cfl.text())
+        panel.set_status(None, None, None)
+        self.assertEqual("-", panel._run._cfl.text())
+
+    def test_the_cfl_field_colors_without_an_analytic_column(self):
+        # The zone table judges a field against the analytic answer, which
+        # a CFL number has none of, so its rows stay empty.
+        self.assertIn('cfl', _panel.FieldBox.FIELDS)
+        panel, _, vmin, _ = self._filled('cfl')
+        self.assertEqual([], self._zone_rows(panel))
+        self.assertEqual(_panel._number(vmin), panel._field._min.text())
+
     def test_remesh_asks_its_owner_to_cut_the_domain_again(self):
         # The button belongs to the numerics box whose values it applies.
         panel = SolutionPanel()

--- a/tests/apps/obsrefl/test_session.py
+++ b/tests/apps/obsrefl/test_session.py
@@ -25,7 +25,7 @@ class RunHistoryTC(unittest.TestCase):
         history = RunHistory(length=3)
         self.assertIsNone(history.last)
         for step in range(1, 6):
-            history.append(step, 1.0 / step)
+            history.append(step, 1.0 / step, 0.1 * step, 0.2 * step)
         self.assertEqual(3, len(history))
         self.assertEqual([(3, 1 / 3), (4, 0.25), (5, 0.2)], history.masses)
         self.assertEqual(5, history.last.step)
@@ -56,6 +56,10 @@ class ReflectionSessionTC(unittest.TestCase):
         self.assertEqual(3, record.step)
         self.assertAlmostEqual(record.mass, sess.field.calc_overall_mass())
         self.assertEqual([(3, record.mass)], sess.history.masses)
+        # The record carries the CFL bounds of its own chunk.
+        self.assertEqual(sess.field.calc_cfl_range(),
+                         (record.cfl_min, record.cfl_max))
+        self.assertGreater(record.cfl_min, 0.0)
         self.assertFalse(sess.finished)
 
     def test_the_last_chunk_lands_on_the_step_cap(self):

--- a/tests/gui/test_domain_subwindow.py
+++ b/tests/gui/test_domain_subwindow.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""How the domain viewer is laid out inside its MDI sub-window.
+
+A sub-window only lays its contents out once it is on a live window, so the
+geometry these check is not reachable from the widget lane: a hidden
+sub-window keeps whatever size its widget was built with.
+"""
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from PySide6.QtWidgets import QApplication, QSizeGrip
+except ImportError:
+    pilot = None
+
+# The offscreen platform cannot back a live window; neither can the headless
+# Windows CI runner, whose WARP software rasterizer faults on one.
+NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
+                  or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class DomainSubWindowTC(unittest.TestCase):
+
+    def _subwindow(self, width, height):
+        """One 3D viewer sub-window of the given size, on a shown window."""
+        mgr = pilot.RManager.instance.setUp()
+        window = mgr.mainWindow
+        window.resize(1000, 800)
+        window.show()
+        QApplication.processEvents()
+        mgr.add3DWidget()
+        # The mdiArea wrapper is thrown away right after use, taking any
+        # sub-window handle reached through it, so it is held here.
+        self.mdi = mgr.mdiArea
+        subwin = self.mdi.activeSubWindow()
+        subwin.resize(width, height)
+        QApplication.processEvents()
+        return subwin
+
+    def test_the_grip_leaves_the_layout_to_the_viewer(self):
+        # QMdiSubWindow adopts a size grip into the layout that holds the
+        # viewer, where it would claim a row of the height.
+        subwin = self._subwindow(816, 584)
+        host = subwin.widget()
+        layout = subwin.layout()
+        self.assertEqual(1, layout.count())
+        self.assertIs(host, layout.itemAt(0).widget())
+        self.assertEqual(layout.contentsRect(), host.geometry())
+
+    def test_the_grip_stays_drawn_in_the_corner(self):
+        # The macOS style draws a grip only for a sub-window's own child; one
+        # parented to the widget inside paints nothing.
+        subwin = self._subwindow(816, 584)
+        grip = subwin.findChild(QSizeGrip)
+        self.assertIs(subwin, grip.parent())
+        self.assertEqual(subwin.rect().bottomRight(),
+                         grip.geometry().bottomRight())
+        shot = grip.grab().toImage()
+        drawn = {shot.pixelColor(ix, iy).rgb()
+                 for ix in range(shot.width())
+                 for iy in range(shot.height())}
+        self.assertGreater(len(drawn), 1)
+
+    def test_the_viewer_and_the_grip_follow_a_resize(self):
+        # Qt does not move a grip that is out of the layout, so it follows
+        # the corner by hand.
+        subwin = self._subwindow(500, 300)
+        short = subwin.widget().height()
+        subwin.resize(500, 600)
+        QApplication.processEvents()
+        self.assertEqual(300, subwin.widget().height() - short)
+        self.assertEqual(subwin.rect().bottomRight(),
+                         subwin.findChild(QSizeGrip).geometry().bottomRight())
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/gui/test_obsrefl.py
+++ b/tests/gui/test_obsrefl.py
@@ -104,6 +104,80 @@ class ObliqueShockAppTC(unittest.TestCase):
                          self.mgr.currentR3DWidget().mesh.ncell)
         QApplication.processEvents()
 
+    def test_stop_ends_the_run_and_keeps_the_field(self):
+        feature = self._feature()
+        self._coarsen(feature)
+        feature._control.start()
+        feature._control._timer.stop()
+        feature._control._on_step()
+        step = feature._control.session.step
+        feature._panel._run._stop.click()
+        sess = feature._control.session
+        self.assertEqual('stopped', sess.stop_reason)
+        self.assertEqual(step, sess.step)
+        self.assertFalse(feature._control._timer.isActive())
+        # The field the march reached is still on screen to be read.
+        self.assertTrue(feature._viewer.is_open)
+        self.assertEqual("stopped", self._status(feature)["state"])
+        QApplication.processEvents()
+
+    def test_reset_drops_the_run_and_the_viewer(self):
+        feature = self._feature()
+        self._coarsen(feature)
+        feature._control.start()
+        feature._panel._run._reset.click()
+        self.assertIsNone(feature._control.session)
+        self.assertFalse(feature._viewer.is_open)
+        self.assertFalse(feature._control._timer.isActive())
+        self.assertFalse(feature._panel._run._viewer_btn.isChecked())
+        self.assertEqual("not started", self._status(feature)["state"])
+        # What was dropped is built again from the controls.
+        feature._control.start()
+        feature._control._timer.stop()
+        self.assertIsNotNone(feature._control.session)
+        self.assertTrue(feature._viewer.is_open)
+        QApplication.processEvents()
+
+    def test_reopening_the_viewer_draws_the_run_back(self):
+        feature = self._feature()
+        self._coarsen(feature)
+        feature._control.start()
+        feature._control._timer.stop()
+        feature._control._on_step()
+        sess = feature._control.session
+        feature._viewer.close()
+        # Closing deletes the sub-window and the viewer inside it.  The run
+        # is not the viewer's, so reopening has to draw it again.
+        self.assertFalse(feature._viewer.is_open)
+        self.assertIs(sess, feature._control.session)
+        drawn = []
+        real = feature._viewer.draw_field
+
+        def spy(*args):
+            drawn.append(args)
+            real(*args)
+
+        feature._viewer.draw_field = spy
+        feature._panel._run._viewer_btn.click()
+        self.assertTrue(feature._viewer.is_open)
+        self.assertEqual(sess.shock.mesh.ncell,
+                         self.mgr.currentR3DWidget().mesh.ncell)
+        self.assertEqual(1, len(drawn))
+        self.assertEqual(sess.step, feature._control.session.step)
+        QApplication.processEvents()
+
+    def test_a_closed_viewer_still_reports_the_run(self):
+        feature = self._feature()
+        self._coarsen(feature)
+        feature._control.start()
+        feature._control._timer.stop()
+        feature._viewer.close()
+        feature._panel._run._stop.click()
+        # The readout belongs to the run, not to the viewer that was drawing
+        # it, so closing the viewer does not leave the panel stale.
+        self.assertEqual("stopped", self._status(feature)["state"])
+        QApplication.processEvents()
+
     def test_running_keeps_the_view_the_user_set(self):
         feature = self._feature()
         self._coarsen(feature)

--- a/tests/gui/test_obsrefl.py
+++ b/tests/gui/test_obsrefl.py
@@ -66,6 +66,63 @@ class ObliqueShockAppTC(unittest.TestCase):
         self.assertEqual(f"0 / {feature._control.session.max_steps}",
                          self._status(feature)["step"])
 
+    @staticmethod
+    def _coarsen(feature, nx=10, ny=4):
+        """Cut the mesh down to what a window test can march quickly."""
+        feature._panel._numerics._nx.setValue(nx)
+        feature._panel._numerics._ny.setValue(ny)
+
+    def test_the_resolution_reaches_the_mesh(self):
+        feature = self._feature()
+        self._coarsen(feature)
+        feature._control.start()
+        feature._control._timer.stop()
+        mesher = feature._control.session.shock.mesher
+        self.assertEqual((10, 4), (mesher.nx, mesher.ny))
+        # The viewer draws the mesh the spin boxes asked for, not the one
+        # the preview was built on.
+        self.assertEqual(feature._control.session.shock.mesh.ncell,
+                         self.mgr.currentR3DWidget().mesh.ncell)
+        QApplication.processEvents()
+
+    def test_remesh_rebuilds_the_run_at_the_new_resolution(self):
+        feature = self._feature()
+        self._coarsen(feature)
+        feature._control.start()
+        feature._control._on_step()
+        self.assertGreater(feature._control.session.step, 0)
+        self._coarsen(feature, nx=14, ny=6)
+        feature._panel._numerics._remesh.click()
+        # The mesh is fixed when a session is built, so a new resolution is
+        # a new run: it waits on its initial state instead of marching on.
+        mesher = feature._control.session.shock.mesher
+        self.assertEqual((14, 6), (mesher.nx, mesher.ny))
+        self.assertEqual(0, feature._control.session.step)
+        self.assertFalse(feature._control._timer.isActive())
+        self.assertTrue(feature._panel._run._pause.isChecked())
+        self.assertEqual(feature._control.session.shock.mesh.ncell,
+                         self.mgr.currentR3DWidget().mesh.ncell)
+        QApplication.processEvents()
+
+    def test_running_keeps_the_view_the_user_set(self):
+        feature = self._feature()
+        self._coarsen(feature)
+        feature._control.start()
+        feature._control._timer.stop()
+        viewer = self.mgr.currentR3DWidget()
+        viewer.zoomCamera(3.0)
+        zoom = viewer.cameraZoom
+        self.assertNotAlmostEqual(1.0, zoom)
+        # Neither marching a frame nor restarting the run at another
+        # resolution may pull the view back to where it was framed.
+        feature._control._on_step()
+        self.assertAlmostEqual(zoom, viewer.cameraZoom)
+        self._coarsen(feature, nx=12, ny=5)
+        feature._control.start()
+        feature._control._timer.stop()
+        self.assertAlmostEqual(zoom, self.mgr.currentR3DWidget().cameraZoom)
+        QApplication.processEvents()
+
     def test_start_sets_viewer_mesh_for_inspector(self):
         feature = self._feature()
         feature._control.start()

--- a/tests/multidim/euler/test_field.py
+++ b/tests/multidim/euler/test_field.py
@@ -121,4 +121,21 @@ class DerivedFieldTC(_EulerFieldTB, unittest.TestCase):
         with self.assertRaises(ValueError):
             self.field.field('nonesuch')
 
+
+class CflReadoutTC(_EulerFieldTB, unittest.TestCase):
+    """The CFL number the solver writes as it marches."""
+
+    def test_the_cfl_view_reads_the_solver_table(self):
+        # The reader only has to drop the ghost rows.
+        arr = self.svr.cflo
+        arr.ndarray[arr.nghost:] = (0.25, 0.5, 0.75)
+        assert_almost_equal(self.field.cfl, (0.25, 0.5, 0.75))
+
+    def test_the_range_bounds_every_cell(self):
+        # An average would hide the one cell over the limit.
+        arr = self.svr.cflo
+        arr.ndarray[arr.nghost:] = (0.25, 1.5, 0.75)
+        self.assertEqual((0.25, 1.5), self.field.calc_cfl_range())
+
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -20,8 +20,9 @@ import solvcon
 
 try:
     from solvcon import pilot
-    from PySide6.QtGui import QImage
-    from PySide6.QtWidgets import QWidget
+    from PySide6.QtCore import QEvent, QPoint, QPointF, Qt
+    from PySide6.QtGui import QImage, QMouseEvent
+    from PySide6.QtWidgets import QApplication, QSizeGrip, QWidget
 except ImportError:
     pilot = None
 
@@ -1907,6 +1908,33 @@ class RDomainWidgetManagerTC(unittest.TestCase):
         current = mgr.currentR3DWidget()
         self.assertIsNotNone(current)
         self.assertEqual(current.mesh.ncell, 3)
+
+    def test_the_subwindow_is_resized_by_its_grip(self):
+        """The sub-window carries a size grip and the grip resizes it.
+
+        The sub-window frame is a few pixels wide, too little to aim a drag
+        at.
+        """
+        mgr = pilot.RManager.instance.setUp()
+        mgr.add3DWidget()
+        # The mdiArea wrapper is thrown away right after use, taking any
+        # sub-window handle reached through it, so it is held here.
+        mdi = mgr.mdiArea
+        subwin = mdi.activeSubWindow()
+        grip = subwin.findChild(QSizeGrip)
+        self.assertIsNotNone(grip)
+        before = subwin.size()
+        start = grip.rect().center()
+        end = start + QPoint(60, 40)
+        for kind, pos, buttons in (
+                (QEvent.Type.MouseButtonPress, start, Qt.LeftButton),
+                (QEvent.Type.MouseMove, end, Qt.LeftButton),
+                (QEvent.Type.MouseButtonRelease, end, Qt.NoButton)):
+            QApplication.sendEvent(grip, QMouseEvent(
+                kind, QPointF(pos), QPointF(grip.mapToGlobal(pos)),
+                Qt.LeftButton, buttons, Qt.NoModifier))
+        self.assertGreater(subwin.width(), before.width())
+        self.assertGreater(subwin.height(), before.height())
 
     def test_factory_widget_screenshot(self):
         """The screenshot path of a factory-hosted widget routes through

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -258,6 +258,33 @@ class RDomainWidgetMeshTC(unittest.TestCase):
         image = _grab_or_skip(widget)
         self.assertGreater(_count_foreground(image), 0)
 
+    def test_a_mesh_over_the_framed_domain_keeps_the_view(self):
+        """A run restarted at another resolution cuts the same domain again,
+        so the view the user set has to survive the rebuild."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        widget.zoomCamera(3.0)
+        widget.panCamera(20.0, 10.0)
+        zoom, target = widget.cameraZoom, widget.cameraTarget
+        self.assertNotAlmostEqual(1.0, zoom)
+        widget.updateMesh(_make_2d_mesh())
+        self.assertAlmostEqual(zoom, widget.cameraZoom)
+        self.assertEqual(target, widget.cameraTarget)
+
+    def test_a_mesh_over_another_domain_reframes_the_view(self):
+        """A mesh standing somewhere else is a new subject, not the old one
+        cut again, so it frames the camera onto itself."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        widget.zoomCamera(3.0)
+        self.assertNotAlmostEqual(1.0, widget.cameraZoom)
+        moved = _make_2d_mesh()
+        moved.ndcrd.ndarray[:, :] += 5.0
+        widget.updateMesh(moved)
+        self.assertAlmostEqual(1.0, widget.cameraZoom)
+
     def test_show_mesh_toggles_visibility(self):
         """showMesh(False) hides the wireframe; showMesh(True) restores it.
 


### PR DESCRIPTION
For issue #1271

Add stop, reset, and remesh buttons for the Euler solver.  Remesh takes `nx` and `ny`.

Report CFL number as it runs.  Make reopening domain view to remember where it were.  Add a size grip for the domain view sub-window to make it easier to resize.  Reduce blank space in the fold boxes.