### PR TITLE
Walk the messages of one MCAP topic

### DIFF
--- a/cpp/solvcon/mcap/mcap_reader.cpp
+++ b/cpp/solvcon/mcap/mcap_reader.cpp
@@ -10,6 +10,9 @@
 #include <cstring>
 #include <stdexcept>
 
+#include <lz4frame.h>
+#include <zstd.h>
+
 namespace solvcon
 {
 
@@ -31,6 +34,8 @@ enum Opcode : uint8_t
     OP_FOOTER = 0x02,
     OP_SCHEMA = 0x03,
     OP_CHANNEL = 0x04,
+    OP_MESSAGE = 0x05,
+    OP_CHUNK = 0x06,
     OP_CHUNK_INDEX = 0x08,
     OP_STATISTICS = 0x0b,
 }; /* end enum Opcode */
@@ -67,6 +72,9 @@ public:
     }
 
     void skip(uint64_t length) { bytes(length); }
+
+    /// The bytes after the cursor.
+    std::string_view rest() { return bytes(m_data.size() - m_pos); }
 
     bool done() const { return m_pos >= m_data.size(); }
 
@@ -115,6 +123,78 @@ static bool is_kept_record(uint8_t opcode)
 {
     return OP_SCHEMA == opcode || OP_CHANNEL == opcode ||
            OP_CHUNK_INDEX == opcode || OP_STATISTICS == opcode;
+}
+
+/**
+ * @internal
+ * Read the record at the cursor of an in-memory section and advance past it.
+ * False means the section holds no further record.
+ */
+static bool next_record(std::string_view buffer, size_t & pos, uint8_t & opcode, std::string_view & content)
+{
+    if (pos == buffer.size())
+    {
+        return false;
+    }
+    // A remainder shorter than a header is a truncated record, not the end
+    // of the section.
+    if (buffer.size() - pos < RECORD_HEADER_SIZE)
+    {
+        throw std::runtime_error("MCAP section ends inside a record header");
+    }
+
+    opcode = static_cast<uint8_t>(buffer[pos]);
+    uint64_t length = 0;
+    std::memcpy(&length, buffer.data() + pos + 1, sizeof(length));
+    if (buffer.size() - pos - RECORD_HEADER_SIZE < length)
+    {
+        throw std::runtime_error("MCAP record runs past the end of its section");
+    }
+
+    content = buffer.substr(pos + RECORD_HEADER_SIZE, length);
+    pos += RECORD_HEADER_SIZE + length;
+    return true;
+}
+
+static std::string decompress(std::string_view compression, std::string_view input, uint64_t output_size)
+{
+    if (compression.empty())
+    {
+        return std::string(input);
+    }
+
+    std::string output(output_size, '\0');
+    if ("lz4" == compression)
+    {
+        // MCAP compresses a chunk as an LZ4 frame, not as a bare LZ4 block.
+        LZ4F_dctx * dctx = nullptr;
+        if (LZ4F_isError(LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION)))
+        {
+            throw std::runtime_error("cannot create the LZ4 decompression context");
+        }
+        size_t dst_size = output.size();
+        size_t src_size = input.size();
+        size_t const ret = LZ4F_decompress(dctx, output.data(), &dst_size, input.data(), &src_size, nullptr);
+        LZ4F_freeDecompressionContext(dctx);
+        if (0 != ret || dst_size != output_size || src_size != input.size())
+        {
+            throw std::runtime_error("cannot decompress the lz4 MCAP chunk");
+        }
+    }
+    else if ("zstd" == compression)
+    {
+        size_t const ret = ZSTD_decompress(output.data(), output.size(), input.data(), input.size());
+        if (ZSTD_isError(ret) || ret != output_size)
+        {
+            throw std::runtime_error("cannot decompress the zstd MCAP chunk");
+        }
+    }
+    else
+    {
+        throw std::runtime_error("unsupported MCAP chunk compression: " + std::string(compression));
+    }
+
+    return output;
 }
 
 Reader::Reader(std::string const & path)
@@ -196,6 +276,7 @@ void Reader::read_summary()
         throw std::runtime_error("the MCAP summary section starts at or past the footer: " + m_path);
     }
 
+    m_data_end = summary_start;
     parse_summary(summary_start, summary_end);
 
     if (m_has_time_range || m_chunk_indices.empty())
@@ -218,27 +299,39 @@ void Reader::read_summary()
     }
 }
 
+bool Reader::read_record_header(uint64_t pos, uint64_t end, uint8_t & opcode, uint64_t & length)
+{
+    if (pos == end)
+    {
+        return false;
+    }
+    // A length out of the file may not be added to the position, because the
+    // sum wraps for a large enough pair.  Every check is a subtraction.
+    if (end - pos < RECORD_HEADER_SIZE)
+    {
+        throw std::runtime_error("an MCAP section ends inside a record header: " + m_path);
+    }
+
+    std::string const head = read_bytes(pos, RECORD_HEADER_SIZE);
+    opcode = static_cast<uint8_t>(head[0]);
+    std::memcpy(&length, head.data() + 1, sizeof(length));
+    if (length > end - pos - RECORD_HEADER_SIZE)
+    {
+        throw std::runtime_error("an MCAP record runs past its section: " + m_path);
+    }
+
+    return true;
+}
+
 void Reader::parse_summary(uint64_t start, uint64_t end)
 {
     // One record is read at a time rather than the section as a whole.  What
     // the walk costs then follows the largest record, not the whole summary.
     uint64_t pos = start;
-    while (pos < end)
+    uint8_t opcode = 0;
+    uint64_t length = 0;
+    while (read_record_header(pos, end, opcode, length))
     {
-        if (end - pos < RECORD_HEADER_SIZE)
-        {
-            throw std::runtime_error("the MCAP summary section ends inside a record: " + m_path);
-        }
-
-        std::string const head = read_bytes(pos, RECORD_HEADER_SIZE);
-        uint64_t length = 0;
-        std::memcpy(&length, head.data() + 1, sizeof(length));
-        if (length > end - pos - RECORD_HEADER_SIZE)
-        {
-            throw std::runtime_error("an MCAP summary record runs past the section: " + m_path);
-        }
-
-        auto const opcode = static_cast<uint8_t>(head[0]);
         if (is_kept_record(opcode))
         {
             parse_summary_record(opcode, read_bytes(pos + RECORD_HEADER_SIZE, length));
@@ -382,6 +475,146 @@ std::map<std::string, std::string> Reader::topics() const
     }
 
     return out;
+}
+
+MessageIterator Reader::messages(std::string const & topic)
+{
+    small_vector<uint16_t> channel_ids;
+    for (auto const & pair : m_channels)
+    {
+        if (topic == pair.second.topic)
+        {
+            channel_ids.push_back(pair.first);
+        }
+    }
+    if (channel_ids.empty())
+    {
+        throw std::runtime_error("no such topic in the MCAP file: " + topic);
+    }
+
+    return MessageIterator(*this, channel_ids);
+}
+
+std::string Reader::read_chunk(uint64_t offset, uint64_t length)
+{
+    std::string const record = read_bytes(offset, length);
+    size_t pos = 0;
+    uint8_t opcode = 0;
+    std::string_view content;
+    if (!next_record(record, pos, opcode, content) || OP_CHUNK != opcode)
+    {
+        throw std::runtime_error("no MCAP chunk record where the chunk index points");
+    }
+
+    FieldReader field(content);
+    field.u64(); // message_start_time
+    field.u64(); // message_end_time
+    uint64_t const uncompressed_size = field.u64();
+    field.u32(); // uncompressed_crc
+    std::string_view const compression = field.str();
+    return decompress(compression, field.bytes(field.u64()), uncompressed_size);
+}
+
+MessageIterator::MessageIterator(Reader & reader, small_vector<uint16_t> const & channel_ids)
+    : m_reader(&reader)
+    , m_channel_ids(channel_ids)
+    , m_offset(MAGIC_SIZE)
+{
+    for (size_t it = 0; it < reader.m_chunk_indices.size(); ++it)
+    {
+        small_vector<uint16_t> const & held = reader.m_chunk_indices[it].channel_ids;
+        // The channel ids come from the map of message index offsets, and an
+        // empty map means no message indexing is available.  It says nothing
+        // about what the chunk holds, so the pruning must keep the chunk.
+        bool const keep = held.empty() || std::any_of(held.begin(), held.end(), [this](uint16_t id)
+                                                      { return wanted(id); });
+        if (keep)
+        {
+            m_chunks.push_back(it);
+        }
+    }
+
+    std::vector<ChunkIndexRecord> const & indices = reader.m_chunk_indices;
+    std::sort(m_chunks.begin(), m_chunks.end(), [&indices](size_t lhs, size_t rhs)
+              { return indices[lhs].chunk_start_offset < indices[rhs].chunk_start_offset; });
+}
+
+bool MessageIterator::wanted(uint16_t channel_id) const
+{
+    return m_channel_ids.end() != std::find(m_channel_ids.begin(), m_channel_ids.end(), channel_id);
+}
+
+bool MessageIterator::next(uint64_t & log_time, std::string_view & payload)
+{
+    while (true)
+    {
+        uint8_t opcode = 0;
+        std::string_view content;
+        if (!next_record(m_buffer, m_cursor, opcode, content))
+        {
+            if (!load_next_buffer())
+            {
+                return false;
+            }
+            continue;
+        }
+
+        if (OP_MESSAGE != opcode)
+        {
+            continue;
+        }
+
+        FieldReader field(content);
+        if (!wanted(field.u16()))
+        {
+            continue;
+        }
+        field.u32(); // sequence
+        log_time = field.u64();
+        field.u64(); // publish_time
+        payload = field.rest();
+        return true;
+    }
+}
+
+bool MessageIterator::load_next_buffer()
+{
+    m_buffer.clear();
+    m_cursor = 0;
+
+    if (m_next_chunk < m_chunks.size())
+    {
+        ChunkIndexRecord const & chunk = m_reader->m_chunk_indices[m_chunks[m_next_chunk++]];
+        m_buffer = m_reader->read_chunk(chunk.chunk_start_offset, chunk.chunk_length);
+        return true;
+    }
+
+    // A file carrying chunk indexes should hold every message in a chunk, but
+    // the specification only recommends it, and a message record is legal in
+    // the data section.  The walk therefore runs after the indexed chunks so
+    // that a writer ignoring the recommendation cannot make messages vanish;
+    // it reads a chunk itself only when no index named it.
+    uint64_t const end = m_reader->m_data_end;
+    uint8_t opcode = 0;
+    uint64_t length = 0;
+    while (m_reader->read_record_header(m_offset, end, opcode, length))
+    {
+        uint64_t const start = m_offset;
+        m_offset += RECORD_HEADER_SIZE + length;
+
+        if (OP_MESSAGE == opcode)
+        {
+            m_buffer = m_reader->read_bytes(start, RECORD_HEADER_SIZE + length);
+            return true;
+        }
+        if (OP_CHUNK == opcode && m_reader->m_chunk_indices.empty())
+        {
+            m_buffer = m_reader->read_chunk(start, RECORD_HEADER_SIZE + length);
+            return true;
+        }
+    }
+
+    return false;
 }
 
 } /* end namespace mcap */

--- a/cpp/solvcon/mcap/mcap_reader.hpp
+++ b/cpp/solvcon/mcap/mcap_reader.hpp
@@ -73,16 +73,64 @@ struct ChunkIndexRecord
     small_vector<uint16_t> channel_ids;
 }; /* end struct ChunkIndexRecord */
 
+class Reader;
+
+/**
+ * Forward iterator over the messages of one topic.  It yields the log time
+ * and the undecoded payload of each message.
+ *
+ * A payload stays valid until the next call to next(), because it points into
+ * the buffer that holds the record it came from.
+ *
+ * @ingroup group_inout
+ */
+class MessageIterator
+{
+
+public:
+
+    MessageIterator(Reader & reader, small_vector<uint16_t> const & channel_ids);
+
+    /**
+     * Read the next message of the topic.
+     *
+     * @param[out] log_time Log time of the message, in nanoseconds.
+     * @param[out] payload Undecoded bytes of the message.
+     * @return Whether the call read a message; false at the end of the topic.
+     */
+    bool next(uint64_t & log_time, std::string_view & payload);
+
+    /// Number of chunks left to read after pruning; zero without an index.
+    size_t selected_chunk_count() const { return m_chunks.size(); }
+
+private:
+
+    bool wanted(uint16_t channel_id) const;
+    bool load_next_buffer();
+
+    Reader * m_reader = nullptr;
+    small_vector<uint16_t> m_channel_ids;
+    // Indexes into the chunk index records of the reader.  They are in file
+    // order and name only the chunks that carry a wanted channel.
+    small_vector<size_t> m_chunks;
+    size_t m_next_chunk = 0;
+    uint64_t m_offset = 0;
+    std::string m_buffer;
+    size_t m_cursor = 0;
+}; /* end class MessageIterator */
+
 /**
  * Reader for the container layer of an MCAP recording.
  *
  * Construction validates the file magic and the footer, then parses the
  * summary section only: the schema, channel, chunk index, and statistics
- * records.  No chunk is read, and the message payloads stay where they are.
+ * records.  The reader decompresses no chunk until messages() walks a topic.
+ * It never reads a chunk whose index names none of the wanted channels.
  *
  * The file must carry a summary section.  Every writer that indexes its output
  * writes one.  Without it, a reader would have to walk the whole recording to
- * collect the topics.
+ * collect the topics, and a query for one topic would have to decompress all
+ * of it.
  *
  * @ingroup group_inout
  */
@@ -119,6 +167,13 @@ public:
     /// Whether the summary stated the log time range.
     bool has_time_range() const { return m_has_time_range; }
 
+    /**
+     * Messages of a topic, in the order the recording stores them.  A file
+     * that holds messages both in chunks and beside them yields the chunked
+     * ones first, which is not log time order.
+     */
+    MessageIterator messages(std::string const & topic);
+
     /// Number of chunk index records the summary carries.
     size_t chunk_count() const { return m_chunk_indices.size(); }
 
@@ -133,17 +188,32 @@ public:
 
 private:
 
+    friend class MessageIterator;
+
     void read_summary();
     /// Walk the summary section one record at a time, from start to end.
+    /**
+     * Read the record header at an offset in a section.
+     *
+     * @param[in] pos Byte offset of the record.
+     * @param[in] end Byte offset the section ends at.
+     * @param[out] opcode Record type.
+     * @param[out] length Byte length of the record content.
+     * @return Whether a record starts at the offset; false at the end.
+     */
+    bool read_record_header(uint64_t pos, uint64_t end, uint8_t & opcode, uint64_t & length);
     void parse_summary(uint64_t start, uint64_t end);
     void parse_summary_record(uint8_t opcode, std::string_view content);
     std::string read_bytes(uint64_t offset, uint64_t length);
+    /// Read the chunk record at the offset and return its decompressed records.
+    std::string read_chunk(uint64_t offset, uint64_t length);
     /// The channel that names a topic, or nullptr when no channel carries it.
     ChannelRecord const * channel_for(std::string const & topic) const;
 
     std::string m_path;
     std::ifstream m_stream;
     uint64_t m_file_size = 0;
+    uint64_t m_data_end = 0;
     // TODO: Replace the STL containers below once the buffer subsystem offers
     // an id-keyed map and a collector of records; SimpleCollector holds
     // fundamental types and these hold records (issue #1286).

--- a/cpp/solvcon/mcap/pymod/wrap_McapReader.cpp
+++ b/cpp/solvcon/mcap/pymod/wrap_McapReader.cpp
@@ -46,6 +46,48 @@ protected:
 
 }; /* end class WrapMcapSchema */
 
+class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapMcapMessageIterator
+    : public WrapBase<WrapMcapMessageIterator, mcap::MessageIterator, std::shared_ptr<mcap::MessageIterator>>
+{
+
+public:
+
+    using base_type = WrapBase<WrapMcapMessageIterator, mcap::MessageIterator, std::shared_ptr<mcap::MessageIterator>>;
+    using wrapped_type = typename base_type::wrapped_type;
+
+    friend root_base_type;
+
+protected:
+
+    WrapMcapMessageIterator(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : base_type(mod, pyname, pydoc)
+    {
+        namespace py = pybind11; // NOLINT(misc-unused-alias-decls)
+
+        (*this)
+            .def(
+                "__iter__",
+                [](py::object self)
+                { return self; })
+            .def(
+                "__next__",
+                [](wrapped_type & self)
+                {
+                    uint64_t log_time = 0;
+                    std::string_view payload;
+                    if (!self.next(log_time, payload))
+                    {
+                        throw py::stop_iteration();
+                    }
+                    return py::make_tuple(log_time, py::bytes(payload.data(), payload.size()));
+                })
+            .def("selected_chunk_count", &wrapped_type::selected_chunk_count)
+            //
+            ;
+    }
+
+}; /* end class WrapMcapMessageIterator */
+
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapMcapReader
     : public WrapBase<WrapMcapReader, mcap::Reader, std::shared_ptr<mcap::Reader>>
 {
@@ -80,6 +122,8 @@ protected:
             .def("schema", &wrapped_type::schema, py::arg("topic"))
             .def("time_range", &wrapped_type::time_range)
             .def("has_time_range", &wrapped_type::has_time_range)
+            // The iterator reads from the file the reader holds open.
+            .def("messages", &wrapped_type::messages, py::arg("topic"), py::keep_alive<0, 1>())
             //
             ;
     }
@@ -89,6 +133,7 @@ protected:
 void wrap_McapReader(pybind11::module & mod)
 {
     WrapMcapSchema::commit(mod, "McapSchema", "McapSchema");
+    WrapMcapMessageIterator::commit(mod, "McapMessageIterator", "McapMessageIterator");
     WrapMcapReader::commit(mod, "McapReader", "McapReader");
 }
 

--- a/solvcon/core.py
+++ b/solvcon/core.py
@@ -87,6 +87,7 @@ list_of_python = [
 list_of_mcap = [
     'McapReader',
     'McapSchema',
+    'McapMessageIterator',
 ]
 
 # toggle directory symbols

--- a/tests/test_mcap.py
+++ b/tests/test_mcap.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, solvcon team <contact@solvcon.net>
 # BSD 3-Clause License, see COPYING
 
+import itertools
 import os
 import struct
 import tempfile
@@ -28,56 +29,104 @@ END_TIME = START_TIME + (MESSAGE_COUNT - 1) * PERIOD
 # The 256-byte chunk size of the generator packs the messages into this many
 # chunks. Regenerating the fixtures with another chunk size changes it.
 CHUNK_COUNT = 19
+# One imu message per this many status messages.
+IMU_PERIOD = 12
+# The imu messages reach only this many of the chunks, so a query for the
+# topic leaves the rest unread.
+IMU_CHUNK_COUNT = 8
+
+# Little-endian CDR encapsulation header, as a ROS 2 recording carries it.
+CDR_HEADER = b"\x00\x01\x00\x00"
+
+# A cursor shared between two iterators still answers the first two reads
+# correctly, so the interleaving tests alternate this many times.
+INTERLEAVED_READS = 4
 
 
-MAGIC = b"\x89MCAP0\r\n"
+class McapBytes:
+    """Builders for the records of an MCAP file, as raw bytes.
 
-
-def _record(opcode, content):
-    return bytes([opcode]) + struct.pack("<Q", len(content)) + content
-
-
-def _prefixed(raw):
-    return struct.pack("<I", len(raw)) + raw
-
-
-def _text(value):
-    return _prefixed(value.encode())
-
-
-def _schema(schema_id, name, encoding="ros2msg", data=b"float64 x\n"):
-    return _record(0x03, struct.pack("<H", schema_id) + _text(name)
-                   + _text(encoding) + _prefixed(data))
-
-
-def _channel(channel_id, schema_id, topic, encoding="cdr", metadata=b""):
-    return _record(0x04, struct.pack("<HH", channel_id, schema_id)
-                   + _text(topic) + _text(encoding) + _prefixed(metadata))
-
-
-def _chunk_index(start, end, channel_ids=(1,)):
-    offsets = b"".join(struct.pack("<HQ", cid, 0) for cid in channel_ids)
-    return _record(0x08, struct.pack("<QQQQ", start, end, 0, 0)
-                   + _prefixed(offsets) + struct.pack("<Q", 0) + _text("")
-                   + struct.pack("<QQ", 0, 0))
-
-
-def _statistics(start, end):
-    return _record(0x0B, struct.pack("<QHIIII", 0, 0, 0, 0, 0, 0)
-                   + struct.pack("<QQ", start, end) + _prefixed(b""))
-
-
-def _assemble(records, trailing=b""):
-    """The smallest file the reader accepts, carrying the given summary.
-
-    The data section holds no message, because the reader under test reads
-    the footer and the summary and nothing else.
+    The fixture writer cannot produce a malformed or hand-tuned summary, so
+    the tests that need one assemble the file byte by byte.
     """
-    head = (MAGIC + _record(0x01, _text("") + _text("solvcon test"))
-            + _record(0x0F, struct.pack("<I", 0)))
-    summary = b"".join(records) + trailing
-    footer = _record(0x02, struct.pack("<QQI", len(head), 0, 0))
-    return head + summary + footer + MAGIC
+
+    MAGIC = b"\x89MCAP0\r\n"
+
+    @staticmethod
+    def record(opcode, content):
+        return bytes([opcode]) + struct.pack("<Q", len(content)) + content
+
+    @staticmethod
+    def prefixed(raw):
+        return struct.pack("<I", len(raw)) + raw
+
+    @classmethod
+    def text(cls, value):
+        return cls.prefixed(value.encode())
+
+    @classmethod
+    def schema(cls, schema_id, name, encoding="ros2msg",
+               data=b"float64 x\n"):
+        return cls.record(0x03, struct.pack("<H", schema_id)
+                          + cls.text(name) + cls.text(encoding)
+                          + cls.prefixed(data))
+
+    @classmethod
+    def channel(cls, channel_id, schema_id, topic, encoding="cdr",
+                metadata=b""):
+        return cls.record(0x04, struct.pack("<HH", channel_id, schema_id)
+                          + cls.text(topic) + cls.text(encoding)
+                          + cls.prefixed(metadata))
+
+    @classmethod
+    def chunk_index(cls, start, end, channel_ids=(1,), offset=0, length=0):
+        offsets = b"".join(struct.pack("<HQ", cid, 0) for cid in channel_ids)
+        return cls.record(0x08, struct.pack("<QQQQ", start, end, offset,
+                                            length)
+                          + cls.prefixed(offsets) + struct.pack("<Q", 0)
+                          + cls.text("") + struct.pack("<QQ", 0, 0))
+
+    @classmethod
+    def message(cls, channel_id, log_time, payload):
+        return cls.record(0x05, struct.pack("<HIQQ", channel_id, 0, log_time,
+                                            log_time) + payload)
+
+    @classmethod
+    def chunk(cls, *records):
+        """Return an uncompressed chunk record holding the given records."""
+        body = b"".join(records)
+        return cls.record(0x06, struct.pack("<QQQI", 0, 0, len(body), 0)
+                          + cls.text("") + struct.pack("<Q", len(body))
+                          + body)
+
+    @classmethod
+    def statistics(cls, start, end):
+        return cls.record(0x0B, struct.pack("<QHIIII", 0, 0, 0, 0, 0, 0)
+                          + struct.pack("<QQ", start, end)
+                          + cls.prefixed(b""))
+
+    @classmethod
+    def preamble(cls):
+        """Return the magic and the header record.
+
+        They precede the data section, so their length is the file offset
+        of the first data record.
+        """
+        return cls.MAGIC + cls.record(0x01, cls.text("")
+                                      + cls.text("solvcon test"))
+
+    @classmethod
+    def assemble(cls, records, trailing=b"", data=b""):
+        """Return the smallest file the reader accepts, with that summary.
+
+        The data section holds only the records the data argument carries.
+        Most of these tests read the footer and the summary and nothing
+        else.
+        """
+        head = cls.preamble() + data + cls.record(0x0F, struct.pack("<I", 0))
+        summary = b"".join(records) + trailing
+        footer = cls.record(0x02, struct.pack("<QQI", len(head), 0, 0))
+        return head + summary + footer + cls.MAGIC
 
 
 @unittest.skipUnless(sc.mcap.HAS_MCAP, "built without BUILD_MCAP")
@@ -87,6 +136,24 @@ class McapReaderTB(unittest.TestCase):
 
     def path(self, name):
         return os.path.join(self.DATADIR, "%s.mcap" % name)
+
+    def expected_messages(self, topic):
+        """Return the log time and payload of every message on a topic.
+
+        The generator tests/data/make_mcap_fixtures.py wrote them, and this
+        method repeats the arithmetic it used.
+        """
+        out = []
+        for index in range(MESSAGE_COUNT):
+            log_time = START_TIME + index * PERIOD
+            if STATUS == topic:
+                out.append((log_time, CDR_HEADER
+                            + struct.pack("<dB", 1.5 * index, index % 2)))
+            elif 0 == index % IMU_PERIOD:
+                out.append((log_time, CDR_HEADER
+                            + struct.pack("<ddd", index, -index, 9.81)))
+
+        return out
 
 
 class McapSummaryTC(McapReaderTB):
@@ -168,7 +235,7 @@ class McapSummaryTC(McapReaderTB):
                         sc.mcap.Reader(path)
 
 
-class McapSyntheticTC(McapReaderTB):
+class McapSyntheticTC(McapReaderTB, McapBytes):
     """Summaries the fixture writer never produces, assembled byte by byte."""
 
     def setUp(self):
@@ -178,26 +245,26 @@ class McapSyntheticTC(McapReaderTB):
     def build(self, *records, **kw):
         path = os.path.join(self.tmp.name, "synthetic.mcap")
         with open(path, "wb") as stream:
-            stream.write(_assemble(records, **kw))
+            stream.write(self.assemble(records, **kw))
 
         return path
 
     def test_time_range_from_chunk_indexes(self):
         reader = sc.mcap.Reader(self.build(
-            _schema(1, "S"), _channel(1, 1, "/t"),
-            _chunk_index(300, 400), _chunk_index(100, 200)))
+            self.schema(1, "S"), self.channel(1, 1, "/t"),
+            self.chunk_index(300, 400), self.chunk_index(100, 200)))
         self.assertTrue(reader.has_time_range())
         self.assertEqual(reader.time_range(), (100, 400))
 
     def test_empty_chunk_keeps_the_start_time(self):
         reader = sc.mcap.Reader(self.build(
-            _schema(1, "S"), _channel(1, 1, "/t"),
-            _chunk_index(0, 0), _chunk_index(100, 200)))
+            self.schema(1, "S"), self.channel(1, 1, "/t"),
+            self.chunk_index(0, 0), self.chunk_index(100, 200)))
         self.assertEqual(reader.time_range(), (100, 200))
 
     def test_summary_stating_no_time(self):
-        reader = sc.mcap.Reader(self.build(_schema(1, "S"),
-                                           _channel(1, 1, "/t")))
+        reader = sc.mcap.Reader(self.build(self.schema(1, "S"),
+                                           self.channel(1, 1, "/t")))
         self.assertFalse(reader.has_time_range())
         self.assertEqual(reader.time_range(), (0, 0))
 
@@ -205,31 +272,34 @@ class McapSyntheticTC(McapReaderTB):
         # Written in descending id, so answering with the last record rather
         # than the highest id would name A.
         reader = sc.mcap.Reader(self.build(
-            _schema(1, "A"), _schema(2, "B"),
-            _channel(2, 2, "/t"), _channel(1, 1, "/t"),
-            _statistics(100, 200)))
+            self.schema(1, "A"), self.schema(2, "B"),
+            self.channel(2, 2, "/t"), self.channel(1, 1, "/t"),
+            self.statistics(100, 200)))
         self.assertEqual(reader.topics(), {"/t": "B"})
         self.assertEqual(reader.schema("/t").name, "B")
 
     def test_schema_id_zero_is_no_schema(self):
-        reader = sc.mcap.Reader(self.build(_schema(0, "ignored"),
-                                           _channel(1, 0, "/t")))
+        reader = sc.mcap.Reader(self.build(self.schema(0, "ignored"),
+                                           self.channel(1, 0, "/t")))
         self.assertEqual(reader.topics(), {"/t": ""})
         with self.assertRaisesRegex(RuntimeError, "no schema"):
             reader.schema("/t")
 
     def test_duplicate_records_must_agree(self):
-        reader = sc.mcap.Reader(self.build(_schema(1, "A"), _schema(1, "A"),
-                                           _channel(1, 1, "/t")))
+        reader = sc.mcap.Reader(self.build(
+            self.schema(1, "A"), self.schema(1, "A"),
+            self.channel(1, 1, "/t")))
         self.assertEqual(reader.topics(), {"/t": "A"})
         conflicts = (
-            ((_schema(1, "A"), _schema(1, "B")), "two schemas"),
-            ((_schema(1, "A"), _schema(1, "A", data=b"other\n")),
+            ((self.schema(1, "A"), self.schema(1, "B")), "two schemas"),
+            ((self.schema(1, "A"), self.schema(1, "A", data=b"other\n")),
              "two schemas"),
-            ((_schema(1, "A"), _channel(1, 1, "/a"), _channel(1, 1, "/b")),
+            ((self.schema(1, "A"), self.channel(1, 1, "/a"),
+              self.channel(1, 1, "/b")),
              "two channels"),
-            ((_schema(1, "A"), _channel(1, 1, "/t"),
-              _channel(1, 1, "/t", metadata=_text("k") + _text("v"))),
+            ((self.schema(1, "A"), self.channel(1, 1, "/t"),
+              self.channel(1, 1, "/t",
+                           metadata=self.text("k") + self.text("v"))),
              "two channels"),
         )
         for records, message in conflicts:
@@ -239,14 +309,104 @@ class McapSyntheticTC(McapReaderTB):
 
     def test_record_missing_a_mandatory_field(self):
         # A channel record that stops before its metadata map.
-        short = _record(0x04, struct.pack("<HH", 1, 1) + _text("/t")
-                        + _text("cdr"))
+        short = self.record(0x04, struct.pack("<HH", 1, 1)
+                            + self.text("/t") + self.text("cdr"))
         with self.assertRaisesRegex(RuntimeError, "truncated"):
-            sc.mcap.Reader(self.build(_schema(1, "S"), short))
+            sc.mcap.Reader(self.build(self.schema(1, "S"), short))
+
+    def test_an_index_without_channel_ids_cannot_prune(self):
+        """An empty channel list says nothing, so the chunk must be read.
+
+        The specification gives the empty map of message index offsets the
+        meaning "no message indexing is available", and the reader derives
+        the channel ids from that map.  Reading the emptiness as "holds no
+        wanted channel" would drop every message of a conforming file.
+        """
+        chunk = self.chunk(self.message(1, 10, b"payload"))
+        path = self.build(
+            self.schema(1, "S"), self.channel(1, 1, "/t"),
+            self.chunk_index(10, 10, channel_ids=(),
+                             offset=len(self.preamble()),
+                             length=len(chunk)),
+            data=chunk)
+        reader = sc.mcap.Reader(path)
+        self.assertEqual(reader.messages("/t").selected_chunk_count(), 1)
+        self.assertEqual(list(reader.messages("/t")), [(10, b"payload")])
+
+    def test_a_message_beside_a_chunk(self):
+        """A chunk index names the chunks and must not hide the rest.
+
+        The walk that picks up the lone message must also not yield the
+        chunk a second time.
+        """
+        chunk = self.chunk(self.message(1, 10, b"in"))
+        path = self.build(
+            self.schema(1, "S"), self.channel(1, 1, "/t"),
+            self.chunk_index(10, 10, offset=len(self.preamble()),
+                             length=len(chunk)),
+            data=chunk + self.message(1, 20, b"out"))
+        reader = sc.mcap.Reader(path)
+        self.assertEqual(reader.messages("/t").selected_chunk_count(), 1)
+        self.assertEqual(list(reader.messages("/t")),
+                         [(10, b"in"), (20, b"out")])
 
     def test_summary_ending_inside_a_record_header(self):
         with self.assertRaisesRegex(RuntimeError, "ends inside a record"):
-            sc.mcap.Reader(self.build(_schema(1, "S"), trailing=b"\x03\x00"))
+            sc.mcap.Reader(self.build(self.schema(1, "S"),
+                                      trailing=b"\x03\x00"))
+
+
+class McapMessageTC(McapReaderTB):
+    def test_messages(self):
+        for name, topic in itertools.product(FIXTURES, TOPICS):
+            with self.subTest(name=name, topic=topic):
+                reader = sc.mcap.Reader(self.path(name))
+                self.assertEqual(list(reader.messages(topic)),
+                                 self.expected_messages(topic))
+
+    def test_interleaved_iterators_do_not_share_a_cursor(self):
+        """Two iterators on one topic each walk it from the start."""
+        expected = self.expected_messages(STATUS)
+        reader = sc.mcap.Reader(self.path("vehicle_zstd"))
+        first = reader.messages(STATUS)
+        second = reader.messages(STATUS)
+        for index in range(INTERLEAVED_READS):
+            first_message = next(first)
+            second_message = next(second)
+            self.assertEqual(first_message, expected[index])
+            self.assertEqual(second_message, expected[index])
+
+    def test_reading_one_topic_leaves_another_alone(self):
+        """A read on one topic must not advance another topic's iterator."""
+        status_expected = self.expected_messages(STATUS)
+        imu_expected = self.expected_messages(IMU)
+        reader = sc.mcap.Reader(self.path("vehicle_zstd"))
+        status = reader.messages(STATUS)
+        imu = reader.messages(IMU)
+        for index in range(INTERLEAVED_READS):
+            status_message = next(status)
+            imu_message = next(imu)
+            self.assertEqual(status_message, status_expected[index])
+            self.assertEqual(imu_message, imu_expected[index])
+
+    def test_sparse_topic_prunes_chunks(self):
+        for name in CHUNKED:
+            with self.subTest(name=name):
+                reader = sc.mcap.Reader(self.path(name))
+                self.assertEqual(
+                    reader.messages(STATUS).selected_chunk_count(),
+                    CHUNK_COUNT)
+                self.assertEqual(reader.messages(IMU).selected_chunk_count(),
+                                 IMU_CHUNK_COUNT)
+
+    def test_unchunked_file_has_no_chunk_to_prune(self):
+        reader = sc.mcap.Reader(self.path(UNCHUNKED))
+        self.assertEqual(reader.messages(IMU).selected_chunk_count(), 0)
+
+    def test_messages_of_unknown_topic(self):
+        reader = sc.mcap.Reader(self.path("vehicle_zstd"))
+        with self.assertRaisesRegex(RuntimeError, "no such topic"):
+            reader.messages("/vehicle/nothing")
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`Reader::messages()` returns an iterator over the log time and the undecoded payload of every message on a topic. The reader stopped at the summary until now, so a caller could learn what a recording holds but could not read any of it.

The summary's chunk indexes say which channels each chunk holds, so a query decompresses only the chunks that carry the topic: on the fixtures the imu topic reads 8 of the 19 chunks, while the status topic reads all 19. An index states its channels through the map of message index offsets, and an empty map means no message indexing is available, so an index without channel ids cannot prune its chunk.

A file carrying chunk indexes should hold every message in a chunk, but the specification only recommends it and a message record is legal in the data section, so the walk continues through the data section after the indexed chunks. That guards against a writer ignoring the recommendation, which would otherwise lose messages with no error. No writer is known to produce such a file; the Python and Go writers both fix the choice for a whole file at construction.

About two hundred of the lines in `tests/test_mcap.py` are mechanical: the record builders that hand-assemble a file move into an `McapBytes` mixin, which renames every call site but leaves the assembled bytes the same. The rest exercises the iterator against the fixtures and against hand-assembled files.

Related to #1286.
