### PR TITLE
Compile ROS 2 IDL schemas into a flat CDR decode plan

### DIFF
--- a/solvcon/mcap/__init__.py
+++ b/solvcon/mcap/__init__.py
@@ -10,10 +10,15 @@ The extension carries the subsystem only when it is configured with
 """
 
 from .. import core
+from . import _decode_plan
 
 HAS_MCAP = core.HAS_MCAP
+DecodePlan = _decode_plan.DecodePlan
+DecodePlanError = _decode_plan.DecodePlanError
 
 __all__ = [
+    "DecodePlan",
+    "DecodePlanError",
     "HAS_MCAP",
 ]
 

--- a/solvcon/mcap/_decode_plan.py
+++ b/solvcon/mcap/_decode_plan.py
@@ -1,0 +1,412 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""Compile ROS 2 IDL schemas into flat CDR decode instructions.
+
+MCAP ``ros2idl`` schemas contain the root IDL and dependency sections.
+``DecodePlan`` resolves their structs and compiles dotted field paths into
+the instruction sequence an executor runs over one message payload.  Every
+offset is relative to the start of the CDR body, which begins after the
+four-byte encapsulation header that also states the byte order.
+
+Each instruction is a tuple whose first item names it:
+
+- ``("align", n)`` advances to the next multiple of ``n`` bytes.
+- ``("skip", n)`` advances ``n`` bytes.
+- ``("skip_string", )`` reads a 4-byte length and advances past the text.
+- ``("skip_sequence", name)`` reads a 4-byte count and advances past that
+  many primitives of type ``name``.  CDR pads between the count and the
+  elements, so a nonzero count aligns to the width of ``name`` first.  An
+  empty sequence carries no padding.
+- ``("skip_sequence_body", n)`` reads a 4-byte count and runs the ``n``
+  instructions that follow it that many times.
+- ``("skip_array_body", count, n)`` runs the ``n`` instructions that follow
+  it ``count`` times.
+- ``("read", name, column)`` reads one primitive of type ``name`` into the
+  output column ``column``.
+
+A body may hold another body, so an executor walks nested containers by
+recursion.  Selection is numeric and bool scalars only, and an enum reads as
+its 32-bit ordinal; a container, a string, or a nested struct in the output
+position is rejected, as is an indexed path.
+"""
+
+import dataclasses
+import re
+
+
+class DecodePlanError(ValueError):
+    """A schema or requested field cannot form a supported decode plan."""
+
+
+@dataclasses.dataclass(frozen=True)
+class _Type:
+    kind: str
+    name: str = ""
+    size: int = 0
+    count: int = 0
+    element: object = None
+
+
+@dataclasses.dataclass(frozen=True)
+class _Field:
+    name: str
+    type: _Type
+
+
+_PRIMITIVES = {
+    "boolean": ("bool", 1),
+    "octet": ("uint8", 1),
+    "char": ("uint8", 1),
+    "float": ("float32", 4),
+    "double": ("float64", 8),
+    "int8": ("int8", 1),
+    "uint8": ("uint8", 1),
+    "int16": ("int16", 2),
+    "uint16": ("uint16", 2),
+    "int32": ("int32", 4),
+    "uint32": ("uint32", 4),
+    "int64": ("int64", 8),
+    "uint64": ("uint64", 8),
+}
+
+# Annotations that move bytes on the wire.  Stripping one would compile a
+# plan against a layout the message does not use, so reject it instead.
+_LAYOUT_ANNOTATIONS = frozenset((
+    "optional", "bit_bound", "extensibility", "mutable", "appendable",
+    "external", "id", "hashid", "try_construct",
+))
+
+_SECTION_RE = re.compile(r"(?m)^={16,}\s*\nIDL:\s*([^\n]+?)\s*\n")
+_STRUCT_RE = re.compile(
+    r"\bstruct\s+([A-Za-z]\w*)\s*\{(.*?)\}\s*;", re.DOTALL)
+_ENUM_RE = re.compile(
+    r"\benum\s+([A-Za-z]\w*)\s*\{.*?\}\s*;", re.DOTALL)
+_MEMBER_RE = re.compile(
+    r"(.+?)\s+([a-zA-Z]\w*)(?:\s*\[\s*([^]]+)\s*\])?")
+_PATH_RE = re.compile(r"[a-zA-Z]\w*(?:\.[a-zA-Z]\w*)*")
+
+
+def _schema_text(schema):
+    root = getattr(schema, "name", "")
+    if hasattr(schema, "data"):
+        encoding = getattr(schema, "encoding", None)
+        if encoding != "ros2idl":
+            raise DecodePlanError(
+                "schema encoding must be 'ros2idl', not %r" % encoding)
+        schema = schema.data
+    if isinstance(schema, bytes):
+        try:
+            schema = schema.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise DecodePlanError("schema is not valid UTF-8") from exc
+    if not isinstance(schema, str):
+        raise TypeError("schema must be text, bytes, or an MCAP schema")
+    return root.replace("/", "::"), schema
+
+
+def _skip_literal(text, index):
+    quote = text[index]
+    index += 1
+    while index < len(text):
+        if text[index] == "\\":
+            index += 2
+            continue
+        if text[index] == quote:
+            return index + 1
+        index += 1
+    return index
+
+
+def _skip_annotation(text, index):
+    start = index + 1
+    index = start
+    while index < len(text) and (text[index].isalnum()
+                                 or text[index] == "_"):
+        index += 1
+    name_end = index
+    if text[start:index] in _LAYOUT_ANNOTATIONS:
+        raise DecodePlanError(
+            "annotation @%s changes the CDR layout" % text[start:index])
+    while index < len(text) and text[index].isspace():
+        index += 1
+    if index >= len(text) or text[index] != "(":
+        return name_end
+    depth = 0
+    while index < len(text):
+        char = text[index]
+        if char in "\"'":
+            index = _skip_literal(text, index)
+            continue
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if 0 == depth:
+                return index + 1
+        index += 1
+    return index
+
+
+def _clean_idl(text):
+    # One pass, so that a "//" inside an annotation string does not end
+    # the annotation early.
+    text = re.sub(r"(?m)^\s*#.*$", " ", text)
+    out, index = [], 0
+    while index < len(text):
+        char = text[index]
+        if char in "\"'":
+            index = _skip_literal(text, index)
+        elif text.startswith("//", index):
+            end = text.find("\n", index)
+            index = len(text) if end < 0 else end
+        elif text.startswith("/*", index):
+            end = text.find("*/", index + 2)
+            index = len(text) if end < 0 else end + 2
+        elif char == "@":
+            index = _skip_annotation(text, index)
+        else:
+            out.append(char)
+            index += 1
+            continue
+        out.append(" ")
+    return "".join(out)
+
+
+def _sections(text, root):
+    matches = list(_SECTION_RE.finditer(text))
+    if not matches:
+        if not root:
+            raise DecodePlanError("IDL text has no root type name")
+        return [(root, text)]
+    sections = []
+    for index, match in enumerate(matches):
+        end = (matches[index + 1].start()
+               if index + 1 < len(matches) else len(text))
+        sections.append((match.group(1).replace("/", "::"),
+                         text[match.end():end]))
+    return sections
+
+
+def _split_arguments(text):
+    arguments, start, depth = [], 0, 0
+    for index, char in enumerate(text):
+        if char == "<":
+            depth += 1
+        elif char == ">":
+            depth -= 1
+        elif char == "," and depth == 0:
+            arguments.append(text[start:index])
+            start = index + 1
+    arguments.append(text[start:])
+    return [argument.strip() for argument in arguments]
+
+
+def _type_of(text, namespace, enums):
+    text = re.sub(r"\s*::\s*", "::", text.strip())
+    text = re.sub(r"\s*([<>,])\s*", r"\1", text)
+    primitive = _PRIMITIVES.get(text)
+    if primitive:
+        return _Type("primitive", *primitive)
+    if re.fullmatch(r"string(?:<[^>]+>)?", text):
+        return _Type("string")
+    if text.startswith("sequence<") and text.endswith(">"):
+        arguments = _split_arguments(text[9:-1])
+        if len(arguments) not in (1, 2):
+            raise DecodePlanError("invalid sequence type %r" % text)
+        return _Type("sequence",
+                     element=_type_of(arguments[0], namespace, enums))
+    qualified = text if "::" in text else namespace + "::" + text
+    if qualified in enums:
+        return _Type("primitive", "uint32", 4)
+    if not re.fullmatch(r"[A-Za-z]\w*(?:::[A-Za-z]\w*)*", qualified):
+        raise DecodePlanError("unsupported IDL type %r" % text)
+    return _Type("struct", qualified)
+
+
+def _parse_schema(schema):
+    root, text = _schema_text(schema)
+    parts = _sections(text, root)
+    if not root:
+        root = parts[0][0]
+    raw_structs, enums = {}, set()
+    for section_name, source in parts:
+        namespace = section_name.rsplit("::", 1)[0]
+        clean = _clean_idl(source)
+        enums.update(namespace + "::" + match.group(1)
+                     for match in _ENUM_RE.finditer(clean))
+        for match in _STRUCT_RE.finditer(clean):
+            raw_structs[namespace + "::" + match.group(1)] = (
+                namespace, match.group(2))
+
+    structs = {}
+    for name, (namespace, body) in raw_structs.items():
+        fields = []
+        for statement in body.split(";"):
+            statement = " ".join(statement.split())
+            if not statement or statement.startswith("const "):
+                continue
+            match = _MEMBER_RE.fullmatch(statement)
+            if not match:
+                raise DecodePlanError(
+                    "unsupported member declaration %r in %s" %
+                    (statement, name))
+            type_text, field_name, count = match.groups()
+            field_type = _type_of(type_text, namespace, enums)
+            if count is not None:
+                if not count.strip().isdigit():
+                    raise DecodePlanError(
+                        "array field %r has a non-integer bound" % field_name)
+                field_type = _Type("array", count=int(count),
+                                   element=field_type)
+            fields.append(_Field(field_name, field_type))
+        structs[name] = tuple(fields)
+    if root not in structs:
+        raise DecodePlanError("schema does not define root struct %r" % root)
+    return root, structs
+
+
+def _requested_fields(fields):
+    if isinstance(fields, str):
+        raise TypeError("fields must be a sequence of field paths")
+    try:
+        fields = tuple(fields)
+    except TypeError as exc:
+        raise TypeError("fields must be a sequence of field paths") from exc
+    if not fields:
+        raise DecodePlanError("at least one field must be requested")
+    for field in fields:
+        if not isinstance(field, str):
+            raise TypeError("each requested field path must be a string")
+        if not _PATH_RE.fullmatch(field):
+            raise DecodePlanError(
+                "indexed or invalid field path %r is not supported" % field)
+    if len(set(fields)) != len(fields):
+        raise DecodePlanError("requested field paths must be unique")
+    return fields
+
+
+def _align(instructions, boundary):
+    if boundary > 1:
+        instructions.append(("align", boundary))
+
+
+class _Compiler:
+
+    def __init__(self, structs, requested):
+        self.structs = structs
+        self.instructions = []
+        self.types = [None] * len(requested)
+        self.selected = [(tuple(path.split(".")), column, path)
+                         for column, path in enumerate(requested)]
+        self.active = set()
+
+    def skip_container(self, opcode, element, count=None):
+        """Emit a loop over the walk program of one container element."""
+        head = len(self.instructions)
+        self.instructions.append(None)
+        self.skip(element)
+        body = len(self.instructions) - head - 1
+        self.instructions[head] = ((opcode, body) if count is None
+                                   else (opcode, count, body))
+
+    def skip(self, field_type):
+        element = field_type.element
+        if field_type.kind == "primitive":
+            _align(self.instructions, field_type.size)
+            self.instructions.append(("skip", field_type.size))
+        elif field_type.kind == "string":
+            _align(self.instructions, 4)
+            self.instructions.append(("skip_string",))
+        elif field_type.kind == "struct":
+            self.compile_struct(field_type.name, (), True)
+        elif field_type.kind == "array":
+            if element.kind == "primitive":
+                _align(self.instructions, element.size)
+                self.instructions.append(("skip",
+                                          element.size * field_type.count))
+            else:
+                self.skip_container("skip_array_body", element,
+                                    field_type.count)
+        else:
+            _align(self.instructions, 4)
+            if element.kind == "primitive":
+                self.instructions.append(("skip_sequence", element.name))
+            else:
+                self.skip_container("skip_sequence_body", element)
+
+    def compile_struct(self, name, selected, need_end):
+        fields = self.structs.get(name)
+        if fields is None:
+            raise DecodePlanError("schema lacks nested struct %r" % name)
+        if name in self.active:
+            raise DecodePlanError("struct %r contains itself" % name)
+        self.active.add(name)
+        groups = {}
+        for parts, column, path in selected:
+            groups.setdefault(parts[0], []).append((parts[1:], column, path))
+        field_names = {field.name for field in fields}
+        for part, wanted in groups.items():
+            if part not in field_names:
+                raise DecodePlanError(
+                    "schema has no field path %r" % wanted[0][2])
+        last = max((index for index, field in enumerate(fields)
+                    if field.name in groups), default=-1)
+        limit = len(fields) if need_end else last + 1
+        for index, field in enumerate(fields[:limit]):
+            wanted = groups.get(field.name, ())
+            if not wanted:
+                self.skip(field.type)
+                continue
+            if (field.type.kind == "primitive"
+                    and all(not tail for tail, _c, _p in wanted)):
+                _align(self.instructions, field.type.size)
+                for _tail, column, _path in wanted:
+                    self.instructions.append(
+                        ("read", field.type.name, column))
+                    self.types[column] = field.type.name
+            elif (field.type.kind == "struct"
+                  and all(tail for tail, _c, _p in wanted)):
+                self.compile_struct(field.type.name, wanted,
+                                    need_end or index + 1 < limit)
+            else:
+                raise DecodePlanError(
+                    "field path %r does not select a numeric or bool scalar" %
+                    wanted[0][2])
+        self.active.discard(name)
+
+    def compile(self, root):
+        self.compile_struct(root, self.selected, False)
+        return tuple(self.types), tuple(self.instructions)
+
+
+class DecodePlan:
+    """A flat CDR walk program for selected scalar IDL field paths."""
+
+    __slots__ = ("_fields", "_types", "_instructions")
+
+    def __init__(self, schema, fields):
+        requested = _requested_fields(fields)
+        root, structs = _parse_schema(schema)
+        types, instructions = _Compiler(structs, requested).compile(root)
+        self._fields = requested
+        self._types = types
+        self._instructions = instructions
+
+    @property
+    def fields(self):
+        """Requested field paths in output-column order."""
+        return self._fields
+
+    @property
+    def types(self):
+        """Canonical primitive type of each output column."""
+        return self._types
+
+    @property
+    def instructions(self):
+        """Immutable flat instruction sequence in schema walk order."""
+        return self._instructions
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_mcap_decode_plan.py
+++ b/tests/test_mcap_decode_plan.py
@@ -1,0 +1,277 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+import types
+import unittest
+
+import solvcon as sc
+
+
+class DecodePlanTC(unittest.TestCase):
+
+    SCHEMA_TEXT = """\
+================================================================================
+IDL: vhclsim_msgs/msg/Status
+#include "vhclsim_msgs/msg/State.idl"
+module vhclsim_msgs { module msg {
+  enum Mode { OFF, ON };
+  struct Status {
+    @default (value=0.0) double dt;
+    State current;
+    sequence<float, 8> samples;
+    string<64> label;
+    Mode mode;
+    int32 sim_end;
+  };
+}; };
+================================================================================
+IDL: vhclsim_msgs/msg/State
+module vhclsim_msgs { module msg {
+  struct State {
+    double x;
+    double y;
+    boolean active;
+  };
+}; };
+"""
+
+    def schema(self, encoding="ros2idl"):
+        return types.SimpleNamespace(
+            name="vhclsim_msgs/msg/Status",
+            encoding=encoding,
+            data=self.SCHEMA_TEXT.encode(),
+        )
+
+    def test_nested_struct_fields(self):
+        plan = sc.mcap.DecodePlan(
+            self.schema(), fields=["dt", "current.x", "current.active"])
+        self.assertEqual(plan.fields,
+                         ("dt", "current.x", "current.active"))
+        self.assertEqual(plan.types, ("float64", "float64", "bool"))
+        self.assertEqual(
+            plan.instructions,
+            (
+                ("align", 8), ("read", "float64", 0),
+                ("align", 8), ("read", "float64", 1),
+                ("align", 8), ("skip", 8),
+                ("read", "bool", 2),
+            ),
+        )
+
+    def test_requested_order_is_column_order(self):
+        plan = sc.mcap.DecodePlan(
+            self.schema(), fields=["current.active", "current.x"])
+        self.assertEqual(plan.types, ("bool", "float64"))
+        self.assertEqual(
+            plan.instructions,
+            (
+                ("align", 8), ("skip", 8),
+                ("align", 8), ("read", "float64", 1),
+                ("align", 8), ("skip", 8),
+                ("read", "bool", 0),
+            ),
+        )
+
+    def test_walks_nested_struct_sequence_string_and_enum(self):
+        plan = sc.mcap.DecodePlan(self.schema(), fields=["sim_end"])
+        self.assertEqual(
+            plan.instructions,
+            (
+                ("align", 8), ("skip", 8),
+                ("align", 8), ("skip", 8),
+                ("align", 8), ("skip", 8),
+                ("skip", 1),
+                ("align", 4), ("skip_sequence", "float32"),
+                ("align", 4), ("skip_string",),
+                ("align", 4), ("skip", 4),
+                ("align", 4), ("read", "int32", 0),
+            ),
+        )
+
+    def test_fixed_primitive_array(self):
+        text = """\
+module p { module msg { struct S {
+  double matrix[4];
+  boolean valid;
+}; }; };
+"""
+        schema = types.SimpleNamespace(
+            name="p/msg/S", encoding="ros2idl", data=text.encode())
+        plan = sc.mcap.DecodePlan(schema, fields=["valid"])
+        self.assertEqual(
+            plan.instructions,
+            (("align", 8), ("skip", 32), ("read", "bool", 0)),
+        )
+
+    def test_enum_reads_as_its_ordinal(self):
+        plan = sc.mcap.DecodePlan(self.schema(), fields=["mode"])
+        self.assertEqual(plan.types, ("uint32",))
+        self.assertEqual(plan.instructions[-1], ("read", "uint32", 0))
+
+    CONTAINER_TEXT = """\
+module p { module msg {
+  struct Item {
+    double weight;
+    string label;
+  };
+  struct Grid {
+    sequence<Item> items;
+    Item corners[4];
+    sequence<string> tags;
+    sequence<double> samples;
+    int32 tail;
+  };
+}; };
+"""
+
+    def container_schema(self):
+        return types.SimpleNamespace(
+            name="p/msg/Grid", encoding="ros2idl",
+            data=self.CONTAINER_TEXT.encode())
+
+    def test_walks_every_container_to_reach_a_later_field(self):
+        plan = sc.mcap.DecodePlan(self.container_schema(), fields=["tail"])
+        self.assertEqual(
+            plan.instructions,
+            (
+                ("align", 4), ("skip_sequence_body", 4),
+                ("align", 8), ("skip", 8),
+                ("align", 4), ("skip_string",),
+                ("skip_array_body", 4, 4),
+                ("align", 8), ("skip", 8),
+                ("align", 4), ("skip_string",),
+                ("align", 4), ("skip_sequence_body", 2),
+                ("align", 4), ("skip_string",),
+                ("align", 4), ("skip_sequence", "float64"),
+                ("align", 4), ("read", "int32", 0),
+            ),
+        )
+
+    def test_rejects_a_struct_that_contains_itself(self):
+        text = """\
+module p { module msg { struct Node {
+  sequence<Node> children;
+  int32 value;
+}; }; };
+"""
+        schema = types.SimpleNamespace(
+            name="p/msg/Node", encoding="ros2idl", data=text.encode())
+        with self.assertRaisesRegex(sc.mcap.DecodePlanError,
+                                    "contains itself"):
+            sc.mcap.DecodePlan(schema, fields=["value"])
+
+    def test_accepts_an_uppercase_field_name(self):
+        text = """\
+module p { module msg { struct S {
+  int32 N;
+  double N_min;
+}; }; };
+"""
+        schema = types.SimpleNamespace(
+            name="p/msg/S", encoding="ros2idl", data=text.encode())
+        plan = sc.mcap.DecodePlan(schema, fields=["N", "N_min"])
+        self.assertEqual(plan.types, ("int32", "float64"))
+
+    def test_rejects_non_scalar_output(self):
+        cases = (
+            ("label", "numeric or bool scalar"),
+            ("samples", "numeric or bool scalar"),
+            ("current", "numeric or bool scalar"),
+            ("current[0].x", "indexed or invalid"),
+        )
+        for field, message in cases:
+            with self.subTest(field=field):
+                with self.assertRaisesRegex(
+                        sc.mcap.DecodePlanError, message):
+                    sc.mcap.DecodePlan(self.schema(), fields=[field])
+
+    def test_rejects_missing_paths_and_dependencies(self):
+        with self.assertRaisesRegex(sc.mcap.DecodePlanError, "no field path"):
+            sc.mcap.DecodePlan(self.schema(), fields=["current.z"])
+        incomplete = self.SCHEMA_TEXT.rsplit("=" * 80, 1)[0]
+        schema = types.SimpleNamespace(
+            name="vhclsim_msgs/msg/Status",
+            encoding="ros2idl",
+            data=incomplete.encode(),
+        )
+        with self.assertRaisesRegex(sc.mcap.DecodePlanError,
+                                    "lacks nested struct"):
+            sc.mcap.DecodePlan(schema, fields=["current.x"])
+
+    # rosidl writes every .msg comment as a @verbatim annotation, and the
+    # stock builtin_interfaces/msg/Time carries a URL in one.
+    STAMPED_TEXT = '''\
+================================================================================
+IDL: p/msg/Stamped
+module p { module msg {
+  struct Stamped {
+    builtin_interfaces::msg::Time stamp;
+    double value;
+  };
+}; };
+================================================================================
+IDL: builtin_interfaces/msg/Time
+module builtin_interfaces { module msg {
+  @verbatim (language="comment", text=
+    " This message communicates ROS Time defined here:" "\\n"
+    " https://design.ros2.org/articles/clock_and_time.html")
+  struct Time {
+    int32 sec;
+    uint32 nanosec;
+  };
+}; };
+'''
+
+    def test_annotation_url_keeps_the_dependency_section(self):
+        schema = types.SimpleNamespace(
+            name="p/msg/Stamped", encoding="ros2idl",
+            data=self.STAMPED_TEXT.encode())
+        plan = sc.mcap.DecodePlan(
+            schema, fields=["stamp.nanosec", "value"])
+        self.assertEqual(plan.types, ("uint32", "float64"))
+        self.assertEqual(
+            plan.instructions,
+            (
+                ("align", 4), ("skip", 4),
+                ("align", 4), ("read", "uint32", 0),
+                ("align", 8), ("read", "float64", 1),
+            ),
+        )
+
+    def test_rejects_an_annotation_that_moves_bytes(self):
+        text = """\
+module p { module msg { struct S {
+  @optional int32 maybe;
+  double value;
+}; }; };
+"""
+        schema = types.SimpleNamespace(
+            name="p/msg/S", encoding="ros2idl", data=text.encode())
+        with self.assertRaisesRegex(sc.mcap.DecodePlanError,
+                                    "@optional changes the CDR layout"):
+            sc.mcap.DecodePlan(schema, fields=["value"])
+
+    def test_keeps_an_unknown_metadata_annotation(self):
+        text = """\
+module p { module msg { struct S {
+  @defalut (value=0) @unit (value="m") double span;
+  int32 tail;
+}; }; };
+"""
+        schema = types.SimpleNamespace(
+            name="p/msg/S", encoding="ros2idl", data=text.encode())
+        plan = sc.mcap.DecodePlan(schema, fields=["tail"])
+        self.assertEqual(
+            plan.instructions,
+            (("align", 8), ("skip", 8), ("align", 4), ("read", "int32", 0)))
+
+    def test_rejects_other_mcap_schema_encodings(self):
+        for encoding in ("ros2msg", "apex_json"):
+            with self.subTest(encoding=encoding):
+                with self.assertRaisesRegex(
+                        sc.mcap.DecodePlanError, "ros2idl"):
+                    sc.mcap.DecodePlan(
+                        self.schema(encoding), fields=["dt"])
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`DecodePlan` compiles the `ros2idl` schema text of an MCAP recording, plus a list of dotted field paths, into a flat CDR walk program. This is the second step of #1286: the plan is the contract that the C++ executor of the next PR runs over each message payload, so no C++ lands here. The module docstring states the instruction set.

A container is walked through a loop instruction that carries the length of its body, and a body may hold another body, so a sequence or an array of structs or strings does not block the fields behind it. Selection stays numeric and bool scalars, and an enum reads as its 32-bit ordinal.

Two CDR rules are easy to get wrong, so the plan settles them rather than leaving them to the executor. `skip_sequence` aligns to the element width on a nonzero count, because CDR pads between a sequence count and its elements. An annotation that moves bytes, such as `@optional`, is rejected rather than stripped; metadata annotations, including a misspelled one, still pass.

One scanner strips comments, annotations, and string literals in a single pass. `rosidl` writes each `.msg` comment as a `@verbatim (text="...")` annotation, and the stock `builtin_interfaces/msg/Time` carries a URL in one, so removing `//` comments first would end that annotation at the URL and discard the rest of the schema section.

`tests/test_mcap_decode_plan.py` covers each instruction form and each rejection path.

Related to #1286
