### PR TITLE
Add movavg and held to the timeseries subsystem

### DIFF
--- a/cpp/solvcon/timeseries/pymod/timeseries_pymod.hpp
+++ b/cpp/solvcon/timeseries/pymod/timeseries_pymod.hpp
@@ -25,7 +25,7 @@ struct type_list
 }; /* end struct type_list */
 
 // clang-format off
-/// The value types `deriv()` takes, common ones first because pybind11 tries overloads in order.
+/// The real number value types the kernels take, common ones first because pybind11 tries overloads in order.
 using timeseries_real_types = type_list<
     double, float, int64_t, int32_t, int16_t, int8_t, uint64_t, uint32_t, uint16_t, uint8_t>;
 

--- a/cpp/solvcon/timeseries/pymod/wrap_timeseries.cpp
+++ b/cpp/solvcon/timeseries/pymod/wrap_timeseries.cpp
@@ -58,7 +58,23 @@ void wrap_timeseries(pybind11::module & mod)
                 py::arg("times"),
                 py::arg("values"),
                 "Differentiate a series by the backward difference; returns (times[1:], derivatives)");
+            mod.def(
+                "movavg",
+                &timeseries::movavg<T>,
+                py::arg("times"),
+                py::arg("values"),
+                py::arg("span"),
+                "Average a series over the trailing half-open window (t - span, t]; returns (times, means)");
         });
+
+    mod.def(
+        "held",
+        &timeseries::held,
+        py::arg("times"),
+        py::arg("values"),
+        py::arg("span"),
+        "Report whether a boolean series was true over the trailing half-open window (t - span, t]; "
+        "the last sample at or before t - span must be true as well; returns (times, answers)");
 }
 
 } /* end namespace python */

--- a/cpp/solvcon/timeseries/timeseries.hpp
+++ b/cpp/solvcon/timeseries/timeseries.hpp
@@ -72,6 +72,21 @@ inline void validate_sorted(
     }
 }
 
+/// Throw `std::invalid_argument` when a trailing window has no length, which would leave it empty everywhere.
+inline void validate_span(uint64_t span, char const * op)
+{
+    if (0 == span)
+    {
+        throw std::invalid_argument(std::format("timeseries::{}(): span must be positive but is 0", op));
+    }
+}
+
+/// Report whether a timestamp is before the trailing half-open window `(t - span, t]`.
+inline bool is_before_window(uint64_t stamp, uint64_t t, uint64_t span)
+{
+    return span <= t && stamp <= t - span;
+}
+
 template <typename R, typename T>
 R subtract_exact(T x1, T x0)
 {
@@ -211,14 +226,15 @@ dedup_last(SimpleArray<uint64_t> const & times, SimpleArray<T> const & values)
 }
 
 /**
- * The element type `deriv()` returns.
+ * The result element type of a kernel that computes in floating point.
  *
- * @tparam T The value type of the input series.
+ * @tparam T The value type of the input series. A floating-point type keeps its own width; every other real
+ *         number type promotes to `double`.
  *
  * @ingroup group_numerics
  */
 template <typename T>
-using deriv_value_t = std::conditional_t<std::is_floating_point_v<T>, T, double>;
+using real_value_t = std::conditional_t<std::is_floating_point_v<T>, T, double>;
 
 /**
  * Differentiate a series by the backward difference `(x_i - x_{i-1}) / (t_i - t_{i-1})`.
@@ -238,11 +254,11 @@ using deriv_value_t = std::conditional_t<std::is_floating_point_v<T>, T, double>
  * @ingroup group_numerics
  */
 template <typename T>
-std::pair<SimpleArray<uint64_t>, SimpleArray<deriv_value_t<T>>>
+std::pair<SimpleArray<uint64_t>, SimpleArray<real_value_t<T>>>
 deriv(SimpleArray<uint64_t> const & times, SimpleArray<T> const & values)
 {
     static_assert(std::is_arithmetic_v<T> && !solvcon::detail::is_bool_v<T>, "deriv() requires a real number type");
-    using result_type = deriv_value_t<T>;
+    using result_type = real_value_t<T>;
 
     detail::validate_series(times, values, "deriv");
     detail::validate_sorted(times, "deriv", "times", /*strict*/ true);
@@ -265,6 +281,125 @@ deriv(SimpleArray<uint64_t> const & times, SimpleArray<T> const & values)
     }
 
     return {std::move(otimes), std::move(oderiv)};
+}
+
+/**
+ * Average a series over the trailing half-open window `(t - span, t]` at each of its timestamps.
+ *
+ * The sweep carries one running sum, so rounding error accumulates over the whole series rather than over one
+ * window. One non-finite sample makes every later mean a NaN; drop such a sample before the call. The sum
+ * is kept in `double`, so an integer sample with a magnitude above 2^53 rounds on entry.
+ *
+ * @tparam T The value type, which must be a real number type.
+ * @param times The sample timestamps in nanoseconds, non-decreasing.
+ * @param values The values sampled at @p times, of the same length.
+ * @param span The window length in nanoseconds, which must be positive.
+ * @return @p times and one mean per sample. An empty series gives empty arrays.
+ * @throw std::invalid_argument An array that is not one-dimensional or that carries ghost elements, a length
+ *        mismatch, a decreasing timestamp, or a zero @p span.
+ *
+ * @ingroup group_numerics
+ */
+template <typename T>
+std::pair<SimpleArray<uint64_t>, SimpleArray<real_value_t<T>>>
+movavg(SimpleArray<uint64_t> const & times, SimpleArray<T> const & values, uint64_t span)
+{
+    static_assert(std::is_arithmetic_v<T> && !solvcon::detail::is_bool_v<T>, "movavg() requires a real number type");
+    using result_type = real_value_t<T>;
+
+    detail::validate_series(times, values, "movavg");
+    detail::validate_sorted(times, "movavg", "times");
+    detail::validate_span(span, "movavg");
+
+    ssize_t const nsample = times.shape(0);
+    SimpleArray<uint64_t> otimes = times.to_row_major();
+    SimpleArray<result_type> omean(nsample);
+
+    uint64_t const * const tsrc = times.logical_data();
+    ssize_t const tstep = times.stride(0);
+    T const * const vsrc = values.logical_data();
+    ssize_t const vstep = values.stride(0);
+    // TODO: this running sum is the fastest sweep but not an exact one; the caveat in the function comment
+    // names the cost. A sweep that never subtracts fixes it: hold the window as a suffix-sum table over its
+    // front and a running total over its back, and rebuild the table when the window passes the end of it.
+    // That sweep is also linear, and costs about 1.7x the time and one double of scratch per sample.
+    ssize_t first = 0, last = 0;
+    double sum = 0;
+    for (ssize_t i = 0; i < nsample; ++i)
+    {
+        uint64_t const t = tsrc[i * tstep];
+        for (; last < nsample && tsrc[last * tstep] <= t; ++last)
+        {
+            sum += static_cast<double>(vsrc[last * vstep]);
+        }
+        for (; first < last && detail::is_before_window(tsrc[first * tstep], t, span); ++first)
+        {
+            sum -= static_cast<double>(vsrc[first * vstep]);
+        }
+
+        omean[i] = static_cast<result_type>(sum / static_cast<double>(last - first));
+    }
+
+    return {std::move(otimes), std::move(omean)};
+}
+
+/**
+ * Report whether a boolean series was true over the trailing half-open window `(t - span, t]` at each of its
+ * timestamps.
+ *
+ * The boundary sample, the last one stamped at or before `t - span`, carries the state into the window and must
+ * be true as well; the answer is false before one exists.
+ *
+ * @param times The sample timestamps in nanoseconds, non-decreasing.
+ * @param values The booleans sampled at @p times, of the same length.
+ * @param span The window length in nanoseconds, which must be positive.
+ * @return @p times and one answer per sample. An empty series gives empty arrays.
+ * @throw std::invalid_argument An array that is not one-dimensional or that carries ghost elements, a length
+ *        mismatch, a decreasing timestamp, or a zero @p span.
+ *
+ * @ingroup group_numerics
+ */
+inline std::pair<SimpleArray<uint64_t>, SimpleArray<bool>>
+held(SimpleArray<uint64_t> const & times, SimpleArray<bool> const & values, uint64_t span)
+{
+    detail::validate_series(times, values, "held");
+    detail::validate_sorted(times, "held", "times");
+    detail::validate_span(span, "held");
+
+    ssize_t const nsample = times.shape(0);
+    SimpleArray<uint64_t> otimes = times.to_row_major();
+    SimpleArray<bool> oheld(nsample);
+
+    uint64_t const * const tsrc = times.logical_data();
+    ssize_t const tstep = times.stride(0);
+    bool const * const vsrc = values.logical_data();
+    ssize_t const vstep = values.stride(0);
+
+    ssize_t first = 0; // first sample in the window
+    ssize_t last = 0; // one past the last sample in the window
+    ssize_t newest_false = -1; // newest false among all samples read so far, or -1 if none
+    for (ssize_t i = 0; i < nsample; ++i)
+    {
+        uint64_t const t = tsrc[i * tstep];
+        for (; last < nsample && tsrc[last * tstep] <= t; ++last)
+        {
+            if (!vsrc[last * vstep])
+            {
+                newest_false = last;
+            }
+        }
+
+        while (first < last && detail::is_before_window(tsrc[first * tstep], t, span))
+        {
+            ++first;
+        }
+        ssize_t const boundary = first - 1; // the sample whose value covers the start of the window
+
+        // No boundary sample yet makes boundary -1, which no newest_false is below.
+        oheld[i] = newest_false < boundary;
+    }
+
+    return {std::move(otimes), std::move(oheld)};
 }
 
 } /* end namespace timeseries */

--- a/doc/source/compute/numerics/timeseries.md
+++ b/doc/source/compute/numerics/timeseries.md
@@ -2,36 +2,32 @@
 
 `solvcon.timeseries` holds kernels over recorded time series. A series is a
 pair of one-dimensional arrays of the same length. The first holds the
-timestamps in integer nanoseconds as a non-decreasing `SimpleArrayUint64`. The
-second holds the values sampled at them as a SimpleArray. Each kernel states
-the value classes it takes, reads its input, and returns new arrays. The C++
-kernels live in `cpp/solvcon/timeseries/` in the namespace
+timestamps in integer nanoseconds as a non-decreasing `SimpleArrayUint64`;
+the second holds the values sampled at them as a SimpleArray. Each kernel
+reads its input and returns new arrays.
+The C++ kernels live in `cpp/solvcon/timeseries/` in the namespace
 `solvcon::timeseries`.
 
-The kernels replace the per-sample Python loops that a recorded log otherwise
-needs. Sample lookup on the timestamps is not a kernel here; it is
-`searchsorted`, which {doc}`the reduce page <../buffer/reduce>` describes.
-
-A kernel that takes a series raises `TypeError` when `times` is not a
-`SimpleArrayUint64` or `values` is a class the kernel does not take. It raises
-`ValueError` for an array that is not one-dimensional, for an array that
-carries ghost elements, for arrays of different length, or for a decreasing
-timestamp.
+A kernel raises `TypeError` when `times` is not a `SimpleArrayUint64` or
+`values` is a class the kernel does not take. It raises `ValueError` for an
+array that is not one-dimensional or carries ghost elements, for arrays of
+different length, or for a decreasing timestamp. Sample lookup
+on the timestamps is `searchsorted`, which
+{doc}`the reduce page <../buffer/reduce>` describes.
 
 ## Repeated Timestamps
 
 A recorded log can stamp two messages in the same nanosecond, so a repeated
 timestamp is valid input. A group of equal timestamps resolves to its last
 sample. `deriv` is the exception: a zero time step has no derivative, so
-`deriv` raises `ValueError`. `dedup_last` collapses a repeat, so its result is
-valid input to `deriv`.
+`deriv` raises `ValueError`. `dedup_last` collapses a repeat, so its result
+is valid input to `deriv`.
 
 ## The `merge_sorted_unique` Function
 
-`merge_sorted_unique(*arrays)` merges any number of sorted `SimpleArrayUint64`
-timestamp arrays into one sorted `SimpleArrayUint64` that holds every
-distinct timestamp once. This is the union time grid that compares two
-signals sampled at different rates:
+`merge_sorted_unique(*arrays)` merges sorted `SimpleArrayUint64` timestamp
+arrays into one sorted array that holds every distinct timestamp once. This
+is the union time grid that compares two signals sampled at different rates:
 
 ```python
 from solvcon import timeseries as ts
@@ -39,21 +35,16 @@ from solvcon import timeseries as ts
 t1 = solvcon.SimpleArrayUint64(array=np.array([0, 10, 20], dtype='uint64'))
 t2 = solvcon.SimpleArrayUint64(array=np.array([5, 10, 10], dtype='uint64'))
 assert ts.merge_sorted_unique(t1, t2).ndarray.tolist() == [0, 5, 10, 20]
-assert ts.merge_sorted_unique().shape == (0,)
 ```
 
-A timestamp repeated within one array or shared between arrays appears once.
 No argument, or only empty arrays, gives an empty result. Every argument must
-be a `SimpleArrayUint64`; another class raises `TypeError`. A `ValueError`
-names the offending array by its position.
+be a `SimpleArrayUint64`; another class raises `TypeError`, and a
+`ValueError` names the offending array by its position.
 
 ## The `dedup_last` Function
 
 `dedup_last(times, values)` keeps the last sample of every group of equal
-timestamps. It returns a new array of the kept timestamps and a new array of
-the kept values. The result timestamps are strictly increasing, and the result
-values keep the class of the input values. The kernel takes every typed
-SimpleArray class. A series without a repeat comes back as a copy:
+timestamps, so the result timestamps are strictly increasing:
 
 ```python
 times = solvcon.SimpleArrayUint64(array=np.array([0, 1, 1, 2], dtype='uint64'))
@@ -63,26 +54,81 @@ assert t_u.ndarray.tolist() == [0, 1, 2]
 assert speed_u.ndarray.tolist() == [0.5, 1.5, 2.0]
 ```
 
+The kernel takes every typed SimpleArray class, and the result values keep
+the class of the input values. A series without a repeat comes back as a
+copy.
+
 ## The `deriv` Function
 
 `deriv(times, values)` differentiates a series by the backward difference
-`(x_i - x_{i-1}) / (t_i - t_{i-1})` and returns the tuple
-`(times[1:], derivatives)`. The first sample has no predecessor, so `n`
-samples give `n - 1` derivatives and fewer than two samples give empty
-arrays. The output timestamps are strictly increasing, so a second `deriv`
-chains directly. The kernel takes the real-number classes only, so
-`SimpleArrayBool` and the complex classes raise `TypeError`. A
-`SimpleArrayFloat32` input gives `SimpleArrayFloat32` derivatives; every
-other class gives `SimpleArrayFloat64`:
+`(x_i - x_{i-1}) / (t_i - t_{i-1})` and returns `(times[1:], derivatives)`:
 
 ```python
 times = solvcon.SimpleArrayUint64(array=np.array([0, 10, 30], dtype='uint64'))
 speed = solvcon.SimpleArrayFloat64(array=np.array([1.0, 3.0, 2.0]))
 t_acc, acc = ts.deriv(times, speed)
 assert t_acc.ndarray.tolist() == [10, 30]
-# (3.0-1.0)/(10.0-0.0) and (2.0-3.0)/(30.0-10.0)
-assert acc.ndarray.tolist() == [0.2, -0.05]
-t_jerk, jerk = ts.deriv(t_acc, acc)
+assert acc.ndarray.tolist() == [0.2, -0.05]  # (3.0-1.0)/10 and (2.0-3.0)/20
+```
+
+The first sample has no predecessor, so `n` samples give `n - 1` derivatives
+and fewer than two samples give empty arrays. The output timestamps are
+strictly increasing, so a second `deriv` chains directly. The kernel takes
+the real-number classes only; `SimpleArrayBool` and the complex classes raise
+`TypeError`. A `SimpleArrayFloat32` input gives `SimpleArrayFloat32`
+derivatives, and every other class gives `SimpleArrayFloat64`.
+
+## Trailing Windows
+
+`movavg` and `held` answer at every timestamp of the series from the
+trailing half-open window `(t - span, t]`. `span` is a length in integer
+nanoseconds and must be positive; a zero `span` raises `ValueError`. A
+`span` wider than the whole log is valid. Every sample of a group of equal
+timestamps is in the window together and gets the same answer. Both kernels
+return the tuple `(times, results)` with the input timestamps, so a chain of
+kernels keeps its length and time base.
+
+## The `movavg` Function
+
+`movavg(times, values, span)` takes the arithmetic mean of the samples in
+the window at each timestamp, which smooths a noisy signal:
+
+```python
+times = solvcon.SimpleArrayUint64(
+    array=np.array([0, 10, 20, 30], dtype='uint64'))
+noisy = solvcon.SimpleArrayFloat64(array=np.array([1.0, 5.0, 1.0, 5.0]))
+t_s, smooth = ts.movavg(times, noisy, span=20)
+assert t_s.ndarray.tolist() == [0, 10, 20, 30]
+# The window at t=20 is (0, 20] and averages 5.0 and 1.0.
+assert smooth.ndarray.tolist() == [1.0, 3.0, 3.0, 3.0]
+```
+
+The kernel takes the real-number classes only, and the result class follows
+the same rule as `deriv`. The sweep carries one running sum, so one
+non-finite sample makes every later mean NaN; drop such a sample first.
+
+## The `held` Function
+
+`held(times, values, span)` reports whether a `SimpleArrayBool` series was
+true over the whole window `(t - span, t]` at every timestamp and returns a
+`SimpleArrayBool`. The boundary sample, the last one stamped at or before
+`t - span`, must be true as well. No boundary sample exists over the first
+`span` of the log, so the answer there is false:
+
+```python
+times = solvcon.SimpleArrayUint64(
+    array=np.array([0, 10, 20, 30, 40], dtype='uint64'))
+brake = solvcon.SimpleArrayBool(
+    array=np.array([True, True, False, True, True]))
+t_h, brake_held = ts.held(times, brake, span=10)
+
+# t=0: no boundary sample, answer is False
+# t=10: boundary at 0 is True, window (0, 10] holds True, answer is True
+# t=20: window (10, 20] holds the False at 20, answer is False
+# t=30: boundary at 20 is False, answer is False
+# t=40: boundary at 30 is True, window (30, 40] holds True, answer is True
+assert t_h.ndarray.tolist() == [0, 10, 20, 30, 40]
+assert brake_held.ndarray.tolist() == [False, True, False, False, True]
 ```
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/solvcon/timeseries.py
+++ b/solvcon/timeseries.py
@@ -17,6 +17,8 @@ _toload = [
     'merge_sorted_unique',
     'dedup_last',
     'deriv',
+    'movavg',
+    'held',
 ]
 
 

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -23,6 +23,10 @@ def f64(values):
     return arr('float64', values)
 
 
+def bl(values):
+    return arr('bool', values)
+
+
 INT_DTYPES = ('int8', 'int16', 'int32', 'int64',
               'uint8', 'uint16', 'uint32', 'uint64')
 ALL_DTYPES = ('bool',) + INT_DTYPES + ('float32', 'float64',
@@ -262,6 +266,234 @@ class DerivTC(unittest.TestCase):
                        arr('complex128', [1 + 1j, 2j])):
             with self.assertRaisesRegex(TypeError, msg):
                 ts.deriv(u64([0, 1]), values)
+
+
+def naive_movavg(times, values, span):
+    out = []
+    for t in times:
+        window = [v for tj, v in zip(times, values)
+                  if tj <= t and tj + span > t]
+        out.append(sum(window) / len(window))
+    return out
+
+
+class MovavgTC(unittest.TestCase):
+
+    def test_window_is_trailing_and_half_open(self):
+        times = u64([0, 10, 20, 30])
+        values = f64([1.0, 2.0, 3.0, 4.0])
+        otimes, omean = ts.movavg(times, values, span=20)
+        self.assertIs(type(omean), solvcon.SimpleArrayFloat64)
+        self.assertEqual(otimes.ndarray.tolist(), [0, 10, 20, 30])
+        # At t=20 the window is (0, 20]: the sample at 0 is exactly span
+        # behind and out, so the mean is over 2.0 and 3.0. The two head
+        # windows are partial and never empty.
+        self.assertEqual(omean.ndarray.tolist(), [1.0, 1.5, 2.5, 3.5])
+
+    def test_span_wider_than_the_log_does_not_underflow(self):
+        # t - span wraps in uint64 near the head; every sample must stay in
+        # the window instead of the window going empty.
+        times = u64([0, 1, 2, 3])
+        values = f64([1.0, 3.0, 5.0, 7.0])
+        _, omean = ts.movavg(times, values, span=2**64 - 1)
+        self.assertEqual(omean.ndarray.tolist(), [1.0, 2.0, 3.0, 4.0])
+        big = u64([2**63, 2**63 + 1])
+        _, omean = ts.movavg(big, f64([2.0, 4.0]), span=2**63 + 5)
+        self.assertEqual(omean.ndarray.tolist(), [2.0, 3.0])
+
+    def test_a_bad_sample_outlives_its_window(self):
+        # The running sum subtracts a sample on the way out (see the TODO
+        # on movavg()). Subtracting a non-finite sample back leaves NaN in
+        # every later mean, and subtracting the 1e17 takes the absorbed
+        # 1.0 with it: the exact trailing means are [1e17, 1.0, 1.0].
+        times = u64([0, 1, 2, 3])
+        for bad in (float('inf'), float('-inf'), np.nan):
+            _, omean = ts.movavg(times, f64([bad, 1.0, 1.0, 1.0]), span=1)
+            np.testing.assert_array_equal(omean.ndarray[0], bad)
+            self.assertTrue(np.all(np.isnan(omean.ndarray[1:])))
+        _, omean = ts.movavg(u64([0, 1, 2]), f64([1e17, 1.0, 1.0]), span=1)
+        self.assertEqual(omean.ndarray.tolist(), [1e17, 0.0, 0.0])
+
+    def test_float32_stays_accurate_over_a_long_series(self):
+        # The running sum is kept in double, so a float32 series with a
+        # large offset stays close to the exact window mean.
+        rng = np.random.default_rng(20260819)
+        nvalues = (1e5 + rng.standard_normal(5000)).astype('float32')
+        _, omean = ts.movavg(u64(np.arange(5000, dtype='uint64')),
+                             arr('float32', nvalues), span=10)
+        expected = [nvalues[max(0, i - 9):i + 1].astype('float64').mean()
+                    for i in range(5000)]
+        np.testing.assert_allclose(omean.ndarray, expected, atol=0.05)
+
+    def test_repeated_timestamp_weighs_the_window_by_its_count(self):
+        # Every sample of a repeated timestamp sees the same window, and
+        # the three samples at 10 all weigh in it; a repeated group at the
+        # head shares the head window the same way.
+        times = u64([0, 10, 10, 10, 20])
+        values = f64([0.0, 1.0, 2.0, 3.0, 4.0])
+        otimes, omean = ts.movavg(times, values, span=15)
+        self.assertEqual(otimes.ndarray.tolist(), [0, 10, 10, 10, 20])
+        self.assertEqual(omean.ndarray.tolist(), [0.0, 1.5, 1.5, 1.5, 2.5])
+        _, omean = ts.movavg(u64([10, 10, 20]), f64([1.0, 3.0, 5.0]), span=5)
+        self.assertEqual(omean.ndarray.tolist(), [2.0, 2.0, 5.0])
+
+    def test_against_a_naive_sweep(self):
+        rng = np.random.default_rng(20260819)
+        for _ in range(20):
+            ntimes = np.sort(rng.integers(0, 200, 60, dtype='uint64'))
+            nvalues = rng.standard_normal(60, dtype='float64')
+            times, values = u64(ntimes), f64(nvalues)
+            ltimes, lvalues = ntimes.tolist(), nvalues.tolist()
+            for span in (1, 7, 50, 500):
+                _, omean = ts.movavg(times, values, span)
+                np.testing.assert_allclose(
+                    omean.ndarray, naive_movavg(ltimes, lvalues, span))
+
+    def test_empty_and_single_series(self):
+        otimes, omean = ts.movavg(u64([]), f64([]), span=5)
+        self.assertEqual((otimes.shape, omean.shape), ((0,), (0,)))
+        otimes, omean = ts.movavg(u64([9]), f64([2.5]), span=5)
+        self.assertEqual((otimes.ndarray.tolist(), omean.ndarray.tolist()),
+                         ([9], [2.5]))
+
+    def test_float32_keeps_float32_and_integer_gives_float64(self):
+        times = u64([0, 1])
+        _, omean = ts.movavg(times, arr('float32', [1.0, 2.0]), span=5)
+        self.assertIs(type(omean), solvcon.SimpleArrayFloat32)
+        self.assertEqual(omean.ndarray.tolist(), [1.0, 1.5])
+        for dtype in INT_DTYPES:
+            _, omean = ts.movavg(times, arr(dtype, [3, 4]), span=5)
+            self.assertIs(type(omean), solvcon.SimpleArrayFloat64, dtype)
+            self.assertEqual(omean.ndarray.tolist(), [3.0, 3.5], dtype)
+
+    def test_strided_view_is_read_in_array_order(self):
+        times = solvcon.SimpleArrayUint64(
+            array=np.arange(12, dtype='uint64')[::4])
+        values = solvcon.SimpleArrayFloat64(
+            array=np.arange(6, dtype='float64')[::2])
+        otimes, omean = ts.movavg(times, values, span=5)
+        self.assertEqual(otimes.ndarray.tolist(), [0, 4, 8])
+        self.assertEqual(omean.ndarray.tolist(), [0.0, 1.0, 3.0])
+
+    def test_smooths_a_derivative(self):
+        t_acc, acc = ts.deriv(u64([0, 1, 2, 3, 4]),
+                              f64([0.0, 1.0, 0.0, 1.0, 0.0]))
+        t_smooth, smooth = ts.movavg(t_acc, acc, span=2)
+        self.assertEqual(t_smooth.ndarray.tolist(), [1, 2, 3, 4])
+        self.assertEqual(smooth.ndarray.tolist(), [1.0, 0.0, 0.0, 0.0])
+
+    def test_invalid_input_raises(self):
+        with self.assertRaisesRegex(ValueError,
+                                    "movavg.*span must be positive but is 0"):
+            ts.movavg(u64([0, 1]), f64([0.0, 1.0]), span=0)
+        with self.assertRaisesRegex(ValueError, "movavg.*non-decreasing"):
+            ts.movavg(u64([2, 1]), f64([0.0, 0.0]), span=5)
+        with self.assertRaisesRegex(ValueError, "movavg.*2 samples but "
+                                    "values has 3"):
+            ts.movavg(u64([1, 2]), f64([0.0, 0.0, 0.0]), span=5)
+        with self.assertRaisesRegex(TypeError, "incompatible function "
+                                    "arguments"):
+            ts.movavg(u64([0, 1]), bl([True, False]), span=5)
+
+
+class HeldTC(unittest.TestCase):
+
+    def test_true_only_after_a_full_window_of_true(self):
+        times = u64([0, 10, 20, 30, 40])
+        values = bl([True, True, True, True, True])
+        otimes, oheld = ts.held(times, values, span=20)
+        self.assertIs(type(oheld), solvcon.SimpleArrayBool)
+        self.assertEqual(otimes.ndarray.tolist(), [0, 10, 20, 30, 40])
+        # No sample at or before t - 20 until t = 20.
+        self.assertEqual(oheld.ndarray.tolist(),
+                         [False, False, True, True, True])
+
+    def test_a_false_inside_the_window_clears_it(self):
+        times = u64([0, 10, 20, 30, 40, 50])
+        values = bl([True, False, True, True, True, True])
+        _, oheld = ts.held(times, values, span=20)
+        # The false at 10 is in the window until t = 30, and the window at
+        # t = 30 starts from the sample at 10, which is false as well.
+        self.assertEqual(oheld.ndarray.tolist(),
+                         [False, False, False, False, True, True])
+
+    def test_the_boundary_sample_carries_the_claim(self):
+        # The boundary sample is the last one stamped at or before
+        # t - span. The window (10, 30] holds only true samples, but the
+        # state over (10, 20) comes from the boundary sample at 10.
+        times = u64([0, 10, 30])
+        _, oheld = ts.held(times, bl([True, False, True]), span=20)
+        self.assertEqual(oheld.ndarray.tolist(), [False, False, False])
+        _, oheld = ts.held(times, bl([True, True, True]), span=20)
+        self.assertEqual(oheld.ndarray.tolist(), [False, False, True])
+        # A sample exactly span behind t is the boundary, not a member.
+        _, oheld = ts.held(u64([0, 20]), bl([True, True]), span=20)
+        self.assertEqual(oheld.ndarray.tolist(), [False, True])
+        _, oheld = ts.held(u64([0, 20]), bl([False, True]), span=20)
+        self.assertEqual(oheld.ndarray.tolist(), [False, False])
+
+    def test_span_wider_than_the_log_gives_false(self):
+        times = u64([0, 1, 2])
+        _, oheld = ts.held(times, bl([True, True, True]), span=2**64 - 1)
+        self.assertEqual(oheld.ndarray.tolist(), [False, False, False])
+        big = u64([2**63, 2**63 + 1, 2**63 + 2])
+        _, oheld = ts.held(big, bl([True, True, True]), span=2**63 + 5)
+        self.assertEqual(oheld.ndarray.tolist(), [False, False, False])
+
+    def test_repeated_timestamp_needs_every_sample_of_the_group(self):
+        # A group on the boundary resolves to its last sample; a false
+        # anywhere in a group inside the window clears it.
+        times = u64([0, 10, 10, 20])
+        _, oheld = ts.held(times, bl([True, True, False, True]), span=10)
+        self.assertEqual(oheld.ndarray.tolist(),
+                         [False, False, False, False])
+        _, oheld = ts.held(times, bl([True, False, True, True]), span=10)
+        self.assertEqual(oheld.ndarray.tolist(), [False, False, False, True])
+        _, oheld = ts.held(u64([0, 10, 10, 15]),
+                           bl([True, True, False, True]), span=10)
+        self.assertEqual(oheld.ndarray.tolist(),
+                         [False, False, False, False])
+
+    def test_empty_and_single_series(self):
+        otimes, oheld = ts.held(u64([]), bl([]), span=5)
+        self.assertEqual((otimes.shape, oheld.shape), ((0,), (0,)))
+        otimes, oheld = ts.held(u64([9]), bl([True]), span=5)
+        self.assertEqual((otimes.ndarray.tolist(), oheld.ndarray.tolist()),
+                         ([9], [False]))
+
+    def test_strided_view_is_read_in_array_order(self):
+        times = solvcon.SimpleArrayUint64(
+            array=np.arange(12, dtype='uint64')[::4])
+        values = solvcon.SimpleArrayBool(
+            array=np.array([True, False, True, False, True, False],
+                           dtype='bool')[::2])
+        otimes, oheld = ts.held(times, values, span=4)
+        self.assertEqual(otimes.ndarray.tolist(), [0, 4, 8])
+        self.assertEqual(oheld.ndarray.tolist(), [False, True, True])
+
+    def test_holds_a_thresholded_moving_average(self):
+        times = u64([0, 1, 2, 3, 4, 5])
+        _, smooth = ts.movavg(times, f64([9.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
+                              span=2)
+        under = bl([v < 2.0 for v in smooth.ndarray.tolist()])
+        _, oheld = ts.held(times, under, span=2)
+        self.assertEqual(smooth.ndarray.tolist(),
+                         [9.0, 5.0, 1.0, 1.0, 1.0, 1.0])
+        self.assertEqual(oheld.ndarray.tolist(),
+                         [False, False, False, False, True, True])
+
+    def test_invalid_input_raises(self):
+        with self.assertRaisesRegex(ValueError,
+                                    "held.*span must be positive but is 0"):
+            ts.held(u64([0, 1]), bl([True, True]), span=0)
+        with self.assertRaisesRegex(ValueError, "held.*non-decreasing"):
+            ts.held(u64([2, 1]), bl([True, True]), span=5)
+        with self.assertRaisesRegex(ValueError, "held.*2 samples but values "
+                                    "has 3"):
+            ts.held(u64([1, 2]), bl([True, True, True]), span=5)
+        with self.assertRaisesRegex(TypeError, "incompatible function "
+                                    "arguments"):
+            ts.held(u64([0, 1]), f64([1.0, 0.0]), span=5)
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`movavg(times, values, span)` averages a series over the trailing half-open window `(t - span, t]`, and `held(times, values, span)` reports whether a `SimpleArrayBool` series was true over that same window. Both answer at every timestamp of the input and return those timestamps beside their result, so a chain of kernels keeps one time base.

The window covers timestamps, not positions in the array, so samples that share a timestamp all weigh in it. `t - span` wraps in `uint64_t` near the head of the log, so the window test compares instead of subtracting. `held` stays false until a sample exists at or before `t - span`; that boundary sample carries the state into the window.

`movavg` carries one running sum in `double`. The sweep is linear and fast but not exact: rounding error accumulates over the whole series, and one non-finite sample makes every later mean NaN. The docstrings state the tradeoff, a test pins it, and a `TODO` records the exact suffix-sum sweep that confines both. The result-type alias `deriv_value_t` becomes `real_value_t`, because two kernels now return it.

`make lint` is clean, `make gtest` passes (244 passed), and `make pytest` passes (2270 passed, 14 skipped, 3 xfailed), of which `tests/test_timeseries.py` contributes 46. The five examples on the documentation page execute with their assertions passing.

This is PR 4 of the plan. PR 3 landed as #1372 and #1380.

Related to #1285.
