### PR TITLE
Move nightly CI jobs into nightly- workflows

### DIFF
--- a/.github/workflows/check_skip_ci.yml
+++ b/.github/workflows/check_skip_ci.yml
@@ -19,7 +19,7 @@ name: check_skip_ci
 # request activity types in addition to the defaults.
 #
 # The "skip" output is "true" only for pull_request events; it is empty for
-# push and schedule events, which keeps their existing gating untouched.
+# push events, which keeps their existing gating untouched.
 
 on:
   workflow_call:

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -4,8 +4,6 @@ on:
   push:
   pull_request:
     types: [opened, reopened, synchronize]
-  schedule:
-    - cron: '34 17 * * *'
 
 concurrency:
   # Key each master push on its commit SHA so every merge lands in its own
@@ -21,9 +19,6 @@ concurrency:
 jobs:
 
   check_skip:
-    # A fork inherits no SCGH_NIGHTLY, so this gate stops the nightly cron
-    # from allocating a runner there.
-    if: github.event_name != 'schedule' || (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'
     uses: ./.github/workflows/check_skip_ci.yml
     permissions:
       contents: read
@@ -39,8 +34,7 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
        ((vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH) == '*' ||
-        contains(vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
-      (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'))
+        contains(vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))))
 
     name: standalone_buffer_${{ matrix.os }}
 
@@ -84,9 +78,8 @@ jobs:
           create-symlink: true
           save: ${{ github.event_name != 'pull_request' }}
           # Bound the cache so it does not grow without limit across the rolling
-          # key. A master push or nightly run saves this cache; pull requests
-          # restore it (a PR on a non-default base branch cannot, so it runs
-          # cold).
+          # key. A master push saves this cache; pull requests restore it (a PR
+          # on a non-default base branch cannot, so it runs cold).
           max-size: 500M
 
       - name: make standalone_buffer
@@ -107,9 +100,7 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
        ((vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH) == '*' ||
-        contains(vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
-      (github.event_name == 'schedule' &&
-      (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'))
+        contains(vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))))
 
     name: build_${{ matrix.os }}_${{ matrix.cmake_build_type }}
 
@@ -184,9 +175,8 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ matrix.cmake_build_type }}
         save: ${{ github.event_name != 'pull_request' }}
         # Bound the cache so it does not grow without limit across the rolling
-        # key. A master push or nightly run saves this cache; pull requests
-        # restore it (a PR on a non-default base branch cannot, so it runs
-        # cold).
+        # key. A master push saves this cache; pull requests restore it (a PR
+        # on a non-default base branch cannot, so it runs cold).
         max-size: 1500M
 
     - name: make gtest BUILD_QT=OFF
@@ -251,9 +241,9 @@ jobs:
           JOB_MAKE_ARGS="${JOB_MAKE_ARGS} BUILD_METAL=ON" ; \
         fi
         # A pull request skips tests/gui here, because run_pilot_pytest below
-        # runs it seconds later in the pilot binary. A push and the nightly
-        # schedule run the whole suite in both Qt hosts. SOLVCON_TEST_SHOW_WINDOWS
-        # is left at the default either way, so any window stays off the screen.
+        # runs it seconds later in the pilot binary. A push runs the whole
+        # suite in both Qt hosts. SOLVCON_TEST_SHOW_WINDOWS is left at the
+        # default either way, so any window stays off the screen.
         make ${{ github.event_name == 'pull_request' && 'pytest-fast' || 'pytest' }} ${JOB_MAKE_ARGS}
         echo "::endgroup::"
 
@@ -287,16 +277,17 @@ jobs:
     needs: [check_skip, standalone_buffer]
 
     # cpp != 'false' keeps the expensive Windows build off pull requests that
-    # touch no C++ or build files (it is empty, so truthy, for push/schedule).
+    # touch no C++ or build files (it is empty, so truthy, for a push).
+    # The cron is absent here on purpose. nightly-build_windows.yml builds
+    # Windows in Release and Debug, and packages the portable artifact from
+    # the Release tree.
     if: |
       needs.check_skip.outputs.skip != 'true' &&
       needs.check_skip.outputs.cpp != 'false' && (
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
        ((vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH) == '*' ||
-        contains(vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
-      (github.event_name == 'schedule' &&
-      (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'))
+        contains(vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))))
 
     name: build_${{ matrix.os }}_${{ matrix.cmake_build_type }}
 
@@ -318,11 +309,10 @@ jobs:
     strategy:
       matrix:
         os: [windows-2022]
-        # Release runs on every pull request and master push. Debug is the
-        # only Windows Debug compile (lint.yml has no Windows job), but it is
-        # heavy and rarely breaks on its own, so it runs on the nightly
-        # schedule only.
-        cmake_build_type: ${{ (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable' && fromJSON('["Release", "Debug"]')) || fromJSON('["Release"]') }}
+        # Release runs on every pull request and master push. Debug is heavy
+        # and rarely breaks on its own, so nightly-build_windows.yml carries
+        # it instead.
+        cmake_build_type: [Release]
 
       fail-fast: false
 
@@ -372,9 +362,9 @@ jobs:
           restore-keys: ${{ runner.os }}-sccache-${{ matrix.cmake_build_type }}
           save: ${{ github.event_name != 'pull_request' }}
           # Bound the cache so it does not grow without limit across the rolling
-          # key. A master push or nightly run saves this cache; pull requests
-          # restore it (a PR on a non-default base branch cannot, so it runs
-          # cold).
+          # key. A master push here and the nightly Release leg both save under
+          # this key; pull requests restore it (a PR on a non-default base
+          # branch cannot, so it runs cold).
           max-size: 500M
 
       - name: install Intel MKL (vendor BLAS/LAPACK)
@@ -435,289 +425,11 @@ jobs:
       - name: cmake workflow
         run: |
           echo "::group::cmake workflow"
-          # The ci-win-* presets in CMakePresets.json state the whole
+          # The ci-win-rel preset in CMakePresets.json states the whole
           # configure.
           $env:PYBIND11_DIR = "$(pybind11-config --cmakedir)"
           # A runner has no desktop to take over, so let this job map its
           # windows, the way it has always run them.
           $env:SOLVCON_TEST_SHOW_WINDOWS = "ON"
-          $preset = if ('${{ matrix.cmake_build_type }}' -eq 'Debug') {
-            'ci-win-dbg'
-          } else {
-            'ci-win-rel'
-          }
-          cmake --workflow --preset $preset
+          cmake --workflow --preset ci-win-rel
           echo "::endgroup::"
-
-      - name: generate portable
-        if: ${{ matrix.cmake_build_type == 'Release' && github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable' }}
-        run: |
-          echo "::group::generate portable"
-          # Get the Python version installed and extract the major+minor version components
-          $py_ver=$(python3 -V | awk '{print $2}')
-          $py_main_ver=$(echo $py_ver | awk -F. '{print $1$2}')
-          $destination=".\solvcon-pilot-win64\solvcon-pilot-win64"
-          $py_exec="$destination\python.exe"
-
-          # Create the destination directory
-          New-Item -ItemType Directory -Path $destination
-
-          # Download and extract the Python embeddable package
-          $pyembed_url="https://www.python.org/ftp/python/$py_ver/python-$py_ver-embed-amd64.zip"
-          $pyembed_dl="python-$py_ver-embed-amd64.zip"
-          Invoke-WebRequest -Uri $pyembed_url -OutFile $pyembed_dl
-          Expand-Archive -Path $pyembed_dl -DestinationPath $destination
-
-          # Patch the .pth file to enable 'site' package (required for using pip)
-          $pth_file="$destination\python$py_main_ver._pth"
-          (Get-Content $pth_file) -replace '#import site', 'import site' | Set-Content $pth_file
-
-          # Download and setup pip installation script
-          $get_pip_url="https://bootstrap.pypa.io/get-pip.py"
-          $get_pip_script="$destination\get-pip.py"
-          Invoke-WebRequest -Uri $get_pip_url -OutFile $get_pip_script
-          & $py_exec $get_pip_script
-
-          # Install necessary packages for the pilot
-          $qt_ver=$(qmake -query QT_VERSION)
-          & $py_exec -m pip install numpy matplotlib PySide6==$qt_ver shiboken6-generator==$qt_ver
-
-          # Copy pyside6 and shiboken6 DLLs alongside the pilot executable
-          $pyside6_path=$(& $py_exec -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))")
-          $shiboken6_path=$(& $py_exec -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
-          copy "$pyside6_path\pyside6.abi3.dll" $destination
-          copy "$shiboken6_path\shiboken6.abi3.dll" $destination
-          # Remove redundant Qt DLLs from PySide6
-          Remove-Item -Path $pyside6_path\Qt*.dll
-
-          # The workflow preset above already configured and built this tree
-          # with the Ninja single-config generator, so rebuild the pilot in
-          # place and read pilot.exe from the runtime output directory the
-          # preset names.
-          cmake --build --preset ci-win-rel --target pilot
-
-          # Deploy the Qt environment for the pilot executable and copy necessary files
-          Copy-Item -Path ".\build\ci-win-rel\pilot.exe" -Destination $destination
-          windeployqt --release "$destination\pilot.exe"
-          Copy-Item -Path ".\solvcon" -Destination $destination -Recurse
-          # Also include potential thirdparty
-          Copy-Item -Path ".\thirdparty" -Destination $destination -Recurse
-          echo "::endgroup::"
-
-      - name: archive portable artifacts
-        if: ${{ matrix.cmake_build_type == 'Release' && github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: solvcon-pilot-win64
-          path: solvcon-pilot-win64/
-
-  sanitizer:
-
-    needs: [check_skip]
-
-    # A genuine -DUSE_SANITIZER=ON ASAN/UBSAN build. It is slow, so it runs on
-    # the nightly schedule only (set SCGH_FORCE_SANITIZER to 'enable' to force
-    # it on a fork). This restores the real sanitizer coverage that the build
-    # job used to stub out by configuring -DUSE_SANITIZER=OFF.
-    if: |
-      needs.check_skip.outputs.skip != 'true' && (
-      (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable') ||
-      (vars.SCGH_FORCE_SANITIZER || vars.MMGH_FORCE_SANITIZER) == 'enable')
-
-    name: sanitizer_${{ matrix.os }}
-
-    runs-on: ${{ matrix.os }}
-
-    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_BUILD || vars.MMGH_TIMEOUT_BUILD || '45') }}
-
-    env:
-      MAKE_PARALLEL: -j2
-      PIP_BREAK_SYSTEM_PACKAGES: 1
-
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-        # Sanitizer reports name a file and a line only when the binary
-        # carries debug symbols, so this job builds RelWithDebInfo.
-        cmake_build_type: [RelWithDebInfo]
-
-      fail-fast: false
-
-    steps:
-
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 1
-
-    - name: event name
-      run: |
-        echo "github.event_name: ${{ github.event_name }}"
-
-    - name: setup dependencies for Linux
-      uses: ./.github/actions/setup_linux
-      with:
-        workflow: 'build'
-
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.23
-      with:
-        key: ${{ runner.os }}-sanitizer-${{ matrix.cmake_build_type }}
-        restore-keys: ${{ runner.os }}-sanitizer-${{ matrix.cmake_build_type }}
-        save: ${{ github.event_name != 'pull_request' }}
-        max-size: 1500M
-
-    - name: make gtest USE_SANITIZER=ON
-      run: |
-        echo "::group::make gtest USE_SANITIZER=ON"
-        # Run ASAN/UBSAN over the C++ gtest binary rather than pytest. The
-        # gtest executable is linked directly against the sanitizer runtime,
-        # so ASan initializes first and intercepts every allocation.
-        make gtest \
-          VERBOSE=1 USE_CLANG_TIDY=OFF \
-          BUILD_QT=OFF \
-          CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_SANITIZER=ON"
-        echo "::endgroup::"
-
-  sanitizer_windows:
-
-    needs: [check_skip]
-
-    # The MSVC counterpart of the sanitizer job. MSVC ships only
-    # AddressSanitizer. The gtest binary and pilot.exe both link the ASan
-    # runtime directly, so it starts with the process and instruments the C++
-    # core and the Qt pilot. Slow, so nightly-only (set SCGH_FORCE_SANITIZER to
-    # force it on a fork).
-    if: |
-      needs.check_skip.outputs.skip != 'true' && (
-      (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable') ||
-      (vars.SCGH_FORCE_SANITIZER || vars.MMGH_FORCE_SANITIZER) == 'enable')
-
-    name: sanitizer_${{ matrix.os }}
-
-    runs-on: ${{ matrix.os }}
-
-    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_BUILD || vars.MMGH_TIMEOUT_BUILD || '60') }}
-
-    env:
-      AQT_CONFIG: "thirdparty/aqt_settings.ini"
-      QSG_RHI_PREFER_SOFTWARE_RENDERER: "1"
-      QSG_INFO: "1"
-      # Hook the RTL allocators so the uninstrumented Qt and PySide6 DLLs share
-      # ASan's heap (else a cross-module free reads as a false mismatch).
-      ASAN_OPTIONS: "windows_hook_rtl_allocators=1:abort_on_error=1:detect_leaks=0"
-
-    strategy:
-      matrix:
-        # No build type here: this job configures through the ci-win-asan
-        # preset, which states its own.
-        os: [windows-2022]
-
-      fail-fast: false
-
-    steps:
-
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 1
-
-    - name: event name
-      run: |
-        echo "github.event_name: ${{ github.event_name }}"
-
-    - uses: TheMrMilchmann/setup-msvc-dev@v4
-      with:
-        arch: 'x64'
-
-    # CMake in the windows-2022 image is 3.31.6; solvcon needs >= 4.0.1.
-    - name: install CMake>4.0.1
-      uses: lukka/get-cmake@latest
-
-    - name: install qt
-      uses: jurplel/install-qt-action@v4
-      with:
-        # aqtinstall 3.3.0 cannot resolve Qt 6.11's new split Windows
-        # desktop repository, so Windows stays on 6.10.3 while Linux and
-        # macOS run 6.11.1.
-        # Ref: https://github.com/miurahr/aqtinstall/issues/1007
-        version: '6.10.3'
-        host: 'windows'
-        target: 'desktop'
-        arch: 'win64_msvc2022_64'
-        modules: 'qtshadertools'
-        cache: true
-
-    - uses: actions/setup-python@v6
-      with:
-        python-version: '3.12'
-
-    - name: Cache vcpkg (install artifacts)
-      uses: actions/cache@v4
-      with:
-        path: |
-          C:\vcpkg\installed
-          C:\vcpkg\downloads
-          C:\vcpkg\buildtrees
-          C:\vcpkg\packages
-        key: vcpkg-${{ runner.os }}-openblas-lapack
-        restore-keys: vcpkg-${{ runner.os }}-
-
-    - name: install BLAS and LAPACK
-      run: |
-        echo "::group::install BLAS and LAPACK"
-        vcpkg install openblas:x64-windows lapack:x64-windows
-        $vcpkg_bin_path = @(
-          "C:\vcpkg\installed\x64-windows\bin",
-          "C:\vcpkg\installed\x64-windows\debug\bin"
-        ) -join ";"
-        echo "$vcpkg_bin_path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "::endgroup::"
-
-    - name: dependency by pip
-      run: |
-        echo "::group::dependency by pip"
-        pip3 install -U numpy pytest pybind11
-        # For pilot GUI.
-        pip3 install -U matplotlib jsonschema flake8 pyside6==$(qmake -query QT_VERSION)
-        $pyside6_path = $(python3 -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))")
-        $shiboken6_path = $(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
-        echo "$pyside6_path;$shiboken6_path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "::endgroup::"
-
-    - name: cmake workflow USE_SANITIZER=ON
-      run: |
-        echo "::group::cmake workflow USE_SANITIZER=ON"
-        # The ci-win-asan preset instruments both the gtest binary and the Qt
-        # pilot: BUILD_QT and USE_GOOGLETEST build both, USE_SANITIZER adds
-        # /fsanitize=address, and the vcpkg toolchain supplies BLAS and LAPACK.
-        # The MSVC toolset bin dir that setup-msvc-dev puts on PATH also carries
-        # the ASan runtime DLL the instrumented binaries load at start.
-        $env:PYBIND11_DIR = "$(pybind11-config --cmakedir)"
-        # A runner has no desktop to take over, so let this job map its
-        # windows, the way it has always run them.
-        $env:SOLVCON_TEST_SHOW_WINDOWS = "ON"
-        cmake --workflow --preset ci-win-asan
-        echo "::endgroup::"
-
-
-  send_email_on_failure:
-    needs: [standalone_buffer, build, build_windows, sanitizer, sanitizer_windows]
-    # Run if any of the dependencies failed in master branch. A
-    # `timeout-minutes` kill reports `cancelled`, not `failure`.
-    if: |
-      always() &&
-      (contains(needs.*.result, 'failure') ||
-       contains(needs.*.result, 'cancelled')) &&
-      github.ref_name == 'master' &&
-      github.event.repository.fork == false
-    uses: ./.github/workflows/send_email_on_fail.yml
-    with:
-      job_results: |
-        - standalone_buffer: ${{ needs.standalone_buffer.result }}
-        - build: ${{ needs.build.result }}
-        - build_windows: ${{ needs.build_windows.result }}
-        - sanitizer: ${{ needs.sanitizer.result }}
-        - sanitizer_windows: ${{ needs.sanitizer_windows.result }}
-    secrets:
-      EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
-      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,8 +4,6 @@ on:
   push:
   pull_request:
     types: [opened, reopened, synchronize]
-  schedule:
-    - cron: '34 17 * * *'
 
 concurrency:
   # Key each master push on its commit SHA so every merge lands in its own
@@ -21,9 +19,6 @@ concurrency:
 jobs:
 
   check_skip:
-    # A fork inherits no SCGH_NIGHTLY, so this gate stops the nightly cron
-    # from allocating a runner there.
-    if: github.event_name != 'schedule' || (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'
     uses: ./.github/workflows/check_skip_ci.yml
     permissions:
       contents: read
@@ -41,8 +36,7 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
        ((vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH) == '*' ||
-        contains(vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
-      (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'))
+        contains(vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))))
 
     runs-on: ${{ matrix.os }}
 
@@ -97,10 +91,10 @@ jobs:
       with:
         workflow: 'lint'
 
-    # Only a push or a nightly run reaches this cache. A pull request builds
-    # no pilot and runs pilot_clang_tidy_diff instead, which drives clang-tidy
-    # and never the compiler, so it compiles nothing and would pull close to a
-    # gigabyte down for no hit at all.
+    # Only a push reaches this cache. A pull request builds no pilot and runs
+    # pilot_clang_tidy_diff instead, which drives clang-tidy and never the
+    # compiler, so it compiles nothing and would pull close to a gigabyte down
+    # for no hit at all.
     - name: ccache
       if: github.event_name != 'pull_request'
       uses: hendrikmuhs/ccache-action@v1.2.23
@@ -189,21 +183,3 @@ jobs:
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON" \
           SOLVCON_DIFF_BASE=${{ github.event.pull_request.base.sha }}
-
-  send_email_on_failure:
-    needs: [lint]
-    # Run if any of the dependencies failed in master branch. A
-    # `timeout-minutes` kill reports `cancelled`, not `failure`.
-    if: |
-      always() &&
-      (contains(needs.*.result, 'failure') ||
-       contains(needs.*.result, 'cancelled')) &&
-      github.ref_name == 'master' &&
-      github.event.repository.fork == false
-    uses: ./.github/workflows/send_email_on_fail.yml
-    with:
-      job_results: |
-        - lint: ${{ needs.lint.result }}
-    secrets:
-      EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
-      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/.github/workflows/nightly-build_windows.yml
+++ b/.github/workflows/nightly-build_windows.yml
@@ -1,0 +1,255 @@
+name: nightly-build_windows
+
+on:
+  schedule:
+    - cron: '34 17 * * *'
+  # No SCGH_FORCE_* variable reaches this workflow, so a manual run is the
+  # only way to exercise the Debug build or rebuild the portable artifact.
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-build-windows
+  cancel-in-progress: false
+
+jobs:
+
+  build_windows:
+
+    # devbuild builds Windows Release on a pull request and a master push.
+    # Release repeats here because the portable artifact needs a Release tree
+    # to package; Debug is the only Windows Debug compile anywhere.
+    #
+    # In devbuild this job waited on the standalone_buffer smoke compile. A
+    # cron cannot name a job in another workflow, so that gate is gone.
+    #
+    # A fork inherits no SCGH_NIGHTLY, so this gate stops the nightly cron
+    # from allocating a runner there. A manual run is deliberate and needs
+    # no variable.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'
+
+    name: build_${{ matrix.os }}_${{ matrix.cmake_build_type }}
+
+    runs-on: ${{ matrix.os }}
+
+    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_BUILD || vars.MMGH_TIMEOUT_BUILD || '60') }}
+
+    env:
+      QT_DEBUG_PLUGINS: 1
+      # Fix issue: https://github.com/solvcon/solvcon/issues/366
+      # Use custom config for jurplel/install-qt-action@v4
+      AQT_CONFIG: "thirdparty/aqt_settings.ini"
+      # The GPU-less Windows runner has no display; steer the QRhi D3D11
+      # backend to the WARP software rasterizer so the pilot's QRhiWidget can
+      # render offscreen. QSG_INFO surfaces the chosen adapter in the log.
+      QSG_RHI_PREFER_SOFTWARE_RENDERER: "1"
+      QSG_INFO: "1"
+
+    strategy:
+      matrix:
+        os: [windows-2022]
+        cmake_build_type: [Release, Debug]
+
+      fail-fast: false
+
+    steps:
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: event name
+        run: |
+          echo "github.event_name: ${{ github.event_name }}"
+
+      - uses: TheMrMilchmann/setup-msvc-dev@v4
+        with:
+          arch: 'x64'
+
+      # CMake version in windows-2022 runner-image is 3.31.6, so we install CMake>=4.0.1 from github marketplace.
+      # Reference: https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
+      - name: install CMake>4.0.1
+        uses: lukka/get-cmake@latest
+
+      - name: install qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          # aqtinstall 3.3.0 cannot resolve Qt 6.11's new split Windows
+          # desktop repository, so Windows stays on 6.10.3 while Linux and
+          # macOS run 6.11.1.
+          # Ref: https://github.com/miurahr/aqtinstall/issues/1007
+          version: '6.10.3'
+          host: 'windows'
+          target: 'desktop'
+          arch: 'win64_msvc2022_64'
+          # qtshadertools provides qsb and the ShaderTools CMake package for QRhi.
+          modules: 'qtshadertools'
+          cache: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: sccache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          variant: sccache
+          key: ${{ runner.os }}-sccache-${{ matrix.cmake_build_type }}
+          restore-keys: ${{ runner.os }}-sccache-${{ matrix.cmake_build_type }}
+          # Bound the cache so it does not grow without limit across the rolling
+          # key. This run saves both build types. devbuild shares the Release
+          # key on a master push and restores it on a pull request; nothing
+          # else writes the Debug key.
+          max-size: 500M
+
+      - name: install Intel MKL (vendor BLAS/LAPACK)
+        run: |
+          echo "::group::install Intel MKL"
+          # Pre-built vendor BLAS/LAPACK from Intel's official wheels, the same
+          # source build-scdv-windows.ps1 uses for SCDV_WIN_BLAS=mkl.
+          pip install mkl mkl-devel mkl-include intel-openmp
+          $prefix = python -c "import sys; sys.stdout.write(sys.prefix)"
+          # Locate the wheel-installed pieces by name (the layout varies across
+          # wheel versions) and hand CMake their dirs so find_path(mkl_cblas.h)
+          # and find_library(mkl_rt) succeed.
+          $mkl = Get-ChildItem -LiteralPath $prefix -Recurse -File -Include 'mkl_cblas.h', 'mkl_rt.lib', 'mkl_rt*.dll'
+          $hdr = $mkl | Where-Object Name -EQ 'mkl_cblas.h' | Select-Object -First 1
+          $lib = $mkl | Where-Object Name -EQ 'mkl_rt.lib' | Select-Object -First 1
+          $dll = $mkl | Where-Object Name -Like 'mkl_rt*.dll' | Select-Object -First 1
+          if (-not ($hdr -and $lib -and $dll)) {
+            throw "MKL pieces not found (hdr=$hdr lib=$lib dll=$dll)"
+          }
+          echo "MKL_INCLUDE_DIR=$($hdr.DirectoryName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "MKL_LIBRARY_DIR=$($lib.DirectoryName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          # mkl_rt loads the mkl_* kernels and libiomp5md at runtime; put their
+          # dir on PATH so the test executables find them.
+          echo "$($dll.DirectoryName)" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "::endgroup::"
+
+      - name: dependency by pip
+        run: |
+          echo "::group::dependency by pip"
+          pip3 install -U numpy matplotlib pytest jsonschema flake8 pybind11 pyside6==$(qmake -query QT_VERSION)
+          # Add PySide6 and Shiboken6 path into system path, that allow exe file can find
+          # dll during runtime
+          # If user needs to modified system path in github actions container
+          # user should use GITHUB_PATH
+          # ref: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+          # But the way of update GITHUB_PATH in github action document does not work, there is a other way to update it.
+          # ref: https://stackoverflow.com/questions/60169752/how-to-update-the-path-in-a-github-action-workflow-file-for-a-windows-latest-hos
+          $pyside6_path = $(python3 -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))")
+          $shiboken6_path = $(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
+          echo "$pyside6_path;$shiboken6_path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "::endgroup::"
+
+      - name: show dependency
+        run: |
+          echo "::group::show dependency"
+          Get-Command cl
+          Get-Command cmake
+          Get-Command python3
+          Get-Command pip3
+          python3 -c 'import numpy as np; print("np.__version__:", np.__version__, np.get_include())'
+          python3 -c "import pybind11 ; print('pybind11.__version__:', pybind11.__version__)"
+          pybind11-config --cmakedir
+          Get-Command pytest
+          Get-Command clang-tidy
+          Get-Command flake8
+          echo "::endgroup::"
+
+      - name: cmake workflow
+        run: |
+          echo "::group::cmake workflow"
+          # The ci-win-* presets in CMakePresets.json state the whole
+          # configure.
+          $env:PYBIND11_DIR = "$(pybind11-config --cmakedir)"
+          # A runner has no desktop to take over, so let this job map its
+          # windows, the way it has always run them.
+          $env:SOLVCON_TEST_SHOW_WINDOWS = "ON"
+          $preset = if ('${{ matrix.cmake_build_type }}' -eq 'Debug') {
+            'ci-win-dbg'
+          } else {
+            'ci-win-rel'
+          }
+          cmake --workflow --preset $preset
+          echo "::endgroup::"
+
+      - name: generate portable
+        if: ${{ matrix.cmake_build_type == 'Release' }}
+        run: |
+          echo "::group::generate portable"
+          # Get the Python version installed and extract the major+minor version components
+          $py_ver=$(python3 -V | awk '{print $2}')
+          $py_main_ver=$(echo $py_ver | awk -F. '{print $1$2}')
+          $destination=".\solvcon-pilot-win64\solvcon-pilot-win64"
+          $py_exec="$destination\python.exe"
+
+          # Create the destination directory
+          New-Item -ItemType Directory -Path $destination
+
+          # Download and extract the Python embeddable package
+          $pyembed_url="https://www.python.org/ftp/python/$py_ver/python-$py_ver-embed-amd64.zip"
+          $pyembed_dl="python-$py_ver-embed-amd64.zip"
+          Invoke-WebRequest -Uri $pyembed_url -OutFile $pyembed_dl
+          Expand-Archive -Path $pyembed_dl -DestinationPath $destination
+
+          # Patch the .pth file to enable 'site' package (required for using pip)
+          $pth_file="$destination\python$py_main_ver._pth"
+          (Get-Content $pth_file) -replace '#import site', 'import site' | Set-Content $pth_file
+
+          # Download and setup pip installation script
+          $get_pip_url="https://bootstrap.pypa.io/get-pip.py"
+          $get_pip_script="$destination\get-pip.py"
+          Invoke-WebRequest -Uri $get_pip_url -OutFile $get_pip_script
+          & $py_exec $get_pip_script
+
+          # Install necessary packages for the pilot
+          $qt_ver=$(qmake -query QT_VERSION)
+          & $py_exec -m pip install numpy matplotlib PySide6==$qt_ver shiboken6-generator==$qt_ver
+
+          # Copy pyside6 and shiboken6 DLLs alongside the pilot executable
+          $pyside6_path=$(& $py_exec -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))")
+          $shiboken6_path=$(& $py_exec -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
+          copy "$pyside6_path\pyside6.abi3.dll" $destination
+          copy "$shiboken6_path\shiboken6.abi3.dll" $destination
+          # Remove redundant Qt DLLs from PySide6
+          Remove-Item -Path $pyside6_path\Qt*.dll
+
+          # The workflow preset above already configured and built this tree
+          # with the Ninja single-config generator, so rebuild the pilot in
+          # place and read pilot.exe from the runtime output directory the
+          # preset names.
+          cmake --build --preset ci-win-rel --target pilot
+
+          # Deploy the Qt environment for the pilot executable and copy necessary files
+          Copy-Item -Path ".\build\ci-win-rel\pilot.exe" -Destination $destination
+          windeployqt --release "$destination\pilot.exe"
+          Copy-Item -Path ".\solvcon" -Destination $destination -Recurse
+          # Also include potential thirdparty
+          Copy-Item -Path ".\thirdparty" -Destination $destination -Recurse
+          echo "::endgroup::"
+
+      - name: archive portable artifacts
+        if: ${{ matrix.cmake_build_type == 'Release' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: solvcon-pilot-win64
+          path: solvcon-pilot-win64/
+
+  send_email_on_failure:
+    needs: [build_windows]
+    # A `timeout-minutes` kill reports `cancelled`, not `failure`.
+    if: |
+      always() &&
+      (contains(needs.*.result, 'failure') ||
+       contains(needs.*.result, 'cancelled')) &&
+      github.event_name == 'schedule' &&
+      github.event.repository.fork == false
+    uses: ./.github/workflows/send_email_on_fail.yml
+    with:
+      job_results: |
+        - build_windows: ${{ needs.build_windows.result }}
+    secrets:
+      EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/.github/workflows/nightly-nouse_install.yml
+++ b/.github/workflows/nightly-nouse_install.yml
@@ -1,4 +1,4 @@
-name: nouse_install
+name: nightly-nouse_install
 
 on:
   push:
@@ -6,6 +6,7 @@ on:
     types: [opened, reopened, synchronize]
   schedule:
     - cron: '34 17 * * *'
+  workflow_dispatch:
 
 concurrency:
   # Key each master push on its commit SHA so every merge lands in its own
@@ -18,21 +19,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.sha) || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
+# The push and pull_request triggers exist for the release-tag push and so
+# that SCGH_FORCE_NOUSE_INSTALL can drive this workflow from a fork's pull
+# request. That force variable is the opposite of a skip-ci request, so no
+# check_skip call gates it, which matches nightly-sanitizer and
+# nightly-profiling.
 jobs:
 
-  check_skip:
-    # A fork inherits no SCGH_NIGHTLY, so this gate stops the nightly cron
-    # from allocating a runner there.
-    if: github.event_name != 'schedule' || (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable'
-    uses: ./.github/workflows/check_skip_ci.yml
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-
   nouse_install:
-
-    needs: [check_skip]
 
     # The setup.py install path re-verifies packaging and duplicates the build
     # job's pytest. It does not gate correctness on a pull request, so it runs
@@ -40,10 +34,10 @@ jobs:
     # requests or master pushes. Set the SCGH_FORCE_NOUSE_INSTALL variable to
     # 'enable' to force it on a fork.
     if: |
-      needs.check_skip.outputs.skip != 'true' && (
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-      (vars.SCGH_FORCE_NOUSE_INSTALL || vars.MMGH_FORCE_NOUSE_INSTALL) == 'enable')
+      (vars.SCGH_FORCE_NOUSE_INSTALL || vars.MMGH_FORCE_NOUSE_INSTALL) == 'enable'
 
     name: nouse_install_${{ matrix.os }}_Release
 
@@ -94,9 +88,9 @@ jobs:
           restore-keys: ${{ runner.os }}-nouse-Release
           save: ${{ github.event_name != 'pull_request' }}
           # Bound the cache so it does not grow without limit across the rolling
-          # key. A master push or nightly run saves this cache; pull requests
-          # restore it (a PR on a non-default base branch cannot, so it runs
-          # cold).
+          # key. A nightly run, a manual run, or a release-tag push saves this
+          # cache; a forced pull request restores it (a PR on a non-default
+          # base branch cannot, so it runs cold).
           max-size: 1500M
 
       - name: setup.py install build_ext
@@ -131,13 +125,13 @@ jobs:
 
   send_email_on_failure:
     needs: [nouse_install]
-    # Run if any of the dependencies failed in master branch. A
-    # `timeout-minutes` kill reports `cancelled`, not `failure`.
+    # Mail a nightly failure only, not one a force variable drove from a pull
+    # request. A `timeout-minutes` kill reports `cancelled`, not `failure`.
     if: |
       always() &&
       (contains(needs.*.result, 'failure') ||
        contains(needs.*.result, 'cancelled')) &&
-      github.ref_name == 'master' &&
+      github.event_name == 'schedule' &&
       github.event.repository.fork == false
     uses: ./.github/workflows/send_email_on_fail.yml
     with:

--- a/.github/workflows/nightly-profiling.yml
+++ b/.github/workflows/nightly-profiling.yml
@@ -1,17 +1,18 @@
-name: profiling
+name: nightly-profiling
 
 on:
   push:
   pull_request:
   schedule:
     - cron: '34 17 * * *'
+  workflow_dispatch:
 
 jobs:
   profile:
 
-    # Run profiling only on schedule or when SCGH_FORCE_PROFILE is set to 'enable'
+    # Run profiling only on schedule, on a manual run, or when SCGH_FORCE_PROFILE is set to 'enable'
     # You can refer to https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables to set SCGH_FORCE_PROFILE in the fork repository settings for testing purposes.
-    if: ${{ (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable') || (vars.SCGH_FORCE_PROFILE || vars.MMGH_FORCE_PROFILE) == 'enable' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable') || (vars.SCGH_FORCE_PROFILE || vars.MMGH_FORCE_PROFILE) == 'enable' }}
 
     name: profile_${{ matrix.os }}
 
@@ -89,13 +90,13 @@ jobs:
 
   send_email_on_failure:
     needs: [profile]
-    # Run if any of the dependencies failed in master branch. A
-    # `timeout-minutes` kill reports `cancelled`, not `failure`.
+    # Mail a nightly failure only, not one a force variable drove from a pull
+    # request. A `timeout-minutes` kill reports `cancelled`, not `failure`.
     if: |
       always() &&
       (contains(needs.*.result, 'failure') ||
        contains(needs.*.result, 'cancelled')) &&
-      github.ref_name == 'master' &&
+      github.event_name == 'schedule' &&
       github.event.repository.fork == false
     uses: ./.github/workflows/send_email_on_fail.yml
     with:

--- a/.github/workflows/nightly-sanitizer.yml
+++ b/.github/workflows/nightly-sanitizer.yml
@@ -1,0 +1,231 @@
+name: nightly-sanitizer
+
+on:
+  push:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  schedule:
+    - cron: '34 17 * * *'
+  workflow_dispatch:
+
+concurrency:
+  # Key each master push on its commit SHA so every merge lands in its own
+  # concurrency group. Sharing one group serializes master runs, and with
+  # cancel-in-progress disabled GitHub still cancels a pending run when the
+  # next merge queues behind the one in progress, so a later merge would
+  # drop an earlier merge's result. A unique group per SHA keeps every
+  # master run independent. Pull requests key on the PR number and other
+  # branches on the ref, so their superseded runs still cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.sha) || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+# The push and pull_request triggers exist only so that SCGH_FORCE_SANITIZER
+# can drive this workflow from a fork's pull request. That force variable is
+# the opposite of a skip-ci request, so no check_skip call gates it.
+jobs:
+
+  sanitizer:
+
+    # A genuine -DUSE_SANITIZER=ON ASAN/UBSAN build. It is slow, so it runs on
+    # the nightly schedule only (set SCGH_FORCE_SANITIZER to 'enable' to force
+    # it on a fork). This is the real sanitizer coverage that devbuild's build
+    # job used to stub out by configuring -DUSE_SANITIZER=OFF.
+    #
+    # A fork inherits no SCGH_NIGHTLY, so this gate also stops the nightly cron
+    # from allocating a runner there.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable') ||
+      (vars.SCGH_FORCE_SANITIZER || vars.MMGH_FORCE_SANITIZER) == 'enable'
+
+    name: sanitizer_${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+
+    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_BUILD || vars.MMGH_TIMEOUT_BUILD || '45') }}
+
+    env:
+      MAKE_PARALLEL: -j2
+      PIP_BREAK_SYSTEM_PACKAGES: 1
+
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+        # Sanitizer reports name a file and a line only when the binary
+        # carries debug symbols, so this job builds RelWithDebInfo.
+        cmake_build_type: [RelWithDebInfo]
+
+      fail-fast: false
+
+    steps:
+
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+
+    - name: event name
+      run: |
+        echo "github.event_name: ${{ github.event_name }}"
+
+    - name: setup dependencies for Linux
+      uses: ./.github/actions/setup_linux
+      with:
+        workflow: 'build'
+
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2.23
+      with:
+        key: ${{ runner.os }}-sanitizer-${{ matrix.cmake_build_type }}
+        restore-keys: ${{ runner.os }}-sanitizer-${{ matrix.cmake_build_type }}
+        save: ${{ github.event_name != 'pull_request' }}
+        max-size: 1500M
+
+    - name: make gtest USE_SANITIZER=ON
+      run: |
+        echo "::group::make gtest USE_SANITIZER=ON"
+        # Run ASAN/UBSAN over the C++ gtest binary rather than pytest. The
+        # gtest executable is linked directly against the sanitizer runtime,
+        # so ASan initializes first and intercepts every allocation.
+        make gtest \
+          VERBOSE=1 USE_CLANG_TIDY=OFF \
+          BUILD_QT=OFF \
+          CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
+          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_SANITIZER=ON"
+        echo "::endgroup::"
+
+  sanitizer_windows:
+
+    # The MSVC counterpart of the sanitizer job. MSVC ships only
+    # AddressSanitizer. The gtest binary and pilot.exe both link the ASan
+    # runtime directly, so it starts with the process and instruments the C++
+    # core and the Qt pilot. Slow, so nightly-only (set SCGH_FORCE_SANITIZER to
+    # force it on a fork).
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && (vars.SCGH_NIGHTLY || vars.MMGH_NIGHTLY) == 'enable') ||
+      (vars.SCGH_FORCE_SANITIZER || vars.MMGH_FORCE_SANITIZER) == 'enable'
+
+    name: sanitizer_${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+
+    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_BUILD || vars.MMGH_TIMEOUT_BUILD || '60') }}
+
+    env:
+      AQT_CONFIG: "thirdparty/aqt_settings.ini"
+      QSG_RHI_PREFER_SOFTWARE_RENDERER: "1"
+      QSG_INFO: "1"
+      # Hook the RTL allocators so the uninstrumented Qt and PySide6 DLLs share
+      # ASan's heap (else a cross-module free reads as a false mismatch).
+      ASAN_OPTIONS: "windows_hook_rtl_allocators=1:abort_on_error=1:detect_leaks=0"
+
+    strategy:
+      matrix:
+        # No build type here: this job configures through the ci-win-asan
+        # preset, which states its own.
+        os: [windows-2022]
+
+      fail-fast: false
+
+    steps:
+
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+
+    - name: event name
+      run: |
+        echo "github.event_name: ${{ github.event_name }}"
+
+    - uses: TheMrMilchmann/setup-msvc-dev@v4
+      with:
+        arch: 'x64'
+
+    # CMake in the windows-2022 image is 3.31.6; solvcon needs >= 4.0.1.
+    - name: install CMake>4.0.1
+      uses: lukka/get-cmake@latest
+
+    - name: install qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        # aqtinstall 3.3.0 cannot resolve Qt 6.11's new split Windows
+        # desktop repository, so Windows stays on 6.10.3 while Linux and
+        # macOS run 6.11.1.
+        # Ref: https://github.com/miurahr/aqtinstall/issues/1007
+        version: '6.10.3'
+        host: 'windows'
+        target: 'desktop'
+        arch: 'win64_msvc2022_64'
+        modules: 'qtshadertools'
+        cache: true
+
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Cache vcpkg (install artifacts)
+      uses: actions/cache@v4
+      with:
+        path: |
+          C:\vcpkg\installed
+          C:\vcpkg\downloads
+          C:\vcpkg\buildtrees
+          C:\vcpkg\packages
+        key: vcpkg-${{ runner.os }}-openblas-lapack
+        restore-keys: vcpkg-${{ runner.os }}-
+
+    - name: install BLAS and LAPACK
+      run: |
+        echo "::group::install BLAS and LAPACK"
+        vcpkg install openblas:x64-windows lapack:x64-windows
+        $vcpkg_bin_path = @(
+          "C:\vcpkg\installed\x64-windows\bin",
+          "C:\vcpkg\installed\x64-windows\debug\bin"
+        ) -join ";"
+        echo "$vcpkg_bin_path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "::endgroup::"
+
+    - name: dependency by pip
+      run: |
+        echo "::group::dependency by pip"
+        pip3 install -U numpy pytest pybind11
+        # For pilot GUI.
+        pip3 install -U matplotlib jsonschema flake8 pyside6==$(qmake -query QT_VERSION)
+        $pyside6_path = $(python3 -c "import sys, os, PySide6; sys.stdout.write(os.path.dirname(PySide6.__file__))")
+        $shiboken6_path = $(python3 -c "import sys, os, shiboken6; sys.stdout.write(os.path.dirname(shiboken6.__file__))")
+        echo "$pyside6_path;$shiboken6_path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "::endgroup::"
+
+    - name: cmake workflow USE_SANITIZER=ON
+      run: |
+        echo "::group::cmake workflow USE_SANITIZER=ON"
+        # The ci-win-asan preset instruments both the gtest binary and the Qt
+        # pilot: BUILD_QT and USE_GOOGLETEST build both, USE_SANITIZER adds
+        # /fsanitize=address, and the vcpkg toolchain supplies BLAS and LAPACK.
+        # The MSVC toolset bin dir that setup-msvc-dev puts on PATH also carries
+        # the ASan runtime DLL the instrumented binaries load at start.
+        $env:PYBIND11_DIR = "$(pybind11-config --cmakedir)"
+        # A runner has no desktop to take over, so let this job map its
+        # windows, the way it has always run them.
+        $env:SOLVCON_TEST_SHOW_WINDOWS = "ON"
+        cmake --workflow --preset ci-win-asan
+        echo "::endgroup::"
+
+  send_email_on_failure:
+    needs: [sanitizer, sanitizer_windows]
+    # Mail a nightly failure only, not one a force variable drove from a pull
+    # request. A `timeout-minutes` kill reports `cancelled`, not `failure`.
+    if: |
+      always() &&
+      (contains(needs.*.result, 'failure') ||
+       contains(needs.*.result, 'cancelled')) &&
+      github.event_name == 'schedule' &&
+      github.event.repository.fork == false
+    uses: ./.github/workflows/send_email_on_fail.yml
+    with:
+      job_results: |
+        - sanitizer: ${{ needs.sanitizer.result }}
+        - sanitizer_windows: ${{ needs.sanitizer_windows.result }}
+    secrets:
+      EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -22,11 +22,10 @@ developed by using C++ and Python to provide:
 10. A graphical user interface (GUI) application based on Qt for the spatial
     data and analysis.
 
-An experimental Windows binary (portable) can be downloaded from the [devbuild
-GitHub
-Action](https://github.com/solvcon/solvcon/actions/workflows/devbuild.yml?query=event%3Aschedule+is%3Asuccess+branch%3Amaster).
-Click the Windows release run and scroll down to the "artifacts" section to
-download the zip file (login to [GitHub](https://github.com/) is required).  A
-direct download link can be found in https://doc.solvcon.net/.
+The [nightly-build_windows GitHub
+Action](https://github.com/solvcon/solvcon/actions/workflows/nightly-build_windows.yml?query=event%3Aschedule+is%3Asuccess+branch%3Amaster)
+builds an experimental portable Windows binary. Open the newest successful run
+and scroll down to the "artifacts" section to download the zip file. You need a
+[GitHub](https://github.com/) login.
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/devguide/testing.md
+++ b/doc/source/devguide/testing.md
@@ -52,43 +52,54 @@ forward `PYTEST_OPTS` to a subset.
 ## Automatic Testing on GitHub Actions
 
 Continuous integration runs on GitHub Actions. The workflows live in
-`.github/workflows/`. Most checks run on every change, while the heavier and
-slowly-changing ones run on a nightly schedule. Each job drives the same `make`
-targets described above, so a failure can usually be reproduced locally.
+`.github/workflows/` and form two sets. Only a `nightly-` workflow runs tests
+on a cron, so the name states which set a workflow belongs to. (Two crons
+outside those workflows do maintenance rather than testing: `cache cleanup`
+sweeps stale caches daily, and `Update Contributors` files a monthly issue.)
+Each job drives the `make` targets above, so you can reproduce a failure
+locally.
 
 The fast set runs on every pull request and `master` push:
 
-- `check_skip`: decides whether to skip the heavy jobs (see below).
-- `lint`: `make cformat`, `cinclude`, `checkascii`, `checktws`, `flake8`, and
-  clang-tidy on the diff, on ubuntu and macOS.
-- `standalone_buffer`: the standalone buffer build on ubuntu.
-- `build`: `make gtest` plus `make pytest` with Qt off and on, and the pilot,
-  on ubuntu and macOS (Release).
-- `build_windows` (Release): the Windows build and tests, driven by the
-  `ci-win-rel` workflow preset, which chains configure, build, and the CTest
-  run over the C++ cases and the pilot suite.
+- `check_skip`: the gate that decides whether the heavy jobs run (see below).
+- `lint`: `make cformat`, `cinclude`, `checkascii`, `checktws`, `checktests`,
+  `flake8`, and clang-tidy on the diff, on ubuntu and macOS.
+- `standalone_buffer` (in `devbuild`): the standalone buffer build on ubuntu.
+- `build` (in `devbuild`): `make gtest` plus `make pytest` with Qt off and on,
+  and the pilot, on ubuntu (Release) and macOS (RelWithDebInfo).
+- `build_windows` (in `devbuild`, Release): the Windows build and tests, driven
+  by the `ci-win-rel` workflow preset, which chains configure, build, and the
+  CTest run over the C++ cases and the pilot suite.
 
-The heavy set runs on the nightly schedule only:
+The heavy set runs on the cron, one workflow per concern:
 
-- `build_windows` (Debug): the second Windows configuration.
-- `nouse_install`: the `setup.py install` packaging path.
-- the ASAN/UBSAN sanitizer build (`-DUSE_SANITIZER=ON` over the gtest suite).
-- `profiling`: the benchmark suite.
-- the Windows portable artifact.
+- `nightly-build_windows`: the Windows build in Release and Debug, and the
+  portable artifact packaged from the Release tree.
+- `nightly-nouse_install`: the `setup.py install` packaging path.
+- `nightly-sanitizer`: the ASAN/UBSAN build on ubuntu (`-DUSE_SANITIZER=ON`
+  over the gtest suite), and the MSVC ASan build on Windows.
+- `nightly-profiling`: the benchmark suite.
 
-The nightly run is the superset: the fast set plus these extras.
+The two sets are disjoint, so a nightly result states nothing about the fast
+set. Three other events reach a heavy workflow: `workflow_dispatch` on any of
+them, a release-tag push for `nightly-nouse_install`, and a `SCGH_FORCE_*`
+variable (see below).
 
-Compiler caches (`ccache` on Linux and macOS, `sccache` for MSVC on Windows)
-are saved by pushes to `master` and by nightly runs, and restored by pull
-requests. A pull request on a non-default base branch cannot read them and runs
-cold.
+Only a nightly workflow mails a failure. Each `send_email_on_failure` job calls
+`send_email_on_fail.yml` under `github.event_name == 'schedule'`, so a force
+variable that drives one of these jobs from a pull request mails no one.
+
+A `master` push and a nightly run save the compiler caches (`ccache` on Linux
+and macOS, `sccache` on Windows). A pull request restores them, unless its base
+branch is not the default one, in which case it runs cold.
 
 ### Skipping in a pull request
 
-- A pull request skips the heavy jobs when it carries the `skip-ci` label or a
+- A pull request skips the fast set when it carries the `skip-ci` label or a
   repository member writes `[skip-ci]` alone on a line of its description or a
   comment. A documentation-only pull request (only `doc/**`, `*.md`, `*.rst`,
-  or `contrib/prompt/**`) skips them automatically.
+  or `contrib/prompt/**`) skips it automatically. Only `devbuild` and `lint`
+  consult `check_skip`, so a `SCGH_FORCE_*` variable overrides the label.
 - A pull request that touches no C++ or build file skips the Windows build but
   still runs the Python build and lint.
 
@@ -98,43 +109,41 @@ These variables tune the workflows. Set them as repository variables (under
 Settings, then Secrets and variables, then Actions, then the Variables tab).
 Each is read with a default, so an unset variable keeps the default behavior.
 
-- `SCGH_NIGHTLY`: set to `enable` to let the nightly schedule run its jobs.
-  Unset, every scheduled run is skipped.
+- `SCGH_NIGHTLY`: set to `enable` to let the nightly cron run its jobs. Unset,
+  the cron skips every job.
 - `SCGH_PUSH_RUN_BRANCH`: which branches run the fast set on a `push`. Use `*`
   for all branches, or a branch name (matched as a substring). Unset, a push
   runs nothing.
 - `SCGH_FORCE_PROFILE`, `SCGH_FORCE_NOUSE_INSTALL`, `SCGH_FORCE_SANITIZER`: set
-  any to `enable` to force that nightly-only job to run on any event, so it can
-  be exercised from a pull request.
+  any to `enable` to run that nightly job on any event, so a pull request can
+  exercise it. `nightly-build_windows` reads no such variable, so use
+  `workflow_dispatch` for it. Every nightly workflow accepts a manual run.
 - `SCGH_TIMEOUT_BUILD` (45), `SCGH_TIMEOUT_LINT` (45),
   `SCGH_TIMEOUT_STANDALONE_BUFFER` (10), `SCGH_TIMEOUT_NOUSE_INSTALL` (30),
-  `SCGH_TIMEOUT_PROFILE` (30): per-job `timeout-minutes`. The number is the
-  default used when the variable is unset. `SCGH_TIMEOUT_BUILD` is shared by
-  the ubuntu, macOS, and sanitizer builds (default 45) and the Windows build,
-  which defaults to 60 because its vcpkg plus MSVC compile runs slower than the
-  others.
+  `SCGH_TIMEOUT_PROFILE` (30): per-job `timeout-minutes`, with the default in
+  parentheses. `SCGH_TIMEOUT_BUILD` covers the ubuntu and macOS builds and
+  the ubuntu sanitizer at 45, and the slower Windows builds, MSVC ASan
+  included, at 60.
 - `SCGH_REMIND_REPOSITORY` (`solvcon/solvcon`): the repository whose monthly
   `Update Contributors` cron files its reminder issue. The job also requires a
   non-fork repository, so a fork never files one whatever this is set to.
 
 ### Behavior on a forked repository
 
-- A fork inherits neither these variables nor the secrets, so `SCGH_NIGHTLY`
-  and `SCGH_PUSH_RUN_BRANCH` are unset there. By default only `pull_request`
-  events run, so the fast set runs on a pull request opened in the fork, while
-  pushes and the nightly schedule run nothing until the variables are set.
-- GitHub creates a run entry for the nightly cron in every fork that has
-  Actions enabled, and offers no way to suppress it. `SCGH_NIGHTLY` gates
-  `check_skip` as well as the heavy jobs, so that entry holds no job and
-  takes no runner.
-- Scheduled workflows run only on the default branch, and GitHub keeps Actions
-  disabled on a new fork until it is enabled (a public fork's schedule also
-  pauses after 60 days without activity).
-- To exercise a single nightly-only job on a fork, set the matching
-  `SCGH_FORCE_*` variable and open a pull request.
-- A fork pull request on a non-default base branch runs cold, since it cannot
-  read the warmed caches. The failure-notification job is guarded by
-  `github.event.repository.fork == false`, so it never runs on a fork (and the
-  email secrets it needs are unavailable there).
+- A fork inherits neither these variables nor the secrets, so only
+  `pull_request` events run there. A push and the cron run nothing until you
+  set the variables.
+- GitHub creates a run entry for the nightly cron in every fork that enables
+  Actions, and offers no way to suppress it. `SCGH_NIGHTLY` gates every job the
+  cron reaches, so the entry takes no runner and marks its jobs skipped.
+- A cron workflow runs on the default branch only. GitHub also keeps Actions
+  off on a new fork until someone enables it, and pauses a public fork's cron
+  after 60 days without activity.
+- To exercise one nightly job on a fork, set the matching `SCGH_FORCE_*`
+  variable and open a pull request. `nightly-build_windows` has no such
+  variable; run it from the Actions tab instead.
+- A fork pull request on a non-default base branch runs cold, because it cannot
+  read the warm caches. The failure mail requires
+  `github.event.repository.fork == false`, and a fork has no email secrets.
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/tests/gui/README.md
+++ b/tests/gui/README.md
@@ -14,11 +14,11 @@ Run one side or the other:
 
     make pytest-fast    # everything except this directory
     make pytest-gui     # only this directory
-    make pytest         # both, and what CI runs on master and nightly
+    make pytest         # both, and what CI runs on a push
 
 A pull request runs `pytest-fast` under python plus PySide6, because the same
 tests run seconds later inside the pilot binary in the same job, where the
-embedded interpreter is the environment nothing else exercises. A push and the
-nightly schedule run the whole suite in both hosts.
+embedded interpreter is the environment nothing else exercises. A push runs
+the whole suite in both hosts.
 
 <!-- vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4: -->


### PR DESCRIPTION
The nightly cron used to fire in four workflows, and two of them (`devbuild` and `lint`) mixed nightly-only jobs with the fast set that answers a pull request. Reading the Actions list gave no way to tell which run was which, and a job that ran only at night sat next to one that ran on every push.

This change puts every nightly job in a workflow whose name starts with `nightly-`, and leaves the cron out of everything else. `profiling` and `nouse_install` are renames. The sanitizer pair moves out of `devbuild` into `nightly-sanitizer`. The Windows Debug build and the portable artifact move into `nightly-build_windows`, which also builds Release, because the artifact needs a Release tree to package. `devbuild` keeps Windows Release for pull requests and master pushes. Every `nightly-` workflow accepts `workflow_dispatch`, and `nightly-build_windows` has no `SCGH_FORCE_*` variable, so a manual run is the way to exercise it from a fork.

`send_email_on_fail.yml` now has four callers, all nightly, each gated on the schedule event so that a force variable cannot mail from a pull request. `devbuild` and `lint` lose their mail job with the cron. Before, that job also mailed when a master push failed; now a broken master push mails no one, and only the next nightly (or a person reading the Actions list) reports it. That is a deliberate narrowing, so please push back if the master-push mail should stay.

`nouse_install` and the sanitizer jobs no longer consult `check_skip`, since a `SCGH_FORCE_*` variable is a request to run and a `skip-ci` label is a request not to. Only `devbuild` and `lint` read the label now.

The two sets are disjoint as a result, so the nightly is no longer a superset of the fast set. Nothing runs the Linux and macOS build, the pilot tests, or lint on the cron. That gives up the overnight canary against external drift, a new runner image or an updated dependency, which will now surface on the next pull request instead. A `nightly-devbuild` workflow would restore it if we want it back.

`doc/source/devguide/testing.md` describes the two sets, `tests/gui/README.md` follows (the full pytest now runs on a push only), and the README points at the new workflow for the portable Windows binary. The README no longer claims a direct download link on doc.solvcon.net, because the site does not carry one.
