### PR TITLE
Add true_intervals and benchmarks to the timeseries subsystem

### DIFF
--- a/cpp/solvcon/timeseries/pymod/wrap_timeseries.cpp
+++ b/cpp/solvcon/timeseries/pymod/wrap_timeseries.cpp
@@ -75,6 +75,14 @@ void wrap_timeseries(pybind11::module & mod)
         py::arg("span"),
         "Report whether a boolean series was true over the trailing half-open window (t - span, t]; "
         "the last sample at or before t - span must be true as well; returns (times, answers)");
+
+    mod.def(
+        "true_intervals",
+        &timeseries::true_intervals,
+        py::arg("times"),
+        py::arg("values"),
+        "Run-length encode the true stretches of a boolean series into rows of (start, end, duration); "
+        "a run still open at the last sample ends there");
 }
 
 } /* end namespace python */

--- a/cpp/solvcon/timeseries/timeseries.hpp
+++ b/cpp/solvcon/timeseries/timeseries.hpp
@@ -402,6 +402,72 @@ held(SimpleArray<uint64_t> const & times, SimpleArray<bool> const & values, uint
     return {std::move(otimes), std::move(oheld)};
 }
 
+/**
+ * Run-length encode the true stretches of a boolean series into `(start, end, duration)` rows.
+ *
+ * A run starts at the timestamp of the sample that turns the series true and ends at the timestamp of the sample
+ * that turns it false again, so each row spans the half-open interval `[start, end)` and `duration = end - start`.
+ * A group of equal timestamps is read at its last sample only. A run still open at the last sample ends there,
+ * so it has zero duration when it also started there.
+ *
+ * @param times The sample timestamps in nanoseconds, non-decreasing.
+ * @param values The booleans sampled at @p times, of the same length.
+ * @return An array of shape `(nrun, 3)` whose columns are the start, the end, and the duration in nanoseconds.
+ *         A series that is never true gives shape `(0, 3)`.
+ * @throw std::invalid_argument An array that is not one-dimensional or that carries ghost elements, a length
+ *        mismatch, or a decreasing timestamp.
+ *
+ * @ingroup group_numerics
+ */
+inline SimpleArray<uint64_t> true_intervals(SimpleArray<uint64_t> const & times, SimpleArray<bool> const & values)
+{
+    detail::validate_series(times, values, "true_intervals");
+    detail::validate_sorted(times, "true_intervals", "times");
+
+    ssize_t const nsample = times.shape(0);
+    uint64_t const * const tsrc = times.logical_data();
+    ssize_t const tstep = times.stride(0);
+    bool const * const vsrc = values.logical_data();
+    ssize_t const vstep = values.stride(0);
+
+    // A group of equal timestamps is read at its last sample only.
+    SimpleCollector<uint64_t> rows;
+    bool open = false;
+    uint64_t start = 0;
+    auto const close = [&rows, &start](uint64_t end)
+    {
+        rows.push_back(start);
+        rows.push_back(end);
+        rows.push_back(end - start);
+    };
+    for (ssize_t i = 0; i < nsample; ++i)
+    {
+        uint64_t const t = tsrc[i * tstep];
+        if (i + 1 < nsample && tsrc[(i + 1) * tstep] == t)
+        {
+            continue;
+        }
+        bool const value = vsrc[i * vstep];
+        if (value && !open)
+        {
+            open = true;
+            start = t;
+        }
+        else if (!value && open)
+        {
+            open = false;
+            close(t);
+        }
+    }
+    if (open)
+    {
+        close(tsrc[(nsample - 1) * tstep]);
+    }
+
+    ssize_t const nrun = static_cast<ssize_t>(rows.size()) / 3;
+    return rows.as_array().reshape<uint64_t>(solvcon::detail::shape_type{nrun, 3});
+}
+
 } /* end namespace timeseries */
 
 } /* end namespace solvcon */

--- a/doc/source/compute/numerics/timeseries.md
+++ b/doc/source/compute/numerics/timeseries.md
@@ -131,4 +131,31 @@ assert t_h.ndarray.tolist() == [0, 10, 20, 30, 40]
 assert brake_held.ndarray.tolist() == [False, True, False, False, True]
 ```
 
+## The `true_intervals` Function
+
+`true_intervals(times, values)` run-length encodes a `SimpleArrayBool`
+series into the intervals where it was true. The result is a
+`SimpleArrayUint64` of shape `(nrun, 3)` whose columns are the start, the
+end, and the duration in nanoseconds; a series that is never true gives
+shape `(0, 3)`. A run starts at the timestamp of the sample that turns the
+series true and ends at the timestamp of the sample that turns it false
+again, so each row spans the half-open interval `[start, end)`:
+
+```python
+times = solvcon.SimpleArrayUint64(
+    array=np.array([0, 10, 20, 30, 40], dtype='uint64'))
+over = solvcon.SimpleArrayBool(
+    array=np.array([False, True, True, False, True]))
+runs = ts.true_intervals(times, over)
+assert runs.ndarray.tolist() == [[10, 30, 20], [40, 40, 0]]
+assert int(runs.ndarray[:, 2].sum()) == 20  # total time over the limit
+```
+
+## Benchmarks
+
+`profiling/profile_timeseries.py` times every kernel against the pure-Python
+loop it replaces on an hour-long log sampled at 100 Hz. `make pyprof` runs
+it with the other profiling scripts and writes the table to
+`profiling/results/`.
+
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/profiling/profile_timeseries.py
+++ b/profiling/profile_timeseries.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Time the time-series kernels against the pure-Python loops they replace, on
+an hour-long log sampled at one hundred hertz.
+"""
+
+import bisect
+import functools
+import time
+
+import numpy as np
+
+import solvcon
+from solvcon import timeseries as ts
+
+HOUR_NS = 3_600 * 10**9
+RATE_HZ = 100
+SPAN_NS = 200_000_000
+
+
+def profile_function(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        _ = solvcon.CallProfilerProbe(func.__name__)
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def make_log(nsample, rng):
+    # Jittered sampling with a few repeated stamps, as a recorded log has.
+    step = HOUR_NS // nsample
+    jitter = rng.integers(0, step // 4, nsample, dtype='int64')
+    times = (np.arange(nsample, dtype='int64') * step + jitter)
+    dup = rng.random(nsample) < 0.01
+    times[1:][dup[1:]] = times[:-1][dup[1:]]
+    times = np.sort(times).astype('uint64')
+    speed = np.cumsum(rng.normal(0.0, 0.1, nsample)) + 20.0
+    brake = rng.random(nsample) < 0.9
+    return times, speed, brake
+
+
+@profile_function
+def py_merge_sorted_unique(a, b):
+    return sorted(set(a.tolist()) | set(b.tolist()))
+
+
+@profile_function
+def py_dedup_last(times, values):
+    out_t, out_v = [], []
+    for t, v in zip(times.tolist(), values.tolist()):
+        if out_t and out_t[-1] == t:
+            out_v[-1] = v
+        else:
+            out_t.append(t)
+            out_v.append(v)
+    return out_t, out_v
+
+
+@profile_function
+def py_deriv(times, values):
+    tl, vl = times.tolist(), values.tolist()
+    return tl[1:], [(vl[i] - vl[i - 1]) / (tl[i] - tl[i - 1])
+                    for i in range(1, len(tl))]
+
+
+@profile_function
+def py_movavg(times, values, span):
+    tl, vl = times.tolist(), values.tolist()
+    out = []
+    for i, t in enumerate(tl):
+        lo = bisect.bisect_right(tl, t - span)
+        hi = bisect.bisect_right(tl, t)
+        out.append(sum(vl[lo:hi]) / (hi - lo))
+    return tl, out
+
+
+@profile_function
+def py_held(times, values, span):
+    tl, vl = times.tolist(), values.tolist()
+    out = []
+    for t in tl:
+        lo = bisect.bisect_right(tl, t - span)
+        hi = bisect.bisect_right(tl, t)
+        out.append(lo > 0 and vl[lo - 1] and all(vl[lo:hi]))
+    return tl, out
+
+
+@profile_function
+def py_true_intervals(times, values):
+    tl, vl = times.tolist(), values.tolist()
+    runs, start = [], None
+    for i, (t, v) in enumerate(zip(tl, vl)):
+        if i + 1 < len(tl) and tl[i + 1] == t:
+            continue
+        if v and start is None:
+            start = t
+        elif not v and start is not None:
+            runs.append((start, t, t - start))
+            start = None
+    if start is not None:
+        runs.append((start, tl[-1], tl[-1] - start))
+    return runs
+
+
+@profile_function
+def py_searchsorted_zoh(times, grid):
+    tl = times.tolist()
+    return [bisect.bisect_right(tl, g) - 1 for g in grid.tolist()]
+
+
+@profile_function
+def sa_merge_sorted_unique(a, b):
+    return ts.merge_sorted_unique(a, b)
+
+
+@profile_function
+def sa_dedup_last(times, values):
+    return ts.dedup_last(times, values)
+
+
+@profile_function
+def sa_deriv(times, values):
+    return ts.deriv(times, values)
+
+
+@profile_function
+def sa_movavg(times, values, span):
+    return ts.movavg(times, values, span)
+
+
+@profile_function
+def sa_held(times, values, span):
+    return ts.held(times, values, span)
+
+
+@profile_function
+def sa_true_intervals(times, values):
+    return ts.true_intervals(times, values)
+
+
+@profile_function
+def sa_searchsorted_zoh(times, grid):
+    return times.searchsorted(grid, side='right')
+
+
+def run(nsample, it):
+    rng = np.random.default_rng(20260821)
+    ntimes, nspeed, nbrake = make_log(nsample, rng)
+    ngrid = np.sort(rng.integers(0, HOUR_NS, nsample, dtype='uint64'))
+    times = solvcon.SimpleArrayUint64(array=ntimes)
+    speed = solvcon.SimpleArrayFloat64(array=nspeed)
+    brake = solvcon.SimpleArrayBool(array=nbrake)
+    grid = solvcon.SimpleArrayUint64(array=ngrid)
+    times_u, speed_u = ts.dedup_last(times, speed)
+    ntimes_u, nspeed_u = times_u.ndarray, speed_u.ndarray
+
+    cases = [
+        ('merge_sorted_unique', (ntimes, ngrid), (times, grid)),
+        ('dedup_last', (ntimes, nspeed), (times, speed)),
+        ('deriv', (ntimes_u, nspeed_u), (times_u, speed_u)),
+        ('movavg', (ntimes, nspeed, SPAN_NS), (times, speed, SPAN_NS)),
+        ('held', (ntimes, nbrake, SPAN_NS), (times, brake, SPAN_NS)),
+        ('true_intervals', (ntimes, nbrake), (times, brake)),
+        ('searchsorted_zoh', (ntimes, ngrid), (times, grid)),
+    ]
+
+    print(f"\n# N = {nsample} samples over one hour, {it} iterations")
+    print("| {:20s} | {:>14s} | {:>14s} | {:>9s} |".format(
+        'kernel', 'python (ms)', 'solvcon (ms)', 'speedup'))
+    print("| {:20s} | {:>14s} | {:>14s} | {:>9s} |".format(
+        '-' * 20, '-' * 14, '-' * 14, '-' * 9))
+    for name, pyargs, saargs in cases:
+        pyfunc = globals()['py_' + name]
+        safunc = globals()['sa_' + name]
+        solvcon.call_profiler.reset()
+        for _ in range(it):
+            pyfunc(*pyargs)
+            safunc(*saargs)
+        per_call = {r['name']: r['total_time'] / r['count']
+                    for r in solvcon.call_profiler.result()['children']}
+        pytime = per_call['py_' + name]
+        satime = per_call['sa_' + name]
+        print("| {:20s} | {:14.3f} | {:14.3f} | {:8.1f}x |".format(
+            name, pytime, satime, pytime / satime))
+
+
+def main():
+    start = time.perf_counter()
+    run(HOUR_NS // 10**9 * RATE_HZ, it=3)
+    print(f"\ntotal wall time: {time.perf_counter() - start:.1f} s")
+
+
+if __name__ == "__main__":
+    main()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/timeseries.py
+++ b/solvcon/timeseries.py
@@ -19,6 +19,7 @@ _toload = [
     'deriv',
     'movavg',
     'held',
+    'true_intervals',
 ]
 
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -2992,6 +2992,17 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         sarr.nghost = 1
         self.assertEqual(np.std(nparr), sarr.std())
 
+    def test_std_population_is_the_default(self):
+        # ddof=0 divides by N, so a single sample has a spread of 0.
+        nparr = np.array([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0],
+                         dtype='float64')
+        sarr = solvcon.SimpleArrayFloat64(array=nparr)
+        self.assertEqual(sarr.std(ddof=0), 2.0)
+        self.assertEqual(sarr.std(), np.std(nparr, ddof=0))
+        self.assertEqual(sarr.std(ddof=1), np.std(nparr, ddof=1))
+        self.assertEqual(solvcon.SimpleArrayFloat64(array=nparr[:1]).std(),
+                         0.0)
+
     def test_std_with_axis(self):
         nparr = np.arange(120, dtype='float64').reshape((4, 5, 6))
         sarr = solvcon.SimpleArrayFloat64(array=nparr)

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -496,4 +496,96 @@ class HeldTC(unittest.TestCase):
             ts.held(u64([0, 1]), f64([1.0, 0.0]), span=5)
 
 
+class TrueIntervalsTC(unittest.TestCase):
+
+    def test_runs_are_half_open_rows(self):
+        times = u64([0, 10, 20, 30, 40, 50])
+        values = bl([False, True, True, False, True, False])
+        runs = ts.true_intervals(times, values)
+        self.assertIs(type(runs), solvcon.SimpleArrayUint64)
+        self.assertEqual(runs.shape, (2, 3))
+        self.assertEqual(runs.ndarray.tolist(),
+                         [[10, 30, 20], [40, 50, 10]])
+
+    def test_run_open_at_log_end_closes_at_the_last_sample(self):
+        # The log cannot say when the run ended, so the run ends with the
+        # log; a run that starts at the last sample is kept with duration 0.
+        runs = ts.true_intervals(u64([0, 10, 20]), bl([False, True, True]))
+        self.assertEqual(runs.ndarray.tolist(), [[10, 20, 10]])
+        runs = ts.true_intervals(u64([0, 10, 20]), bl([True, False, True]))
+        self.assertEqual(runs.ndarray.tolist(), [[0, 10, 10], [20, 20, 0]])
+        runs = ts.true_intervals(u64([7]), bl([True]))
+        self.assertEqual(runs.ndarray.tolist(), [[7, 7, 0]])
+
+    def test_repeated_timestamp_resolves_to_its_last_sample(self):
+        # Only the last sample of a group counts, both for starting a run
+        # and for ending one.
+        runs = ts.true_intervals(u64([0, 10, 10, 20]),
+                                 bl([False, True, False, False]))
+        self.assertEqual(runs.shape, (0, 3))
+        runs = ts.true_intervals(u64([0, 10, 10, 20]),
+                                 bl([True, False, True, False]))
+        self.assertEqual(runs.ndarray.tolist(), [[0, 20, 20]])
+        runs = ts.true_intervals(u64([5, 5]), bl([False, True]))
+        self.assertEqual(runs.ndarray.tolist(), [[5, 5, 0]])
+
+    def test_never_true_and_empty_give_no_rows(self):
+        runs = ts.true_intervals(u64([0, 1, 2]), bl([False, False, False]))
+        self.assertEqual(runs.shape, (0, 3))
+        self.assertEqual(ts.true_intervals(u64([]), bl([])).shape, (0, 3))
+
+    def test_against_a_naive_sweep(self):
+        rng = np.random.default_rng(20260821)
+        for _ in range(20):
+            n = int(rng.integers(0, 40))
+            ntimes = np.sort(rng.integers(0, 30, n, dtype='uint64'))
+            nvalues = rng.random(n) < 0.5
+            expected, open_start = [], None
+            for i in range(n):
+                if i + 1 < n and ntimes[i + 1] == ntimes[i]:
+                    continue
+                if nvalues[i] and open_start is None:
+                    open_start = int(ntimes[i])
+                elif not nvalues[i] and open_start is not None:
+                    expected.append([open_start, int(ntimes[i]),
+                                     int(ntimes[i]) - open_start])
+                    open_start = None
+            if open_start is not None:
+                expected.append([open_start, int(ntimes[-1]),
+                                 int(ntimes[-1]) - open_start])
+            runs = ts.true_intervals(u64(ntimes), bl(nvalues))
+            self.assertEqual(runs.ndarray.tolist(), expected)
+
+    def test_strided_view_is_read_in_array_order(self):
+        times = solvcon.SimpleArrayUint64(
+            array=np.arange(12, dtype='uint64')[::4])
+        values = solvcon.SimpleArrayBool(
+            array=np.array([True, False, False, True, True, False],
+                           dtype='bool')[::2])
+        runs = ts.true_intervals(times, values)
+        self.assertEqual(runs.ndarray.tolist(), [[0, 4, 4], [8, 8, 0]])
+
+    def test_extracts_where_a_smoothed_signal_exceeds_a_limit(self):
+        times = u64([0, 1, 2, 3, 4, 5, 6])
+        _, smooth = ts.movavg(times, f64([0.0, 0.0, 6.0, 6.0, 0.0, 0.0,
+                                          0.0]), span=2)
+        over = bl([v > 2.0 for v in smooth.ndarray.tolist()])
+        runs = ts.true_intervals(times, over)
+        self.assertEqual(smooth.ndarray.tolist(),
+                         [0.0, 0.0, 3.0, 6.0, 3.0, 0.0, 0.0])
+        self.assertEqual(runs.ndarray.tolist(), [[2, 5, 3]])
+        self.assertEqual(int(runs.ndarray[:, 2].sum()), 3)
+
+    def test_invalid_input_raises(self):
+        with self.assertRaisesRegex(ValueError,
+                                    "true_intervals.*non-decreasing"):
+            ts.true_intervals(u64([2, 1]), bl([True, True]))
+        with self.assertRaisesRegex(ValueError, "true_intervals.*2 samples "
+                                    "but values has 3"):
+            ts.true_intervals(u64([1, 2]), bl([True, True, True]))
+        with self.assertRaisesRegex(TypeError, "incompatible function "
+                                    "arguments"):
+            ts.true_intervals(u64([0, 1]), f64([1.0, 0.0]))
+
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`true_intervals(times, values)` run-length encodes a `SimpleArrayBool` series into the intervals where it was true and returns a `SimpleArrayUint64` of shape `(nrun, 3)` holding `(start, end, duration)` per run. Each row spans the half-open `[start, end)`: a run starts at the sample that turns the series true and ends at the sample that turns it false again. The rows stay a `SimpleArray`, so the total duration is one column sum.

Two policies the plan left open are settled and pinned in tests. A run still open at the last sample ends there, where the log ends, and a run that also started there is kept with zero duration. A group of equal timestamps is read at its last sample only, as the other kernels resolve one, so a true that a false overrides in the same nanosecond starts no run. A test in `tests/test_buffer.py` pins that `SimpleArray.std()` defaults to the population form (`ddof=0`).

`profiling/profile_timeseries.py` times every kernel of the subsystem against the pure-Python loop it replaces on an hour-long log at 100 Hz with repeated stamps. On one machine the kernels run 22x to 92x faster; `true_intervals` takes about 0.9 ms for 360k samples.

`make lint` is clean, `make gtest` passes (244 passed), and `make pytest-fast` passes (2067 passed, 12 skipped, 3 xfailed), of which `tests/test_timeseries.py` contributes 54. The documentation example executes with its assertions passing.

This is PR 5 of the plan. PR 4 landed as #1384.

Related to #1285.
