### PR TITLE
Expose selectable matmul kernels

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -1186,6 +1186,7 @@ public:
     }
 
     A matmul(A const & other) const;
+    A matmul(A const & other, MatmulKernel kernel) const;
     A & imatmul(A const & other);
 
 private:
@@ -1378,6 +1379,17 @@ A SimpleArrayMixinCalculators<A, T>::matmul(A const & other) const
     A output(plan.output_shape());
     MatmulExecutor<A> executor(std::move(plan), output, *athis, other);
     executor.execute();
+    return output;
+}
+
+template <typename A, typename T>
+A SimpleArrayMixinCalculators<A, T>::matmul(A const & other, MatmulKernel kernel) const
+{
+    auto const * athis = static_cast<A const *>(this);
+    MatmulPlan plan = MatmulPlan::make(*athis, other);
+    A output(plan.output_shape());
+    MatmulExecutor<A> executor(std::move(plan), output, *athis, other);
+    executor.execute(kernel);
     return output;
 }
 

--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -21,6 +21,7 @@
 #include <ranges>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
@@ -46,7 +47,7 @@ inline constexpr bool use_matmul_blas_v = has_blas_backend && is_blas_element_v<
  */
 enum class MatmulKernel : std::uint8_t
 {
-    Generic,
+    Naive,
     BlasDot,
     BlasGevm,
     BlasGemv,
@@ -68,7 +69,7 @@ struct PackingState
 /**
  * @brief Group measured thresholds by matmul dispatch decision.
  *
- * A tuning table supplies the workload boundaries used to compare generic,
+ * A tuning table supplies the workload boundaries used to compare naive,
  * direct BLAS, and packing routes. Keeping the values separate from dispatch
  * code allows a backend or value type to provide another table.
  *
@@ -144,9 +145,36 @@ inline constexpr MatmulTuning::Winograd WINOGRAD_TUNING{
  */
 struct MatmulSelection
 {
-    MatmulKernel kernel = MatmulKernel::Generic;
+    MatmulKernel kernel = MatmulKernel::Naive;
     PackingState packing;
 }; /* end struct MatmulSelection */
+
+inline constexpr std::array<std::string_view, 6> MATMUL_KERNEL_NAMES{
+    "naive",
+    "blas_dot",
+    "blas_gevm",
+    "blas_gemv",
+    "blas_gemm",
+    "winograd",
+};
+
+constexpr std::string_view matmul_kernel_name(MatmulKernel kernel) noexcept
+{
+    auto const index = static_cast<size_t>(kernel);
+    return index < MATMUL_KERNEL_NAMES.size() ? MATMUL_KERNEL_NAMES[index] : "unknown";
+}
+
+constexpr std::optional<MatmulKernel> matmul_kernel_from_name(std::string_view name) noexcept
+{
+    for (size_t index = 0; index < MATMUL_KERNEL_NAMES.size(); ++index)
+    {
+        if (MATMUL_KERNEL_NAMES[index] == name)
+        {
+            return static_cast<MatmulKernel>(index);
+        }
+    }
+    return std::nullopt;
+}
 
 /**
  * @brief Describe matmul operands as an execution-independent contraction.
@@ -270,7 +298,7 @@ private:
  * MatmulExecutor combines plan metadata with MatmulTuning to select a
  * MatmulSelection. It applies the selected operand preparation, rebuilds the
  * plan when a physical layout changes, and traverses every batch offset with
- * the same kernel. Generic kernels read signed strides directly, while BLAS
+ * the same kernel. Naive kernels read signed strides directly, while BLAS
  * kernels consume compatible vector and matrix descriptors. Eligible compact
  * square GEMMs may use one-level Winograd multiplication.
  *
@@ -278,7 +306,7 @@ private:
  * evaluates one `(3,4) @ (4,6)` contraction at each offset. The results are
  * written into the allocated `(2,5,3,6)` output.
  *
- * @note The current implementation selects generic, BLAS, or Winograd kernels
+ * @note The current implementation selects naive, BLAS, or Winograd kernels
  * using measured thresholds. Packing materializes reused broadcast operands
  * once and streams the remaining operands one matrix at a time through
  * bounded row-major scratch.
@@ -296,6 +324,7 @@ public:
     MatmulExecutor & operator=(MatmulExecutor &&) = delete;
 
     void execute();
+    void execute(MatmulKernel kernel);
 
 private:
     using value_type = typename Array::value_type;
@@ -333,7 +362,8 @@ private:
         std::numeric_limits<size_t>::max() / sizeof(value_type),
         static_cast<size_t>(std::numeric_limits<ssize_t>::max()));
 
-    MatmulSelection select_execution() const;
+    MatmulSelection select() const;
+    std::optional<MatmulSelection> select(MatmulKernel kernel) const;
     MatmulSelection select_dot() const;
     MatmulSelection select_gevm() const;
     MatmulSelection select_gemv() const;
@@ -342,6 +372,7 @@ private:
     PackingState select_vector_packing(PackingState required) const;
     bool should_pack_vector() const;
     void pack(PackingState const & packing);
+    void run(MatmulSelection const & selection);
 
     template <MatmulKernel Kernel>
     void execute_contractions();
@@ -377,8 +408,8 @@ private:
         ssize_t rows,
         ssize_t columns);
     template <size_t ColumnBlock>
-    void multiply_generic_column_block(value_type * output, value_type const * lhs, value_type const * rhs);
-    void execute_generic(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base);
+    void multiply_naive_column_block(value_type * output, value_type const * lhs, value_type const * rhs);
+    void execute_naive(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base);
 
     MatmulPlan m_plan;
     Array const & m_lhs;
@@ -654,26 +685,44 @@ MatmulExecutor<Array>::MatmulExecutor(MatmulPlan plan, Array & output, Array con
 template <typename Array>
 void MatmulExecutor<Array>::execute()
 {
+    run(select());
+}
+
+template <typename Array>
+void MatmulExecutor<Array>::execute(MatmulKernel kernel)
+{
+    std::optional<MatmulSelection> const selection = select(kernel);
+    if (!selection)
+    {
+        std::string_view const reason = use_matmul_blas_v<value_type>
+                                            ? "is not eligible for these operands"
+                                            : "requires a BLAS backend";
+        throw std::invalid_argument(
+            std::format("matmul(): kernel '{}' {}", matmul_kernel_name(kernel), reason));
+    }
+    run(selection.value());
+}
+
+template <typename Array>
+void MatmulExecutor<Array>::run(MatmulSelection const & selection)
+{
     if (m_plan.batch_size() == 0)
     {
         return;
     }
-
-    MatmulSelection const selection = select_execution();
 
     if (selection.packing)
     {
         pack(selection.packing);
     }
 
-    // `select_execution()` names a BLAS kernel only where one exists, so the
-    // dispatch stays uninstantiated for a value type that has none, and the
-    // generic kernel is the one path every instantiation keeps.
+    // Non-naive selections exist only for value types with a BLAS backend,
+    // so other instantiations keep only the naive dispatch.
     if constexpr (use_matmul_blas_v<value_type>)
     {
         switch (selection.kernel)
         {
-        case MatmulKernel::Generic:
+        case MatmulKernel::Naive:
             break;
         case MatmulKernel::BlasDot:
             execute_contractions<MatmulKernel::BlasDot>();
@@ -693,11 +742,11 @@ void MatmulExecutor<Array>::execute()
             return;
         }
     }
-    execute_contractions<MatmulKernel::Generic>();
+    execute_contractions<MatmulKernel::Naive>();
 }
 
 template <typename Array>
-MatmulSelection MatmulExecutor<Array>::select_execution() const
+MatmulSelection MatmulExecutor<Array>::select() const
 {
     if constexpr (use_matmul_blas_v<value_type>)
     {
@@ -715,10 +764,7 @@ MatmulSelection MatmulExecutor<Array>::select_execution() const
         }
         return select_gemm();
     }
-    else
-    {
-        return MatmulSelection{};
-    }
+    return MatmulSelection{};
 }
 
 template <typename Array>
@@ -730,7 +776,7 @@ MatmulSelection MatmulExecutor<Array>::select_dot() const
                                    (lhs_stride == -1 && rhs_stride == -1);
     bool const use_blas = m_plan.inner_size() >= TUNING.direct_blas.dot_min_length && strides_supported;
     return MatmulSelection{
-        .kernel = use_blas ? MatmulKernel::BlasDot : MatmulKernel::Generic,
+        .kernel = use_blas ? MatmulKernel::BlasDot : MatmulKernel::Naive,
         .packing = {},
     };
 }
@@ -752,7 +798,7 @@ MatmulSelection MatmulExecutor<Array>::select_gevm() const
                                m_plan.inner_size() * m_plan.columns() >=
                                    TUNING.batched_vector.direct_min_matrix_elements);
         return MatmulSelection{
-            .kernel = use_blas ? MatmulKernel::BlasGevm : MatmulKernel::Generic,
+            .kernel = use_blas ? MatmulKernel::BlasGevm : MatmulKernel::Naive,
             .packing = packing,
         };
     }
@@ -769,7 +815,7 @@ MatmulSelection MatmulExecutor<Array>::select_gevm() const
                               : std::min(m_plan.inner_size(), m_plan.columns()) >=
                                     TUNING.direct_blas.gemv_min_dimension;
     return MatmulSelection{
-        .kernel = use_blas ? MatmulKernel::BlasGevm : MatmulKernel::Generic,
+        .kernel = use_blas ? MatmulKernel::BlasGevm : MatmulKernel::Naive,
         .packing = {},
     };
 }
@@ -791,7 +837,7 @@ MatmulSelection MatmulExecutor<Array>::select_gemv() const
                                m_plan.rows() * m_plan.inner_size() >=
                                    TUNING.batched_vector.direct_min_matrix_elements);
         return MatmulSelection{
-            .kernel = use_blas ? MatmulKernel::BlasGemv : MatmulKernel::Generic,
+            .kernel = use_blas ? MatmulKernel::BlasGemv : MatmulKernel::Naive,
             .packing = packing,
         };
     }
@@ -799,7 +845,7 @@ MatmulSelection MatmulExecutor<Array>::select_gemv() const
     bool const use_blas = m_plan.rhs_inner_stride() > 0 &&
                           std::min(m_plan.rows(), m_plan.inner_size()) >= TUNING.direct_blas.gemv_min_dimension;
     return MatmulSelection{
-        .kernel = use_blas ? MatmulKernel::BlasGemv : MatmulKernel::Generic,
+        .kernel = use_blas ? MatmulKernel::BlasGemv : MatmulKernel::Naive,
         .packing = {},
     };
 }
@@ -839,6 +885,101 @@ MatmulSelection MatmulExecutor<Array>::select_gemm() const
         };
     }
     return MatmulSelection{};
+}
+
+template <typename Array>
+std::optional<MatmulSelection> MatmulExecutor<Array>::select(MatmulKernel kernel) const
+{
+    if (kernel == MatmulKernel::Naive)
+    {
+        return MatmulSelection{};
+    }
+    if constexpr (!use_matmul_blas_v<value_type>)
+    {
+        return std::nullopt;
+    }
+    if (m_plan.rows() <= 0 || m_plan.columns() <= 0 || m_plan.inner_size() <= 0)
+    {
+        return std::nullopt;
+    }
+    MatmulKernel operand_kernel;
+    if (m_plan.lhs_is_vector())
+    {
+        operand_kernel = m_plan.rhs_is_vector() ? MatmulKernel::BlasDot : MatmulKernel::BlasGevm;
+    }
+    else
+    {
+        operand_kernel = m_plan.rhs_is_vector() ? MatmulKernel::BlasGemv : MatmulKernel::BlasGemm;
+    }
+    if (kernel != operand_kernel && kernel != MatmulKernel::Winograd)
+    {
+        return std::nullopt;
+    }
+
+    switch (kernel)
+    {
+    case MatmulKernel::Naive:
+        return MatmulSelection{};
+    case MatmulKernel::BlasDot:
+    {
+        ssize_t const lhs_stride = m_plan.lhs_inner_stride();
+        ssize_t const rhs_stride = m_plan.rhs_inner_stride();
+        bool const direct_negative = lhs_stride == -1 && rhs_stride == -1;
+        return MatmulSelection{
+            .kernel = MatmulKernel::BlasDot,
+            .packing = {
+                .lhs = lhs_stride <= 0 && !direct_negative,
+                .rhs = rhs_stride <= 0 && !direct_negative,
+            },
+        };
+    }
+    case MatmulKernel::BlasGevm:
+        return MatmulSelection{
+            .kernel = MatmulKernel::BlasGevm,
+            .packing = {
+                .lhs = m_plan.lhs_inner_stride() <= 0,
+                .rhs = !rhs_matrix_view(m_rhs_data),
+            },
+        };
+    case MatmulKernel::BlasGemv:
+        return MatmulSelection{
+            .kernel = MatmulKernel::BlasGemv,
+            .packing = {
+                .lhs = !lhs_matrix_view(m_lhs_data),
+                .rhs = m_plan.rhs_inner_stride() <= 0,
+            },
+        };
+    case MatmulKernel::BlasGemm:
+        return MatmulSelection{
+            .kernel = MatmulKernel::BlasGemm,
+            .packing = select_matrix_packing(PackingState{
+                .lhs = !lhs_matrix_view(m_lhs_data),
+                .rhs = !rhs_matrix_view(m_rhs_data),
+            }),
+        };
+    case MatmulKernel::Winograd:
+    {
+        bool const even_dimensions = m_plan.rows() % 2 == 0 &&
+                                     m_plan.columns() % 2 == 0 &&
+                                     m_plan.inner_size() % 2 == 0;
+        if (operand_kernel != MatmulKernel::BlasGemm ||
+            m_plan.has_batch_axes() ||
+            !even_dimensions)
+        {
+            return std::nullopt;
+        }
+        auto const lhs_view = lhs_matrix_view(m_lhs_data);
+        auto const rhs_view = rhs_matrix_view(m_rhs_data);
+        return MatmulSelection{
+            .kernel = MatmulKernel::Winograd,
+            .packing = {
+                .lhs = !lhs_view || lhs_view->m_transpose != BlasTranspose::None,
+                .rhs = !rhs_view || rhs_view->m_transpose != BlasTranspose::None,
+            },
+        };
+    }
+    }
+    return std::nullopt;
 }
 
 template <typename Array>
@@ -930,9 +1071,9 @@ void MatmulExecutor<Array>::execute_at(
     ssize_t lhs_base,
     ssize_t rhs_base)
 {
-    if constexpr (Kernel == MatmulKernel::Generic)
+    if constexpr (Kernel == MatmulKernel::Naive)
     {
-        execute_generic(output_base, lhs_base, rhs_base);
+        execute_naive(output_base, lhs_base, rhs_base);
     }
     else
     {
@@ -1205,7 +1346,7 @@ std::optional<typename MatmulExecutor<Array>::matrix_view_type> MatmulExecutor<A
 
 template <typename Array>
 template <size_t ColumnBlock>
-void MatmulExecutor<Array>::multiply_generic_column_block(
+void MatmulExecutor<Array>::multiply_naive_column_block(
     value_type * output,
     value_type const * lhs,
     value_type const * rhs)
@@ -1229,7 +1370,7 @@ void MatmulExecutor<Array>::multiply_generic_column_block(
 }
 
 template <typename Array>
-void MatmulExecutor<Array>::execute_generic(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base)
+void MatmulExecutor<Array>::execute_naive(ssize_t output_base, ssize_t lhs_base, ssize_t rhs_base)
 {
     constexpr ssize_t LARGE_COLUMN_BLOCK = 8;
     constexpr ssize_t SMALL_COLUMN_BLOCK = 4;
@@ -1247,14 +1388,14 @@ void MatmulExecutor<Array>::execute_generic(ssize_t output_base, ssize_t lhs_bas
             value_type const * lhs = m_lhs_data + lhs_row_base;
             for (; column + LARGE_COLUMN_BLOCK <= m_plan.columns(); column += LARGE_COLUMN_BLOCK)
             {
-                multiply_generic_column_block<LARGE_COLUMN_BLOCK>(
+                multiply_naive_column_block<LARGE_COLUMN_BLOCK>(
                     m_output_data + output_row_base + column,
                     lhs,
                     m_rhs_data + rhs_base + column * m_plan.rhs_column_stride());
             }
             if (column + SMALL_COLUMN_BLOCK <= m_plan.columns())
             {
-                multiply_generic_column_block<SMALL_COLUMN_BLOCK>(
+                multiply_naive_column_block<SMALL_COLUMN_BLOCK>(
                     m_output_data + output_row_base + column,
                     lhs,
                     m_rhs_data + rhs_base + column * m_plan.rhs_column_stride());

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -11,6 +11,7 @@
 
 #include <cctype>
 #include <cstdint>
+#include <string>
 
 namespace solvcon
 {
@@ -26,6 +27,17 @@ namespace detail
 inline char lower_ascii(char ch)
 {
     return static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+}
+
+inline solvcon::detail::MatmulKernel parse_matmul_kernel(pybind11::object const & kernel)
+{
+    auto const name = kernel.cast<std::string>();
+    auto const parsed = solvcon::detail::matmul_kernel_from_name(name);
+    if (!parsed)
+    {
+        throw std::invalid_argument(std::format("matmul(): unknown kernel '{}'", name));
+    }
+    return parsed.value();
 }
 
 } /* end namespace detail */
@@ -428,8 +440,24 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
         }
 
         (*this)
-            .def("matmul", &wrapped_type::matmul)
-            .def("__matmul__", &wrapped_type::matmul)
+            .def(
+                "matmul",
+                [](wrapped_type const & self,
+                   wrapped_type const & other,
+                   py::object const & kernel)
+                {
+                    return kernel.is_none()
+                               ? self.matmul(other)
+                               : self.matmul(other, detail::parse_matmul_kernel(kernel));
+                },
+                py::arg("other"),
+                py::kw_only(),
+                py::arg("kernel") = py::none())
+            .def(
+                "__matmul__",
+                [](wrapped_type const & self, wrapped_type const & other)
+                { return self.matmul(other); },
+                py::arg("other"))
             // TODO: In-place operation should return reference to self to support function chaining
             /*
              * Regular in-place methods (iadd, imul, etc.) are procedural calls and do

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -107,14 +107,44 @@ class MatmulTestBase(sc.testing.TestBase):
             ('step_two', cls.make_strided_view(data, axis, 2)),
         )
 
-    def assert_matmul(self, lhs, rhs, expected):
-        result = lhs.matmul(rhs)
+    def assert_matmul(
+            self, lhs, rhs, expected, forced_kernels=()):
+        for kernel in (None, 'naive', *forced_kernels):
+            dispatch = kernel or 'auto'
+            with self.subTest(dispatch=dispatch):
+                try:
+                    result = lhs.matmul(rhs, kernel=kernel)
+                except ValueError as exc:
+                    if (kernel not in (None, 'naive')
+                            and 'requires a BLAS backend' in str(exc)):
+                        continue
+                    raise
 
-        self.assertEqual(list(result.shape), list(expected.shape))
-        tol = 64 * np.finfo(result.ndarray.real.dtype).eps
-        np.testing.assert_allclose(
-            result.ndarray, expected, rtol=tol, atol=tol)
-        return result
+                self.assertEqual(list(result.shape), list(expected.shape))
+                tol = 64 * np.finfo(result.ndarray.real.dtype).eps
+                if kernel is not None:
+                    tol *= 2 * max(lhs.shape[-1], 1)
+                np.testing.assert_allclose(
+                    result.ndarray, expected, rtol=tol, atol=tol)
+
+    def test_matmul_kernel_validation(self):
+        dtype = np.dtype(self.dtype).name
+        lhs = self.SimpleArray(
+            array=np.ones((3, 3), dtype=dtype))
+        rhs = self.SimpleArray(
+            array=np.ones((3, 3), dtype=dtype))
+
+        with self.assertRaisesRegex(ValueError, "unknown kernel 'unknown'"):
+            lhs.matmul(rhs, kernel='unknown')
+        with self.assertRaisesRegex(
+                ValueError,
+                "kernel 'winograd'.*(not eligible|requires a BLAS backend)"):
+            lhs.matmul(rhs, kernel='winograd')
+        with self.assertRaises(TypeError):
+            lhs.matmul(rhs, 'naive')
+        np.testing.assert_array_equal(
+            lhs.matmul(rhs, kernel=None).ndarray,
+            lhs.matmul(rhs).ndarray)
 
     def test_square(self):
         """Test basic square matrix multiplication"""
@@ -128,7 +158,9 @@ class MatmulTestBase(sc.testing.TestBase):
         # Expected result: [[19, 22], [43, 50]]
         expected = np.array([[19.0, 22.0], [43.0, 50.0]], dtype=self.dtype)
 
-        self.assert_matmul(a, b, expected)
+        self.assert_matmul(
+            a, b, expected,
+            forced_kernels=('blas_gemm', 'winograd'))
 
     def test_rectangular(self):
         """Test rectangular matrix multiplication"""
@@ -271,15 +303,22 @@ class MatmulTestBase(sc.testing.TestBase):
         expected_6 = np.array([32.], dtype=self.dtype)
 
         test_cases = [
-            (a_data_1, b_data_1, expected_1, "2x3 x 3x4"),
-            (a_data_2, b_data_2, expected_2, "4x6 x 6x3"),
-            (a_data_3, b_data_3, expected_3, "3x3 x 3x3"),
-            (a_data_4, b_data_4, expected_4, "4x6 x 6"),
-            (a_data_5, b_data_5, expected_5, "6 x 6x3"),
-            (a_data_6, b_data_6, expected_6, "3 x 3x3")
+            (a_data_1, b_data_1, expected_1,
+             ('blas_gemm',), "2x3 x 3x4"),
+            (a_data_2, b_data_2, expected_2,
+             ('blas_gemm',), "4x6 x 6x3"),
+            (a_data_3, b_data_3, expected_3,
+             ('blas_gemm',), "3x3 x 3x3"),
+            (a_data_4, b_data_4, expected_4,
+             ('blas_gemv',), "4x6 x 6"),
+            (a_data_5, b_data_5, expected_5,
+             ('blas_gevm',), "6 x 6x4"),
+            (a_data_6, b_data_6, expected_6,
+             ('blas_dot',), "3 x 3"),
         ]
 
-        for a_data, b_data, expected, description in test_cases:
+        for (a_data, b_data, expected,
+             forced_kernels, description) in test_cases:
             with self.subTest(description=description):
                 a = self.SimpleArray(array=a_data)
                 b = self.SimpleArray(array=b_data)
@@ -288,10 +327,12 @@ class MatmulTestBase(sc.testing.TestBase):
                 np_result = np.matmul(a_data, b_data)
                 np.testing.assert_array_almost_equal(expected, np_result)
 
-                self.assert_matmul(a, b, expected)
+                self.assert_matmul(
+                    a, b, expected,
+                    forced_kernels=forced_kernels)
 
     def test_matrix_strides(self):
-        """Matrix axes support generic and BLAS-compatible layouts."""
+        """Matrix axes support naive and BLAS-compatible layouts."""
         dtype = np.dtype(self.dtype).name
         for m, k, n in ((3, 4, 2), (16, 17, 18)):
             lhs_data = np.arange(m * k, dtype=dtype).reshape(m, k)
@@ -306,7 +347,9 @@ class MatmulTestBase(sc.testing.TestBase):
 
                 with self.subTest(
                         shape=(m, k, n), lhs=lhs_case, rhs=rhs_case):
-                    self.assert_matmul(lhs, rhs, expected)
+                    self.assert_matmul(
+                        lhs, rhs, expected,
+                        forced_kernels=('blas_gemm',))
 
     def test_batch_strides(self):
         """Batch axes support negative and step-two strides."""
@@ -330,10 +373,12 @@ class MatmulTestBase(sc.testing.TestBase):
 
                 with self.subTest(
                         shape=lhs_shape, lhs=lhs_case, rhs=rhs_case):
-                    self.assert_matmul(lhs, rhs, expected)
+                    self.assert_matmul(
+                        lhs, rhs, expected,
+                        forced_kernels=('blas_gemm',))
 
     def test_broadcast_batch_strides(self):
-        """Broadcast batch strides across generic and direct BLAS routes."""
+        """Broadcast batch strides across naive and direct BLAS routes."""
         dtype = np.dtype(self.dtype).name
         for m, k, n in ((3, 4, 2), (17, 18, 19)):
             lhs_data = np.arange(2 * m * k, dtype=dtype).reshape(2, 1, m, k)
@@ -353,7 +398,7 @@ class MatmulTestBase(sc.testing.TestBase):
                     self.assert_matmul(lhs, rhs, expected)
 
     def test_broadcast_matrix_strides(self):
-        """Broadcast matrix strides work across generic and packed routes."""
+        """Broadcast matrix strides work across naive and packed routes."""
         dtype = np.dtype(self.dtype).name
         for m, k, n in ((3, 4, 2), (17, 18, 19)):
             lhs_data = np.arange(2 * m * k, dtype=dtype).reshape(
@@ -415,7 +460,9 @@ class MatmulTestBase(sc.testing.TestBase):
             expected = np.matmul(case_lhs, case_rhs)
 
             with self.subTest(case=name):
-                self.assert_matmul(lhs, rhs, expected)
+                self.assert_matmul(
+                    lhs, rhs, expected,
+                    forced_kernels=('blas_gemm',))
 
     def test_vector_strides(self):
         """Vector roles preserve signed vector, matrix, and batch strides."""
@@ -451,7 +498,9 @@ class MatmulTestBase(sc.testing.TestBase):
 
                 with self.subTest(
                         role=role, lhs=lhs_case, rhs=rhs_case):
-                    self.assert_matmul(lhs, rhs, expected)
+                    self.assert_matmul(
+                        lhs, rhs, expected,
+                        forced_kernels=(f'blas_{role}',))
 
         lhs_matrix = np.arange(64 * 512, dtype=dtype).reshape(64, 512)
         rhs_matrix = np.arange(512 * 64, dtype=dtype).reshape(512, 64)
@@ -583,12 +632,12 @@ class MatmulTestBase(sc.testing.TestBase):
             rhs_data = vectors[rhs_case]
             lhs = self.SimpleArray(array=lhs_data)
             rhs = self.SimpleArray(array=rhs_data)
-            expected = np.matmul(lhs_data, rhs_data)
+            expected = np.atleast_1d(np.matmul(lhs_data, rhs_data))
 
             with self.subTest(lhs=lhs_case, rhs=rhs_case):
-                result = lhs.matmul(rhs)
-                self.assertEqual((1,), result.shape)
-                np.testing.assert_allclose(result.ndarray[0], expected)
+                self.assert_matmul(
+                    lhs, rhs, expected,
+                    forced_kernels=('blas_dot',))
 
     def test_wrong_shape_error(self):
         """Every operand role reports mismatched contraction dimensions."""


### PR DESCRIPTION
`SimpleArray::matmul()` currently exposes only automatic selection, so benchmark work cannot compare a chosen kernel for the same operands. This change adds a keyword-only `kernel` argument directly to `matmul()`, while preserving automatic selection when the argument is omitted and for the `@` operator.

The Python boundary accepts kernel names as strings, while the C++ implementation uses `MatmulKernel` and rejects unknown or ineligible choices before allocating the output. Tests live with the existing matrix suite and cover float and complex dtypes, vector and matrix roles, strided and batched inputs, empty contractions, and keyword validation.

Related to #1369.