### PR TITLE
Add device-selecting buffer construction

### DIFF
--- a/contrib/standalone_buffer/Makefile
+++ b/contrib/standalone_buffer/Makefile
@@ -63,6 +63,9 @@ $(SETUPROOT)/buffer_pymod.o: $(SETUPROOT)/solvcon/buffer/pymod/buffer_pymod.cpp 
 $(SETUPROOT)/BufferExpander.o: $(SETUPROOT)/solvcon/buffer/BufferExpander.cpp Makefile
 	c++ $(CFLAGS) -c $< -o $@
 
+$(SETUPROOT)/ConcreteBuffer.o: $(SETUPROOT)/solvcon/buffer/ConcreteBuffer.cpp Makefile
+	c++ $(CFLAGS) -c $< -o $@
+
 $(SETUPROOT)/SimpleArray.o: $(SETUPROOT)/solvcon/buffer/SimpleArray.cpp Makefile
 	c++ $(CFLAGS) -c $< -o $@
 
@@ -80,6 +83,7 @@ $(SETUPROOT)/radix_tree.o: $(SETUPROOT)/solvcon/profiling/RadixTree.cpp Makefile
 
 OBJS = \
 	$(SETUPROOT)/BufferExpander.o \
+	$(SETUPROOT)/ConcreteBuffer.o \
 	$(SETUPROOT)/SimpleArray.o \
 	$(SETUPROOT)/blas_compat.o \
 	$(SETUPROOT)/wrap_ConcreteBuffer.o \

--- a/cpp/solvcon/buffer/BufferDevice.hpp
+++ b/cpp/solvcon/buffer/BufferDevice.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Device identity for owned buffer storage.
+ * @ingroup group_core */
+
+#include <cstdint>
+
+namespace solvcon
+{
+
+/**
+ * Identifies where owned buffer storage resides.
+ * @ingroup group_core */
+enum class BufferDevice : std::uint8_t
+{
+    Cpu,
+    Metal,
+}; /* end enum class BufferDevice */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/buffer/CMakeLists.txt
+++ b/cpp/solvcon/buffer/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required(VERSION 4.0.1)
 set(SOLVCON_BUFFER_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/buffer.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BufferBase.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/BufferDevice.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/small_vector.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/signed_stride_layout.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ConcreteBuffer.hpp
@@ -18,6 +19,7 @@ set(SOLVCON_BUFFER_HEADERS
 
 set(SOLVCON_BUFFER_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/BufferExpander.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ConcreteBuffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SimpleArray.cpp
     CACHE FILEPATH "" FORCE)
 

--- a/cpp/solvcon/buffer/ConcreteBuffer.cpp
+++ b/cpp/solvcon/buffer/ConcreteBuffer.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/buffer/ConcreteBuffer.hpp>
+
+namespace solvcon
+{
+
+std::shared_ptr<ConcreteBuffer> ConcreteBuffer::construct(size_t nbytes, size_t alignment, BufferDevice device)
+{
+    validate_alignment(alignment, "ConcreteBuffer::construct");
+    validate_size_alignment(nbytes, alignment, "ConcreteBuffer::construct");
+
+    switch (device)
+    {
+    case BufferDevice::Cpu:
+        return construct(nbytes, alignment);
+    case BufferDevice::Metal:
+        throw std::runtime_error("ConcreteBuffer::construct: Metal storage is unavailable");
+    }
+    throw std::invalid_argument("ConcreteBuffer::construct: unknown buffer device");
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/buffer/ConcreteBuffer.hpp
+++ b/cpp/solvcon/buffer/ConcreteBuffer.hpp
@@ -14,6 +14,7 @@
 
 #include <solvcon/base.hpp>
 #include <solvcon/buffer/BufferBase.hpp>
+#include <solvcon/buffer/BufferDevice.hpp>
 #include <solvcon/buffer/small_vector.hpp>
 
 #include <algorithm>
@@ -142,6 +143,17 @@ public:
     {
         return std::make_shared<ConcreteBuffer>(nbytes, alignment, ctor_passkey());
     }
+
+    /** Construct owned storage on a device.
+     * @param nbytes Size in bytes.
+     * @param alignment Alignment in bytes: 0, 16, 32, or 64. An aligned size
+     * must be a multiple of the alignment.
+     * @param device Device that owns the storage.
+     * @return A new owning buffer.
+     * @throw std::invalid_argument If the alignment, size, or device is invalid.
+     * @throw std::runtime_error If the requested device is unavailable.
+     * @throw std::bad_alloc If storage allocation fails. */
+    static std::shared_ptr<ConcreteBuffer> construct(size_t nbytes, size_t alignment, BufferDevice device);
 
     /*
      * This factory method is dangerous since the data pointer passed in will

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -12,6 +12,37 @@
 #error "Python.h should not be included."
 #endif
 
+TEST(ConcreteBuffer, construct_cpu_device)
+{
+    namespace sc = solvcon;
+
+    auto buffer = sc::ConcreteBuffer::construct(32, 32, sc::BufferDevice::Cpu);
+    EXPECT_EQ(size_t{32}, buffer->size());
+    EXPECT_EQ(size_t{32}, buffer->alignment());
+}
+
+TEST(ConcreteBuffer, construct_unavailable_metal)
+{
+    namespace sc = solvcon;
+
+    EXPECT_THROW(sc::ConcreteBuffer::construct(16, 0, sc::BufferDevice::Metal), std::runtime_error);
+}
+
+TEST(ConcreteBuffer, construct_invalid_metal_request)
+{
+    namespace sc = solvcon;
+
+    EXPECT_THROW(sc::ConcreteBuffer::construct(15, 16, sc::BufferDevice::Metal), std::invalid_argument);
+}
+
+TEST(ConcreteBuffer, construct_unknown_device)
+{
+    namespace sc = solvcon;
+
+    auto const unknown_device = static_cast<sc::BufferDevice>(255);
+    EXPECT_THROW(sc::ConcreteBuffer::construct(16, 0, unknown_device), std::invalid_argument);
+}
+
 TEST(ConcreteBuffer, iterator)
 {
     using namespace solvcon;


### PR DESCRIPTION
`SimpleArray` needs one buffer factory that can choose CPU or Metal storage without exposing a second public allocator.

```text
SimpleArray
    -> ConcreteBuffer::construct(..., device)
        |-> CPU -> existing allocation
        `-> Metal -> unavailable until Task 2
```

This change keeps `BufferDevice` in the buffer layer and adds device selection to the existing `ConcreteBuffer` factory. CPU reuses the existing allocation; Metal reports unavailable until Task 2.

It does not add Metal storage, `SimpleArray` APIs, providers, capability queries, or concurrency.

Related to #1397.