### PR TITLE
Cap the CI apt-get update with a wall-clock timeout

### DIFF
--- a/.github/actions/setup_linux/action.yml
+++ b/.github/actions/setup_linux/action.yml
@@ -54,7 +54,7 @@ runs:
         echo "::group::dependency by apt"
         # To update the cmake version > 4, install the latest cmake by kitware apt repository.
         # Reference: https://apt.kitware.com/
-        sudo apt-get -y update
+        sudo contrib/ci/apt-update.sh -y
         sudo apt-get -qy install ca-certificates gpg wget
         test -f /usr/share/doc/kitware-archive-keyring/copyright || \
             wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
@@ -62,7 +62,7 @@ runs:
             sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
         echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main' | \
             sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
-        sudo apt-get -qqy update
+        sudo contrib/ci/apt-update.sh -qq
         test -f /usr/share/doc/kitware-archive-keyring/copyright || \
             sudo rm /usr/share/keyrings/kitware-archive-keyring.gpg
         sudo apt-get -qy install kitware-archive-keyring
@@ -99,7 +99,7 @@ runs:
         # Install clang-tidy-22 from LLVM repository for full C++23 support
         wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
         echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" | sudo tee /etc/apt/sources.list.d/llvm.list
-        sudo apt-get -qqy update
+        sudo contrib/ci/apt-update.sh -qq
         sudo apt-get -qy install clang-tidy-22
         sudo ln -fs "$(which clang-tidy-22)" "/usr/local/bin/clang-tidy"
         echo "::endgroup::"
@@ -108,8 +108,8 @@ runs:
       shell: bash
       run: |
         echo "::group::Install and configure gcc-16"
-        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-        sudo apt-get -qqy update
+        sudo add-apt-repository -y -n ppa:ubuntu-toolchain-r/test
+        sudo contrib/ci/apt-update.sh -qq
         sudo apt-get -qy install gcc-16 g++-16
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-16 100
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-16 100

--- a/contrib/ci/apt-update.sh
+++ b/contrib/ci/apt-update.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+#
+# Run `apt-get update` under a wall-clock cap and retry it. apt applies its
+# acquire timeout to one read, not to the whole transfer, so a mirror that
+# stays connected and trickles data never trips it, and the update runs until
+# the CI job hits its time limit. A retry opens fresh connections, which a
+# round-robin archive host can answer from a healthy backend. Driven by
+# .github/actions/setup_linux/action.yml, and runnable by hand:
+#
+#   sudo contrib/ci/apt-update.sh -qq
+#
+# Every argument goes to `apt-get` ahead of the `update` sub-command. TIMEOUT
+# is the cap on one attempt in seconds, and ATTEMPTS is how many attempts to
+# make before the script gives up.
+
+set -euo pipefail
+
+TIMEOUT="${TIMEOUT:-120}"
+ATTEMPTS="${ATTEMPTS:-2}"
+
+for ((attempt = 1; attempt <= ATTEMPTS; attempt++)) ; do
+    if [ "$attempt" -gt 1 ] ; then
+        sleep 5
+    fi
+    if timeout --kill-after=10 "$TIMEOUT" apt-get "$@" update ; then
+        exit 0
+    fi
+    echo "apt-get update attempt $attempt of $ATTEMPTS failed or timed out"
+done
+
+exit 1
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
apt applies its acquire timeout to a single read, not to the whole transfer. A mirror that stays connected and delivers data slowly therefore never trips it. On 2026-08-19 the Ubuntu mirrors degraded rather than failed, and one job measured 27.6 MB in 20 minutes 51 seconds. That is 22.1 kB/s against a healthy 732 kB/s. An update in that state runs until the job time limit cancels the job, and a cancelled job states no cause.

This adds `contrib/ci/apt-update.sh`, which caps each run with `timeout` and retries once, and routes every update in the Linux setup action through it. A degraded mirror now fails the step in minutes, with a message that names the attempt, instead of consuming the whole job. The retry also recovers a transient slowdown, because it opens fresh connections. `add-apt-repository` takes `-n` so the PPA step no longer runs an unbounded update of its own.

An earlier version of this branch also added a fourth apt mirror. The logs show that apt never reaches it, because apt advances its mirror list only when a mirror fails, and a slow mirror never fails. That commit is dropped.

The cap covers `apt-get update` only. A slow mirror can still stall an `apt-get install`, whose download needs the `-d` split before a timeout can bound it safely.

No automated test covers the script, so I checked it by hand. It returns 0 for a healthy `apt-get`, and 1 for one that always fails. It stops a run that hangs, it recovers when the second attempt succeeds, and `ATTEMPTS` overrides the attempt count.

Related to #1382.
