### PR TITLE
Add string representation methods for SimpleArray and SimpleArrayPlex

### DIFF
--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -131,6 +131,14 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 })
             .def("__len__", &wrapped_type::size)
             .def(
+                "__str__",
+                [](wrapped_type & self)
+                { return py::str(to_ndarray(self)); })
+            .def(
+                "__repr__",
+                [](wrapped_type & self)
+                { return py::repr(to_ndarray(self)); })
+            .def(
                 "__getitem__",
                 [](wrapped_type const & self, ssize_t key)
                 { return self.at(key); })

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -294,6 +294,24 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
                         });
                 })
             .def("__len__", SC_DECL_EXECUTE_TYPED_ARRAY_METHOD(size))
+            .def(
+                "__str__",
+                [](wrapped_type & self)
+                {
+                    return execute_callback_with_typed_array(
+                        self,
+                        [](auto & array)
+                        { return pybind11::str(to_ndarray(array)); });
+                })
+            .def(
+                "__repr__",
+                [](wrapped_type & self)
+                {
+                    return execute_callback_with_typed_array(
+                        self,
+                        [](auto & array)
+                        { return pybind11::repr(to_ndarray(array)); });
+                })
             .def("__getitem__", &get_typed_array_value<ssize_t>)
             .def("__getitem__", &get_typed_array_value<const std::vector<ssize_t> &>)
             .def("__setitem__",

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -297,6 +297,26 @@ class SimpleArrayBasicTC(unittest.TestCase):
         self.assertEqual((12, 2), sarr.reshape((12, 2)).shape)
         self.assertEqual((2, 2, 2, 3), sarr.reshape((2, 2, 2, 3)).shape)
 
+    def test_SimpleArray_str_and_repr(self):
+        arrays = [
+            np.arange(6, dtype='int32').reshape((2, 3)),
+            np.array([[True, False], [False, True]], dtype='bool'),
+            np.array([1.5 + 2j, -3j], dtype='complex128'),
+        ]
+        for ndarr in arrays:
+            with self.subTest(dtype=ndarr.dtype):
+                cls = getattr(
+                    solvcon, 'SimpleArray' + ndarr.dtype.name.capitalize())
+                sarr = cls(array=ndarr)
+                self.assertEqual(str(ndarr), str(sarr))
+                self.assertEqual(repr(ndarr), repr(sarr))
+
+    def test_SimpleArrayPlex_str_and_repr(self):
+        ndarr = np.arange(6, dtype='float64').reshape((2, 3))
+        sarr = solvcon.SimpleArray(array=ndarr)
+        self.assertEqual(str(ndarr), str(sarr))
+        self.assertEqual(repr(ndarr), repr(sarr))
+
     def test_SimpleArray_reshape_transposed(self):
         ndarr = np.arange(6, dtype="float64").reshape((2, 3))
         view = ndarr.T


### PR DESCRIPTION
This PR adds Python `__str__` and `__repr__` methods to the typed `SimpleArray` bindings and the dtype-erased `SimpleArray` interface, providing useful output from `print()`, `str()`, `repr()`, and interactive Python sessions.

The methods delegate to NumPy's established array formatting through the existing zero-copy ndarray view. Tests cover integer, boolean, complex, and dtype-erased arrays to ensure both representations remain consistent with NumPy.

Related to #428.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
