### PR TITLE
Add dedup_last and deriv to the timeseries subsystem

### DIFF
--- a/cpp/solvcon/timeseries/pymod/timeseries_pymod.hpp
+++ b/cpp/solvcon/timeseries/pymod/timeseries_pymod.hpp
@@ -16,6 +16,34 @@ namespace solvcon
 namespace python
 {
 
+namespace detail
+{
+
+template <typename... Ts>
+struct type_list
+{
+}; /* end struct type_list */
+
+// clang-format off
+/// The value types `deriv()` takes, common ones first because pybind11 tries overloads in order.
+using timeseries_real_types = type_list<
+    double, float, int64_t, int32_t, int16_t, int8_t, uint64_t, uint32_t, uint16_t, uint8_t>;
+
+/// The value types `dedup_last()` takes: every value type `SimpleArray` holds.
+using timeseries_value_types = type_list<
+    double, float, int64_t, int32_t, int16_t, int8_t, uint64_t, uint32_t, uint16_t, uint8_t,
+    bool, Complex<double>, Complex<float>>;
+// clang-format on
+
+/// Call `def.template operator()<T>()` for every `T` in the list.
+template <typename... Ts, typename F>
+void for_each_type(type_list<Ts...>, F const & def)
+{
+    (def.template operator()<Ts>(), ...);
+}
+
+} /* end namespace detail */
+
 void initialize_timeseries(pybind11::module & mod);
 void wrap_timeseries(pybind11::module & mod);
 

--- a/cpp/solvcon/timeseries/pymod/wrap_timeseries.cpp
+++ b/cpp/solvcon/timeseries/pymod/wrap_timeseries.cpp
@@ -5,6 +5,8 @@
 
 #include <solvcon/timeseries/pymod/timeseries_pymod.hpp>
 
+#include <pybind11/stl.h>
+
 namespace solvcon
 {
 
@@ -33,6 +35,30 @@ void wrap_timeseries(pybind11::module & mod)
             return timeseries::merge_sorted_unique(arrays);
         },
         "Merge sorted SimpleArrayUint64 timestamp arrays into one sorted array of the distinct timestamps");
+
+    detail::for_each_type(
+        detail::timeseries_value_types{},
+        [&mod]<typename T>()
+        {
+            mod.def(
+                "dedup_last",
+                &timeseries::dedup_last<T>,
+                py::arg("times"),
+                py::arg("values"),
+                "Keep the last sample of every group of equal timestamps; returns (times, values)");
+        });
+
+    detail::for_each_type(
+        detail::timeseries_real_types{},
+        [&mod]<typename T>()
+        {
+            mod.def(
+                "deriv",
+                &timeseries::deriv<T>,
+                py::arg("times"),
+                py::arg("values"),
+                "Differentiate a series by the backward difference; returns (times[1:], derivatives)");
+        });
 }
 
 } /* end namespace python */

--- a/cpp/solvcon/timeseries/timeseries.hpp
+++ b/cpp/solvcon/timeseries/timeseries.hpp
@@ -12,11 +12,14 @@
  * @ingroup group_numerics
  */
 
+#include <algorithm>
 #include <cstdint>
 #include <format>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <type_traits>
+#include <utility>
 
 #include <solvcon/buffer/buffer.hpp>
 
@@ -29,22 +32,59 @@ namespace timeseries
 namespace detail
 {
 
-/// Reject an array whose timestamps decrease.
-inline void validate_sorted(SimpleArray<uint64_t> const & array, char const * op, std::string_view what)
+template <typename T>
+void validate_series(SimpleArray<uint64_t> const & times, SimpleArray<T> const & values, char const * op)
+{
+    solvcon::detail::validate_1d<std::invalid_argument>(times, op, "times", "timeseries");
+    solvcon::detail::validate_1d<std::invalid_argument>(values, op, "values", "timeseries");
+    if (times.shape(0) != values.shape(0))
+    {
+        throw std::invalid_argument(std::format(
+            "timeseries::{}(): times has {} samples but values has {}", op, times.shape(0), values.shape(0)));
+    }
+
+    // TODO: we don't support ghosted time series yet
+    if (times.nghost() > 0 || values.nghost() > 0)
+    {
+        throw std::invalid_argument(std::format("timeseries::{}(): ghosted time series are not supported yet", op));
+    }
+}
+
+/// Throw `std::invalid_argument` when the timestamps decrease; `strict` also rejects a repeat.
+inline void validate_sorted(
+    SimpleArray<uint64_t> const & array, char const * op, std::string_view what, bool strict = false)
 {
     uint64_t const * const src = array.logical_data();
     ssize_t const step = array.stride(0);
     for (ssize_t i = 1; i < array.shape(0); ++i)
     {
         uint64_t const prev = src[(i - 1) * step], cur = src[i * step];
-        if (cur < prev)
+        if (cur < prev || (strict && cur == prev))
         {
+            char const * const order = strict ? "strictly increasing" : "non-decreasing";
+            char const * const relation = strict ? "does not exceed" : "is less than";
             // clang-format off
             throw std::invalid_argument(std::format(
-                "timeseries::{}(): {} must be non-decreasing but element {} = {} is less than element {} = {}",
-                op, what, i, cur, i - 1, prev));
+                "timeseries::{}(): {} must be {} but element {} = {} {} element {} = {}",
+                op, what, order, i, cur, relation, i - 1, prev));
             // clang-format on
         }
+    }
+}
+
+template <typename R, typename T>
+R subtract_exact(T x1, T x0)
+{
+    static_assert(std::is_floating_point_v<R>, "subtract_exact() must return a floating-point type");
+
+    if constexpr (std::is_integral_v<T>)
+    {
+        auto const u1 = static_cast<uint64_t>(x1), u0 = static_cast<uint64_t>(x0);
+        return x1 >= x0 ? static_cast<R>(u1 - u0) : -static_cast<R>(u0 - u1);
+    }
+    else
+    {
+        return x1 - x0;
     }
 }
 
@@ -107,6 +147,121 @@ inline SimpleArray<uint64_t> merge_sorted_unique(small_vector<SimpleArray<uint64
     }
 
     return merged.as_array();
+}
+
+/**
+ * Keep the last sample of every group of equal timestamps.
+ *
+ * @tparam T The value type, which may be any type `SimpleArray` holds.
+ * @param times The sample timestamps in nanoseconds, non-decreasing.
+ * @param values The values sampled at @p times, of the same length.
+ * @return The kept timestamps, strictly increasing, and the values kept with them. A series with no repeat comes
+ *         back as a copy.
+ * @throw std::invalid_argument An array that is not one-dimensional or that carries ghost elements, a length
+ *        mismatch, or a decreasing timestamp.
+ * @throw std::logic_error The counting pass and the filling pass disagreed, which is a bug in this function.
+ *
+ * @ingroup group_numerics
+ */
+template <typename T>
+std::pair<SimpleArray<uint64_t>, SimpleArray<T>>
+dedup_last(SimpleArray<uint64_t> const & times, SimpleArray<T> const & values)
+{
+    detail::validate_series(times, values, "dedup_last");
+    detail::validate_sorted(times, "dedup_last", "times");
+
+    ssize_t const nsample = times.shape(0);
+    uint64_t const * const tsrc = times.logical_data();
+    ssize_t const tstep = times.stride(0);
+
+    ssize_t ngroup = nsample > 0 ? 1 : 0;
+    for (ssize_t i = 1; i < nsample; ++i)
+    {
+        if (tsrc[i * tstep] != tsrc[(i - 1) * tstep])
+        {
+            ++ngroup;
+        }
+    }
+
+    SimpleArray<uint64_t> otimes(ngroup);
+    SimpleArray<T> ovalues(ngroup);
+    T const * const vsrc = values.logical_data();
+    ssize_t const vstep = values.stride(0);
+    ssize_t igroup = 0;
+    for (ssize_t i = 0; i < nsample; ++i)
+    {
+        if (i + 1 == nsample || tsrc[(i + 1) * tstep] != tsrc[i * tstep])
+        {
+            otimes[igroup] = tsrc[i * tstep];
+            ovalues[igroup] = vsrc[i * vstep];
+            ++igroup;
+        }
+    }
+
+    if (igroup != ngroup)
+    {
+        throw std::logic_error(
+            std::format("timeseries::dedup_last(): counted {} groups but filled {}", ngroup, igroup));
+    }
+
+    return {std::move(otimes), std::move(ovalues)};
+}
+
+/**
+ * The element type `deriv()` returns.
+ *
+ * @tparam T The value type of the input series.
+ *
+ * @ingroup group_numerics
+ */
+template <typename T>
+using deriv_value_t = std::conditional_t<std::is_floating_point_v<T>, T, double>;
+
+/**
+ * Differentiate a series by the backward difference `(x_i - x_{i-1}) / (t_i - t_{i-1})`.
+ *
+ * Integer values subtract exactly, so a falling unsigned signal gives a negative derivative instead of wrapping.
+ * The cast of that difference to the result type rounds a magnitude above 2^53.
+ *
+ * @tparam T The value type, which must be a real number type.
+ * @param times The sample timestamps in nanoseconds, strictly increasing.
+ * @param values The values sampled at @p times, of the same length.
+ * @return `times[1:]` and one derivative per remaining sample; the first sample has no predecessor. Fewer than two
+ *         samples give empty arrays.
+ * @throw std::invalid_argument An array that is not one-dimensional or that carries ghost elements, a length
+ *        mismatch, or a decreasing or repeated timestamp. A repeat has no time step to divide by, and `dedup_last()` collapses
+ *        one beforehand.
+ *
+ * @ingroup group_numerics
+ */
+template <typename T>
+std::pair<SimpleArray<uint64_t>, SimpleArray<deriv_value_t<T>>>
+deriv(SimpleArray<uint64_t> const & times, SimpleArray<T> const & values)
+{
+    static_assert(std::is_arithmetic_v<T> && !solvcon::detail::is_bool_v<T>, "deriv() requires a real number type");
+    using result_type = deriv_value_t<T>;
+
+    detail::validate_series(times, values, "deriv");
+    detail::validate_sorted(times, "deriv", "times", /*strict*/ true);
+
+    ssize_t const nsample = times.shape(0);
+    ssize_t const nout = std::max<ssize_t>(nsample - 1, 0);
+    SimpleArray<uint64_t> otimes(nout);
+    SimpleArray<result_type> oderiv(nout);
+
+    uint64_t const * const tsrc = times.logical_data();
+    ssize_t const tstep = times.stride(0);
+    T const * const vsrc = values.logical_data();
+    ssize_t const vstep = values.stride(0);
+    for (ssize_t i = 1; i < nsample; ++i)
+    {
+        uint64_t const cur = tsrc[i * tstep], prev = tsrc[(i - 1) * tstep];
+        otimes[i - 1] = cur;
+        result_type const dvalue = detail::subtract_exact<result_type>(vsrc[i * vstep], vsrc[(i - 1) * vstep]);
+        oderiv[i - 1] = dvalue / static_cast<result_type>(cur - prev);
+    }
+
+    return {std::move(otimes), std::move(oderiv)};
 }
 
 } /* end namespace timeseries */

--- a/doc/source/compute/numerics/timeseries.md
+++ b/doc/source/compute/numerics/timeseries.md
@@ -1,22 +1,30 @@
 # Time Series
 
 `solvcon.timeseries` holds kernels over recorded time series. A series is a
-pair of one-dimensional arrays of the same length. The first array holds the
-timestamps in integer nanoseconds as a `SimpleArrayUint64` in non-decreasing
-order. The second holds the values sampled at them as a SimpleArray of any
-class. Each kernel reads its input, returns new arrays, and never changes the
-input. The C++ kernels live in `cpp/solvcon/timeseries/` in the namespace
+pair of one-dimensional arrays of the same length. The first holds the
+timestamps in integer nanoseconds as a non-decreasing `SimpleArrayUint64`. The
+second holds the values sampled at them as a SimpleArray. Each kernel states
+the value classes it takes, reads its input, and returns new arrays. The C++
+kernels live in `cpp/solvcon/timeseries/` in the namespace
 `solvcon::timeseries`.
 
 The kernels replace the per-sample Python loops that a recorded log otherwise
 needs. Sample lookup on the timestamps is not a kernel here; it is
 `searchsorted`, which {doc}`the reduce page <../buffer/reduce>` describes.
 
-## Duplicate Timestamps
+A kernel that takes a series raises `TypeError` when `times` is not a
+`SimpleArrayUint64` or `values` is a class the kernel does not take. It raises
+`ValueError` for an array that is not one-dimensional, for an array that
+carries ghost elements, for arrays of different length, or for a decreasing
+timestamp.
 
-A recorded log may stamp two messages in the same nanosecond, so a repeated
+## Repeated Timestamps
+
+A recorded log can stamp two messages in the same nanosecond, so a repeated
 timestamp is valid input. A group of equal timestamps resolves to its last
-sample.
+sample. `deriv` is the exception: a zero time step has no derivative, so
+`deriv` raises `ValueError`. `dedup_last` collapses a repeat, so its result is
+valid input to `deriv`.
 
 ## The `merge_sorted_unique` Function
 
@@ -36,8 +44,45 @@ assert ts.merge_sorted_unique().shape == (0,)
 
 A timestamp repeated within one array or shared between arrays appears once.
 No argument, or only empty arrays, gives an empty result. Every argument must
-be a `SimpleArrayUint64`; another class raises `TypeError`. An array that is
-not one-dimensional, or that holds a decreasing timestamp, raises
-`ValueError` and names the array by its position.
+be a `SimpleArrayUint64`; another class raises `TypeError`. A `ValueError`
+names the offending array by its position.
+
+## The `dedup_last` Function
+
+`dedup_last(times, values)` keeps the last sample of every group of equal
+timestamps. It returns a new array of the kept timestamps and a new array of
+the kept values. The result timestamps are strictly increasing, and the result
+values keep the class of the input values. The kernel takes every typed
+SimpleArray class. A series without a repeat comes back as a copy:
+
+```python
+times = solvcon.SimpleArrayUint64(array=np.array([0, 1, 1, 2], dtype='uint64'))
+speed = solvcon.SimpleArrayFloat64(array=np.array([0.5, 1.0, 1.5, 2.0]))
+t_u, speed_u = ts.dedup_last(times, speed)
+assert t_u.ndarray.tolist() == [0, 1, 2]
+assert speed_u.ndarray.tolist() == [0.5, 1.5, 2.0]
+```
+
+## The `deriv` Function
+
+`deriv(times, values)` differentiates a series by the backward difference
+`(x_i - x_{i-1}) / (t_i - t_{i-1})` and returns the tuple
+`(times[1:], derivatives)`. The first sample has no predecessor, so `n`
+samples give `n - 1` derivatives and fewer than two samples give empty
+arrays. The output timestamps are strictly increasing, so a second `deriv`
+chains directly. The kernel takes the real-number classes only, so
+`SimpleArrayBool` and the complex classes raise `TypeError`. A
+`SimpleArrayFloat32` input gives `SimpleArrayFloat32` derivatives; every
+other class gives `SimpleArrayFloat64`:
+
+```python
+times = solvcon.SimpleArrayUint64(array=np.array([0, 10, 30], dtype='uint64'))
+speed = solvcon.SimpleArrayFloat64(array=np.array([1.0, 3.0, 2.0]))
+t_acc, acc = ts.deriv(times, speed)
+assert t_acc.ndarray.tolist() == [10, 30]
+# (3.0-1.0)/(10.0-0.0) and (2.0-3.0)/(30.0-10.0)
+assert acc.ndarray.tolist() == [0.2, -0.05]
+t_jerk, jerk = ts.deriv(t_acc, acc)
+```
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/solvcon/timeseries.py
+++ b/solvcon/timeseries.py
@@ -15,6 +15,8 @@ except ImportError:
 
 _toload = [
     'merge_sorted_unique',
+    'dedup_last',
+    'deriv',
 ]
 
 

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -10,8 +10,23 @@ import solvcon
 from solvcon import timeseries as ts
 
 
+def arr(dtype, values):
+    cls = getattr(solvcon, 'SimpleArray' + dtype.capitalize())
+    return cls(array=np.array(values, dtype=dtype))
+
+
 def u64(values):
-    return solvcon.SimpleArrayUint64(array=np.array(values, dtype='uint64'))
+    return arr('uint64', values)
+
+
+def f64(values):
+    return arr('float64', values)
+
+
+INT_DTYPES = ('int8', 'int16', 'int32', 'int64',
+              'uint8', 'uint16', 'uint32', 'uint64')
+ALL_DTYPES = ('bool',) + INT_DTYPES + ('float32', 'float64',
+                                       'complex64', 'complex128')
 
 
 class MergeSortedUniqueTC(unittest.TestCase):
@@ -75,6 +90,178 @@ class MergeSortedUniqueTC(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "currently only support 1D "
                                     "array but the array 0 is 2 dimension"):
             ts.merge_sorted_unique(solvcon.SimpleArrayUint64((2, 2), 0))
+
+
+class DedupLastTC(unittest.TestCase):
+
+    def test_keeps_last_of_each_group(self):
+        times = u64([0, 1, 1, 1, 2, 3, 3])
+        values = f64([0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5])
+        otimes, ovalues = ts.dedup_last(times, values)
+        self.assertEqual(otimes.ndarray.tolist(), [0, 1, 2, 3])
+        self.assertEqual(ovalues.ndarray.tolist(), [0.5, 2.0, 2.5, 3.5])
+
+    def test_series_without_repeat_comes_back_as_a_copy(self):
+        times, values = u64([2, 5, 9]), f64([1.0, 2.0, 3.0])
+        otimes, ovalues = ts.dedup_last(times, values)
+        self.assertEqual(otimes.ndarray.tolist(), [2, 5, 9])
+        self.assertEqual(ovalues.ndarray.tolist(), [1.0, 2.0, 3.0])
+        otimes[0], ovalues[0] = 99, -1.0
+        self.assertEqual((times[0], values[0]), (2, 1.0))
+
+    def test_strided_view_is_read_in_array_order(self):
+        times = solvcon.SimpleArrayUint64(
+            array=np.arange(12, dtype='uint64')[::4])
+        values = solvcon.SimpleArrayFloat64(
+            array=np.arange(6, dtype='float64')[::2])
+        otimes, ovalues = ts.dedup_last(times, values)
+        self.assertEqual(otimes.ndarray.tolist(), [0, 4, 8])
+        self.assertEqual(ovalues.ndarray.tolist(), [0.0, 2.0, 4.0])
+        otimes, ovalues = ts.dedup_last(u64([0, 0, 5]), values)
+        self.assertEqual(otimes.ndarray.tolist(), [0, 5])
+        self.assertEqual(ovalues.ndarray.tolist(), [2.0, 4.0])
+
+    def test_repeat_at_head_and_all_equal_keep_the_last(self):
+        otimes, ovalues = ts.dedup_last(u64([0, 0, 1]), f64([1.0, 2.0, 3.0]))
+        self.assertEqual(otimes.ndarray.tolist(), [0, 1])
+        self.assertEqual(ovalues.ndarray.tolist(), [2.0, 3.0])
+        otimes, ovalues = ts.dedup_last(u64([7, 7, 7]), f64([1.0, 2.0, 3.0]))
+        self.assertEqual(otimes.ndarray.tolist(), [7])
+        self.assertEqual(ovalues.ndarray.tolist(), [3.0])
+
+    def test_empty_and_single_pass_through(self):
+        otimes, ovalues = ts.dedup_last(u64([]), f64([]))
+        self.assertEqual((otimes.shape, ovalues.shape), ((0,), (0,)))
+        otimes, ovalues = ts.dedup_last(u64([4]), f64([1.5]))
+        self.assertEqual((otimes.ndarray.tolist(), ovalues.ndarray.tolist()),
+                         ([4], [1.5]))
+
+    def test_output_keeps_the_value_dtype(self):
+        times = u64([1, 1, 2])
+        for dtype in ALL_DTYPES:
+            values = arr(dtype, [1, 0, 1])
+            otimes, ovalues = ts.dedup_last(times, values)
+            self.assertIs(type(ovalues), type(values), dtype)
+            self.assertEqual(otimes.ndarray.tolist(), [1, 2], dtype)
+            self.assertEqual(ovalues.ndarray.tolist(), [0, 1], dtype)
+
+    def test_invalid_input_raises(self):
+        with self.assertRaisesRegex(ValueError, "dedup_last.*non-decreasing"):
+            ts.dedup_last(u64([2, 1]), f64([0.0, 0.0]))
+        with self.assertRaisesRegex(ValueError, "dedup_last.*2 samples but "
+                                    "values has 3"):
+            ts.dedup_last(u64([1, 2]), f64([0.0, 0.0, 0.0]))
+        with self.assertRaisesRegex(ValueError, "currently only support 1D "
+                                    "array but the values is 2 dimension"):
+            ts.dedup_last(u64([1, 2]), solvcon.SimpleArrayFloat64((1, 2), 0.0))
+        ghost_msg = "ghosted time series are not supported"
+        gtimes = solvcon.SimpleArrayUint64((2,), 0)
+        gtimes.nghost = 1
+        with self.assertRaisesRegex(ValueError, ghost_msg):
+            ts.dedup_last(gtimes, f64([0.0, 0.0]))
+        gvalues = solvcon.SimpleArrayFloat64((2,), 0.0)
+        gvalues.nghost = 1
+        with self.assertRaisesRegex(ValueError, ghost_msg):
+            ts.dedup_last(u64([1, 2]), gvalues)
+
+
+class DerivTC(unittest.TestCase):
+
+    def test_backward_difference_drops_first_point(self):
+        times = u64([0, 10, 30, 60])
+        values = f64([1.0, 3.0, 2.0, 5.0])
+        otimes, oderiv = ts.deriv(times, values)
+        self.assertIs(type(oderiv), solvcon.SimpleArrayFloat64)
+        self.assertEqual(otimes.ndarray.tolist(), [10, 30, 60])
+        self.assertEqual(oderiv.ndarray.tolist(), [0.2, -0.05, 0.1])
+
+    def test_against_numpy_diff_ratio(self):
+        rng = np.random.default_rng(20260817)
+        ntimes = np.cumsum(rng.integers(1, 100, 200, dtype='uint64'))
+        nvalues = rng.standard_normal(200, dtype='float64')
+        otimes, oderiv = ts.deriv(u64(ntimes), f64(nvalues))
+        np.testing.assert_array_equal(otimes.ndarray, ntimes[1:])
+        np.testing.assert_allclose(
+            oderiv.ndarray,
+            np.diff(nvalues) / np.diff(ntimes).astype('float64'))
+
+    def test_fewer_than_two_samples_give_empty_result(self):
+        for data in ([], [3.0]):
+            otimes, oderiv = ts.deriv(u64(range(len(data))), f64(data))
+            self.assertEqual((otimes.shape, oderiv.shape), ((0,), (0,)))
+
+    def test_float32_keeps_float32_and_integer_gives_float64(self):
+        times = u64([0, 4])
+        _, oderiv = ts.deriv(times, arr('float32', [1.0, 3.0]))
+        self.assertIs(type(oderiv), solvcon.SimpleArrayFloat32)
+        self.assertEqual(oderiv.ndarray.tolist(), [0.5])
+        for dtype in INT_DTYPES:
+            _, oderiv = ts.deriv(times, arr(dtype, [5, 3]))
+            self.assertIs(type(oderiv), solvcon.SimpleArrayFloat64, dtype)
+            self.assertEqual(oderiv.ndarray.tolist(), [-0.5], dtype)
+
+    def test_integer_difference_keeps_sign_and_full_width(self):
+        # SimpleArrayUint64.diff() wraps a fall to 2**64 - 2; deriv() takes
+        # the smaller integer from the larger in uint64 and negates, so a
+        # fall keeps its sign and a difference wider than T keeps its
+        # magnitude.
+        times = u64([0, 1, 2])
+        _, oderiv = ts.deriv(times, arr('uint64', [5, 3, 2**63 + 1]))
+        self.assertEqual(oderiv.ndarray.tolist(), [-2.0, float(2**63 - 2)])
+        expected = [float(2**64 - 1), -float(2**64 - 1)]
+        _, oderiv = ts.deriv(times, arr('uint64', [0, 2**64 - 1, 0]))
+        self.assertEqual(oderiv.ndarray.tolist(), expected)
+        _, oderiv = ts.deriv(times, arr('int64', [-2**63, 2**63 - 1, -2**63]))
+        self.assertEqual(oderiv.ndarray.tolist(), expected)
+        _, oderiv = ts.deriv(u64([0, 1]), arr('int8', [-128, 127]))
+        self.assertEqual(oderiv.ndarray.tolist(), [255.0])
+
+    def test_invalid_input_raises(self):
+        msg = "strictly increasing"
+        with self.assertRaisesRegex(ValueError, msg):
+            ts.deriv(u64([0, 1, 1, 2]), f64([0.0, 1.0, 2.0, 3.0]))
+        with self.assertRaisesRegex(ValueError, msg):
+            ts.deriv(u64([0, 0, 1]), f64([0.0, 1.0, 2.0]))
+        with self.assertRaisesRegex(ValueError, "element 2 = 1 does not "
+                                    "exceed element 1 = 2"):
+            ts.deriv(u64([0, 2, 1]), f64([0.0, 1.0, 2.0]))
+        with self.assertRaisesRegex(ValueError, "deriv.*3 samples but values "
+                                    "has 2"):
+            ts.deriv(u64([0, 1, 2]), f64([0.0, 1.0]))
+
+    def test_dedup_last_makes_a_repeated_log_differentiable(self):
+        cases = (
+            ([0, 1, 1, 2], [0.0, 1.0, 2.0, 3.0], [1, 2], [2.0, 1.0]),
+            ([0, 0, 1], [0.0, 1.0, 2.0], [1], [1.0]),
+            ([3, 3, 3], [0.0, 1.0, 2.0], [], []),
+        )
+        for times, values, etimes, ederiv in cases:
+            otimes, oderiv = ts.deriv(*ts.dedup_last(u64(times), f64(values)))
+            self.assertEqual(otimes.ndarray.tolist(), etimes)
+            self.assertEqual(oderiv.ndarray.tolist(), ederiv)
+
+    def test_strided_view_is_read_in_array_order(self):
+        times = solvcon.SimpleArrayUint64(
+            array=np.arange(12, dtype='uint64')[::4])
+        values = solvcon.SimpleArrayFloat64(
+            array=np.arange(6, dtype='float64')[::2])
+        otimes, oderiv = ts.deriv(times, values)
+        self.assertEqual(otimes.ndarray.tolist(), [4, 8])
+        self.assertEqual(oderiv.ndarray.tolist(), [0.5, 0.5])
+
+    def test_chains_into_a_second_derivative(self):
+        times = u64([0, 1, 2, 3])
+        t_first, first = ts.deriv(times, f64([0.0, 1.0, 4.0, 9.0]))
+        t_second, second = ts.deriv(t_first, first)
+        self.assertEqual(t_second.ndarray.tolist(), [2, 3])
+        self.assertEqual(second.ndarray.tolist(), [2.0, 2.0])
+
+    def test_rejects_bool_and_complex_values(self):
+        msg = "incompatible function arguments"
+        for values in (arr('bool', [True, False]),
+                       arr('complex128', [1 + 1j, 2j])):
+            with self.assertRaisesRegex(TypeError, msg):
+                ts.deriv(u64([0, 1]), values)
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`dedup_last(times, values)` keeps the last sample of every group of equal timestamps and returns strictly increasing times, which is what `deriv` requires. It takes every typed SimpleArray value class.

`deriv(times, values)` is the backward difference and returns `(times[1:], derivatives)`. It takes the real-number classes only, so `SimpleArrayBool` and the complex classes raise `TypeError`. A repeated timestamp throws instead of dividing by zero. An integer difference is taken unsigned with the sign restored, so it is exact over the full 64-bit range and a falling unsigned signal gives a negative derivative where `SimpleArray::diff()` wraps. A `SimpleArrayFloat32` input gives `SimpleArrayFloat32` derivatives; every other class gives `SimpleArrayFloat64`. The returned timestamps are always `SimpleArrayUint64`.

`timeseries.hpp` gains the shared check for a times and values pair, and `validate_sorted()` gains a `strict` flag so a kernel can reject a repeated timestamp as well as a decreasing one. The bindings instantiate each kernel over a shared type list, so a kernel added later names the types it takes once.

A ghosted series has no settled meaning in this subsystem, so the shared check rejects an array that carries ghost elements, and a TODO records the open question.

This is the second of the two stacked PRs from PR 3 of the plan. The first, #1372, is merged.

`make lint` is clean and `make gtest` passes (244 passed). `make pytest-fast` passes (1707 passed, 343 skipped, 3 xfailed), of which `tests/test_timeseries.py` contributes 26. The three examples on the documentation page execute with their assertions passing. I did not run the `tests/gui/` lane, because the change touches no GUI code.

Related to #1285.
