### PR TITLE
Add the timeseries subsystem with merge_sorted_unique

### DIFF
--- a/cpp/solvcon/CMakeLists.txt
+++ b/cpp/solvcon/CMakeLists.txt
@@ -46,6 +46,7 @@ add_subdirectory(serialization)
 add_subdirectory(transform)
 add_subdirectory(math)
 add_subdirectory(linalg)
+add_subdirectory(timeseries)
 add_subdirectory(simd)
 
 set(SOLVCON_ROOT_HEADERS
@@ -98,6 +99,7 @@ set(SOLVCON_TERMINAL_FILES
     ${SOLVCON_TRANSFORM_FILES}
     ${SOLVCON_MATH_FILES}
     ${SOLVCON_LINALG_FILES}
+    ${SOLVCON_TIMESERIES_FILES}
     ${SOLVCON_SIMD_FILES}
     CACHE FILEPATH "" FORCE)
 

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -35,6 +35,7 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
@@ -225,18 +226,15 @@ std::string format_flat_index(shape_type const & shape, ssize_t offset);
 /**
  * Reject an array that is not one-dimensional. `op` names the calling
  * operation and `what` the role the array plays in it, both for the message.
+ * A caller outside `SimpleArray` overrides `scope` to name its own namespace
+ * and `E` to raise the exception its interface promises.
  */
-template <typename A>
-void validate_1d(A const & array, char const * op, char const * what = "array")
+template <typename E = std::runtime_error, typename A>
+void validate_1d(A const & array, char const * op, std::string_view what = "array", char const * scope = "SimpleArray")
 {
     if (array.ndim() != 1)
     {
-        throw std::runtime_error(
-            std::format("SimpleArray::{}(): "
-                        "currently only support 1D array but the {} is {} dimension",
-                        op,
-                        what,
-                        array.ndim()));
+        throw E(std::format("{}::{}(): currently only support 1D array but the {} is {} dimension", scope, op, what, array.ndim()));
     }
 }
 

--- a/cpp/solvcon/python/module.cpp
+++ b/cpp/solvcon/python/module.cpp
@@ -18,6 +18,7 @@
 #include <solvcon/math/pymod/math_pymod.hpp>
 #include <solvcon/transform/pymod/transform_pymod.hpp>
 #include <solvcon/linalg/pymod/linalg_pymod.hpp>
+#include <solvcon/timeseries/pymod/timeseries_pymod.hpp>
 #include <solvcon/oasis/pymod/oasis_pymod.hpp>
 
 #ifdef QT_CORE_LIB
@@ -46,6 +47,8 @@ void initialize(pybind11::module_ mod)
     pybind11::module_ onedim_mod = mod.def_submodule("onedim", "onedim");
     initialize_onedim(onedim_mod);
     initialize_transform(mod);
+    pybind11::module_ timeseries_mod = mod.def_submodule("timeseries", "timeseries");
+    initialize_timeseries(timeseries_mod);
     initialize_oasis(mod);
 
 #ifdef QT_CORE_LIB

--- a/cpp/solvcon/timeseries/CMakeLists.txt
+++ b/cpp/solvcon/timeseries/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+cmake_minimum_required(VERSION 4.0.1)
+
+set(SOLVCON_TIMESERIES_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/timeseries.hpp
+    CACHE FILEPATH "" FORCE)
+
+set(SOLVCON_TIMESERIES_PYMODHEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/timeseries_pymod.hpp
+    CACHE FILEPATH "" FORCE)
+
+set(SOLVCON_TIMESERIES_PYMODSOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/timeseries_pymod.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_timeseries.cpp
+    CACHE FILEPATH "" FORCE)
+
+set(SOLVCON_TIMESERIES_FILES
+    ${SOLVCON_TIMESERIES_HEADERS}
+    ${SOLVCON_TIMESERIES_PYMODHEADERS}
+    ${SOLVCON_TIMESERIES_PYMODSOURCES}
+    CACHE FILEPATH "" FORCE)
+
+# vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/timeseries/pymod/timeseries_pymod.cpp
+++ b/cpp/solvcon/timeseries/pymod/timeseries_pymod.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/timeseries/pymod/timeseries_pymod.hpp>
+
+namespace solvcon
+{
+
+namespace python
+{
+
+struct timeseries_pymod_tag;
+
+template <>
+OneTimeInitializer<timeseries_pymod_tag> & OneTimeInitializer<timeseries_pymod_tag>::me()
+{
+    static OneTimeInitializer<timeseries_pymod_tag> instance;
+    return instance;
+}
+
+void initialize_timeseries(pybind11::module & mod)
+{
+    auto initialize_impl = [](pybind11::module & mod)
+    {
+        wrap_timeseries(mod);
+    };
+
+    OneTimeInitializer<timeseries_pymod_tag>::me()(mod, initialize_impl);
+}
+
+} /* end namespace python */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/timeseries/pymod/timeseries_pymod.hpp
+++ b/cpp/solvcon/timeseries/pymod/timeseries_pymod.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <pybind11/pybind11.h> // Must be the first include.
+
+#include <solvcon/python/common.hpp>
+#include <solvcon/timeseries/timeseries.hpp>
+
+namespace solvcon
+{
+
+namespace python
+{
+
+void initialize_timeseries(pybind11::module & mod);
+void wrap_timeseries(pybind11::module & mod);
+
+} /* end namespace python */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/timeseries/pymod/wrap_timeseries.cpp
+++ b/cpp/solvcon/timeseries/pymod/wrap_timeseries.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/timeseries/pymod/timeseries_pymod.hpp>
+
+namespace solvcon
+{
+
+namespace python
+{
+
+void wrap_timeseries(pybind11::module & mod)
+{
+    namespace py = pybind11;
+
+    mod.def(
+        "merge_sorted_unique",
+        [](py::args const & args)
+        {
+            small_vector<SimpleArray<uint64_t> const *> arrays;
+            for (py::handle const arg : args)
+            {
+                if (!py::isinstance<SimpleArray<uint64_t>>(arg))
+                {
+                    throw py::type_error(std::format(
+                        "timeseries::merge_sorted_unique(): every array must be SimpleArrayUint64 but got {}",
+                        py::str(py::type::of(arg).attr("__name__")).cast<std::string>()));
+                }
+                arrays.push_back(&arg.cast<SimpleArray<uint64_t> const &>());
+            }
+            return timeseries::merge_sorted_unique(arrays);
+        },
+        "Merge sorted SimpleArrayUint64 timestamp arrays into one sorted array of the distinct timestamps");
+}
+
+} /* end namespace python */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/timeseries/timeseries.hpp
+++ b/cpp/solvcon/timeseries/timeseries.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * The interface header file for the time-series kernels.
+ *
+ * @ingroup group_numerics
+ */
+
+#include <cstdint>
+#include <format>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+#include <solvcon/buffer/buffer.hpp>
+
+namespace solvcon
+{
+
+namespace timeseries
+{
+
+namespace detail
+{
+
+/// Reject an array whose timestamps decrease.
+inline void validate_sorted(SimpleArray<uint64_t> const & array, char const * op, std::string_view what)
+{
+    uint64_t const * const src = array.logical_data();
+    ssize_t const step = array.stride(0);
+    for (ssize_t i = 1; i < array.shape(0); ++i)
+    {
+        uint64_t const prev = src[(i - 1) * step], cur = src[i * step];
+        if (cur < prev)
+        {
+            // clang-format off
+            throw std::invalid_argument(std::format(
+                "timeseries::{}(): {} must be non-decreasing but element {} = {} is less than element {} = {}",
+                op, what, i, cur, i - 1, prev));
+            // clang-format on
+        }
+    }
+}
+
+} /* end namespace detail */
+
+/**
+ * Merge sorted one-dimensional timestamp arrays into one sorted array that
+ * holds every distinct timestamp once. Each input must be non-decreasing; a
+ * timestamp repeated within one array or shared between arrays appears once
+ * in the result. No input, or only empty input, gives an empty result.
+ *
+ * @ingroup group_numerics
+ */
+inline SimpleArray<uint64_t> merge_sorted_unique(small_vector<SimpleArray<uint64_t> const *> const & arrays)
+{
+    struct Cursor
+    {
+        uint64_t const * head;
+        ssize_t step;
+        ssize_t left;
+    }; /* end struct Cursor */
+
+    small_vector<Cursor> cursors;
+    ssize_t total = 0;
+    for (size_t k = 0; k < arrays.size(); ++k)
+    {
+        SimpleArray<uint64_t> const & array = *arrays[k];
+        std::string const what = std::format("array {}", k);
+        solvcon::detail::validate_1d<std::invalid_argument>(array, "merge_sorted_unique", what, "timeseries");
+        detail::validate_sorted(array, "merge_sorted_unique", what);
+        cursors.push_back(Cursor{.head = array.logical_data(), .step = array.stride(0), .left = array.shape(0)});
+        total += array.shape(0);
+    }
+
+    SimpleCollector<uint64_t> merged;
+    merged.reserve(total);
+    while (true)
+    {
+        Cursor * lowest = nullptr;
+        for (Cursor & c : cursors)
+        {
+            if (c.left > 0 && (lowest == nullptr || *c.head < *lowest->head))
+            {
+                lowest = &c;
+            }
+        }
+        if (lowest == nullptr)
+        {
+            break;
+        }
+
+        uint64_t const value = *lowest->head;
+        if (merged.empty() || merged.back() != value)
+        {
+            merged.push_back(value);
+        }
+
+        lowest->head += lowest->step;
+        --lowest->left;
+    }
+
+    return merged.as_array();
+}
+
+} /* end namespace timeseries */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -16,7 +16,8 @@
  */
 
 /** @defgroup group_numerics Numerics
- *  BLAS and LAPACK wrappers, dense factorizations, and integral transforms.
+ *  BLAS and LAPACK wrappers, dense factorizations, integral transforms, and
+ *  time-series kernels.
  */
 
 /** @defgroup group_geometry Geometry

--- a/doc/source/compute/numerics/index.md
+++ b/doc/source/compute/numerics/index.md
@@ -4,6 +4,7 @@
 :maxdepth: 2
 
 matrix
+timeseries
 ```
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/compute/numerics/timeseries.md
+++ b/doc/source/compute/numerics/timeseries.md
@@ -1,0 +1,43 @@
+# Time Series
+
+`solvcon.timeseries` holds kernels over recorded time series. A series is a
+pair of one-dimensional arrays of the same length. The first array holds the
+timestamps in integer nanoseconds as a `SimpleArrayUint64` in non-decreasing
+order. The second holds the values sampled at them as a SimpleArray of any
+class. Each kernel reads its input, returns new arrays, and never changes the
+input. The C++ kernels live in `cpp/solvcon/timeseries/` in the namespace
+`solvcon::timeseries`.
+
+The kernels replace the per-sample Python loops that a recorded log otherwise
+needs. Sample lookup on the timestamps is not a kernel here; it is
+`searchsorted`, which {doc}`the reduce page <../buffer/reduce>` describes.
+
+## Duplicate Timestamps
+
+A recorded log may stamp two messages in the same nanosecond, so a repeated
+timestamp is valid input. A group of equal timestamps resolves to its last
+sample.
+
+## The `merge_sorted_unique` Function
+
+`merge_sorted_unique(*arrays)` merges any number of sorted `SimpleArrayUint64`
+timestamp arrays into one sorted `SimpleArrayUint64` that holds every
+distinct timestamp once. This is the union time grid that compares two
+signals sampled at different rates:
+
+```python
+from solvcon import timeseries as ts
+
+t1 = solvcon.SimpleArrayUint64(array=np.array([0, 10, 20], dtype='uint64'))
+t2 = solvcon.SimpleArrayUint64(array=np.array([5, 10, 10], dtype='uint64'))
+assert ts.merge_sorted_unique(t1, t2).ndarray.tolist() == [0, 5, 10, 20]
+assert ts.merge_sorted_unique().shape == (0,)
+```
+
+A timestamp repeated within one array or shared between arrays appears once.
+No argument, or only empty arrays, gives an empty result. Every argument must
+be a `SimpleArrayUint64`; another class raises `TypeError`. An array that is
+not one-dimensional, or that holds a decreasing timestamp, raises
+`ValueError` and names the array by its position.
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/solvcon/__init__.py
+++ b/solvcon/__init__.py
@@ -15,6 +15,7 @@ from .core import *  # noqa: F401, F403
 from . import apputil  # noqa: F401
 from . import spacetime  # noqa: F401
 from . import onedim  # noqa: F401
+from . import timeseries  # noqa: F401
 from . import multidim  # noqa: F401
 from . import system  # noqa: F401
 from . import testing  # noqa: F401

--- a/solvcon/timeseries.py
+++ b/solvcon/timeseries.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Kernels over recorded time series: sorted integer-nanosecond timestamps
+paired with the values sampled at them.
+"""
+
+
+try:
+    from _solvcon import timeseries as _impl  # noqa: F401
+except ImportError:
+    from ._solvcon import timeseries as _impl  # noqa: F401
+
+_toload = [
+    'merge_sorted_unique',
+]
+
+
+def _load():
+    for name in _toload:  # noqa: F821
+        globals()[name] = getattr(_impl, name)
+
+
+__all__ = _toload
+
+
+_load()
+del _load
+del _toload
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import unittest
+
+import numpy as np
+
+import solvcon
+from solvcon import timeseries as ts
+
+
+def u64(values):
+    return solvcon.SimpleArrayUint64(array=np.array(values, dtype='uint64'))
+
+
+class MergeSortedUniqueTC(unittest.TestCase):
+
+    def test_union_grid(self):
+        grid = ts.merge_sorted_unique(u64([0, 10, 20, 30]), u64([5, 10, 25]))
+        self.assertIs(type(grid), solvcon.SimpleArrayUint64)
+        self.assertEqual(grid.ndarray.tolist(), [0, 5, 10, 20, 25, 30])
+
+    def test_repeat_within_and_across_arrays_appears_once(self):
+        grid = ts.merge_sorted_unique(u64([1, 1, 2]), u64([2, 3, 3]),
+                                      u64([3]))
+        self.assertEqual(grid.ndarray.tolist(), [1, 2, 3])
+
+    def test_single_array_drops_its_repeats(self):
+        grid = ts.merge_sorted_unique(u64([4, 4, 4, 9]))
+        self.assertEqual(grid.ndarray.tolist(), [4, 9])
+
+    def test_no_or_empty_input_gives_empty_grid(self):
+        self.assertEqual(ts.merge_sorted_unique().shape, (0,))
+        self.assertEqual(ts.merge_sorted_unique(u64([]), u64([])).shape,
+                         (0,))
+        grid = ts.merge_sorted_unique(u64([]), u64([7]))
+        self.assertEqual(grid.ndarray.tolist(), [7])
+
+    def test_against_numpy_union(self):
+        rng = np.random.default_rng(20260817)
+        for _ in range(20):
+            ndatas = [np.sort(rng.integers(0, 50, rng.integers(0, 30),
+                                           dtype='uint64'))
+                      for _ in range(4)]
+            grid = ts.merge_sorted_unique(*(u64(nd) for nd in ndatas))
+            np.testing.assert_array_equal(grid.ndarray,
+                                          np.unique(np.concatenate(ndatas)))
+
+    def test_strided_view_is_read_in_array_order(self):
+        ndata = np.arange(12, dtype='uint64')[::4]
+        grid = ts.merge_sorted_unique(solvcon.SimpleArrayUint64(array=ndata),
+                                      u64([2]))
+        self.assertEqual(grid.ndarray.tolist(), [0, 2, 4, 8])
+
+    def test_zero_stride_view_counts_its_elements(self):
+        # A broadcast view repeats one element with stride 0; the merge
+        # walks it by count, so the repeated timestamp still appears once.
+        base = np.array([7], dtype='uint64')
+        view = np.lib.stride_tricks.as_strided(base, shape=(3,), strides=(0,))
+        grid = ts.merge_sorted_unique(solvcon.SimpleArrayUint64(array=view),
+                                      u64([5]))
+        self.assertEqual(grid.ndarray.tolist(), [5, 7])
+
+    def test_unsorted_array_raises(self):
+        msg = ("array 1 must be non-decreasing but element 2 = 2 is less "
+               "than element 1 = 3")
+        with self.assertRaisesRegex(ValueError, msg):
+            ts.merge_sorted_unique(u64([1, 2]), u64([1, 3, 2]))
+
+    def test_rejects_other_dtype_and_dimension(self):
+        with self.assertRaisesRegex(TypeError, "SimpleArrayInt64"):
+            ts.merge_sorted_unique(solvcon.SimpleArrayInt64(
+                array=np.array([1], dtype='int64')))
+        with self.assertRaisesRegex(ValueError, "currently only support 1D "
+                                    "array but the array 0 is 2 dimension"):
+            ts.merge_sorted_unique(solvcon.SimpleArrayUint64((2, 2), 0))
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`cpp/solvcon/timeseries/` holds kernels over recorded time series: integer-nanosecond timestamps as `SimpleArrayUint64` and the values sampled at them. Python reaches them as the `solvcon.timeseries` submodule, so generic kernel names stay out of the top-level namespace. `SimpleArray`'s `validate_1d()` now takes the exception class and the scope name, so a kernel outside `SimpleArray` reuses it.

`merge_sorted_unique(*arrays)` merges sorted timestamp arrays into one array of the distinct timestamps, the union time grid for two signals sampled at different rates.

`make lint` is clean, `make pytest` passes (1690 passed, 542 skipped), and `make gtest` passes (244 passed).

This is the first of two stacked PRs from PR 3 of the plan; the next adds `dedup_last` and `deriv` on this branch.

Related to #1285.
