### PR TITLE
Use underscores only in the workflow names

### DIFF
--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -1,4 +1,4 @@
-name: cache cleanup
+name: cache_cleanup
 
 on:
   schedule:

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -278,7 +278,7 @@ jobs:
 
     # cpp != 'false' keeps the expensive Windows build off pull requests that
     # touch no C++ or build files (it is empty, so truthy, for a push).
-    # The cron is absent here on purpose. nightly-build_windows.yml builds
+    # The cron is absent here on purpose. nightly_build_windows.yml builds
     # Windows in Release and Debug, and packages the portable artifact from
     # the Release tree.
     if: |
@@ -310,7 +310,7 @@ jobs:
       matrix:
         os: [windows-2022]
         # Release runs on every pull request and master push. Debug is heavy
-        # and rarely breaks on its own, so nightly-build_windows.yml carries
+        # and rarely breaks on its own, so nightly_build_windows.yml carries
         # it instead.
         cmake_build_type: [Release]
 

--- a/.github/workflows/nightly_build_windows.yml
+++ b/.github/workflows/nightly_build_windows.yml
@@ -1,4 +1,4 @@
-name: nightly-build_windows
+name: nightly_build_windows
 
 on:
   schedule:
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: nightly-build-windows
+  group: nightly_build_windows
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/nightly_nouse_install.yml
+++ b/.github/workflows/nightly_nouse_install.yml
@@ -1,4 +1,4 @@
-name: nightly-nouse_install
+name: nightly_nouse_install
 
 on:
   push:
@@ -22,8 +22,8 @@ concurrency:
 # The push and pull_request triggers exist for the release-tag push and so
 # that SCGH_FORCE_NOUSE_INSTALL can drive this workflow from a fork's pull
 # request. That force variable is the opposite of a skip-ci request, so no
-# check_skip call gates it, which matches nightly-sanitizer and
-# nightly-profiling.
+# check_skip call gates it, which matches nightly_sanitizer and
+# nightly_profiling.
 jobs:
 
   nouse_install:

--- a/.github/workflows/nightly_profiling.yml
+++ b/.github/workflows/nightly_profiling.yml
@@ -1,4 +1,4 @@
-name: nightly-profiling
+name: nightly_profiling
 
 on:
   push:

--- a/.github/workflows/nightly_sanitizer.yml
+++ b/.github/workflows/nightly_sanitizer.yml
@@ -1,4 +1,4 @@
-name: nightly-sanitizer
+name: nightly_sanitizer
 
 on:
   push:

--- a/.github/workflows/send_email_on_fail.yml
+++ b/.github/workflows/send_email_on_fail.yml
@@ -1,4 +1,4 @@
-name: Send Email on Failure
+name: send_email_on_fail
 
 on:
   workflow_call:

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -1,4 +1,4 @@
-name: Update Contributors
+name: update_contributors
 
 on:
   schedule:

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ developed by using C++ and Python to provide:
 10. A graphical user interface (GUI) application based on Qt for the spatial
     data and analysis.
 
-The [nightly-build_windows GitHub
-Action](https://github.com/solvcon/solvcon/actions/workflows/nightly-build_windows.yml?query=event%3Aschedule+is%3Asuccess+branch%3Amaster)
+The [nightly_build_windows GitHub
+Action](https://github.com/solvcon/solvcon/actions/workflows/nightly_build_windows.yml?query=event%3Aschedule+is%3Asuccess+branch%3Amaster)
 builds an experimental portable Windows binary. Open the newest successful run
 and scroll down to the "artifacts" section to download the zip file. You need a
 [GitHub](https://github.com/) login.

--- a/doc/source/devguide/testing.md
+++ b/doc/source/devguide/testing.md
@@ -52,10 +52,10 @@ forward `PYTEST_OPTS` to a subset.
 ## Automatic Testing on GitHub Actions
 
 Continuous integration runs on GitHub Actions. The workflows live in
-`.github/workflows/` and form two sets. Only a `nightly-` workflow runs tests
+`.github/workflows/` and form two sets. Only a `nightly_` workflow runs tests
 on a cron, so the name states which set a workflow belongs to. (Two crons
-outside those workflows do maintenance rather than testing: `cache cleanup`
-sweeps stale caches daily, and `Update Contributors` files a monthly issue.)
+outside those workflows do maintenance rather than testing: `cache_cleanup`
+sweeps stale caches daily, and `update_contributors` files a monthly issue.)
 Each job drives the `make` targets above, so you can reproduce a failure
 locally.
 
@@ -73,16 +73,16 @@ The fast set runs on every pull request and `master` push:
 
 The heavy set runs on the cron, one workflow per concern:
 
-- `nightly-build_windows`: the Windows build in Release and Debug, and the
+- `nightly_build_windows`: the Windows build in Release and Debug, and the
   portable artifact packaged from the Release tree.
-- `nightly-nouse_install`: the `setup.py install` packaging path.
-- `nightly-sanitizer`: the ASAN/UBSAN build on ubuntu (`-DUSE_SANITIZER=ON`
+- `nightly_nouse_install`: the `setup.py install` packaging path.
+- `nightly_sanitizer`: the ASAN/UBSAN build on ubuntu (`-DUSE_SANITIZER=ON`
   over the gtest suite), and the MSVC ASan build on Windows.
-- `nightly-profiling`: the benchmark suite.
+- `nightly_profiling`: the benchmark suite.
 
 The two sets are disjoint, so a nightly result states nothing about the fast
 set. Three other events reach a heavy workflow: `workflow_dispatch` on any of
-them, a release-tag push for `nightly-nouse_install`, and a `SCGH_FORCE_*`
+them, a release-tag push for `nightly_nouse_install`, and a `SCGH_FORCE_*`
 variable (see below).
 
 Only a nightly workflow mails a failure. Each `send_email_on_failure` job calls
@@ -116,7 +116,7 @@ Each is read with a default, so an unset variable keeps the default behavior.
   runs nothing.
 - `SCGH_FORCE_PROFILE`, `SCGH_FORCE_NOUSE_INSTALL`, `SCGH_FORCE_SANITIZER`: set
   any to `enable` to run that nightly job on any event, so a pull request can
-  exercise it. `nightly-build_windows` reads no such variable, so use
+  exercise it. `nightly_build_windows` reads no such variable, so use
   `workflow_dispatch` for it. Every nightly workflow accepts a manual run.
 - `SCGH_TIMEOUT_BUILD` (45), `SCGH_TIMEOUT_LINT` (45),
   `SCGH_TIMEOUT_STANDALONE_BUFFER` (10), `SCGH_TIMEOUT_NOUSE_INSTALL` (30),
@@ -125,7 +125,7 @@ Each is read with a default, so an unset variable keeps the default behavior.
   the ubuntu sanitizer at 45, and the slower Windows builds, MSVC ASan
   included, at 60.
 - `SCGH_REMIND_REPOSITORY` (`solvcon/solvcon`): the repository whose monthly
-  `Update Contributors` cron files its reminder issue. The job also requires a
+  `update_contributors` cron files its reminder issue. The job also requires a
   non-fork repository, so a fork never files one whatever this is set to.
 
 ### Behavior on a forked repository
@@ -140,7 +140,7 @@ Each is read with a default, so an unset variable keeps the default behavior.
   off on a new fork until someone enables it, and pauses a public fork's cron
   after 60 days without activity.
 - To exercise one nightly job on a fork, set the matching `SCGH_FORCE_*`
-  variable and open a pull request. `nightly-build_windows` has no such
+  variable and open a pull request. `nightly_build_windows` has no such
   variable; run it from the Actions tab instead.
 - A fork pull request on a non-default base branch runs cold, because it cannot
   read the warm caches. The failure mail requires


### PR DESCRIPTION
yungyuc asked in #1371 that a workflow name not mix a hyphen with an underscore. Every workflow name now uses an underscore. The four nightly workflows read `nightly_build_windows`, `nightly_nouse_install`, `nightly_profiling`, and `nightly_sanitizer`. The file name and the `name:` in the Actions list both carry the new spelling.

Three other workflows carried a free-form title that did not match their file name. `cache cleanup`, `Send Email on Failure`, and `Update Contributors` now read `cache_cleanup`, `send_email_on_fail`, and `update_contributors`.

The job names keep their spelling. Each job name is a check-run name that branch protection matches on. A rename would drop a required check until someone updates the repository settings.

The README link, `doc/source/devguide/testing.md`, and the comments in `devbuild.yml` and `nightly_nouse_install.yml` follow the new names. No reusable-workflow path changed, because `check_skip_ci.yml` and `send_email_on_fail.yml` keep their file names.

Every workflow parses as YAML with the expected `name:`, every `uses: ./.github/workflows/...` path resolves, and `make lint` passes. The diff changes no code, so no test suite covers it.

Related to #1371.
