### PR TITLE
Record the reflection run into an animated movie

### DIFF
--- a/solvcon/pilot/apps/obsrefl/_app.py
+++ b/solvcon/pilot/apps/obsrefl/_app.py
@@ -62,6 +62,7 @@ class ObliqueShockApp(_gui_common.PilotFeature):
             return
         self._panel = SolutionPanel()
         self._control = RunController(self._panel, self._viewer)
+        self._control.reported = self._report
         self._dock = QDockWidget("euler solver")
         self._dock.setWidget(self._panel)
         self._mgr.mainWindow.addDockWidget(Qt.LeftDockWidgetArea, self._dock)
@@ -71,5 +72,13 @@ class ObliqueShockApp(_gui_common.PilotFeature):
     def _notify_viewer_updated(self):
         if self.viewer_updated is not None:
             self.viewer_updated()
+
+    def _report(self, message):
+        """Carry what the controller has to say to the pilot console.
+
+        The console belongs to the outer GUI, so the controller says it and
+        the feature, which holds the GUI, writes it.
+        """
+        self._pycon.writeToHistory(f"euler solver {message}\n")
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/apps/obsrefl/_control.py
+++ b/solvcon/pilot/apps/obsrefl/_control.py
@@ -10,10 +10,15 @@ wire between them lands here.  Panel gestures arrive through the callbacks
 the controller plants on the panel, a viewer close arrives through the
 viewer's ``closed``, and everything the widgets show is pushed back into
 them from this side.  No widget ever reaches into a sibling.
+
+The movie a run records is driven from here as well.  It rides on the
+frames the viewer draws, so it belongs beside the march rather than in the
+run session, which stays free of the GUI it is watched from.
 """
 
 from PySide6.QtCore import QTimer
 
+from ...visual import _movie
 from ._field_render import FieldPainter
 from ._session import ReflectionSession
 
@@ -33,6 +38,10 @@ class RunController(object):
 
     :ivar session: The running :class:`~._session.ReflectionSession`, or
         None until the first :meth:`preview` or :meth:`start` builds one.
+    :ivar movie: The open :class:`~solvcon.pilot.visual.MovieRecorder`, or
+        None while the run is not being recorded.
+    :ivar reported: Owner-supplied callback that says what became of a
+        movie, or None to keep it to the panel.
     """
 
     #: Qt timer interval in milliseconds.
@@ -42,7 +51,12 @@ class RunController(object):
         self._panel = panel
         self._viewer = viewer
         self.session = None
+        self.movie = None
+        self.reported = None
         self._painter = None
+        # The mesh flavor the standing run was built with, which names its
+        # movie; the control may have moved on since.
+        self._cell_type = None
         self._timer = QTimer()
         self._timer.timeout.connect(self._advance)
         panel.viewer_toggled = self._on_viewer
@@ -54,6 +68,7 @@ class RunController(object):
         panel.remesh_requested = self.remesh
         panel.field_changed = self._on_field
         panel.placement_changed = self._on_bar_placement
+        panel.record_toggled = self._on_record
         viewer.closed = self._on_viewer_closed
 
     def preview(self):
@@ -68,8 +83,12 @@ class RunController(object):
 
     def start(self):
         """(Re)build the run session from the controls and march it into the
-        viewer, opening the viewer sub-window first if it was closed."""
-        self._build()
+        viewer, opening the viewer sub-window first if it was closed.
+
+        A run started with the record box ticked records from its first
+        frame, so the movie opens on the state the march starts from.
+        """
+        self._build(record=self._panel.recording())
         self._panel.set_paused(False)
         self._timer.start(self.INTERVAL_MS)
 
@@ -87,21 +106,33 @@ class RunController(object):
         if self.session is not None:
             self.session.stop()
             self._draw_frame()
+        self._finish_movie()
 
     def reset(self):
         """Drop the run and its viewer, back to where the panel started."""
         self._timer.stop()
+        self._finish_movie()
         self.session = None
         self._painter = None
         self._viewer.close()
         self._panel.set_paused(False)
         self._draw_frame()
 
-    def _build(self):
-        """Halt any march, then build the configured run and draw it."""
+    def _build(self, record=False):
+        """Halt any march, then build the configured run and draw it.
+
+        Whatever the previous run recorded is written out first: the movie
+        belongs to the run that drew its frames, not to the one replacing
+        it.
+        """
         self._timer.stop()
-        self.session = ReflectionSession(**self._panel.params())
+        self._finish_movie()
+        params = self._panel.params()
+        self._cell_type = params['cell_type']
+        self.session = ReflectionSession(**params)
         self._painter = FieldPainter(self.session.shock.mesh)
+        if record:
+            self._start_movie()
         self._open_viewer()
 
     def _open_viewer(self):
@@ -129,8 +160,10 @@ class RunController(object):
 
     def _on_viewer_closed(self):
         # Reached from the sub-window's close event; stop the run before Qt
-        # frees the viewer.
+        # frees the viewer, and write out what it recorded, as no frame can
+        # follow a viewer that is gone.
         self._timer.stop()
+        self._finish_movie()
         self._panel.set_viewer_open(False)
 
     def _on_pause(self, paused):
@@ -153,6 +186,16 @@ class RunController(object):
         """Move the legend to the edge the field box now names."""
         self._viewer.show_bar(placement)
 
+    def _on_record(self, on):
+        """Open or close the recorder of a run already under way; a run
+        started later reads the box in :meth:`start`."""
+        if self.session is None:
+            return
+        if on:
+            self._start_movie()
+        else:
+            self._finish_movie()
+
     def _advance(self):
         if not self._viewer.is_open:
             self._timer.stop()
@@ -160,6 +203,7 @@ class RunController(object):
         if self.session.finished:
             self._timer.stop()
             self._panel.set_paused(True)
+            self._finish_movie()
             return
         self._march_frame()
 
@@ -195,6 +239,58 @@ class RunController(object):
             self._viewer.draw_field(self._painter.verts,
                                     self._painter.colors(field, lo, hi),
                                     self._painter.indices)
+            if self.movie is not None:
+                self._capture_frame()
         self._panel.set_status(session, vmin, vmax)
+
+    def _start_movie(self):
+        """Open a recorder over the running session, if none is open."""
+        if self.movie is None:
+            self.movie = _movie.MovieRecorder()
+            self._report(f"recording to {self._movie_path()}")
+
+    def _capture_frame(self):
+        """Hold the frame the viewer just drew.
+
+        A viewer with nothing to grab (no graphics surface behind it)
+        drops the recording instead of breaking the march.
+        """
+        try:
+            self._viewer.capture(self.movie)
+        except RuntimeError as exc:
+            self.movie.close()
+            self.movie = None
+            self._panel.set_recording(False)
+            self._report(f"stopped recording: {exc}")
+
+    def _finish_movie(self):
+        """Write out what the recorder holds and report where it landed."""
+        if self.movie is None:
+            return
+        movie = self.movie
+        self.movie = None
+        path = self._movie_path()
+        try:
+            nframe = movie.write(path)
+        except (OSError, ValueError) as exc:
+            self._report(f"wrote no movie: {exc}")
+        else:
+            self._report(f"wrote {nframe} frames to {path}")
+        finally:
+            movie.close()
+
+    def _movie_path(self):
+        """Where the standing run's movie is to land."""
+        return self._panel.movie_path(self._cell_type)
+
+    def _report(self, message):
+        """Say what became of the movie, in the panel and to the owner.
+
+        The panel keeps the line in view, since the console scrolls away
+        under the run's own output and the movie is easy to lose track of.
+        """
+        self._panel.set_movie_status(message)
+        if self.reported is not None:
+            self.reported(message)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/apps/obsrefl/_panel.py
+++ b/solvcon/pilot/apps/obsrefl/_panel.py
@@ -6,22 +6,24 @@
 
 The panel stacks its boxes in the order a run is used: the free-stream and
 numerics inputs consumed when a run starts, the run controls with the live
-march readout, the field the viewer colors with the range it spans, and
-the zone readout that judges the field against the analytic reflection.
-Each box is a passive widget that only reports what its controls hold and
-calls back into its owner; the panel composes the boxes and forwards their
-surface, and the solver and the viewer belong to the controller in
-:mod:`._control`.
+march readout, the movie the run records as it marches, the field the
+viewer colors with the range it spans, and the zone readout that judges
+the field against the analytic reflection.  Each box is a passive widget
+that only reports what its controls hold and calls back into its owner;
+the panel composes the boxes and forwards their surface, and the solver
+and the viewer belong to the controller in :mod:`._control`.
 """
 
 import math
+import os
 
 from PySide6.QtCore import Qt, QSize
 from PySide6.QtGui import QFontDatabase
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QFormLayout,
                                QGridLayout, QLabel, QComboBox, QDoubleSpinBox,
                                QSpinBox, QPushButton, QToolButton,
-                               QSizePolicy, QScrollArea, QFrame)
+                               QSizePolicy, QScrollArea, QFrame, QCheckBox,
+                               QLineEdit)
 
 from ....multidim.euler import EulerField
 
@@ -370,6 +372,67 @@ class RunBox(FoldBox):
             self.reset_requested()
 
 
+class MovieBox(FoldBox):
+    """Whether the run records what the viewer draws, and where it lands.
+
+    The box is read when a run starts and can be ticked mid-march to join
+    one already going; the movie is written when the recording ends.
+    """
+
+    #: Where a recorded movie lands; the mesh flavor of the run is
+    #: substituted for the placeholder and the suffix picks the format
+    #: (:attr:`~solvcon.pilot.visual.MovieRecorder.SUFFIXES`).  Shown
+    #: resolved against the working directory, which for a pilot started
+    #: from the desktop is not the checkout, so the control names the
+    #: movie's real destination.
+    MOVIE_PATH = 'tmp/obrefl_{cell_type}.webp'
+
+    def __init__(self, parent=None):
+        super().__init__("Movie", parent)
+        # Owner-supplied callback that opens or closes the recorder.
+        self.record_toggled = None
+        self._record = QCheckBox()
+        self._record.toggled.connect(self._on_record_toggled)
+        self._path = QLineEdit(os.path.abspath(self.MOVIE_PATH))
+        # Names the movie's destination and, once written, what landed
+        # there; selectable so the path can be copied out.
+        self._status = QLabel("")
+        self._status.setWordWrap(True)
+        self._status.setTextInteractionFlags(Qt.TextSelectableByMouse)
+
+        form = QFormLayout()
+        form.addRow("record movie", self._record)
+        form.addRow("movie path", self._path)
+        form.addRow(self._status)
+        self.set_content_layout(form)
+
+    def recording(self):
+        return self._record.isChecked()
+
+    def movie_path(self, cell_type):
+        """The movie output path with the run's mesh flavor substituted in.
+
+        Absolute, because a relative path lands next to whatever the pilot
+        was launched from and the movie is then anyone's guess to find.
+        """
+        return os.path.abspath(
+            self._path.text().replace('{cell_type}', cell_type))
+
+    def set_movie_status(self, message):
+        """Say where the movie is going, or where it went."""
+        self._status.setText(message)
+
+    def set_recording(self, on):
+        """Reflect the record state in its box without re-firing it."""
+        self._record.blockSignals(True)
+        self._record.setChecked(on)
+        self._record.blockSignals(False)
+
+    def _on_record_toggled(self, on):
+        if self.record_toggled is not None:
+            self.record_toggled(on)
+
+
 class FieldBox(FoldBox):
     """Which derived field the viewer colors, the range it spans, and where
     the legend of those colors stands.
@@ -493,10 +556,11 @@ class SolutionPanel(QScrollArea):
         self._freestream = FreeStreamBox()
         self._numerics = NumericsBox()
         self._run = RunBox()
+        self._movie = MovieBox()
         self._field = FieldBox()
         self._zones = ZoneBox()
         self._boxes = (self._freestream, self._numerics, self._run,
-                       self._field, self._zones)
+                       self._movie, self._field, self._zones)
 
         inner = QWidget()
         layout = QVBoxLayout(inner)
@@ -583,6 +647,14 @@ class SolutionPanel(QScrollArea):
     def placement_changed(self, callback):
         self._field.placement_changed = callback
 
+    @property
+    def record_toggled(self):
+        return self._movie.record_toggled
+
+    @record_toggled.setter
+    def record_toggled(self, callback):
+        self._movie.record_toggled = callback
+
     def params(self):
         """Collect the current control values for the solver driver."""
         return {**self._freestream.params(), **self._numerics.params()}
@@ -595,6 +667,18 @@ class SolutionPanel(QScrollArea):
 
     def steps_per_frame(self):
         return self._run.steps_per_frame()
+
+    def recording(self):
+        return self._movie.recording()
+
+    def movie_path(self, cell_type):
+        return self._movie.movie_path(cell_type)
+
+    def set_movie_status(self, message):
+        self._movie.set_movie_status(message)
+
+    def set_recording(self, on):
+        self._movie.set_recording(on)
 
     def set_paused(self, paused):
         self._run.set_paused(paused)

--- a/solvcon/pilot/apps/obsrefl/_viewer.py
+++ b/solvcon/pilot/apps/obsrefl/_viewer.py
@@ -2,14 +2,15 @@
 # BSD 3-Clause License, see COPYING
 
 
-"""The domain viewer sub-window a reflection run draws into.
+"""The domain sub-window a reflection run draws into.
 
 :class:`DomainViewer` wraps the one 3D sub-window of a run: it opens and
 closes the window, watches for a close from any source, and forwards what
 the run wants drawn (the mesh, the analytic shock overlay, the colored
-field).  Every drawing call is a no-op while the window is closed, so the
-owner never draws into a freed widget.  What to draw and when stays with
-the owner, which hears about a close through the :attr:`closed` callback.
+field, and the color-bar legend laid over them).  Every drawing call is a
+no-op while the window is closed, so the owner never draws into a freed
+widget.  What to draw and when stays with the owner, which hears about a
+close through the :attr:`closed` callback.
 """
 
 from PySide6.QtCore import Qt, QObject, QEvent
@@ -215,5 +216,18 @@ class DomainViewer(object):
         if self._viewer is None:
             return
         self._viewer.updateColorField(verts, colors, indices)
+
+    def capture(self, movie):
+        """Hold one frame of the whole sub-window in ``movie``.
+
+        The host is grabbed, not the 3D view inside it, so the color bar
+        laid over the view is recorded with it.  A closed window has
+        nothing to record, and records nothing rather than reaching a
+        freed widget.
+        """
+        host = self._host()
+        if host is None:
+            return
+        movie.capture(host)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/visual/__init__.py
+++ b/solvcon/pilot/visual/__init__.py
@@ -3,19 +3,21 @@
 
 
 """
-The mesh view: sample meshes, the Gmsh file dialog, and the mesh style
-status helpers.
+The visual pieces of the pilot: sample meshes, the Gmsh file dialog, the
+mesh style status helpers, and the viewer movie recorder.
 """
 
 from .. import _pilot_core as _pcore
 
 if _pcore.enable:
     from . import _mesh
+    from . import _movie
 
     SampleMesh = _mesh.SampleMesh
     SampleMeshFeature = _mesh.SampleMeshFeature
     MeshStyleStatus = _mesh.MeshStyleStatus
     GmshFileDialog = _mesh.GmshFileDialog
+    MovieRecorder = _movie.MovieRecorder
 else:
     # Bind only the public names: a None module attribute would shadow the
     # real submodule import in no-GUI builds.
@@ -23,10 +25,12 @@ else:
     SampleMeshFeature = None
     MeshStyleStatus = None
     GmshFileDialog = None
+    MovieRecorder = None
 
 __all__ = [
     'GmshFileDialog',
     'MeshStyleStatus',
+    'MovieRecorder',
     'SampleMesh',
     'SampleMeshFeature',
 ]

--- a/solvcon/pilot/visual/_movie.py
+++ b/solvcon/pilot/visual/_movie.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Record what a viewer widget shows into an animated movie.
+
+:class:`MovieRecorder` grabs one frame per capture off a widget and
+assembles the frames into a looping animation.  Grabbing the widget rather
+than asking the 3D view to render itself takes in whatever is laid over it,
+the color bar included, and takes it at the shape the widget has, where
+rendering to a size of its own reframed the scene and cut the domain off at
+the sides.
+
+The frames stay on disk as PNG files in a temporary directory until they
+are written out, so a long run does not pile up on the heap.
+"""
+
+import os
+import tempfile
+
+try:
+    from PIL import Image
+
+    HAS_IMAGE = True
+except ImportError:
+    Image = None
+    HAS_IMAGE = False
+
+__all__ = [
+    'MovieRecorder',
+]
+
+
+class MovieRecorder(object):
+    """Collect frames off a widget and write them out as an animation.
+
+    The widget is anything carrying ``grab()``, which every Qt widget does.
+
+    The movie takes the shape of its first frame, and a later frame of
+    another shape is scaled to it, so resizing the window mid-run leaves an
+    animation that still plays rather than one that changes size partway.
+
+    The output name picks the format.  A ``.webp`` keeps the frames in
+    true color, which a field of smooth colors needs; a ``.gif`` goes
+    everywhere but is quantized to 255 colors.
+
+    :ivar frame_ms: Milliseconds each frame is shown.
+    :ivar hold_ms: Milliseconds the last frame is held, so a loop ends on
+        the result instead of snapping back.
+    :ivar quality: WebP quality, 0 to 100.
+    """
+
+    #: Output suffixes that name a format :meth:`write` can write.
+    SUFFIXES = ('.gif', '.webp')
+    #: Frames sampled across the movie to build its one GIF palette, and
+    #: the factor each sample is shrunk by.
+    PALETTE_FRAMES = 16
+    PALETTE_SHRINK = 2
+    #: WebP encoding effort, 0 (fastest) to 6 (smallest).
+    WEBP_METHOD = 4
+
+    def __init__(self, frame_ms=80, hold_ms=1500, quality=80):
+        self.frame_ms = frame_ms
+        self.hold_ms = hold_ms
+        self.quality = quality
+        self._folder = tempfile.TemporaryDirectory(prefix='solvcon-movie-')
+        self._frames = []
+
+    @property
+    def nframe(self):
+        """Number of frames captured so far."""
+        return len(self._frames)
+
+    def capture(self, widget):
+        """Grab one frame of what ``widget`` shows and hold it."""
+        path = os.path.join(self._folder.name, f"frame{self.nframe:05d}.png")
+        pixmap = widget.grab()
+        if pixmap.isNull() or not pixmap.save(path):
+            raise RuntimeError("the viewer gave no frame")
+        self._frames.append(path)
+        return path
+
+    def write(self, path):
+        """Assemble the held frames into the movie at ``path``; returns how
+        many were assembled.
+
+        The suffix of ``path`` picks the format among :attr:`SUFFIXES`.
+        """
+        if not HAS_IMAGE:
+            raise OSError("writing a movie needs PIL/Pillow installed")
+        if not self._frames:
+            raise ValueError("no frame is captured")
+        suffix = os.path.splitext(path)[1].lower()
+        if suffix not in self.SUFFIXES:
+            raise ValueError(
+                f"cannot write a movie named '{os.path.basename(path)}'; "
+                f"name it {' or '.join(self.SUFFIXES)}")
+        folder = os.path.dirname(path)
+        if folder:
+            os.makedirs(folder, exist_ok=True)
+        durations = ([self.frame_ms] * (len(self._frames) - 1)
+                     + [self.hold_ms])
+        if '.webp' == suffix:
+            return self._write_webp(path, durations)
+        return self._write_gif(path, durations)
+
+    def _load(self):
+        """The held frames, every one the shape of the first."""
+        movie = [Image.open(fn).convert('RGB') for fn in self._frames]
+        size = movie[0].size
+        return [im if im.size == size
+                else im.resize(size, Image.Resampling.LANCZOS)
+                for im in movie]
+
+    def _write_gif(self, path, durations):
+        """Write the GIF at ``path``.
+
+        Every frame is quantized against the one palette of :meth:`_palette`,
+        so the movie does not flicker the way a per-frame palette makes it.
+        The GIF writer merges identical neighboring frames, so the file can
+        end up holding fewer than were assembled into it.
+        """
+        movie = self._load()
+        palette = self._palette(movie)
+        movie = [im.quantize(palette=palette, dither=Image.Dither.NONE)
+                 for im in movie]
+        movie[0].save(path, save_all=True, append_images=movie[1:],
+                      duration=durations, loop=0, optimize=True)
+        return len(movie)
+
+    def _write_webp(self, path, durations):
+        """Write the animated WebP at ``path``.
+
+        The frames go in as they were rendered: WebP carries true color, so
+        there is no palette to build and none of the banding one leaves in
+        a smooth field.
+        """
+        movie = self._load()
+        movie[0].save(path, save_all=True, append_images=movie[1:],
+                      duration=durations, loop=0, quality=self.quality,
+                      method=self.WEBP_METHOD)
+        return len(movie)
+
+    def _palette(self, movie):
+        """Median-cut one palette over frames sampled across the movie.
+
+        A palette read off a single frame misses the colors the rest of the
+        movie needs, which flattens everything that frame does not show.
+        The samples are shrunk with nearest-neighbor, keeping their colors
+        exact while cutting the work.
+        """
+        stride = max(1, len(movie) // self.PALETTE_FRAMES)
+        picks = movie[::stride]
+        width = max(1, picks[0].width // self.PALETTE_SHRINK)
+        height = max(1, picks[0].height // self.PALETTE_SHRINK)
+        strip = Image.new('RGB', (width, height * len(picks)))
+        for it, image in enumerate(picks):
+            strip.paste(image.resize((width, height),
+                                     Image.Resampling.NEAREST),
+                        (0, it * height))
+        return strip.quantize(colors=255)
+
+    def close(self):
+        """Drop the held frames and the temporary directory."""
+        self._frames = []
+        if self._folder is not None:
+            self._folder.cleanup()
+            self._folder = None
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/apps/obsrefl/test_panel.py
+++ b/tests/apps/obsrefl/test_panel.py
@@ -9,6 +9,7 @@ than in the window lane: a `SolutionPanel` and a coarse session are all it
 takes to fill the readout boxes and read the cells back.
 """
 
+import os
 import unittest
 
 import solvcon
@@ -198,6 +199,33 @@ class StatusReadoutTC(unittest.TestCase):
         self.assertEqual(list(_panel.FieldBox.PLACEMENTS),
                          [panel._field._placement.itemText(it)
                           for it in range(panel._field._placement.count())])
+
+    def test_the_movie_box_resolves_where_the_movie_goes(self):
+        # A relative path lands next to whatever the pilot was launched
+        # from, which for a pilot started from the desktop is not the
+        # checkout, so the box resolves both its default and what is typed
+        # into it and names the movie's real destination.
+        panel = SolutionPanel()
+        self.assertTrue(os.path.isabs(panel._movie._path.text()))
+        self.assertEqual(os.path.abspath('tmp/obrefl_unstructured.webp'),
+                         panel.movie_path('unstructured'))
+        panel._movie._path.setText('movie.gif')
+        self.assertEqual(os.path.abspath('movie.gif'),
+                         panel.movie_path('quad'))
+
+    def test_the_movie_box_reports_a_ticked_box_but_not_a_set_one(self):
+        # The controller sets the box back when a recording drops under it,
+        # and a set that reported itself would send the controller round
+        # again to stop what it has already stopped.
+        panel = SolutionPanel()
+        fired = []
+        panel.record_toggled = fired.append
+        panel._movie._record.setChecked(True)
+        self.assertEqual([True], fired)
+        self.assertTrue(panel.recording())
+        panel.set_recording(False)
+        self.assertEqual([True], fired)
+        self.assertFalse(panel.recording())
 
     def test_the_zone_rows_carry_the_computed_analytic_and_error(self):
         panel, _, _, _ = self._filled()

--- a/tests/gui/test_obsrefl.py
+++ b/tests/gui/test_obsrefl.py
@@ -3,6 +3,7 @@
 
 
 import os
+import tempfile
 import unittest
 
 import solvcon
@@ -12,6 +13,7 @@ try:
     from solvcon.pilot.base import _gui
     from solvcon.pilot.apps.obsrefl import ReflectionSession, _app
     from PySide6.QtWidgets import QApplication
+    from PIL import Image
 except ImportError:
     pilot = None
 
@@ -21,17 +23,27 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
-                 "pilot windows need a real window surface")
-class ObliqueShockAppTC(unittest.TestCase):
-    def setUp(self):
-        self.mgr = pilot.RManager.instance.setUp()
+class _AppFixture(object):
+    """Stand the app feature up, for the window classes that drive it."""
 
     def _feature(self):
         feature = _app.ObliqueShockApp(mgr=self.mgr)
         feature.populate_menu()
         feature._action.setChecked(True)  # builds the dock and panel
         return feature
+
+    @staticmethod
+    def _coarsen(feature, nx=10, ny=4):
+        """Cut the mesh down to what a window test can march quickly."""
+        feature._panel._numerics._nx.setValue(nx)
+        feature._panel._numerics._ny.setValue(ny)
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class ObliqueShockAppTC(_AppFixture, unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
 
     @staticmethod
     def _status(feature):
@@ -65,12 +77,6 @@ class ObliqueShockAppTC(unittest.TestCase):
         self.assertIsNotNone(self.mgr.currentR3DWidget())
         self.assertEqual(f"0 / {feature._control.session.max_steps}",
                          self._status(feature)["step"])
-
-    @staticmethod
-    def _coarsen(feature, nx=10, ny=4):
-        """Cut the mesh down to what a window test can march quickly."""
-        feature._panel._numerics._nx.setValue(nx)
-        feature._panel._numerics._ny.setValue(ny)
 
     def test_the_resolution_reaches_the_mesh(self):
         feature = self._feature()
@@ -389,6 +395,83 @@ class ObliqueShockAppTC(unittest.TestCase):
         self.assertIs(feature._viewer._subwin.widget(), bar.parent())
         self.assertIsNotNone(bar.lo)
         QApplication.processEvents()
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class SolutionMovieTC(_AppFixture, unittest.TestCase):
+    """Recording a run into an animated movie."""
+
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.folder = tempfile.TemporaryDirectory()
+        self.addCleanup(self.folder.cleanup)
+
+    def _recording_feature(self):
+        """A started run recording into the scratch folder.
+
+        The first drawn frame is also the first capture, so a viewer with
+        nothing to grab drops the recording right there; skip instead of
+        failing, as the domain-widget capture tests do.
+        """
+        feature = self._feature()
+        self._coarsen(feature)
+        feature._panel._movie._path.setText(self._movie_path('{cell_type}'))
+        feature._panel._movie._record.setChecked(True)
+        feature._control.start()
+        feature._control._timer.stop()
+        if feature._control.movie is None:
+            self.skipTest("the viewer gave no frame to record")
+        return feature
+
+    def _movie_path(self, cell_type='unstructured'):
+        return os.path.join(self.folder.name, f"run_{cell_type}.webp")
+
+    def test_a_run_records_nothing_unless_asked(self):
+        feature = self._feature()
+        self._coarsen(feature)
+        feature._control.start()
+        feature._control._timer.stop()
+        self.assertIsNone(feature._control.movie)
+
+    def test_a_recorded_run_writes_what_the_viewer_drew(self):
+        feature = self._recording_feature()
+        # The box names the destination before there is a movie in it, and
+        # the file once there is one; the console scrolls away under the
+        # run's own output.
+        self.assertIn(self._movie_path(),
+                      feature._panel._movie._status.text())
+        feature._panel._run._steps.setValue(1)
+        feature._control._on_step()
+        # One frame per draw: the state the run started from, and the one
+        # the step marched to.
+        self.assertEqual(2, feature._control.movie.nframe)
+
+        feature._panel._movie._record.setChecked(False)
+        self.assertIsNone(feature._control.movie)
+        note = feature._panel._movie._status.text()
+        self.assertIn(self._movie_path(), note)
+        self.assertIn("frames", note)
+        # The suffix typed into the box is what the movie is written as.
+        self.assertEqual('WEBP', Image.open(self._movie_path()).format)
+        QApplication.processEvents()
+
+    def test_every_way_a_run_ends_writes_the_movie(self):
+        # No frame can follow any of these, so each has to write out what
+        # the recording holds rather than leave it to be dropped.
+        endings = {'the viewer closes': lambda ft: ft._viewer.close(),
+                   'the run stops': lambda ft: ft._control.stop(),
+                   'the run resets': lambda ft: ft._control.reset()}
+        for ending, end_it in endings.items():
+            with self.subTest(ending=ending):
+                feature = self._recording_feature()
+                end_it(feature)
+                self.assertIsNone(feature._control.movie)
+                self.assertTrue(os.path.exists(self._movie_path()))
+                # The next ending writes to the same name, and an old file
+                # would answer for it.
+                os.remove(self._movie_path())
+                QApplication.processEvents()
 
 
 @unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,

--- a/tests/test_pilot_movie.py
+++ b/tests/test_pilot_movie.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Tests for the viewer movie recorder.
+
+The recorder grabs whatever widget it is handed, so a stub widget covers the
+frame bookkeeping and the movie assembly with no graphics surface at all.
+One class hands it a real Qt widget, which is the only way to say that what
+a live grab returns is what lands in the movie.
+"""
+
+import os
+import platform
+import tempfile
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot.visual import _movie
+    from PySide6.QtWidgets import QLabel
+    from PIL import Image
+except ImportError:
+    pilot = None
+    _movie = None
+    Image = None
+
+HAS_IMAGE = getattr(_movie, 'HAS_IMAGE', False)
+
+
+class _StubPixmap(object):
+    """Stand in for the pixmap a widget grab returns."""
+
+    def __init__(self, size, color):
+        self.size = size
+        self.color = color
+
+    def isNull(self):
+        return self.size is None
+
+    def save(self, path):
+        if self.size is None:
+            return False
+        Image.new('RGB', self.size, self.color).save(path)
+        return True
+
+
+class _StubViewer(object):
+    """Stand in for the viewer widget: grab a flat frame of a fixed size.
+
+    ``ok`` turns the grab into the empty pixmap a widget hands back when it
+    has nothing to show.
+    """
+
+    COLORS = ((255, 0, 0), (0, 255, 0), (0, 0, 255))
+
+    def __init__(self, ok=True, size=(64, 32)):
+        self.ok = ok
+        self.size = size
+        self.calls = []
+
+    def grab(self):
+        self.calls.append(self.size)
+        color = self.COLORS[(len(self.calls) - 1) % len(self.COLORS)]
+        return _StubPixmap(self.size if self.ok else None, color)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT and HAS_IMAGE,
+                     "Qt pilot is not built or PIL is missing")
+class MovieRecorderTC(unittest.TestCase):
+    """Frame bookkeeping and movie assembly, over a stub viewer."""
+
+    def setUp(self):
+        self.recorder = _movie.MovieRecorder(frame_ms=40, hold_ms=500)
+        self.addCleanup(self.recorder.close)
+        self.viewer = _StubViewer()
+
+    def _capture(self, nframe):
+        for _ in range(nframe):
+            self.recorder.capture(self.viewer)
+
+    def test_capture_grabs_the_widget_whole(self):
+        path = self.recorder.capture(self.viewer)
+        self.assertEqual(self.recorder.nframe, 1)
+        self.assertTrue(os.path.exists(path))
+        # The frame is the widget's own, not a size asked of it, so
+        # nothing of what the widget shows is cropped away.
+        self.assertEqual(self.viewer.size, Image.open(path).size)
+
+    def test_capture_reports_a_viewer_that_grabs_nothing(self):
+        # A viewer with nothing to show hands back an empty pixmap; holding
+        # a frame that was never written would break the movie later.
+        with self.assertRaises(RuntimeError):
+            self.recorder.capture(_StubViewer(ok=False))
+        self.assertEqual(self.recorder.nframe, 0)
+
+    def test_either_suffix_writes_every_frame_into_a_loop(self):
+        # The suffix is the whole of the format choice, and either format
+        # carries every frame captured, at the shape it was grabbed in.
+        self._capture(3)
+        with tempfile.TemporaryDirectory() as folder:
+            for suffix in _movie.MovieRecorder.SUFFIXES:
+                with self.subTest(suffix=suffix):
+                    path = os.path.join(folder, f"movie{suffix}")
+                    self.assertEqual(self.recorder.write(path), 3)
+                    movie = Image.open(path)
+                    self.assertEqual(movie.format, suffix[1:].upper())
+                    self.assertEqual(movie.n_frames, 3)
+                    self.assertEqual(movie.size, self.viewer.size)
+                    self.assertEqual(movie.info['loop'], 0)
+
+    def test_webp_keeps_the_rendered_colors(self):
+        # The point of WebP over GIF: no palette, so every frame keeps the
+        # color it was rendered in rather than the nearest of 255.  The
+        # encoder is lossy, so a flat frame comes back within a few counts.
+        self._capture(3)
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "movie.webp")
+            self.recorder.write(path)
+            movie = Image.open(path)
+            colors = []
+            for iframe in range(movie.n_frames):
+                movie.seek(iframe)
+                colors.append(movie.convert('RGB').getpixel((0, 0)))
+        for got, rendered in zip(colors, _StubViewer.COLORS):
+            for channel, want in zip(got, rendered):
+                self.assertLessEqual(abs(channel - want), 8)
+
+    def test_write_rejects_a_name_of_no_known_format(self):
+        self._capture(1)
+        with self.assertRaises(ValueError):
+            self.recorder.write("movie.mp4")
+
+    def test_write_holds_the_last_frame_longer(self):
+        self._capture(2)
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "movie.gif")
+            self.recorder.write(path)
+            movie = Image.open(path)
+            durations = []
+            for iframe in range(movie.n_frames):
+                movie.seek(iframe)
+                durations.append(movie.info['duration'])
+        self.assertEqual(durations, [40, 500])
+
+    def test_write_makes_the_output_folder(self):
+        self._capture(1)
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "made", "movie.gif")
+            self.recorder.write(path)
+            self.assertTrue(os.path.exists(path))
+
+    def test_write_without_a_frame_raises(self):
+        with self.assertRaises(ValueError):
+            self.recorder.write("never-written.gif")
+
+    def test_close_drops_the_frames(self):
+        path = self.recorder.capture(self.viewer)
+        self.recorder.close()
+        self.assertEqual(self.recorder.nframe, 0)
+        self.assertFalse(os.path.exists(path))
+        # A second close is a no-op, so a caller need not track it.
+        self.recorder.close()
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT and HAS_IMAGE,
+                     "Qt pilot is not built or PIL is missing")
+@unittest.skipIf("Windows" == platform.system(),
+                 "offscreen grabbing is unreliable on Windows CI")
+class WidgetMovieTC(unittest.TestCase):
+    """The recorder over a real Qt widget, which is what it grabs."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def test_a_resized_widget_records_at_one_shape(self):
+        widget = QLabel("wide")
+        widget.resize(160, 90)
+        recorder = _movie.MovieRecorder()
+        self.addCleanup(recorder.close)
+        recorder.capture(widget)
+        shape = widget.grab().size()
+
+        # The writer merges frames that come out identical, so the widget
+        # has to show something else before the second capture.
+        widget.resize(80, 120)
+        widget.setText("tall")
+        recorder.capture(widget)
+
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "widget.webp")
+            self.assertEqual(recorder.write(path), 2)
+            movie = Image.open(path)
+            self.assertEqual(2, movie.n_frames)
+            # A movie that changes size partway is not one a player can
+            # show, so it keeps the shape of its first frame, whatever the
+            # widget does afterwards.
+            self.assertEqual((shape.width(), shape.height()), movie.size)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
For issue #1272 

Implement a fold box to enable frame recording and create a movie file:

<img width="233" height="117" alt="image" src="https://github.com/user-attachments/assets/289868ed-68b5-47ee-8f1d-61c1e2fb2582" />

The default movie file format is webp:

<img width="2936" height="750" alt="obrefl_unstructured" src="https://github.com/user-attachments/assets/00159b42-bd67-4ebc-8ceb-d97b44887efb" />

The implementation currently uses PIL.  If PIL is not installed, the movie recorder will not work and the behavior is undefined.  I do not want to depend on PIL, but for now, I chose to use the un-enforced dependency to prototype.