### PR TITLE
Clear the clang-tidy errors in the timeseries deriv kernel

### DIFF
--- a/cpp/solvcon/timeseries/timeseries.hpp
+++ b/cpp/solvcon/timeseries/timeseries.hpp
@@ -79,8 +79,11 @@ R subtract_exact(T x1, T x0)
 
     if constexpr (std::is_integral_v<T>)
     {
-        auto const u1 = static_cast<uint64_t>(x1), u0 = static_cast<uint64_t>(x0);
-        return x1 >= x0 ? static_cast<R>(u1 - u0) : -static_cast<R>(u0 - u1);
+        using unsigned_type = std::make_unsigned_t<T>;
+        auto const u1 = static_cast<unsigned_type>(x1), u0 = static_cast<unsigned_type>(x0);
+        return x1 >= x0
+                   ? static_cast<R>(static_cast<unsigned_type>(u1 - u0))
+                   : -static_cast<R>(static_cast<unsigned_type>(u0 - u1));
     }
     else
     {
@@ -257,7 +260,7 @@ deriv(SimpleArray<uint64_t> const & times, SimpleArray<T> const & values)
     {
         uint64_t const cur = tsrc[i * tstep], prev = tsrc[(i - 1) * tstep];
         otimes[i - 1] = cur;
-        result_type const dvalue = detail::subtract_exact<result_type>(vsrc[i * vstep], vsrc[(i - 1) * vstep]);
+        auto const dvalue = detail::subtract_exact<result_type>(vsrc[i * vstep], vsrc[(i - 1) * vstep]);
         oderiv[i - 1] = dvalue / static_cast<result_type>(cur - prev);
     }
 


### PR DESCRIPTION
The lint workflow is red on master. It fails on both ubuntu-24.04 and macos-26 at the `make pilot` step, where clang-tidy runs with `-warnings-as-errors=*`, and the three errors all sit in the `deriv()` kernel that arrived with #1380. Two are bugprone-signed-char-misuse on `subtract_exact()`, raised when the template is instantiated for int8_t, because casting a signed char straight to uint64_t sign-extends through a width the check refuses to trust. The third is modernize-use-auto on a local that repeats the return type of the call initializing it.

The subtraction now happens in `std::make_unsigned_t<T>`, the unsigned counterpart of the operand type, instead of widening to uint64_t. That keeps the magnitude exact for every integer width the kernel accepts. Types narrower than int promote to int in the middle of the expression, so the difference is cast back to the unsigned type before it reaches the floating-point result; without that cast a narrow negative intermediate would survive into the result.

Running clang-tidy over the two translation units the CI compiles, `wrap_timeseries.cpp` and `timeseries_pymod.cpp`, with the repository .clang-tidy reports the same three findings before the change and none after. A separate check of `subtract_exact()` at the extremes of int8, uint8, int16, int32, int64, and uint64 confirms the values are unchanged. `make lint` passes and `make pytest-fast` reports 2038 passed, 12 skipped, 3 xfailed.

Related to #1285.
