### PR TITLE
Add a colormap legend to the reflection domain view

### DIFF
--- a/solvcon/pilot/apps/obsrefl/_colorbar.py
+++ b/solvcon/pilot/apps/obsrefl/_colorbar.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""The colormap legend that says what the colors in the viewer mean.
+
+:class:`ColorBar` draws the ramp of :func:`~._field_render.colormap` over
+the range the viewer pins its colors to, with its two ends labelled, so
+reading the field does not depend on remembering which end of the ramp is
+high.
+
+The bar says what the colors mean and nothing else.  Marking the analytic
+zone values on it would put a second reading on a scale, where the eye
+takes it for part of the scale itself; how far a run stands from those
+states is the zone table's to say, in numbers that need no reading off a
+strip of color.
+
+The bar lies along either axis, since it is meant to sit against an edge of
+the view it explains and the two pairs of edges want opposite runs.  It
+grounds itself in the same color the viewer clears its frame to, so the
+strip it takes reads as part of the view rather than as a panel laid over
+it, and it inks itself to match: a ground that does not follow the theme
+cannot be written on in a color that does.
+
+The widget holds no run.  Its owner pushes in a range whenever a frame is
+drawn, and it paints what it was last given.
+"""
+
+from PySide6.QtCore import Qt, QRect
+from PySide6.QtGui import QPainter, QLinearGradient, QColor, QPen
+from PySide6.QtWidgets import QWidget, QSizePolicy
+
+from ._field_render import colormap
+
+__all__ = [  # noqa: F822
+    'ColorBar',
+]
+
+
+class ColorBar(QWidget):
+    """A slim colormap ramp with its two ends labelled.
+
+    :ivar lo: Low end of the pinned range, or None with nothing to show.
+    :ivar hi: High end of the pinned range.
+    :ivar vertical: Whether the ramp runs up the widget instead of across.
+    """
+
+    #: Colors sampled across the ramp to build the gradient.  The map is
+    #: piecewise linear in four stops, so this is far more than it takes to
+    #: draw it smoothly and still cheap to rebuild every frame.
+    STOPS = 32
+    #: Thickness of the ramp itself, in pixels, across its run.
+    BAR_THICKNESS = 12
+    #: Room kept at each end of the run for half an end label, so the text
+    #: of a label centered on the extreme does not run off the widget.
+    END_PAD = 24
+    #: Width the end-label column takes beside a vertical ramp.
+    LABEL_WIDTH = 52
+    #: Room kept around the ramp, across its run.
+    PAD = 4
+    #: The ground under the bar, which is what the domain viewer clears its
+    #: frame to, so the strip does not read as a panel over the view.
+    BACKGROUND = (1.0, 1.0, 1.0)
+    #: Ink for the frame and the labels.  Fixed rather than
+    #: taken from the palette, because the ground it is written on is: a
+    #: dark theme's near-white text would vanish on it.
+    INK = (0.1, 0.1, 0.1)
+
+    def __init__(self, vertical=False, parent=None):
+        super().__init__(parent)
+        self.lo = None
+        self.hi = None
+        self.vertical = vertical
+        if vertical:
+            self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
+            self.setMinimumWidth(self.thickness())
+        else:
+            self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+            self.setMinimumHeight(self.thickness())
+
+    def thickness(self):
+        """Room the bar needs across its run, labels included.
+
+        One label line, not two: the ends are labelled on one side of the
+        ramp and nothing is written on the other.
+        """
+        room = self.BAR_THICKNESS + 2 * self.PAD
+        if self.vertical:
+            return room + self.LABEL_WIDTH
+        return room + self.fontMetrics().height()
+
+    def show_scale(self, lo, hi):
+        """Draw the ramp over ``lo`` to ``hi``.
+
+        A missing or degenerate range blanks the widget rather than
+        dividing by a zero span.
+        """
+        if None is lo or None is hi or not hi > lo:
+            self.lo = self.hi = None
+        else:
+            self.lo, self.hi = float(lo), float(hi)
+        self.update()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        if None is self.lo:
+            return
+        painter.fillRect(self.rect(), QColor.fromRgbF(*self.BACKGROUND))
+        bar = self._bar_rect()
+        painter.fillRect(bar, self._ramp(bar))
+        painter.setPen(QPen(QColor.fromRgbF(*self.INK)))
+        painter.drawRect(bar)
+        self._draw_ends(painter, bar)
+
+    def _bar_rect(self):
+        """Where the ramp is drawn, with room beside it for the labels."""
+        if self.vertical:
+            return QRect(self.LABEL_WIDTH + self.PAD, self.END_PAD,
+                         self.BAR_THICKNESS,
+                         max(1, self.height() - 2 * self.END_PAD))
+        return QRect(self.END_PAD, self.PAD,
+                     max(1, self.width() - 2 * self.END_PAD),
+                     self.BAR_THICKNESS)
+
+    def _ramp(self, bar):
+        """The colormap as a gradient along ``bar``.
+
+        A vertical ramp runs low at the bottom, the way an axis does, so
+        the gradient is laid out bottom to top.
+        """
+        if self.vertical:
+            gradient = QLinearGradient(0, bar.bottom(), 0, bar.top())
+        else:
+            gradient = QLinearGradient(bar.left(), 0, bar.right(), 0)
+        for it in range(self.STOPS + 1):
+            t = it / self.STOPS
+            red, green, blue = colormap(t)
+            gradient.setColorAt(t, QColor.fromRgbF(red, green, blue))
+        return gradient
+
+    def _at(self, value, bar):
+        """Where ``value`` falls along the ramp, in widget pixels."""
+        t = (value - self.lo) / (self.hi - self.lo)
+        if self.vertical:
+            return bar.bottom() - t * (bar.height() - 1)
+        return bar.left() + t * (bar.width() - 1)
+
+    def _label_rect(self, at, bar, height):
+        """Room for a label beside the ramp at ``at`` along its run."""
+        if self.vertical:
+            return QRect(0, round(at) - height // 2, self.LABEL_WIDTH, height)
+        return QRect(round(at) - self.END_PAD, bar.bottom() + 1,
+                     2 * self.END_PAD, height)
+
+    def _draw_ends(self, painter, bar):
+        """Label the two ends of the range against the ramp."""
+        height = self.fontMetrics().height()
+        align = (Qt.AlignRight if self.vertical else Qt.AlignHCenter)
+        for value in (self.lo, self.hi):
+            painter.drawText(self._label_rect(self._at(value, bar), bar,
+                                              height),
+                             align | Qt.AlignVCenter, _number(value))
+
+
+def _number(value):
+    """Format an end label to three significant digits."""
+    return f"{value:#.3g}"
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/apps/obsrefl/_control.py
+++ b/solvcon/pilot/apps/obsrefl/_control.py
@@ -53,6 +53,7 @@ class RunController(object):
         panel.reset_requested = self.reset
         panel.remesh_requested = self.remesh
         panel.field_changed = self._on_field
+        panel.placement_changed = self._on_bar_placement
         viewer.closed = self._on_viewer_closed
 
     def preview(self):
@@ -115,6 +116,9 @@ class RunController(object):
             shock = self.session.shock
             self._viewer.update_mesh(shock.mesh)
             self._viewer.draw_shock_path(shock)
+        # A reopened sub-window is bare, so the legend goes back on with
+        # the rest of the layers.
+        self._viewer.show_bar(self._panel.bar_placement())
         self._draw_frame()
 
     def _on_viewer(self, open_):
@@ -144,6 +148,10 @@ class RunController(object):
     def _on_field(self, _name):
         if self.session is not None:
             self._draw_frame()
+
+    def _on_bar_placement(self, placement):
+        """Move the legend to the edge the field box now names."""
+        self._viewer.show_bar(placement)
 
     def _advance(self):
         if not self._viewer.is_open:
@@ -181,6 +189,9 @@ class RunController(object):
         vmin, vmax = float(field.min()), float(field.max())
         if self._viewer.is_open:
             lo, hi = session.analysis.color_range(name, vmin, vmax)
+            # The legend reads the same pinned range the colors are mapped
+            # over, so the two cannot say different things about a frame.
+            self._viewer.show_scale(lo, hi)
             self._viewer.draw_field(self._painter.verts,
                                     self._painter.colors(field, lo, hi),
                                     self._painter.indices)

--- a/solvcon/pilot/apps/obsrefl/_panel.py
+++ b/solvcon/pilot/apps/obsrefl/_panel.py
@@ -371,28 +371,51 @@ class RunBox(FoldBox):
 
 
 class FieldBox(FoldBox):
-    """Which derived field the viewer colors, and the range it spans."""
+    """Which derived field the viewer colors, the range it spans, and where
+    the legend of those colors stands.
+
+    The min and max are the frame's own.  The legend is drawn in the domain
+    sub-window rather than here, against the field it explains; this box
+    only says which edge it takes, or that it takes none.
+    """
 
     #: Derived scalar fields the viewer can color, in display order.
     FIELDS = EulerField.FIELDS
+    #: Where the legend may stand in the domain sub-window.
+    PLACEMENTS = ('off', 'left', 'right', 'lower', 'upper')
+    #: The edge it takes until told otherwise.  A legend nobody asked for
+    #: is still the shortest way to learn what the colors mean, so the bar
+    #: is on to begin with.
+    PLACEMENT = 'right'
 
     def __init__(self, parent=None):
         super().__init__("Field", parent)
         self.field_changed = None
+        # Owner-supplied callback fired when the legend is moved.
+        self.placement_changed = None
         self._selector = QComboBox()
         self._selector.addItems(self.FIELDS)
         self._selector.currentTextChanged.connect(self._on_field_changed)
         self._min = _value_label()
         self._max = _value_label()
+        self._placement = QComboBox()
+        self._placement.addItems(self.PLACEMENTS)
+        self._placement.setCurrentText(self.PLACEMENT)
+        self._placement.currentTextChanged.connect(self._on_placement_changed)
 
         form = QFormLayout()
         form.addRow("field", self._selector)
         form.addRow("min", self._min)
         form.addRow("max", self._max)
+        form.addRow("color bar", self._placement)
         self.set_content_layout(form)
 
     def field(self):
         return self._selector.currentText()
+
+    def placement(self):
+        """Which edge of the domain sub-window the legend takes."""
+        return self._placement.currentText()
 
     def show_range(self, vmin, vmax):
         self._min.setText("-" if vmin is None else _number(vmin))
@@ -401,6 +424,10 @@ class FieldBox(FoldBox):
     def _on_field_changed(self, name):
         if self.field_changed is not None:
             self.field_changed(name)
+
+    def _on_placement_changed(self, name):
+        if self.placement_changed is not None:
+            self.placement_changed(name)
 
 
 class ZoneBox(FoldBox):
@@ -548,12 +575,23 @@ class SolutionPanel(QScrollArea):
     def field_changed(self, callback):
         self._field.field_changed = callback
 
+    @property
+    def placement_changed(self):
+        return self._field.placement_changed
+
+    @placement_changed.setter
+    def placement_changed(self, callback):
+        self._field.placement_changed = callback
+
     def params(self):
         """Collect the current control values for the solver driver."""
         return {**self._freestream.params(), **self._numerics.params()}
 
     def field(self):
         return self._field.field()
+
+    def bar_placement(self):
+        return self._field.placement()
 
     def steps_per_frame(self):
         return self._run.steps_per_frame()

--- a/solvcon/pilot/apps/obsrefl/_viewer.py
+++ b/solvcon/pilot/apps/obsrefl/_viewer.py
@@ -14,6 +14,8 @@ the owner, which hears about a close through the :attr:`closed` callback.
 
 from PySide6.QtCore import Qt, QObject, QEvent
 
+from ._colorbar import ColorBar
+
 __all__ = [  # noqa: F822
     'DomainViewer',
 ]
@@ -36,8 +38,27 @@ class _SubWindowCloseFilter(QObject):
         return False
 
 
+class _ResizeRelay(QObject):
+    """Report a watched widget's resize, so an overlay can follow it."""
+
+    def __init__(self, on_resize, parent):
+        super().__init__(parent)
+        self._on_resize = on_resize
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Type.Resize:
+            self._on_resize()
+        return False
+
+
 class DomainViewer(object):
-    """Own the domain sub-window and draw a run into it."""
+    """Own the domain sub-window and draw a run into it.
+
+    The color-bar legend rides here too, as a widget laid over the
+    sub-window against the edge its owner picks.  An overlay rather than a
+    row of the layout, because the 3D widget is the layout's one child and
+    is not a Qt widget this side of the binding to be moved around.
+    """
 
     #: Lift the analytic shock overlay off the z = 0 field plane so it is
     #: not z-fought away by the colored triangles.
@@ -56,6 +77,13 @@ class DomainViewer(object):
         # garbage-collected right after use, invalidating any sub-window
         # handle taken through it.
         self._mdi = None
+        # The legend, its edge, and the scale it was last given.  The scale
+        # outlives the widget, which is rebuilt whenever the edge turns it
+        # through a right angle or the sub-window is closed under it.
+        self._bar = None
+        self._resize_relay = None
+        self._placement = 'off'
+        self._scale = (None, None)
 
     @property
     def is_open(self):
@@ -78,6 +106,64 @@ class DomainViewer(object):
             self._close_filter = _SubWindowCloseFilter(
                 self._on_subwin_closed, self._subwin)
             self._subwin.installEventFilter(self._close_filter)
+            host = self._host()
+            if host is not None:
+                self._resize_relay = _ResizeRelay(self._place_bar, host)
+                host.installEventFilter(self._resize_relay)
+        self._place_bar()
+
+    def _host(self):
+        """The plain widget the 3D view is hosted in, which the legend is
+        laid over, or None while the sub-window is closed."""
+        return None if self._subwin is None else self._subwin.widget()
+
+    def show_bar(self, placement):
+        """Stand the legend against ``placement``, or take it away."""
+        self._placement = placement
+        self._place_bar()
+
+    def show_scale(self, lo, hi):
+        """Give the legend the range it is to draw, whether or not it is
+        standing; a bar built later opens on the last scale seen."""
+        self._scale = (lo, hi)
+        if self._bar is not None:
+            self._bar.show_scale(lo, hi)
+
+    def _place_bar(self):
+        """Build, move, or drop the legend to match the wanted placement."""
+        host = self._host()
+        if host is None or 'off' == self._placement:
+            self._drop_bar()
+            return
+        vertical = self._placement in ('left', 'right')
+        if self._bar is None or self._bar.vertical != vertical:
+            self._drop_bar()
+            self._bar = ColorBar(vertical=vertical)
+            self._bar.show_scale(*self._scale)
+        self._bar.setParent(host)
+        self._bar.setGeometry(*self._bar_geometry(host))
+        self._bar.show()
+        # The 3D view fills the host, so the legend has to be told to sit
+        # over it rather than under.
+        self._bar.raise_()
+
+    def _bar_geometry(self, host):
+        """Where the legend sits against its edge of ``host``."""
+        width, height = host.width(), host.height()
+        thick = self._bar.thickness()
+        if 'left' == self._placement:
+            return (0, 0, thick, height)
+        if 'right' == self._placement:
+            return (width - thick, 0, thick, height)
+        if 'upper' == self._placement:
+            return (0, 0, width, thick)
+        return (0, height - thick, width, thick)
+
+    def _drop_bar(self):
+        """Take the legend off the sub-window, keeping its scale."""
+        if self._bar is not None:
+            self._bar.setParent(None)
+            self._bar = None
 
     def close(self):
         """Close the sub-window; its close event fires :attr:`closed`."""
@@ -87,11 +173,13 @@ class DomainViewer(object):
             self._on_subwin_closed()
 
     def _on_subwin_closed(self):
-        # Reached from the sub-window's close event; drop the widget before
-        # Qt frees it, then tell the owner so it can stop the march.
+        # Reached from the sub-window's close event; drop the widgets before
+        # Qt frees them, then tell the owner so it can stop the march.
+        self._drop_bar()
         self._viewer = None
         self._subwin = None
         self._close_filter = None
+        self._resize_relay = None
         if self.closed is not None:
             self.closed()
 

--- a/tests/apps/obsrefl/test_colorbar.py
+++ b/tests/apps/obsrefl/test_colorbar.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""The color-bar legend of the oblique-shock reflection viewer.
+
+The bar is a widget, not a window, so it is checked here rather than in the
+window lane: a `ColorBar` and a coarse session are all it takes to give it a
+range and read back what it drew.  Where it stands in the sub-window is the
+viewer's business and is checked there.
+"""
+
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot.apps.obsrefl import ReflectionSession
+    from solvcon.pilot.apps.obsrefl._colorbar import ColorBar
+except ImportError:
+    pilot = None
+
+
+class _Recorder(object):
+    """Stand in for the painter and note what it was asked to draw."""
+
+    def __init__(self):
+        self.lines = 0
+        self.texts = []
+
+    def drawLine(self, *_args):
+        self.lines += 1
+
+    def drawText(self, _rect, _align, text):
+        self.texts.append(text)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class ColorBarTC(unittest.TestCase):
+    """What the legend spans, what it ticks, and what it paints."""
+
+    @classmethod
+    def setUpClass(cls):
+        # The manager owns the QApplication the widget needs to exist.
+        pilot.RManager.instance.setUp()
+
+    def _scaled(self, name='density', vertical=False):
+        """A bar filled from one marched chunk of a coarse run, with the
+        run and the drawn field range it was filled from."""
+        sess = ReflectionSession(nx=8, ny=3, steps_per_chunk=3)
+        sess.advance()
+        field = sess.field.field(name)
+        vmin, vmax = float(field.min()), float(field.max())
+        bar = ColorBar(vertical=vertical)
+        bar.show_scale(*sess.analysis.color_range(name, vmin, vmax))
+        return bar, sess, vmin, vmax
+
+    def test_the_legend_spans_the_range_the_viewer_pins(self):
+        # The legend is what says which color means what, so it has to be
+        # drawn over the range the viewer colors against, not the frame's
+        # own: a field short of the answer would otherwise read as if it
+        # had arrived.
+        bar, sess, vmin, vmax = self._scaled()
+        self.assertEqual(sess.analysis.color_range('density', vmin, vmax),
+                         (bar.lo, bar.hi))
+        self.assertLessEqual(bar.lo, vmin)
+        self.assertGreaterEqual(bar.hi, vmax)
+
+    def test_a_field_with_no_analytic_value_spans_the_frame(self):
+        # The CFL number belongs to the discretization, not to the flow, so
+        # there is no analytic value to widen its range to and the ramp is
+        # the frame's own.
+        bar, _, vmin, vmax = self._scaled('cfl')
+        self.assertEqual((vmin, vmax), (bar.lo, bar.hi))
+
+    def test_an_unscaled_legend_draws_nothing_and_survives(self):
+        bar = ColorBar()
+        self.assertIsNone(bar.lo)
+        # A ramp with no range still has to paint, since the bar stands
+        # before the first run fills it.
+        self.assertFalse(bar.grab().isNull())
+        # A degenerate range is no range at all; mapping it would divide by
+        # its zero span.
+        bar.show_scale(1.0, 1.0)
+        self.assertIsNone(bar.lo)
+
+    def test_a_flat_legend_runs_low_at_the_left(self):
+        # The ramp is drawn rather than laid out from child widgets, so
+        # only rendering it says whether it works at all.
+        bar, _, _, _ = self._scaled()
+        bar.resize(200, bar.thickness())
+        pixmap = bar.grab()
+        image = pixmap.toImage()
+        self.assertFalse(image.isNull())
+        # A grab comes back in device pixels, which on a scaled display are
+        # not the widget's own; the ramp has to be sampled where it landed.
+        scale = pixmap.devicePixelRatio()
+        rect = bar._bar_rect()
+        row = round(rect.center().y() * scale)
+        low = image.pixelColor(round((rect.left() + 2) * scale), row)
+        high = image.pixelColor(round((rect.right() - 2) * scale), row)
+        # The map runs blue to red, so the two ends cannot come out alike.
+        self.assertGreater(high.red(), low.red())
+        self.assertGreater(low.blue(), high.blue())
+
+    def test_a_vertical_legend_runs_low_at_the_bottom(self):
+        # A bar against a side edge runs up the view, the way an axis does,
+        # so the low end has to be at the bottom rather than the left.
+        bar, _, _, _ = self._scaled(vertical=True)
+        bar.resize(bar.thickness(), 200)
+        rect = bar._bar_rect()
+        self.assertGreater(bar._at(bar.lo, rect), bar._at(bar.hi, rect))
+        pixmap = bar.grab()
+        image = pixmap.toImage()
+        scale = pixmap.devicePixelRatio()
+        column = round(rect.center().x() * scale)
+        low = image.pixelColor(column, round((rect.bottom() - 2) * scale))
+        high = image.pixelColor(column, round((rect.top() + 2) * scale))
+        self.assertGreater(low.blue(), high.blue())
+        self.assertGreater(high.red(), low.red())
+
+    def test_a_vertical_legend_keeps_its_labels_inside(self):
+        # The end labels sit in a column beside the ramp; a column running
+        # off the widget would lose the reading it carries.
+        bar, _, _, _ = self._scaled(vertical=True)
+        bar.resize(bar.thickness(), 200)
+        rect = bar._bar_rect()
+        self.assertGreaterEqual(rect.left(), bar.LABEL_WIDTH)
+        self.assertLessEqual(rect.right(), bar.width())
+
+    def test_the_ramp_carries_the_two_ends_and_nothing_else(self):
+        # Marking the analytic zone values here would put a second reading
+        # on a scale, where the eye takes it for the scale itself.  The bar
+        # is the two ends of the range and the ramp between them.
+        bar, _, _, _ = self._scaled()
+        bar.resize(240, bar.thickness())
+        drawn = _Recorder()
+        bar._draw_ends(drawn, bar._bar_rect())
+        self.assertEqual(2, len(drawn.texts))
+        self.assertEqual(0, drawn.lines)
+        # And there is no zone marking left to call.
+        self.assertFalse(hasattr(bar, '_draw_zones'))
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/apps/obsrefl/test_panel.py
+++ b/tests/apps/obsrefl/test_panel.py
@@ -184,6 +184,21 @@ class StatusReadoutTC(unittest.TestCase):
         self.assertEqual(_panel._number(vmin), panel._field._min.text())
         self.assertEqual(_panel._number(vmax), panel._field._max.text())
 
+    def test_the_field_box_says_where_the_legend_stands(self):
+        # The legend itself is drawn in the domain sub-window; this box
+        # only carries the choice of edge, and reports it to its owner.
+        panel = SolutionPanel()
+        self.assertEqual(_panel.FieldBox.PLACEMENT, panel.bar_placement())
+        moved = []
+        panel.placement_changed = moved.append
+        panel._field._placement.setCurrentText('lower')
+        self.assertEqual(['lower'], moved)
+        self.assertEqual('lower', panel.bar_placement())
+        # Every edge the viewer knows about is on offer, "off" included.
+        self.assertEqual(list(_panel.FieldBox.PLACEMENTS),
+                         [panel._field._placement.itemText(it)
+                          for it in range(panel._field._placement.count())])
+
     def test_the_zone_rows_carry_the_computed_analytic_and_error(self):
         panel, _, _, _ = self._filled()
         zones = self._zone_rows(panel)

--- a/tests/gui/test_obsrefl.py
+++ b/tests/gui/test_obsrefl.py
@@ -307,6 +307,89 @@ class ObliqueShockAppTC(unittest.TestCase):
         self.assertTrue(feature._panel._run._viewer_btn.isChecked())
         QApplication.processEvents()
 
+    def test_the_legend_stands_against_the_edge_the_panel_names(self):
+        # The legend explains the colors, so it belongs over the field and
+        # not in the control panel: it rides on the sub-window's host
+        # widget, above the 3D view that fills it, against whichever edge
+        # the Field box names.
+        feature = self._feature()
+        self._coarsen(feature)
+        feature._control.start()
+        feature._control._timer.stop()
+        host = feature._viewer._subwin.widget()
+        host.resize(400, 300)
+        QApplication.processEvents()
+        for placement in ('left', 'right', 'upper', 'lower'):
+            feature._panel._field._placement.setCurrentText(placement)
+            bar = feature._viewer._bar
+            self.assertIs(host, bar.parent())
+            self.assertTrue(bar.isVisibleTo(host))
+            # Left and right run the ramp up the view; the other two run it
+            # across, and each sits against its own edge.
+            self.assertEqual(placement in ('left', 'right'), bar.vertical)
+            box = bar.geometry()
+            if 'left' == placement:
+                self.assertEqual(0, box.left())
+            elif 'right' == placement:
+                self.assertEqual(host.width(), box.right() + 1)
+            elif 'upper' == placement:
+                self.assertEqual(0, box.top())
+            else:
+                self.assertEqual(host.height(), box.bottom() + 1)
+        QApplication.processEvents()
+
+    def test_the_legend_is_pinned_to_the_field_the_viewer_colors(self):
+        # The legend and the viewer have to be reading one range, or the
+        # legend explains colors that are not on screen.  Each field pins
+        # its own, so a field switched under the bar has to redraw it
+        # rather than leave the range it was standing on.
+        feature = self._feature()
+        self._coarsen(feature)
+        feature._control.start()
+        feature._control._timer.stop()
+        sess = feature._control.session
+        before = (feature._viewer._bar.lo, feature._viewer._bar.hi)
+        feature._panel._field._selector.setCurrentText('pressure')
+        bar = feature._viewer._bar
+        self.assertNotEqual(before, (bar.lo, bar.hi))
+        field = sess.field.field('pressure')
+        self.assertEqual(
+            sess.analysis.color_range('pressure', float(field.min()),
+                                      float(field.max())),
+            (bar.lo, bar.hi))
+        QApplication.processEvents()
+
+    def test_switching_the_legend_off_takes_it_away(self):
+        feature = self._feature()
+        self._coarsen(feature)
+        feature._control.start()
+        feature._control._timer.stop()
+        feature._panel._field._placement.setCurrentText('off')
+        self.assertIsNone(feature._viewer._bar)
+        # A run drawn with no legend must not go looking for one.
+        feature._control._on_step()
+        self.assertIsNone(feature._viewer._bar)
+        # Naming an edge again brings it back on the standing scale.
+        feature._panel._field._placement.setCurrentText('right')
+        self.assertIsNotNone(feature._viewer._bar.lo)
+        QApplication.processEvents()
+
+    def test_the_reopened_viewer_carries_the_legend_back(self):
+        feature = self._feature()
+        self._coarsen(feature)
+        feature._control.start()
+        feature._control._timer.stop()
+        feature._viewer.close()
+        # Closing deletes the sub-window and the legend laid over it, so
+        # reopening has to stand a new one up on the same scale.
+        self.assertIsNone(feature._viewer._bar)
+        feature._panel._run._viewer_btn.click()
+        bar = feature._viewer._bar
+        self.assertIsNotNone(bar)
+        self.assertIs(feature._viewer._subwin.widget(), bar.parent())
+        self.assertIsNotNone(bar.lo)
+        QApplication.processEvents()
+
 
 @unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")


### PR DESCRIPTION
For issue #1272

Add a colormap bar to the domain viewer window.  The two ends of the color bar are labeled with the extremum value of the corresponding field:

<img width="1455" height="684" alt="image" src="https://github.com/user-attachments/assets/1327ae12-3718-49e4-a5d1-241809b0d250" />

Users can choose what where to place it:

<img width="240" height="145" alt="image" src="https://github.com/user-attachments/assets/40535088-3da5-4f6e-b60c-f6af00bc1c66" />

Example of placing it at the upper side in the window:

<img width="1460" height="671" alt="image" src="https://github.com/user-attachments/assets/69f63753-d85e-411b-99eb-ef78f1914971" />

