### PR TITLE
Define exact `matmul` benchmark specs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ def main():
             'solvcon.agent',
             'solvcon.agent.draw',
             'solvcon.agent.window',
+            'solvcon.benchmark',
             'solvcon.mcap',
             'solvcon.multidim',
             'solvcon.multidim.euler',

--- a/solvcon/benchmark/__init__.py
+++ b/solvcon/benchmark/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""Expose common and operation-specific benchmark specification types."""
+
+from . import matmul
+from . import spec
+
+
+__all__ = [
+    'matmul',
+    'spec',
+]
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/benchmark/matmul.py
+++ b/solvcon/benchmark/matmul.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""Validate exact matmul benchmark specifications without allocating arrays."""
+
+import dataclasses
+
+from . import spec
+
+
+MATMUL_DTYPE_SIZES = {
+    'float32': 4,
+    'float64': 8,
+    'complex64': 8,
+    'complex128': 16,
+}
+MATMUL_DTYPES = tuple(MATMUL_DTYPE_SIZES)
+MATMUL_KERNELS = (
+    'naive',
+    'blas_dot',
+    'blas_gevm',
+    'blas_gemv',
+    'blas_gemm',
+    'winograd',
+)
+
+
+def _broadcast_shape(lhs, rhs):
+    result = []
+    for offset in range(1, max(len(lhs), len(rhs)) + 1):
+        left = lhs[-offset] if offset <= len(lhs) else 1
+        right = rhs[-offset] if offset <= len(rhs) else 1
+        if left == right:
+            extent = left
+        elif left == 1:
+            extent = right
+        elif right == 1:
+            extent = left
+        else:
+            raise spec.SpecError(
+                'matmul batch dimensions do not match')
+        result.append(extent)
+    return tuple(reversed(result))
+
+
+def _batch_shape(shape):
+    return () if len(shape) == 1 else shape[:-2]
+
+
+@dataclasses.dataclass(frozen=True)
+class MatmulSpec:
+    """Describe one exact comparison of matmul kernels."""
+
+    OPERATION = 'matmul'
+
+    lhs: spec.OperandSpec
+    rhs: spec.OperandSpec
+    dtype: str
+    sampling: spec.Sampling
+    kernels: tuple
+
+    def __post_init__(self):
+        if not isinstance(self.dtype, str) or self.dtype not in MATMUL_DTYPES:
+            raise spec.SpecError(f'unsupported dtype: {self.dtype!r}')
+        if not isinstance(self.lhs, spec.OperandSpec):
+            raise spec.SpecError('lhs must be an OperandSpec')
+        if not isinstance(self.rhs, spec.OperandSpec):
+            raise spec.SpecError('rhs must be an OperandSpec')
+        if not isinstance(self.sampling, spec.Sampling):
+            raise spec.SpecError('sampling must be a Sampling')
+        itemsize = MATMUL_DTYPE_SIZES[self.dtype]
+        spec._validate_byte_layout(self.lhs, 'lhs', itemsize)
+        spec._validate_byte_layout(self.rhs, 'rhs', itemsize)
+        if not isinstance(self.kernels, (list, tuple)):
+            raise spec.SpecError('kernels must be an array')
+        kernels = tuple(self.kernels)
+        if not kernels:
+            raise spec.SpecError('kernels must not be empty')
+        if any(not isinstance(kernel, str) or not kernel
+               for kernel in kernels):
+            raise spec.SpecError(
+                'kernels must contain non-empty strings')
+        if len(kernels) != len(set(kernels)):
+            raise spec.SpecError(
+                'kernels must not contain duplicates')
+        unknown = sorted(set(kernels) - set(MATMUL_KERNELS))
+        if unknown:
+            raise spec.SpecError(f'unsupported kernels: {unknown}')
+        object.__setattr__(self, 'kernels', kernels)
+        self._validate_shape()
+        spec._validate_logical_shape(
+            self.output_shape, 'output', itemsize)
+
+    def _validate_shape(self):
+        rhs_inner_axis = -1 if len(self.rhs.shape) == 1 else -2
+        if self.lhs.shape[-1] != self.rhs.shape[rhs_inner_axis]:
+            raise spec.SpecError(
+                'matmul contraction dimensions do not match')
+        _broadcast_shape(
+            _batch_shape(self.lhs.shape), _batch_shape(self.rhs.shape))
+
+    @property
+    def output_shape(self):
+        lhs_vector = len(self.lhs.shape) == 1
+        rhs_vector = len(self.rhs.shape) == 1
+        if lhs_vector and rhs_vector:
+            return (1,)
+        batch = _broadcast_shape(
+            _batch_shape(self.lhs.shape), _batch_shape(self.rhs.shape))
+        rows = () if lhs_vector else (self.lhs.shape[-2],)
+        columns = () if rhs_vector else (self.rhs.shape[-1],)
+        return batch + rows + columns
+
+    @classmethod
+    def from_dict(cls, data):
+        fields = (
+            'operation', 'lhs', 'rhs', 'dtype', 'sampling', 'kernels',
+        )
+        spec._require_fields(data, 'spec', fields)
+        operation = data['operation']
+        if operation != cls.OPERATION:
+            raise spec.SpecError(
+                f'unsupported operation: {operation!r}')
+        return cls(
+            lhs=spec.OperandSpec.from_dict(data['lhs']),
+            rhs=spec.OperandSpec.from_dict(data['rhs']),
+            dtype=data['dtype'],
+            sampling=spec.Sampling.from_dict(data['sampling']),
+            kernels=data['kernels'],
+        )
+
+    def to_dict(self):
+        return {
+            'operation': self.OPERATION,
+            'lhs': self.lhs.to_dict(),
+            'rhs': self.rhs.to_dict(),
+            'dtype': self.dtype,
+            'sampling': self.sampling.to_dict(),
+            'kernels': list(self.kernels),
+        }
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/benchmark/spec.py
+++ b/solvcon/benchmark/spec.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""Types shared by operation benchmark specifications."""
+
+import dataclasses
+import sys
+
+
+class SpecError(ValueError):
+    """Report an invalid benchmark specification."""
+
+
+def _require_fields(data, name, fields):
+    if not isinstance(data, dict):
+        raise SpecError(f'{name} must be an object')
+    if any(not isinstance(field, str) for field in data):
+        raise SpecError(f'{name} field names must be strings')
+    missing = sorted(set(fields) - set(data))
+    if missing:
+        raise SpecError(f'{name} is missing fields: {missing}')
+    unknown = sorted(set(data) - set(fields))
+    if unknown:
+        raise SpecError(f'{name} has unknown fields: {unknown}')
+
+
+def _require_int(value, name, minimum=None, maximum=None):
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise SpecError(f'{name} must be an integer')
+    if minimum is not None and value < minimum:
+        raise SpecError(f'{name} must be at least {minimum}')
+    if maximum is not None and value > maximum:
+        raise SpecError(f'{name} must be at most {maximum}')
+    return value
+
+
+def _int_tuple(value, name, minimum=None, maximum=None):
+    if not isinstance(value, (list, tuple)):
+        raise SpecError(f'{name} must be an array')
+    return tuple(
+        _require_int(item, f'{name}[{index}]', minimum, maximum)
+        for index, item in enumerate(value)
+    )
+
+
+def _validate_logical_shape(shape, name, itemsize):
+    byte_size = itemsize
+    for extent in shape:
+        byte_size *= max(extent, 1)
+        if byte_size > sys.maxsize:
+            raise SpecError(
+                f'{name} logical byte size exceeds {sys.maxsize}')
+
+
+def _validate_byte_layout(operand, name, itemsize):
+    _validate_logical_shape(operand.shape, name, itemsize)
+    minimum_stride = (-sys.maxsize - 1) // itemsize
+    maximum_stride = sys.maxsize // itemsize
+    for index, stride in enumerate(operand.strides):
+        _require_int(
+            stride, f'{name} byte stride[{index}]',
+            minimum_stride, maximum_stride)
+
+    if any(extent == 0 for extent in operand.shape):
+        return
+    minimum_offset = 0
+    maximum_offset = 0
+    for extent, stride in zip(operand.shape, operand.strides):
+        displacement = (extent - 1) * stride
+        minimum_offset += min(0, displacement)
+        maximum_offset += max(0, displacement)
+    _require_int(
+        minimum_offset * itemsize, f'{name} minimum byte offset',
+        -sys.maxsize, sys.maxsize)
+    _require_int(
+        maximum_offset * itemsize, f'{name} maximum byte offset',
+        -sys.maxsize, sys.maxsize)
+    byte_span = (maximum_offset - minimum_offset + 1) * itemsize
+    _require_int(
+        byte_span, f'{name} byte span', 1, sys.maxsize)
+
+
+@dataclasses.dataclass(frozen=True)
+class OperandSpec:
+    """Describe one operand with full shape and element strides."""
+
+    shape: tuple
+    strides: tuple
+
+    def __post_init__(self):
+        shape = _int_tuple(self.shape, 'shape', 0, sys.maxsize)
+        strides = _int_tuple(
+            self.strides, 'strides', -sys.maxsize - 1, sys.maxsize)
+        if not shape:
+            raise SpecError('an operand must have at least one axis')
+        if len(shape) != len(strides):
+            raise SpecError('shape and strides must have the same length')
+        object.__setattr__(self, 'shape', shape)
+        object.__setattr__(self, 'strides', strides)
+
+    @classmethod
+    def from_dict(cls, data):
+        _require_fields(data, 'operand', ('shape', 'strides'))
+        return cls(shape=data['shape'], strides=data['strides'])
+
+    def to_dict(self):
+        return {
+            'shape': list(self.shape),
+            'strides': list(self.strides),
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class Sampling:
+    """Define exact setup and measurement call counts."""
+
+    warmups: int
+    repetitions: int
+    rounds: int
+
+    def __post_init__(self):
+        _require_int(self.warmups, 'sampling.warmups', 0)
+        _require_int(self.repetitions, 'sampling.repetitions', 1)
+        _require_int(self.rounds, 'sampling.rounds', 1)
+
+    @classmethod
+    def from_dict(cls, data):
+        fields = ('warmups', 'repetitions', 'rounds')
+        _require_fields(data, 'sampling', fields)
+        return cls(**{field: data[field] for field in fields})
+
+    def to_dict(self):
+        return dataclasses.asdict(self)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+import math
+import sys
+import unittest
+
+from solvcon import benchmark
+
+
+def make_matmul_spec(**updates):
+    data = {
+        'operation': 'matmul',
+        'lhs': {'shape': [2, 3], 'strides': [3, 1]},
+        'rhs': {'shape': [3, 2], 'strides': [2, 1]},
+        'dtype': 'float64',
+        'sampling': {'warmups': 2, 'repetitions': 5, 'rounds': 2},
+        'kernels': ['naive', 'blas_gemm'],
+    }
+    data.update(updates)
+    return benchmark.matmul.MatmulSpec.from_dict(data)
+
+
+class OperandSpecTC(unittest.TestCase):
+    def test_round_trip(self):
+        data = {'shape': [2, 3], 'strides': [-5, 0]}
+        operand = benchmark.spec.OperandSpec.from_dict(data)
+
+        self.assertEqual(operand.shape, (2, 3))
+        self.assertEqual(operand.strides, (-5, 0))
+        self.assertEqual(operand.to_dict(), data)
+
+    def test_invalid(self):
+        cases = (
+            ({'shape': [], 'strides': []}, 'at least one'),
+            ({'shape': [2, 3], 'strides': [1]}, 'same length'),
+            ({'shape': [2, -3], 'strides': [3, 1]}, 'at least 0'),
+            ({'shape': [2, True], 'strides': [3, 1]}, 'integer'),
+            ({'shape': [sys.maxsize + 1], 'strides': [0]}, 'at most'),
+            ({'shape': [1], 'strides': [sys.maxsize + 1]}, 'at most'),
+            ({'shape': [1], 'strides': [-sys.maxsize - 2]}, 'at least'),
+            ({'shape': [2, 3]}, 'missing fields'),
+        )
+        for data, message in cases:
+            with self.subTest(data=data):
+                with self.assertRaisesRegex(
+                        benchmark.spec.SpecError, message):
+                    benchmark.spec.OperandSpec.from_dict(data)
+
+
+class SamplingTC(unittest.TestCase):
+    def test_no_upper_limit(self):
+        data = {
+            'warmups': 1_000_000,
+            'repetitions': 2_000_000,
+            'rounds': 3_000_000,
+        }
+        sampling = benchmark.spec.Sampling.from_dict(data)
+
+        self.assertEqual(sampling.to_dict(), data)
+
+    def test_invalid(self):
+        cases = (
+            ({'warmups': -1, 'repetitions': 1, 'rounds': 1},
+             'warmups'),
+            ({'warmups': 0, 'repetitions': 0, 'rounds': 1},
+             'repetitions'),
+            ({'warmups': 0, 'repetitions': 1, 'rounds': False},
+             'integer'),
+            ({'warmups': 0, 'repetitions': 1}, 'missing fields'),
+        )
+        for data, message in cases:
+            with self.subTest(data=data):
+                with self.assertRaisesRegex(
+                        benchmark.spec.SpecError, message):
+                    benchmark.spec.Sampling.from_dict(data)
+
+
+class MatmulSpecTC(unittest.TestCase):
+    def test_round_trip(self):
+        spec = make_matmul_spec(
+            lhs={'shape': [2, 3], 'strides': [-5, 1]},
+            rhs={'shape': [3, 2], 'strides': [0, 1]},
+            sampling={'warmups': 0, 'repetitions': 7, 'rounds': 3},
+            kernels=['naive', 'blas_gemm', 'winograd'],
+        )
+
+        rebuilt = benchmark.matmul.MatmulSpec.from_dict(spec.to_dict())
+
+        self.assertEqual(rebuilt, spec)
+
+    def test_output_shape(self):
+        cases = (
+            ({'shape': [3], 'strides': [-1]},
+             {'shape': [3], 'strides': [0]}, (1,)),
+            ({'shape': [3], 'strides': [1]},
+             {'shape': [4, 3, 2], 'strides': [6, 2, 1]},
+             (4, 2)),
+            ({'shape': [2, 1, 3, 4], 'strides': [12, 0, 4, 1]},
+             {'shape': [1, 5, 4, 6], 'strides': [0, 24, 6, 1]},
+             (2, 5, 3, 6)),
+        )
+        for lhs, rhs, output_shape in cases:
+            with self.subTest(lhs=lhs['shape'], rhs=rhs['shape']):
+                self.assertEqual(
+                    make_matmul_spec(lhs=lhs, rhs=rhs).output_shape,
+                    output_shape,
+                )
+
+    def test_invalid_shape(self):
+        cases = (
+            ({'shape': [2, 3], 'strides': [3, 1]},
+             {'shape': [4, 2], 'strides': [2, 1]}, 'contraction'),
+            ({'shape': [2, 3, 4], 'strides': [12, 4, 1]},
+             {'shape': [5, 4, 6], 'strides': [24, 6, 1]}, 'batch'),
+        )
+        for lhs, rhs, message in cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(
+                        benchmark.spec.SpecError, message):
+                    make_matmul_spec(lhs=lhs, rhs=rhs)
+
+    def test_invalid_layout(self):
+        cases = (
+            ({'shape': [1, 3],
+              'strides': [sys.maxsize // 8 + 1, 1]}, 'byte stride'),
+            ({'shape': [3, 3],
+              'strides': [sys.maxsize // 8, 1]}, 'byte offset'),
+            ({'shape': [2, 3],
+              'strides': [sys.maxsize // 8, 0]}, 'byte span'),
+            ({'shape': [sys.maxsize // 8 + 1, 3],
+              'strides': [0, 0]}, 'logical byte size'),
+            ({'shape': [sys.maxsize // 8 + 1, 0, 3],
+              'strides': [0, 0, 0]}, 'logical byte size'),
+        )
+        for lhs, message in cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(
+                        benchmark.spec.SpecError, message):
+                    make_matmul_spec(lhs=lhs)
+
+    def test_invalid_output_layout(self):
+        side = math.isqrt(sys.maxsize // 8) + 1
+        lhs = {
+            'shape': [side, 1, 1, 1],
+            'strides': [0, 0, 0, 0],
+        }
+        rhs = {
+            'shape': [1, side, 1, 1],
+            'strides': [0, 0, 0, 0],
+        }
+
+        with self.assertRaisesRegex(
+                benchmark.spec.SpecError,
+                'output logical byte size'):
+            make_matmul_spec(lhs=lhs, rhs=rhs)
+
+    def test_invalid_dtype_and_kernel(self):
+        cases = (
+            ({'dtype': 'int64'}, 'dtype'),
+            ({'dtype': []}, 'dtype'),
+            ({'kernels': []}, 'must not be empty'),
+            ({'kernels': [1]}, 'non-empty strings'),
+            ({'kernels': ['naive', 'naive']}, 'duplicates'),
+            ({'kernels': ['auto']}, 'unsupported kernels'),
+        )
+        for updates, message in cases:
+            with self.subTest(updates=updates):
+                with self.assertRaisesRegex(
+                        benchmark.spec.SpecError, message):
+                    make_matmul_spec(**updates)
+
+    def test_invalid_fields(self):
+        data = make_matmul_spec().to_dict()
+        cases = []
+        for field in ('operation', 'lhs', 'sampling'):
+            missing = data.copy()
+            del missing[field]
+            cases.append((missing, 'missing fields'))
+        unknown = data.copy()
+        unknown['mode'] = 'preview'
+        cases.append((unknown, 'unknown fields'))
+        non_string = data.copy()
+        non_string[0] = None
+        non_string[None] = None
+        cases.append((non_string, 'field names'))
+        wrong_operation = data.copy()
+        wrong_operation['operation'] = 'convolution'
+        cases.append((wrong_operation, 'operation'))
+
+        for spec, message in cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(
+                        benchmark.spec.SpecError, message):
+                    benchmark.matmul.MatmulSpec.from_dict(spec)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
## Motivation

The Route Inspector needs a serializable specification of one exact matmul comparison before the benchmark worker allocates operands.

## Approach

Add immutable specification types with strict dictionary round trips. Validate supported dtypes, complete operand shapes, element strides, representable native and NumPy byte layouts, sampling counts, and selected kernel names. Derive contraction, broadcast, and output shapes without allocating arrays or imposing runtime workload limits.

Related to #1369.