### PR TITLE
Add the `Float16` C++ array type

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.cpp
+++ b/cpp/solvcon/buffer/SimpleArray.cpp
@@ -430,6 +430,12 @@ DataType DataType::from<uint64_t>()
 }
 
 template <>
+DataType DataType::from<Float16>()
+{
+    return DataType::Float16;
+}
+
+template <>
 DataType DataType::from<float>()
 {
     return DataType::Float32;
@@ -477,6 +483,7 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const DataType data_t
         SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape)
         SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape)
         SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Float16, SimpleArrayFloat16, shape)
         SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape)
         SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape)
         SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Complex64, SimpleArrayComplex64, shape)
@@ -501,6 +508,7 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const std::shared_ptr
         SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint16, SimpleArrayUint16, shape, buffer)
         SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint32, SimpleArrayUint32, shape, buffer)
         SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Uint64, SimpleArrayUint64, shape, buffer)
+        SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Float16, SimpleArrayFloat16, shape, buffer)
         SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Float32, SimpleArrayFloat32, shape, buffer)
         SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Float64, SimpleArrayFloat64, shape, buffer)
         SC_DECL_CREATE_SIMPLE_ARRAY(DataType::Complex64, SimpleArrayComplex64, shape, buffer)
@@ -532,6 +540,7 @@ SimpleArrayPlex::SimpleArrayPlex(const shape_type & shape, const DataType data_t
         SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Uint16, SimpleArrayUint16)
         SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Uint32, SimpleArrayUint32)
         SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Uint64, SimpleArrayUint64)
+        SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Float16, SimpleArrayFloat16)
         SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Float32, SimpleArrayFloat32)
         SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Float64, SimpleArrayFloat64)
         SC_DECL_CREATE_SIMPLE_ARRAY_WITH_ALIGNMENT(DataType::Complex64, SimpleArrayComplex64)
@@ -616,6 +625,13 @@ SimpleArrayPlex::SimpleArrayPlex(SimpleArrayPlex const & other)
         const auto * array = static_cast<SimpleArrayUint64 *>(other.m_instance_ptr);
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayUint64(*array));
+        break;
+    }
+    case DataType::Float16:
+    {
+        const auto * array = static_cast<SimpleArrayFloat16 *>(other.m_instance_ptr);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayFloat16(*array));
         break;
     }
     case DataType::Float32:
@@ -749,6 +765,13 @@ SimpleArrayPlex & SimpleArrayPlex::operator=(SimpleArrayPlex const & other)
         m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayUint64(*array));
         break;
     }
+    case DataType::Float16:
+    {
+        const auto * array = static_cast<SimpleArrayFloat16 *>(other.m_instance_ptr);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        m_instance_ptr = reinterpret_cast<void *>(new SimpleArrayFloat16(*array));
+        break;
+    }
     case DataType::Float32:
     {
         const auto * array = static_cast<SimpleArrayFloat32 *>(other.m_instance_ptr);
@@ -829,6 +852,8 @@ size_t SimpleArrayPlex::alignment() const
         return static_cast<const SimpleArrayUint32 *>(m_instance_ptr)->alignment();
     case DataType::Uint64:
         return static_cast<const SimpleArrayUint64 *>(m_instance_ptr)->alignment();
+    case DataType::Float16:
+        return static_cast<const SimpleArrayFloat16 *>(m_instance_ptr)->alignment();
     case DataType::Float32:
         return static_cast<const SimpleArrayFloat32 *>(m_instance_ptr)->alignment();
     case DataType::Float64:
@@ -903,6 +928,12 @@ SimpleArrayPlex::~SimpleArrayPlex()
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         delete reinterpret_cast<SimpleArrayUint64 *>(m_instance_ptr);
+        break;
+    }
+    case DataType::Float16:
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        delete reinterpret_cast<SimpleArrayFloat16 *>(m_instance_ptr);
         break;
     }
     case DataType::Float32:

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -3790,6 +3790,7 @@ using SimpleArrayUint8 = SimpleArray<uint8_t>;
 using SimpleArrayUint16 = SimpleArray<uint16_t>;
 using SimpleArrayUint32 = SimpleArray<uint32_t>;
 using SimpleArrayUint64 = SimpleArray<uint64_t>;
+using SimpleArrayFloat16 = SimpleArray<Float16>;
 using SimpleArrayFloat32 = SimpleArray<float>;
 using SimpleArrayFloat64 = SimpleArray<double>;
 using SimpleArrayComplex64 = SimpleArray<Complex<float>>;
@@ -3798,10 +3799,8 @@ using SimpleArrayComplex128 = SimpleArray<Complex<double>>;
 /**
  * Runtime element-type tag mirroring the scalar types a SimpleArray supports.
  *
- * Covers bool, the signed and unsigned 8- to 64-bit integers, the 32- and
- * 64-bit floats, and the 64- and 128-bit complex types. Converts to and from
- * its enum and a type string, and DataType::from<T>() maps a C++ type to its
- * tag.
+ * DataType::from<T>() maps a C++ type to its tag. The string constructor maps
+ * registered public type names to tags.
  *
  * @ingroup group_core
  */
@@ -3820,6 +3819,7 @@ public:
         Uint16,
         Uint32,
         Uint64,
+        Float16,
         Float32,
         Float64,
         Complex64,

--- a/cpp/solvcon/math/CMakeLists.txt
+++ b/cpp/solvcon/math/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 4.0.1)
 
 set(SOLVCON_MATH_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/math.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Float16.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/blas_compat.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lapack_compat.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Complex.hpp

--- a/cpp/solvcon/math/Float16.hpp
+++ b/cpp/solvcon/math/Float16.hpp
@@ -1,0 +1,273 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Portable IEEE 754 binary16 storage and conversion.
+ *
+ * @ingroup group_core
+ */
+
+#include <bit>
+#include <concepts>
+#include <cstdint>
+#include <limits>
+#if __has_include(<stdfloat>)
+#include <stdfloat>
+#endif
+#include <type_traits>
+
+#if __has_include(<stdfloat>) && defined(__STDCPP_FLOAT16_T__)
+#define SC_FLOAT16_NATIVE_TYPE std::float16_t
+#elif defined(__FLT16_MANT_DIG__) && __FLT16_MANT_DIG__ == 11
+#define SC_FLOAT16_NATIVE_TYPE _Float16
+#endif
+
+namespace solvcon
+{
+
+/**
+ * Two-byte IEEE 754 binary16 value with stable cross-platform type identity.
+ *
+ * Native compiler conversions follow the current rounding mode. Other
+ * toolchains use a bitwise round-to-nearest-even fallback.
+ *
+ * @ingroup group_core
+ */
+class Float16
+{
+
+public:
+
+    using storage_type = uint16_t;
+
+    Float16() = default;
+    Float16(Float16 const &) = default;
+    Float16(Float16 &&) = default;
+    Float16 & operator=(Float16 const &) = default;
+    Float16 & operator=(Float16 &&) = default;
+    ~Float16() = default;
+
+    /**
+     * Construct from a single-precision value.
+     *
+     * @param value Source value.
+     */
+    constexpr Float16(float value); // NOLINT(google-explicit-constructor)
+
+    /**
+     * Construct from a double-precision value.
+     *
+     * @param value Source value.
+     */
+    constexpr Float16(double value); // NOLINT(google-explicit-constructor)
+
+    /**
+     * Construct from an integral value.
+     *
+     * @tparam T Integral source type.
+     * @param value Source value.
+     */
+    template <std::integral T>
+    constexpr Float16(T value); // NOLINT(google-explicit-constructor)
+
+    /**
+     * Convert to a single-precision value.
+     *
+     * @return The represented value as ``float``.
+     */
+    explicit constexpr operator float() const { return decode(m_bits); }
+
+    /**
+     * Return the raw binary16 representation.
+     *
+     * @return The sign, exponent, and fraction bits.
+     */
+    constexpr storage_type bits() const { return m_bits; }
+
+    /**
+     * Construct directly from a raw binary16 representation.
+     *
+     * @param bits The sign, exponent, and fraction bits.
+     * @return A value containing the supplied representation.
+     */
+    static constexpr Float16 from_bits(storage_type bits);
+
+private:
+
+#ifdef SC_FLOAT16_NATIVE_TYPE
+    using native_type = SC_FLOAT16_NATIVE_TYPE;
+    static_assert(sizeof(native_type) == sizeof(storage_type));
+#endif
+
+    template <typename T>
+    static constexpr storage_type encode(T value);
+    static constexpr float decode(storage_type value_bits);
+    template <typename T>
+    static constexpr storage_type encode_fallback(T value);
+    static constexpr float decode_fallback(storage_type value_bits);
+
+    storage_type m_bits;
+
+}; /* end class Float16 */
+
+constexpr Float16 Float16::from_bits(storage_type bits) { return std::bit_cast<Float16>(bits); }
+
+template <typename T>
+constexpr Float16::storage_type Float16::encode(T value)
+{
+#ifdef SC_FLOAT16_NATIVE_TYPE
+    return std::bit_cast<storage_type>(static_cast<native_type>(value));
+#else
+    return encode_fallback(value);
+#endif
+}
+
+constexpr Float16::Float16(float value)
+    : m_bits(encode(value))
+{
+}
+
+constexpr Float16::Float16(double value)
+    : m_bits(encode(value))
+{
+}
+
+template <std::integral T>
+constexpr Float16::Float16(T value)
+    : Float16(static_cast<double>(value))
+{
+}
+
+constexpr float Float16::decode(storage_type value_bits)
+{
+#ifdef SC_FLOAT16_NATIVE_TYPE
+    return static_cast<float>(std::bit_cast<native_type>(value_bits));
+#else
+    return decode_fallback(value_bits);
+#endif
+}
+
+template <typename T>
+constexpr Float16::storage_type Float16::encode_fallback(T value)
+{
+    static_assert(sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint64_t));
+    static_assert(std::numeric_limits<T>::is_iec559);
+
+    using bits_type = std::conditional_t<sizeof(T) == sizeof(uint32_t), uint32_t, uint64_t>;
+    constexpr uint32_t frac_bits = std::numeric_limits<T>::digits - 1;
+    constexpr uint32_t exp_bits = sizeof(T) * 8 - frac_bits - 1;
+    constexpr bits_type exp_mask = (bits_type{1} << exp_bits) - 1;
+    constexpr bits_type frac_mask = (bits_type{1} << frac_bits) - 1;
+    constexpr int32_t exp_bias = (1 << (exp_bits - 1)) - 1;
+
+    auto const value_bits = std::bit_cast<bits_type>(value);
+    uint32_t const sign = static_cast<uint32_t>(value_bits >> (frac_bits + exp_bits)) << 15;
+    bits_type const exponent = (value_bits >> frac_bits) & exp_mask;
+    bits_type const fraction = value_bits & frac_mask;
+
+    if (exponent == exp_mask)
+    {
+        if (fraction == 0)
+        {
+            return static_cast<storage_type>(sign | 0x7c00U);
+        }
+        bits_type const payload = (fraction >> (frac_bits - 10)) | 0x200U;
+        return static_cast<storage_type>(sign | 0x7c00U | payload);
+    }
+
+    int32_t half_exp = static_cast<int32_t>(exponent) - exp_bias + 15;
+    if (half_exp < -10)
+    {
+        return static_cast<storage_type>(sign);
+    }
+
+    if (half_exp <= 0)
+    {
+        bits_type const significand = fraction | (bits_type{1} << frac_bits);
+        auto const shift = static_cast<uint32_t>(static_cast<int32_t>(frac_bits) - 9 - half_exp);
+        bits_type rounded = significand >> shift;
+        bits_type const remainder = significand & ((bits_type{1} << shift) - 1);
+        bits_type const halfway = bits_type{1} << (shift - 1);
+        if (remainder > halfway || (remainder == halfway && (rounded & 1U)))
+        {
+            ++rounded;
+        }
+        return static_cast<storage_type>(sign | rounded);
+    }
+
+    if (half_exp >= 31)
+    {
+        return static_cast<storage_type>(sign | 0x7c00U);
+    }
+
+    constexpr uint32_t shift = frac_bits - 10;
+    bits_type rounded = fraction >> shift;
+    bits_type const remainder = fraction & ((bits_type{1} << shift) - 1);
+    bits_type const halfway = bits_type{1} << (shift - 1);
+    if (remainder > halfway || (remainder == halfway && (rounded & 1U)))
+    {
+        ++rounded;
+        if (rounded == 0x400U)
+        {
+            rounded = 0;
+            ++half_exp;
+        }
+    }
+    if (half_exp >= 31)
+    {
+        return static_cast<storage_type>(sign | 0x7c00U);
+    }
+    return static_cast<storage_type>(sign | (static_cast<uint32_t>(half_exp) << 10) | rounded);
+}
+
+constexpr float Float16::decode_fallback(storage_type value_bits)
+{
+    uint32_t const sign = static_cast<uint32_t>(value_bits & 0x8000U) << 16;
+    uint32_t const exponent = (value_bits >> 10) & 0x1fU;
+    uint32_t fraction = value_bits & 0x3ffU;
+    uint32_t result = sign;
+
+    if (exponent == 0)
+    {
+        if (fraction != 0)
+        {
+            int32_t unbiased_exp = -14;
+            while ((fraction & 0x400U) == 0)
+            {
+                fraction <<= 1;
+                --unbiased_exp;
+            }
+            fraction &= 0x3ffU;
+            result |= static_cast<uint32_t>(unbiased_exp + 127) << 23;
+            result |= fraction << 13;
+        }
+    }
+    else if (exponent == 0x1fU)
+    {
+        result |= 0x7f800000U;
+        if (fraction != 0)
+        {
+            result |= (fraction << 13) | 0x00400000U;
+        }
+    }
+    else
+    {
+        result |= (exponent + 112U) << 23;
+        result |= fraction << 13;
+    }
+    return std::bit_cast<float>(result);
+}
+
+static_assert(sizeof(Float16) == 2);
+static_assert(std::is_trivially_copyable_v<Float16>);
+
+} /* end namespace solvcon */
+
+#undef SC_FLOAT16_NATIVE_TYPE
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/math/math.hpp
+++ b/cpp/solvcon/math/math.hpp
@@ -6,6 +6,7 @@
  */
 
 #include <solvcon/math/Complex.hpp>
+#include <solvcon/math/Float16.hpp>
 #include <solvcon/math/blas_compat.hpp>
 #ifdef SC_HAS_VENDOR_LAPACK
 #include <solvcon/math/lapack_compat.hpp>

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -2,7 +2,12 @@
 
 #include <gtest/gtest.h>
 
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <limits>
 #include <random>
+#include <type_traits>
 #ifdef Py_PYTHON_H
 #error "Python.h should not be included."
 #endif
@@ -25,6 +30,118 @@ TEST(ConcreteBuffer, iterator)
     }
 }
 
+TEST(Float16, type_properties)
+{
+    namespace sc = solvcon;
+
+    static_assert(sizeof(sc::Float16) == 2);
+    static_assert(std::is_trivially_copyable_v<sc::Float16>);
+    static_assert(std::is_convertible_v<float, sc::Float16>);
+    static_assert(std::is_convertible_v<double, sc::Float16>);
+    static_assert(std::is_convertible_v<int, sc::Float16>);
+    static_assert(!std::is_convertible_v<sc::Float16, float>);
+    static_assert(sc::Float16(1.0F).bits() == 0x3c00U);
+}
+
+TEST(Float16, binary_layout)
+{
+    namespace sc = solvcon;
+
+    float const pos_input = 1.5F;
+    auto const pos_bits = std::bit_cast<uint32_t>(pos_input);
+    sc::Float16 const pos_output(pos_input);
+    float const neg_input = -2.0F;
+    auto const neg_bits = std::bit_cast<uint32_t>(neg_input);
+    sc::Float16 const neg_output(neg_input);
+
+    // Separators group the sign, exponent, and fraction fields.
+    EXPECT_EQ(0b0'01111111'10000000000000000000000U, pos_bits);
+    EXPECT_EQ(0b0'01111'1000000000U, pos_output.bits());
+    EXPECT_FLOAT_EQ(pos_input, static_cast<float>(pos_output));
+    EXPECT_EQ(0b1'10000000'00000000000000000000000U, neg_bits);
+    EXPECT_EQ(0b1'10000'0000000000U, neg_output.bits());
+    EXPECT_FLOAT_EQ(neg_input, static_cast<float>(neg_output));
+}
+
+TEST(Float16, boundaries)
+{
+    namespace sc = solvcon;
+
+    float const max_finite = 65504.0F;
+    float const min_subnormal = std::ldexp(1.0F, -24);
+    float const underflow_tie = std::ldexp(1.0F, -25);
+
+    EXPECT_EQ(0b0'11110'1111111111U, sc::Float16(max_finite).bits());
+    EXPECT_EQ(0b0'00000'0000000001U, sc::Float16(min_subnormal).bits());
+    EXPECT_EQ(0b0'00000'0000000000U, sc::Float16(underflow_tie).bits());
+
+    EXPECT_FLOAT_EQ(max_finite, static_cast<float>(sc::Float16(max_finite)));
+    EXPECT_FLOAT_EQ(min_subnormal, static_cast<float>(sc::Float16(min_subnormal)));
+    EXPECT_FLOAT_EQ(0.0F, static_cast<float>(sc::Float16(underflow_tie)));
+}
+
+TEST(Float16, ties_to_even)
+{
+    namespace sc = solvcon;
+
+    float const even_tie = 1.0F + std::ldexp(1.0F, -11);
+    float const odd_tie = 1.0F + 3.0F * std::ldexp(1.0F, -11);
+
+    // Midpoints select the result with an even least-significant fraction bit.
+    EXPECT_EQ(0b0'01111'0000000000U, sc::Float16(even_tie).bits());
+    EXPECT_EQ(0b0'01111'0000000010U, sc::Float16(odd_tie).bits());
+}
+
+TEST(Float16, double_rounding)
+{
+    namespace sc = solvcon;
+
+    double const input = 1.0 + std::ldexp(1.0, -11) + std::ldexp(1.0, -25);
+
+    // Narrowing through float loses the term above the binary16 midpoint.
+    EXPECT_EQ(0b0'01111'0000000001U, sc::Float16(input).bits());
+    EXPECT_EQ(0b0'01111'0000000000U, sc::Float16(static_cast<float>(input)).bits());
+}
+
+TEST(Float16, value_vs_bits)
+{
+    namespace sc = solvcon;
+
+    sc::Float16 const numeric(1);
+    sc::Float16 const raw = sc::Float16::from_bits(1);
+
+    EXPECT_EQ(0b0'01111'0000000000U, numeric.bits());
+    EXPECT_EQ(0b0'00000'0000000001U, raw.bits());
+    EXPECT_FLOAT_EQ(1.0F, static_cast<float>(numeric));
+    EXPECT_FLOAT_EQ(std::ldexp(1.0F, -24), static_cast<float>(raw));
+}
+
+TEST(Float16, special_values)
+{
+    namespace sc = solvcon;
+
+    sc::Float16 const pos_inf(std::numeric_limits<float>::infinity());
+    sc::Float16 const neg_inf(-std::numeric_limits<float>::infinity());
+    EXPECT_EQ(0x7c00U, pos_inf.bits());
+    EXPECT_EQ(0xfc00U, neg_inf.bits());
+    EXPECT_TRUE(std::isinf(static_cast<float>(pos_inf)));
+    EXPECT_TRUE(std::signbit(static_cast<float>(neg_inf)));
+
+    float const quiet_nan = std::bit_cast<float>(0x7fcaa000U);
+    float const signaling_nan = std::bit_cast<float>(0x7f8aa000U);
+    EXPECT_EQ(0x7e55U, sc::Float16(quiet_nan).bits());
+    EXPECT_EQ(0x7e55U, sc::Float16(signaling_nan).bits());
+    auto const decoded_quiet = static_cast<float>(sc::Float16::from_bits(0x7e55U));
+    auto const decoded_signaling = static_cast<float>(sc::Float16::from_bits(0x7c55U));
+    EXPECT_EQ(0x7fcaa000U, std::bit_cast<uint32_t>(decoded_quiet));
+    EXPECT_EQ(0x7fcaa000U, std::bit_cast<uint32_t>(decoded_signaling));
+
+    sc::Float16 const neg_zero(-0.0F);
+    EXPECT_EQ(0x8000U, neg_zero.bits());
+    EXPECT_TRUE(std::signbit(static_cast<float>(neg_zero)));
+    EXPECT_EQ(0x7e55U, sc::Float16::from_bits(0x7e55U).bits());
+}
+
 TEST(SimpleArray, construction)
 {
     namespace sc = solvcon;
@@ -32,6 +149,25 @@ TEST(SimpleArray, construction)
     EXPECT_EQ(arr_double.nbody(), 10);
     sc::SimpleArray<int> arr_int(17);
     EXPECT_EQ(arr_int.nbody(), 17);
+}
+
+TEST(SimpleArray, float16_storage)
+{
+    namespace sc = solvcon;
+
+    sc::SimpleArrayFloat16 array(sc::small_vector<ssize_t>{2, 2});
+    array(0, 0) = sc::Float16(1.5F);
+    array(0, 1) = sc::Float16(-2.0F);
+    array(1, 0) = sc::Float16(3.25F);
+    array(1, 1) = sc::Float16(4.5F);
+
+    sc::SimpleArrayFloat16 copy(array);
+
+    EXPECT_NE(array.data(), copy.data());
+    EXPECT_FLOAT_EQ(1.5F, static_cast<float>(copy(0, 0)));
+    EXPECT_FLOAT_EQ(-2.0F, static_cast<float>(copy(0, 1)));
+    EXPECT_FLOAT_EQ(3.25F, static_cast<float>(copy(1, 0)));
+    EXPECT_FLOAT_EQ(4.5F, static_cast<float>(copy(1, 1)));
 }
 
 TEST(SimpleArray, minmaxsum)
@@ -182,6 +318,9 @@ TEST(SimpleArray, logical_data)
 
 TEST(SimpleArray_DataType, from_type)
 {
+    solvcon::DataType dt_half = solvcon::DataType::from<solvcon::Float16>();
+    EXPECT_EQ(dt_half.type(), solvcon::DataType::Float16);
+
     solvcon::DataType dt_double = solvcon::DataType::from<double>();
     EXPECT_EQ(dt_double.type(), solvcon::DataType::Float64);
 
@@ -197,8 +336,38 @@ TEST(SimpleArray_DataType, from_string)
     solvcon::DataType dt_bool = solvcon::DataType("bool");
     EXPECT_EQ(dt_bool.type(), solvcon::DataType::Bool);
 
-    EXPECT_THROW(solvcon::DataType("float16"), std::invalid_argument); // float16 does not exist
+    // Float16 has no registered string name.
+    EXPECT_THROW(solvcon::DataType("float16"), std::invalid_argument);
     EXPECT_THROW(solvcon::DataType("bool8"), std::invalid_argument); // bool8 does not exist
+}
+
+TEST(SimpleArrayPlex, float16_lifecycle)
+{
+    namespace sc = solvcon;
+
+    sc::small_vector<ssize_t> const shape{16};
+    sc::SimpleArrayPlex plex(shape, sc::DataType::Float16, 32);
+    EXPECT_EQ(sc::DataType::Float16, plex.data_type());
+
+    auto * array = static_cast<sc::SimpleArrayFloat16 *>(plex.mutable_instance_ptr());
+    EXPECT_EQ(0U, reinterpret_cast<std::uintptr_t>(array->data()) % 32U);
+    (*array)[0] = sc::Float16(2.0F);
+
+    sc::SimpleArrayPlex copy(plex);
+    auto const * copy_array = static_cast<sc::SimpleArrayFloat16 const *>(copy.instance_ptr());
+    EXPECT_NE(array->data(), copy_array->data());
+    EXPECT_FLOAT_EQ(2.0F, static_cast<float>((*copy_array)[0]));
+
+    sc::SimpleArrayPlex assigned;
+    assigned = plex;
+    auto const * assigned_array = static_cast<sc::SimpleArrayFloat16 const *>(assigned.instance_ptr());
+    EXPECT_NE(array->data(), assigned_array->data());
+    EXPECT_FLOAT_EQ(2.0F, static_cast<float>((*assigned_array)[0]));
+
+    auto buffer = sc::ConcreteBuffer::construct(shape[0] * sizeof(sc::Float16));
+    sc::SimpleArrayPlex buffered(shape, buffer, sc::DataType::Float16);
+    auto const * buffered_array = static_cast<sc::SimpleArrayFloat16 const *>(buffered.instance_ptr());
+    EXPECT_EQ(buffer->data(), static_cast<void const *>(buffered_array->data()));
 }
 
 TEST(BufferExpander, iterator)


### PR DESCRIPTION
`SimpleArray` needs one portable IEEE 754 binary16 type across GCC, Clang, and MSVC. C++23 does not guarantee `std::float16_t`, and MSVC STL does not currently provide it.

The conversion path is selected at compile time:

```cpp
#if defined(__STDCPP_FLOAT16_T__)
using native_type = std::float16_t;
#elif defined(__FLT16_MANT_DIG__) && __FLT16_MANT_DIG__ == 11
using native_type = _Float16;
#else
// MSVC: use portable software conversion.
#endif
```

This change stores the same two-byte binary16 representation behind `solvcon::Float16` on every path, then integrates `DataType::Float16` and `SimpleArrayFloat16` with the existing array lifecycle and buffer management.

Related to #1393.