### PR TITLE
MCAP 2: Read the container layer of an MCAP recording

### DIFF
--- a/.github/actions/setup_linux/action.yml
+++ b/.github/actions/setup_linux/action.yml
@@ -66,9 +66,11 @@ runs:
         test -f /usr/share/doc/kitware-archive-keyring/copyright || \
             sudo rm /usr/share/keyrings/kitware-archive-keyring.gpg
         sudo apt-get -qy install kitware-archive-keyring
+        # liblz4-dev and libzstd-dev back BUILD_MCAP, which decompresses the
+        # chunks of an MCAP recording.
         sudo apt-get -qy install \
             sudo curl git build-essential make cmake libc6-dev gcc g++ \
-            libopenblas-dev \
+            libopenblas-dev liblz4-dev libzstd-dev \
             python3 python3-dev python3-venv
         # The path of apt-get cmake is `/usr/bin/cmake`,
         # but the path of built-in cmake of runner image is `/usr/local/bin/cmake`.

--- a/.github/actions/setup_macos/action.yml
+++ b/.github/actions/setup_macos/action.yml
@@ -42,6 +42,9 @@ runs:
         # qt6 versioning independently from the OS.
         # brew install llvm@21 qt6
         brew install llvm@22
+        # lz4 and zstd back BUILD_MCAP, which decompresses the chunks of an
+        # MCAP recording.
+        brew install lz4 zstd
         # The macos-26 runner ships with Homebrew llvm@20 linked into
         # /usr/local/bin/ (clang, clang++, clang-format, clang-tidy, etc.),
         # which precedes /usr/bin on PATH. Use -sf to overwrite the existing

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -226,6 +226,25 @@ jobs:
         make pytest ${JOB_MAKE_ARGS}
         echo "::endgroup::"
 
+    - name: make pytest BUILD_MCAP=ON
+      run: |
+        echo "::group::make pytest BUILD_MCAP=ON"
+        # BUILD_MCAP is off in every other lane, so the subsystem gets a lane
+        # of its own rather than riding on one that means something else.
+        # SOLVCON_MCAP reaches module.cpp alone, so this configure recompiles
+        # the subsystem and that file and takes the rest from the cache.
+        rm -f build/*/Makefile
+        make cmake \
+          VERBOSE=1 USE_CLANG_TIDY=OFF \
+          BUILD_QT=OFF BUILD_MCAP=ON \
+          CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
+          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+        make buildext VERBOSE=1
+        # A silent OFF would leave every mcap test skipped and the lane green.
+        python3 -c "import solvcon; assert solvcon.HAS_MCAP == True"
+        make pytest VERBOSE=1 PYTEST_OPTS="-k mcap"
+        echo "::endgroup::"
+
     - name: make buildext BUILD_QT=ON
       run: |
         echo "::group::make buildext BUILD_QT=ON"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,6 @@ if(BUILD_MCAP)
     if(LZ4_LIB AND LZ4_INCLUDE_DIR AND ZSTD_LIB AND ZSTD_INCLUDE_DIR)
         message(STATUS "Found lz4: ${LZ4_LIB}")
         message(STATUS "Found zstd: ${ZSTD_LIB}")
-        add_compile_definitions(SOLVCON_MCAP)
     else()
         message(FATAL_ERROR
             "BUILD_MCAP is ON but lz4 and zstd were not both found.\n"

--- a/cpp/solvcon/CMakeLists.txt
+++ b/cpp/solvcon/CMakeLists.txt
@@ -49,6 +49,13 @@ add_subdirectory(linalg)
 add_subdirectory(timeseries)
 add_subdirectory(simd)
 
+if (BUILD_MCAP)
+    add_subdirectory(mcap)
+else () # BUILD_MCAP
+    set(SOLVCON_MCAP_FILES
+        CACHE FILEPATH "" FORCE)
+endif () # BUILD_MCAP
+
 set(SOLVCON_ROOT_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/solvcon.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/base.hpp
@@ -101,6 +108,7 @@ set(SOLVCON_TERMINAL_FILES
     ${SOLVCON_LINALG_FILES}
     ${SOLVCON_TIMESERIES_FILES}
     ${SOLVCON_SIMD_FILES}
+    ${SOLVCON_MCAP_FILES}
     CACHE FILEPATH "" FORCE)
 
 set(SOLVCON_GRAPHIC_FILES
@@ -126,6 +134,13 @@ add_library(
 )
 
 set(SOLVCON_LIBRARIES solvcon_primary)
+
+# The mcap subsystem is core, not graphic, so its decompression libraries
+# reach the extension through solvcon_primary.
+if (BUILD_MCAP)
+    target_include_directories(solvcon_primary PUBLIC ${LZ4_INCLUDE_DIR} ${ZSTD_INCLUDE_DIR})
+    target_link_libraries(solvcon_primary PUBLIC ${LZ4_LIB} ${ZSTD_LIB})
+endif () # BUILD_MCAP
 
 if (BUILD_QT)
     qt_add_library(
@@ -203,6 +218,14 @@ add_library(
 # to register the pilot submodule; the macro is Qt's own, so nothing here has
 # to restate the setting.
 target_link_libraries(solvcon_entry PUBLIC ${SOLVCON_LIBRARIES})
+
+# module.cpp is the only unit that reads SOLVCON_MCAP, and it decides there
+# whether to register the mcap bindings. Defining the macro on this target
+# alone keeps BUILD_MCAP off the command line of every other unit. Turning the
+# option on then recompiles the subsystem and this file, and nothing else.
+if (BUILD_MCAP)
+    target_compile_definitions(solvcon_entry PRIVATE SOLVCON_MCAP)
+endif () # BUILD_MCAP
 
 list(APPEND SOLVCON_LIBRARIES solvcon_entry)
 

--- a/cpp/solvcon/mcap/CMakeLists.txt
+++ b/cpp/solvcon/mcap/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+cmake_minimum_required(VERSION 4.0.1)
+
+set(SOLVCON_MCAP_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/mcap.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mcap_reader.hpp
+    CACHE FILEPATH "" FORCE)
+
+set(SOLVCON_MCAP_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/mcap_reader.cpp
+    CACHE FILEPATH "" FORCE)
+
+set(SOLVCON_MCAP_PYMODHEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/mcap_pymod.hpp
+    CACHE FILEPATH "" FORCE)
+
+set(SOLVCON_MCAP_PYMODSOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/mcap_pymod.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_McapReader.cpp
+    CACHE FILEPATH "" FORCE)
+
+set(SOLVCON_MCAP_FILES
+    ${SOLVCON_MCAP_HEADERS}
+    ${SOLVCON_MCAP_SOURCES}
+    ${SOLVCON_MCAP_PYMODHEADERS}
+    ${SOLVCON_MCAP_PYMODSOURCES}
+    CACHE FILEPATH "" FORCE)
+
+# vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/mcap/mcap.hpp
+++ b/cpp/solvcon/mcap/mcap.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/mcap/mcap_reader.hpp>
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/mcap/mcap_reader.cpp
+++ b/cpp/solvcon/mcap/mcap_reader.cpp
@@ -1,0 +1,391 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/mcap/mcap_reader.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <stdexcept>
+
+namespace solvcon
+{
+
+namespace mcap
+{
+
+namespace
+{
+
+constexpr std::array<char, 8> MAGIC = {'\x89', 'M', 'C', 'A', 'P', '0', '\r', '\n'};
+constexpr uint64_t MAGIC_SIZE = MAGIC.size();
+// One opcode byte and one uint64 content length.
+constexpr uint64_t RECORD_HEADER_SIZE = 9;
+// Two uint64 offsets and one uint32 CRC.
+constexpr uint64_t FOOTER_CONTENT_SIZE = 20;
+
+enum Opcode : uint8_t
+{
+    OP_FOOTER = 0x02,
+    OP_SCHEMA = 0x03,
+    OP_CHANNEL = 0x04,
+    OP_CHUNK_INDEX = 0x08,
+    OP_STATISTICS = 0x0b,
+}; /* end enum Opcode */
+
+/**
+ * @internal
+ * Cursor reading the fields of one record content.  MCAP writes its integers
+ * little-endian, and so does every platform solvcon builds for, so a field is
+ * a plain copy out of the buffer.
+ */
+class FieldReader
+{
+
+public:
+
+    explicit FieldReader(std::string_view data)
+        : m_data(data)
+    {
+    }
+
+    uint16_t u16() { return read<uint16_t>(); }
+    uint32_t u32() { return read<uint32_t>(); }
+    uint64_t u64() { return read<uint64_t>(); }
+
+    /// Length-prefixed string or byte array.
+    std::string_view str() { return bytes(u32()); }
+
+    std::string_view bytes(uint64_t length)
+    {
+        require(length);
+        std::string_view const out = m_data.substr(m_pos, length);
+        m_pos += length;
+        return out;
+    }
+
+    void skip(uint64_t length) { bytes(length); }
+
+    bool done() const { return m_pos >= m_data.size(); }
+
+private:
+
+    template <typename T>
+    T read()
+    {
+        require(sizeof(T));
+        T value = 0;
+        std::memcpy(&value, m_data.data() + m_pos, sizeof(T));
+        m_pos += sizeof(T);
+        return value;
+    }
+
+    void require(uint64_t length) const
+    {
+        // The cursor never passes the end, so the room left is a subtraction.
+        // Adding the length to the position instead would wrap for a length
+        // the file states.
+        if (length > m_data.size() - m_pos)
+        {
+            throw std::runtime_error("MCAP record is truncated");
+        }
+    }
+
+    std::string_view m_data;
+    uint64_t m_pos = 0;
+}; /* end class FieldReader */
+
+} /* end namespace */
+
+static bool same_schema(SchemaRecord const & lhs, SchemaRecord const & rhs)
+{
+    return lhs.name == rhs.name && lhs.encoding == rhs.encoding && lhs.data == rhs.data;
+}
+
+static bool same_channel(ChannelRecord const & lhs, ChannelRecord const & rhs)
+{
+    return lhs.schema_id == rhs.schema_id && lhs.topic == rhs.topic &&
+           lhs.message_encoding == rhs.message_encoding && lhs.metadata == rhs.metadata;
+}
+
+/// Whether the summary record of this opcode is one the reader keeps.
+static bool is_kept_record(uint8_t opcode)
+{
+    return OP_SCHEMA == opcode || OP_CHANNEL == opcode ||
+           OP_CHUNK_INDEX == opcode || OP_STATISTICS == opcode;
+}
+
+Reader::Reader(std::string const & path)
+    : m_path(path)
+    , m_stream(path, std::ios::binary)
+{
+    if (!m_stream)
+    {
+        throw std::runtime_error("cannot open the MCAP file: " + path);
+    }
+
+    // A directory opens but does not seek, and an unchecked -1 would become a
+    // file size of every byte there is.
+    m_stream.seekg(0, std::ios::end);
+    std::streamoff const size = m_stream.tellg();
+    if (size < 0)
+    {
+        throw std::runtime_error("cannot open the MCAP file: " + path);
+    }
+    m_file_size = static_cast<uint64_t>(size);
+
+    read_summary();
+}
+
+std::string Reader::read_bytes(uint64_t offset, uint64_t length)
+{
+    // Both arguments come out of the file.  A sum of the two wraps back into
+    // range for a large enough pair, so the check avoids the addition.
+    if (offset > m_file_size || length > m_file_size - offset)
+    {
+        throw std::runtime_error("MCAP read runs past the end of the file: " + m_path);
+    }
+
+    std::string out(length, '\0');
+    m_stream.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
+    m_stream.read(out.data(), static_cast<std::streamsize>(length));
+    if (!m_stream)
+    {
+        throw std::runtime_error("cannot read the MCAP file: " + m_path);
+    }
+
+    return out;
+}
+
+void Reader::read_summary()
+{
+    constexpr uint64_t TAIL_SIZE = RECORD_HEADER_SIZE + FOOTER_CONTENT_SIZE + MAGIC_SIZE;
+    if (m_file_size < MAGIC_SIZE + TAIL_SIZE)
+    {
+        throw std::runtime_error("not an MCAP file, it is too short: " + m_path);
+    }
+
+    std::string const head = read_bytes(0, MAGIC_SIZE);
+    std::string const tail = read_bytes(m_file_size - TAIL_SIZE, TAIL_SIZE);
+    if (0 != std::memcmp(head.data(), MAGIC.data(), MAGIC_SIZE) ||
+        0 != std::memcmp(tail.data() + tail.size() - MAGIC_SIZE, MAGIC.data(), MAGIC_SIZE))
+    {
+        throw std::runtime_error("not an MCAP file, the magic does not match: " + m_path);
+    }
+
+    // The footer sits at a fixed distance from the end.  Its opcode and
+    // length are therefore read in place, not by walking records to it.
+    uint64_t footer_length = 0;
+    std::memcpy(&footer_length, tail.data() + 1, sizeof(footer_length));
+    if (OP_FOOTER != static_cast<uint8_t>(tail[0]) || FOOTER_CONTENT_SIZE != footer_length)
+    {
+        throw std::runtime_error("the MCAP footer record is malformed: " + m_path);
+    }
+
+    FieldReader footer(std::string_view(tail).substr(RECORD_HEADER_SIZE, FOOTER_CONTENT_SIZE));
+    uint64_t const summary_start = footer.u64();
+    if (0 == summary_start)
+    {
+        throw std::runtime_error("the MCAP file carries no summary section: " + m_path);
+    }
+    uint64_t const summary_end = m_file_size - TAIL_SIZE;
+    if (summary_start >= summary_end)
+    {
+        throw std::runtime_error("the MCAP summary section starts at or past the footer: " + m_path);
+    }
+
+    parse_summary(summary_start, summary_end);
+
+    if (m_has_time_range || m_chunk_indices.empty())
+    {
+        return;
+    }
+    // No statistics record, so the chunk indexes bound the same range. A chunk
+    // holding no message states (0, 0) and would drag the start down to zero.
+    for (ChunkIndexRecord const & chunk : m_chunk_indices)
+    {
+        if (0 == chunk.message_start_time && 0 == chunk.message_end_time)
+        {
+            continue;
+        }
+        m_start_time = m_has_time_range
+                           ? std::min(m_start_time, chunk.message_start_time)
+                           : chunk.message_start_time;
+        m_end_time = std::max(m_end_time, chunk.message_end_time);
+        m_has_time_range = true;
+    }
+}
+
+void Reader::parse_summary(uint64_t start, uint64_t end)
+{
+    // One record is read at a time rather than the section as a whole.  What
+    // the walk costs then follows the largest record, not the whole summary.
+    uint64_t pos = start;
+    while (pos < end)
+    {
+        if (end - pos < RECORD_HEADER_SIZE)
+        {
+            throw std::runtime_error("the MCAP summary section ends inside a record: " + m_path);
+        }
+
+        std::string const head = read_bytes(pos, RECORD_HEADER_SIZE);
+        uint64_t length = 0;
+        std::memcpy(&length, head.data() + 1, sizeof(length));
+        if (length > end - pos - RECORD_HEADER_SIZE)
+        {
+            throw std::runtime_error("an MCAP summary record runs past the section: " + m_path);
+        }
+
+        auto const opcode = static_cast<uint8_t>(head[0]);
+        if (is_kept_record(opcode))
+        {
+            parse_summary_record(opcode, read_bytes(pos + RECORD_HEADER_SIZE, length));
+        }
+        pos += RECORD_HEADER_SIZE + length;
+    }
+}
+
+void Reader::parse_summary_record(uint8_t opcode, std::string_view content)
+{
+    // Reading a field is what validates it, because the cursor throws on a
+    // record too short to hold it.  Fields the specification adds after the
+    // ones below stay unread, which is what keeps this reader working against
+    // a newer writer.
+    FieldReader field(content);
+    switch (opcode)
+    {
+    case OP_SCHEMA:
+    {
+        SchemaRecord schema;
+        schema.id = field.u16();
+        schema.name = std::string(field.str());
+        schema.encoding = std::string(field.str());
+        schema.data = std::string(field.str());
+        // Zero is what a channel states for "no schema", so no schema record
+        // may claim it.
+        if (0 == schema.id)
+        {
+            break;
+        }
+        auto const it = m_schemas.find(schema.id);
+        if (m_schemas.end() == it)
+        {
+            m_schemas[schema.id] = std::move(schema);
+        }
+        else if (!same_schema(it->second, schema))
+        {
+            throw std::runtime_error("the MCAP file states two schemas for one id: " + m_path);
+        }
+        break;
+    }
+    case OP_CHANNEL:
+    {
+        ChannelRecord channel;
+        channel.id = field.u16();
+        channel.schema_id = field.u16();
+        channel.topic = std::string(field.str());
+        channel.message_encoding = std::string(field.str());
+        channel.metadata = std::string(field.str());
+        auto const it = m_channels.find(channel.id);
+        if (m_channels.end() == it)
+        {
+            m_channels[channel.id] = std::move(channel);
+        }
+        else if (!same_channel(it->second, channel))
+        {
+            throw std::runtime_error("the MCAP file states two channels for one id: " + m_path);
+        }
+        break;
+    }
+    case OP_CHUNK_INDEX:
+    {
+        ChunkIndexRecord chunk;
+        chunk.message_start_time = field.u64();
+        chunk.message_end_time = field.u64();
+        chunk.chunk_start_offset = field.u64();
+        chunk.chunk_length = field.u64();
+        FieldReader offsets(field.str());
+        while (!offsets.done())
+        {
+            chunk.channel_ids.push_back(offsets.u16());
+            offsets.u64();
+        }
+        field.u64(); // message_index_length
+        field.str(); // compression
+        field.u64(); // compressed_size
+        field.u64(); // uncompressed_size
+        m_chunk_indices.push_back(std::move(chunk));
+        break;
+    }
+    case OP_STATISTICS:
+    {
+        field.u64(); // message_count
+        field.u16(); // schema_count
+        field.u32(); // channel_count
+        field.u32(); // attachment_count
+        field.u32(); // metadata_count
+        field.u32(); // chunk_count
+        m_start_time = field.u64();
+        m_end_time = field.u64();
+        field.skip(field.u32()); // channel_message_counts
+        m_has_time_range = true;
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+ChannelRecord const * Reader::channel_for(std::string const & topic) const
+{
+    // More than one channel may carry a topic.  The last of them names it, and
+    // topics() and schema() have to agree on which that is.
+    ChannelRecord const * found = nullptr;
+    for (auto const & pair : m_channels)
+    {
+        if (topic == pair.second.topic)
+        {
+            found = &pair.second;
+        }
+    }
+
+    return found;
+}
+
+SchemaRecord Reader::schema(std::string const & topic) const
+{
+    ChannelRecord const * const channel = channel_for(topic);
+    if (nullptr == channel)
+    {
+        throw std::runtime_error("no such topic in the MCAP file: " + topic);
+    }
+
+    auto const it = m_schemas.find(channel->schema_id);
+    if (m_schemas.end() == it)
+    {
+        throw std::runtime_error("the MCAP topic states no schema: " + topic);
+    }
+
+    return it->second;
+}
+
+std::map<std::string, std::string> Reader::topics() const
+{
+    std::map<std::string, std::string> out;
+    for (auto const & pair : m_channels)
+    {
+        ChannelRecord const * const channel = channel_for(pair.second.topic);
+        auto const it = m_schemas.find(channel->schema_id);
+        out[channel->topic] = m_schemas.end() == it ? std::string() : it->second.name;
+    }
+
+    return out;
+}
+
+} /* end namespace mcap */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/mcap/mcap_reader.hpp
+++ b/cpp/solvcon/mcap/mcap_reader.hpp
@@ -1,0 +1,162 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Container-level reader for MCAP recordings.
+ *
+ * @ingroup group_inout
+ */
+
+#include <cstdint>
+#include <fstream>
+#include <map>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <solvcon/buffer/small_vector.hpp>
+
+namespace solvcon
+{
+
+namespace mcap
+{
+
+/**
+ * Schema record of the summary section.  The data field holds the schema text
+ * verbatim, for example the message definition of a ROS 2 type.
+ *
+ * @ingroup group_inout
+ */
+struct SchemaRecord
+{
+    uint16_t id = 0;
+    std::string name;
+    std::string encoding;
+    std::string data;
+}; /* end struct SchemaRecord */
+
+/**
+ * Channel record of the summary section.  A channel carries the messages of
+ * one topic and names the schema that describes them.
+ *
+ * @ingroup group_inout
+ */
+struct ChannelRecord
+{
+    uint16_t id = 0;
+    uint16_t schema_id = 0;
+    std::string topic;
+    std::string message_encoding;
+    std::string metadata; ///< Key-value pairs, as the record serializes them.
+}; /* end struct ChannelRecord */
+
+/**
+ * Chunk index record of the summary section.  The channel ids name the
+ * channels the chunk holds messages of.  A query for a topic skips the chunk
+ * when the list omits its channel.
+ *
+ * @ingroup group_inout
+ */
+struct ChunkIndexRecord
+{
+    uint64_t message_start_time = 0; ///< Log time of the first message, in nanoseconds.
+    uint64_t message_end_time = 0; ///< Log time of the last message, in nanoseconds.
+    uint64_t chunk_start_offset = 0; ///< Byte offset of the chunk record in the file.
+    uint64_t chunk_length = 0; ///< Byte length of the chunk record.
+    small_vector<uint16_t> channel_ids;
+}; /* end struct ChunkIndexRecord */
+
+/**
+ * Reader for the container layer of an MCAP recording.
+ *
+ * Construction validates the file magic and the footer, then parses the
+ * summary section only: the schema, channel, chunk index, and statistics
+ * records.  No chunk is read, and the message payloads stay where they are.
+ *
+ * The file must carry a summary section.  Every writer that indexes its output
+ * writes one.  Without it, a reader would have to walk the whole recording to
+ * collect the topics.
+ *
+ * @ingroup group_inout
+ */
+class Reader
+{
+
+public:
+
+    explicit Reader(std::string const & path);
+
+    ~Reader() = default;
+
+    Reader(Reader const & other) = delete;
+    Reader(Reader && other) = delete;
+    Reader & operator=(Reader const & other) = delete;
+    Reader & operator=(Reader && other) = delete;
+
+    std::string const & path() const { return m_path; }
+
+    /**
+     * Topic name to the name of the schema its messages follow.  A topic
+     * carried by more than one channel appears once.  The channel of highest
+     * id names it, and schema() answers with that same channel.
+     */
+    std::map<std::string, std::string> topics() const;
+
+    /**
+     * Log time of the first and of the last message, in nanoseconds.  A
+     * summary that describes no message at all leaves the range at (0, 0);
+     * has_time_range() tells that apart from a recording that starts at zero.
+     */
+    std::pair<uint64_t, uint64_t> time_range() const { return {m_start_time, m_end_time}; }
+
+    /// Whether the summary stated the log time range.
+    bool has_time_range() const { return m_has_time_range; }
+
+    /// Number of chunk index records the summary carries.
+    size_t chunk_count() const { return m_chunk_indices.size(); }
+
+    /**
+     * Schema the messages of a topic follow, as the summary states it.
+     *
+     * TODO: The decode plan is the first caller of this, and what it needs
+     * from a schema decides the shape returned here. Revisit once it lands
+     * (issue #1286).
+     */
+    SchemaRecord schema(std::string const & topic) const;
+
+private:
+
+    void read_summary();
+    /// Walk the summary section one record at a time, from start to end.
+    void parse_summary(uint64_t start, uint64_t end);
+    void parse_summary_record(uint8_t opcode, std::string_view content);
+    std::string read_bytes(uint64_t offset, uint64_t length);
+    /// The channel that names a topic, or nullptr when no channel carries it.
+    ChannelRecord const * channel_for(std::string const & topic) const;
+
+    std::string m_path;
+    std::ifstream m_stream;
+    uint64_t m_file_size = 0;
+    // TODO: Replace the STL containers below once the buffer subsystem offers
+    // an id-keyed map and a collector of records; SimpleCollector holds
+    // fundamental types and these hold records (issue #1286).
+    std::map<uint16_t, SchemaRecord> m_schemas;
+    std::map<uint16_t, ChannelRecord> m_channels;
+    std::vector<ChunkIndexRecord> m_chunk_indices;
+    bool m_has_time_range = false;
+    uint64_t m_start_time = 0;
+    uint64_t m_end_time = 0;
+}; /* end class Reader */
+
+} /* end namespace mcap */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/mcap/pymod/mcap_pymod.cpp
+++ b/cpp/solvcon/mcap/pymod/mcap_pymod.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/mcap/pymod/mcap_pymod.hpp>
+
+namespace solvcon
+{
+
+namespace python
+{
+
+struct mcap_pymod_tag;
+
+template <>
+OneTimeInitializer<mcap_pymod_tag> & OneTimeInitializer<mcap_pymod_tag>::me()
+{
+    static OneTimeInitializer<mcap_pymod_tag> instance;
+    return instance;
+}
+
+void initialize_mcap(pybind11::module & mod)
+{
+    auto initialize_impl = [](pybind11::module & mod)
+    {
+        wrap_McapReader(mod);
+    };
+
+    OneTimeInitializer<mcap_pymod_tag>::me()(mod, initialize_impl);
+}
+
+} /* end namespace python */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/mcap/pymod/mcap_pymod.hpp
+++ b/cpp/solvcon/mcap/pymod/mcap_pymod.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <pybind11/pybind11.h> // Must be the first include.
+#include <pybind11/stl.h>
+
+#include <solvcon/solvcon.hpp>
+#include <solvcon/python/common.hpp>
+#include <solvcon/mcap/mcap.hpp>
+
+namespace solvcon
+{
+
+namespace python
+{
+
+void initialize_mcap(pybind11::module & mod);
+void wrap_McapReader(pybind11::module & mod);
+
+} /* end namespace python */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/mcap/pymod/wrap_McapReader.cpp
+++ b/cpp/solvcon/mcap/pymod/wrap_McapReader.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/mcap/pymod/mcap_pymod.hpp>
+#include <solvcon/solvcon.hpp>
+
+namespace solvcon
+{
+
+namespace python
+{
+
+class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapMcapSchema
+    : public WrapBase<WrapMcapSchema, mcap::SchemaRecord>
+{
+
+public:
+
+    using base_type = WrapBase<WrapMcapSchema, mcap::SchemaRecord>;
+    using wrapped_type = typename base_type::wrapped_type;
+
+    friend root_base_type;
+
+protected:
+
+    WrapMcapSchema(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : base_type(mod, pyname, pydoc)
+    {
+        namespace py = pybind11; // NOLINT(misc-unused-alias-decls)
+
+        (*this)
+            .def_readonly("id", &wrapped_type::id)
+            .def_readonly("name", &wrapped_type::name)
+            .def_readonly("encoding", &wrapped_type::encoding)
+            // The definition is text for a ROS 2 encoding but bytes for a
+            // binary one, so it stays bytes for every encoding.
+            .def_property_readonly(
+                "data",
+                [](wrapped_type const & self)
+                { return py::bytes(self.data); })
+            //
+            ;
+    }
+
+}; /* end class WrapMcapSchema */
+
+class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapMcapReader
+    : public WrapBase<WrapMcapReader, mcap::Reader, std::shared_ptr<mcap::Reader>>
+{
+
+public:
+
+    using base_type = WrapBase<WrapMcapReader, mcap::Reader, std::shared_ptr<mcap::Reader>>;
+    using wrapped_type = typename base_type::wrapped_type;
+
+    friend root_base_type;
+
+protected:
+
+    WrapMcapReader(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : base_type(mod, pyname, pydoc)
+    {
+        namespace py = pybind11; // NOLINT(misc-unused-alias-decls)
+
+        (*this)
+            .def(
+                py::init(
+                    [](std::string const & path)
+                    { return std::make_shared<mcap::Reader>(path); }),
+                py::arg("path"))
+            //
+            ;
+
+        (*this)
+            .def_property_readonly("path", &wrapped_type::path)
+            .def("topics", &wrapped_type::topics)
+            .def("chunk_count", &wrapped_type::chunk_count)
+            .def("schema", &wrapped_type::schema, py::arg("topic"))
+            .def("time_range", &wrapped_type::time_range)
+            .def("has_time_range", &wrapped_type::has_time_range)
+            //
+            ;
+    }
+
+}; /* end class WrapMcapReader */
+
+void wrap_McapReader(pybind11::module & mod)
+{
+    WrapMcapSchema::commit(mod, "McapSchema", "McapSchema");
+    WrapMcapReader::commit(mod, "McapReader", "McapReader");
+}
+
+} /* end namespace python */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/python/module.cpp
+++ b/cpp/solvcon/python/module.cpp
@@ -21,6 +21,10 @@
 #include <solvcon/timeseries/pymod/timeseries_pymod.hpp>
 #include <solvcon/oasis/pymod/oasis_pymod.hpp>
 
+#ifdef SOLVCON_MCAP
+#include <solvcon/mcap/pymod/mcap_pymod.hpp>
+#endif // SOLVCON_MCAP
+
 #ifdef QT_CORE_LIB
 #include <solvcon/pilot/wrap_pilot.hpp>
 #endif // QT_CORE_LIB
@@ -50,6 +54,13 @@ void initialize(pybind11::module_ mod)
     pybind11::module_ timeseries_mod = mod.def_submodule("timeseries", "timeseries");
     initialize_timeseries(timeseries_mod);
     initialize_oasis(mod);
+
+#ifdef SOLVCON_MCAP
+    mod.attr("HAS_MCAP") = true;
+    initialize_mcap(mod);
+#else // SOLVCON_MCAP
+    mod.attr("HAS_MCAP") = false;
+#endif // SOLVCON_MCAP
 
 #ifdef QT_CORE_LIB
     mod.attr("HAS_PILOT") = true;

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -38,8 +38,8 @@
  */
 
 /** @defgroup group_inout Input and output
- *  Mesh and field readers and writers (Gmsh, Plot3d) and device-format
- *  output (OASIS).
+ *  Mesh and field readers and writers (Gmsh, Plot3d), the MCAP recording
+ *  reader, and device-format output (OASIS).
  */
 
 /** @defgroup group_canvas 2D graphical editor

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ def main():
             'solvcon.agent',
             'solvcon.agent.draw',
             'solvcon.agent.window',
+            'solvcon.mcap',
             'solvcon.multidim',
             'solvcon.multidim.euler',
             'solvcon.onedim',

--- a/solvcon/__init__.py
+++ b/solvcon/__init__.py
@@ -22,6 +22,7 @@ from . import testing  # noqa: F401
 from . import toggle  # noqa: F401
 from . import config  # noqa: F401
 from . import track  # noqa: F401
+from . import mcap  # noqa: F401
 
 clinfo = core.ProcessInfo.instance.command_line
 

--- a/solvcon/core.py
+++ b/solvcon/core.py
@@ -79,6 +79,14 @@ list_of_python = [
     'CommandLineInfo',
     'ProcessInfo',
     'HAS_PILOT',
+    'HAS_MCAP',
+]
+
+# mcap directory symbols, loaded only when the extension carries the
+# BUILD_MCAP subsystem.
+list_of_mcap = [
+    'McapReader',
+    'McapSchema',
 ]
 
 # toggle directory symbols
@@ -211,6 +219,10 @@ _load(list_of_transform)
 _load(list_of_linalg)
 _load(list_of_universe)
 _load(list_of_oasis)
+
+if _impl.HAS_MCAP:
+    _load(list_of_mcap)
+    __all__ = __all__ + list_of_mcap
 
 # Walk through the thirdparty folder and register all library
 # into a dictionary.

--- a/solvcon/mcap/__init__.py
+++ b/solvcon/mcap/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+mcap: read MCAP recordings into solvcon.
+
+The extension carries the subsystem only when it is configured with
+``BUILD_MCAP=ON``, because decompressing MCAP chunks needs lz4 and zstd.
+``HAS_MCAP`` is true only in such a build, and ``Reader`` exists only then.
+"""
+
+from .. import core
+
+HAS_MCAP = core.HAS_MCAP
+
+__all__ = [
+    "HAS_MCAP",
+]
+
+if HAS_MCAP:
+    Reader = core.McapReader
+    __all__.append("Reader")
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_mcap.py
+++ b/tests/test_mcap.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+import os
+import struct
+import tempfile
+
+import unittest
+
+import solvcon as sc
+
+# tests/data/make_mcap_fixtures.py writes the fixtures. A chunked fixture
+# takes its name from its chunk compression.
+CHUNKED = ("vehicle_none", "vehicle_lz4", "vehicle_zstd")
+UNCHUNKED = "vehicle_unchunked"
+FIXTURES = CHUNKED + (UNCHUNKED,)
+
+STATUS = "/vehicle/status"
+IMU = "/vehicle/imu"
+TOPICS = (STATUS, IMU)
+
+# What the generator recorded: status messages this far apart in nanoseconds,
+# starting here, and one imu message per twelve of them.
+START_TIME = 1700000000000000000
+PERIOD = 10000000
+MESSAGE_COUNT = 96
+END_TIME = START_TIME + (MESSAGE_COUNT - 1) * PERIOD
+# The 256-byte chunk size of the generator packs the messages into this many
+# chunks. Regenerating the fixtures with another chunk size changes it.
+CHUNK_COUNT = 19
+
+
+MAGIC = b"\x89MCAP0\r\n"
+
+
+def _record(opcode, content):
+    return bytes([opcode]) + struct.pack("<Q", len(content)) + content
+
+
+def _prefixed(raw):
+    return struct.pack("<I", len(raw)) + raw
+
+
+def _text(value):
+    return _prefixed(value.encode())
+
+
+def _schema(schema_id, name, encoding="ros2msg", data=b"float64 x\n"):
+    return _record(0x03, struct.pack("<H", schema_id) + _text(name)
+                   + _text(encoding) + _prefixed(data))
+
+
+def _channel(channel_id, schema_id, topic, encoding="cdr", metadata=b""):
+    return _record(0x04, struct.pack("<HH", channel_id, schema_id)
+                   + _text(topic) + _text(encoding) + _prefixed(metadata))
+
+
+def _chunk_index(start, end, channel_ids=(1,)):
+    offsets = b"".join(struct.pack("<HQ", cid, 0) for cid in channel_ids)
+    return _record(0x08, struct.pack("<QQQQ", start, end, 0, 0)
+                   + _prefixed(offsets) + struct.pack("<Q", 0) + _text("")
+                   + struct.pack("<QQ", 0, 0))
+
+
+def _statistics(start, end):
+    return _record(0x0B, struct.pack("<QHIIII", 0, 0, 0, 0, 0, 0)
+                   + struct.pack("<QQ", start, end) + _prefixed(b""))
+
+
+def _assemble(records, trailing=b""):
+    """The smallest file the reader accepts, carrying the given summary.
+
+    The data section holds no message, because the reader under test reads
+    the footer and the summary and nothing else.
+    """
+    head = (MAGIC + _record(0x01, _text("") + _text("solvcon test"))
+            + _record(0x0F, struct.pack("<I", 0)))
+    summary = b"".join(records) + trailing
+    footer = _record(0x02, struct.pack("<QQI", len(head), 0, 0))
+    return head + summary + footer + MAGIC
+
+
+@unittest.skipUnless(sc.mcap.HAS_MCAP, "built without BUILD_MCAP")
+class McapReaderTB(unittest.TestCase):
+    TESTDIR = os.path.abspath(os.path.dirname(__file__))
+    DATADIR = os.path.join(TESTDIR, "data")
+
+    def path(self, name):
+        return os.path.join(self.DATADIR, "%s.mcap" % name)
+
+
+class McapSummaryTC(McapReaderTB):
+    def test_topics(self):
+        for name in FIXTURES:
+            with self.subTest(name=name):
+                reader = sc.mcap.Reader(self.path(name))
+                self.assertEqual(reader.topics(),
+                                 {STATUS: "vhcl_msgs/msg/Status",
+                                  IMU: "vhcl_msgs/msg/Imu"})
+
+    def test_time_range(self):
+        for name in FIXTURES:
+            with self.subTest(name=name):
+                reader = sc.mcap.Reader(self.path(name))
+                self.assertTrue(reader.has_time_range())
+                self.assertEqual(reader.time_range(),
+                                 (START_TIME, END_TIME))
+
+    def test_schema(self):
+        expect = {
+            STATUS: ("vhcl_msgs/msg/Status",
+                     b"float64 longitudinal_speed\nbool brake_active\n"),
+            IMU: ("vhcl_msgs/msg/Imu",
+                  b"float64 ax\nfloat64 ay\nfloat64 az\n"),
+        }
+        reader = sc.mcap.Reader(self.path("vehicle_zstd"))
+        for topic, (name, data) in expect.items():
+            with self.subTest(topic=topic):
+                schema = reader.schema(topic)
+                self.assertEqual(schema.name, name)
+                self.assertEqual(schema.encoding, "ros2msg")
+                self.assertEqual(schema.data, data)
+
+    def test_schema_of_unknown_topic(self):
+        reader = sc.mcap.Reader(self.path("vehicle_zstd"))
+        with self.assertRaisesRegex(RuntimeError, "no such topic"):
+            reader.schema("/vehicle/nothing")
+
+    def test_path(self):
+        path = self.path("vehicle_zstd")
+        self.assertEqual(sc.mcap.Reader(path).path, path)
+
+    def test_not_an_mcap_file(self):
+        path = os.path.join(self.DATADIR, "rectangle.msh")
+        with self.assertRaisesRegex(RuntimeError, "not an MCAP file"):
+            sc.mcap.Reader(path)
+
+    def test_missing_file(self):
+        with self.assertRaisesRegex(RuntimeError, "cannot open"):
+            sc.mcap.Reader(os.path.join(self.DATADIR, "no_such.mcap"))
+
+    def test_chunk_count(self):
+        for name in CHUNKED:
+            with self.subTest(name=name):
+                reader = sc.mcap.Reader(self.path(name))
+                self.assertEqual(reader.chunk_count(), CHUNK_COUNT)
+
+    def test_unchunked_file_has_no_chunk_index(self):
+        reader = sc.mcap.Reader(self.path(UNCHUNKED))
+        self.assertEqual(reader.chunk_count(), 0)
+
+    def test_summary_offset_past_the_footer(self):
+        """A corrupt offset must not size a read from an underflow."""
+        # The footer holds summary_start as its first uint64, and the tail is
+        # the footer record plus the closing magic.
+        tail = 9 + 20 + 8
+        with open(self.path("vehicle_none"), "rb") as stream:
+            data = bytearray(stream.read())
+        for summary_start in (len(data) - tail, len(data), 2 ** 63):
+            with self.subTest(summary_start=summary_start):
+                struct.pack_into("<Q", data, len(data) - tail + 9,
+                                 summary_start)
+                with tempfile.TemporaryDirectory() as tmp:
+                    path = os.path.join(tmp, "corrupt.mcap")
+                    with open(path, "wb") as stream:
+                        stream.write(bytes(data))
+                    with self.assertRaisesRegex(RuntimeError, "MCAP"):
+                        sc.mcap.Reader(path)
+
+
+class McapSyntheticTC(McapReaderTB):
+    """Summaries the fixture writer never produces, assembled byte by byte."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def build(self, *records, **kw):
+        path = os.path.join(self.tmp.name, "synthetic.mcap")
+        with open(path, "wb") as stream:
+            stream.write(_assemble(records, **kw))
+
+        return path
+
+    def test_time_range_from_chunk_indexes(self):
+        reader = sc.mcap.Reader(self.build(
+            _schema(1, "S"), _channel(1, 1, "/t"),
+            _chunk_index(300, 400), _chunk_index(100, 200)))
+        self.assertTrue(reader.has_time_range())
+        self.assertEqual(reader.time_range(), (100, 400))
+
+    def test_empty_chunk_keeps_the_start_time(self):
+        reader = sc.mcap.Reader(self.build(
+            _schema(1, "S"), _channel(1, 1, "/t"),
+            _chunk_index(0, 0), _chunk_index(100, 200)))
+        self.assertEqual(reader.time_range(), (100, 200))
+
+    def test_summary_stating_no_time(self):
+        reader = sc.mcap.Reader(self.build(_schema(1, "S"),
+                                           _channel(1, 1, "/t")))
+        self.assertFalse(reader.has_time_range())
+        self.assertEqual(reader.time_range(), (0, 0))
+
+    def test_two_channels_on_one_topic(self):
+        # Written in descending id, so answering with the last record rather
+        # than the highest id would name A.
+        reader = sc.mcap.Reader(self.build(
+            _schema(1, "A"), _schema(2, "B"),
+            _channel(2, 2, "/t"), _channel(1, 1, "/t"),
+            _statistics(100, 200)))
+        self.assertEqual(reader.topics(), {"/t": "B"})
+        self.assertEqual(reader.schema("/t").name, "B")
+
+    def test_schema_id_zero_is_no_schema(self):
+        reader = sc.mcap.Reader(self.build(_schema(0, "ignored"),
+                                           _channel(1, 0, "/t")))
+        self.assertEqual(reader.topics(), {"/t": ""})
+        with self.assertRaisesRegex(RuntimeError, "no schema"):
+            reader.schema("/t")
+
+    def test_duplicate_records_must_agree(self):
+        reader = sc.mcap.Reader(self.build(_schema(1, "A"), _schema(1, "A"),
+                                           _channel(1, 1, "/t")))
+        self.assertEqual(reader.topics(), {"/t": "A"})
+        conflicts = (
+            ((_schema(1, "A"), _schema(1, "B")), "two schemas"),
+            ((_schema(1, "A"), _schema(1, "A", data=b"other\n")),
+             "two schemas"),
+            ((_schema(1, "A"), _channel(1, 1, "/a"), _channel(1, 1, "/b")),
+             "two channels"),
+            ((_schema(1, "A"), _channel(1, 1, "/t"),
+              _channel(1, 1, "/t", metadata=_text("k") + _text("v"))),
+             "two channels"),
+        )
+        for records, message in conflicts:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(RuntimeError, message):
+                    sc.mcap.Reader(self.build(*records))
+
+    def test_record_missing_a_mandatory_field(self):
+        # A channel record that stops before its metadata map.
+        short = _record(0x04, struct.pack("<HH", 1, 1) + _text("/t")
+                        + _text("cdr"))
+        with self.assertRaisesRegex(RuntimeError, "truncated"):
+            sc.mcap.Reader(self.build(_schema(1, "S"), short))
+
+    def test_summary_ending_inside_a_record_header(self):
+        with self.assertRaisesRegex(RuntimeError, "ends inside a record"):
+            sc.mcap.Reader(self.build(_schema(1, "S"), trailing=b"\x03\x00"))
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Add an mcap subsystem that reads the container layer of an MCAP recording: the file magic, the footer, and the summary section. Reader reports the topics with their schema names, the schema of one topic, the log time range, and the chunk index count. It reads nothing else, so opening a recording costs the same whatever the length of the log.

The subsystem sits beside inout/ rather than inside it, because inout/ is mesh ingestion and MCAP brings lz4 and zstd along. It depends on buffer/ alone.

The summary is walked one record at a time, so what it costs follows its largest record and not its length, and a record the reader does not keep is stepped over rather than read. Reading a field is what validates it, so a record that stops before a field the specification requires is rejected rather than half-parsed. Fields added after the ones read here stay unread, which keeps this reader working against a newer writer. A file with no summary section, a summary offset at or past the footer, a summary ending inside a record header, and two records that state one id without agreeing are all rejected.

The channel of highest id names a topic that several channels carry, and schema() answers with that same channel, so the two cannot disagree. schema() carries a TODO, because the decode plan is its first caller and what it needs should settle the shape returned; the definition comes back as bytes, since a ROS 2 encoding states it as text while a binary one does not.

Related to #1286.
