### PR TITLE
Add from_columns, asof, and window to the track DataFrame

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -3888,6 +3888,14 @@ public:
     {
     }
 
+    template <typename T>
+    explicit SimpleArrayPlex(SimpleArray<T> && array)
+        : m_has_instance_ownership(true)
+        , m_instance_ptr(static_cast<void *>(new SimpleArray<T>(std::move(array))))
+        , m_data_type(DataType::from<T>())
+    {
+    }
+
     SimpleArrayPlex(SimpleArrayPlex const & other);
     SimpleArrayPlex(SimpleArrayPlex && other) noexcept;
     SimpleArrayPlex & operator=(SimpleArrayPlex const & other);

--- a/cpp/solvcon/buffer/pymod/SimpleArrayCaster.hpp
+++ b/cpp/solvcon/buffer/pymod/SimpleArrayCaster.hpp
@@ -43,7 +43,7 @@ namespace detail
             }                                                                                                                                                 \
                                                                                                                                                               \
             /* Get the SimpleArrayPlex object from the source handle */                                                                                       \
-            solvcon::SimpleArrayPlex arrayplex = src.cast<solvcon::SimpleArrayPlex>(); /* NOLINT(misc-const-correctness) */                                   \
+            solvcon::SimpleArrayPlex const & arrayplex = src.cast<solvcon::SimpleArrayPlex const &>();                                                        \
                                                                                                                                                               \
             /* Check if the data type is matched */                                                                                                           \
             if (arrayplex.data_type() != solvcon::DataType::DATATYPE)                                                                                         \

--- a/cpp/solvcon/buffer/pymod/array_common.hpp
+++ b/cpp/solvcon/buffer/pymod/array_common.hpp
@@ -480,6 +480,124 @@ pybind11::object ArrayPropertyHelper<T>::shift_slice_bound(
     return pybind11::reinterpret_steal<pybind11::object>(index) + pybind11::int_(offset);
 }
 
+/**
+ * Build an array viewing the memory of a numpy array.
+ *
+ * The result shares the buffer with @p arr_in and keeps it alive, so it
+ * carries the per-axis strides in elements and the offset a negative stride
+ * puts the first element at.
+ *
+ * @param[in] arr_in Source array, whose dtype must be @p T.
+ * @return An array over the same memory.
+ */
+template <typename T>
+SimpleArray<T> make_array_from_numpy(pybind11::array & arr_in)
+{
+    namespace py = pybind11;
+
+    using value_type = typename SimpleArray<T>::value_type;
+    using array_order_type = typename SimpleArray<T>::ArrayOrder;
+
+    if (!dtype_is_type<T>(arr_in))
+    {
+        throw std::runtime_error("dtype mismatch");
+    }
+
+    solvcon::detail::shape_type shape;
+    solvcon::detail::shape_type stride;
+    constexpr auto itemsize = static_cast<ssize_t>(sizeof(value_type));
+    ssize_t byte_span_begin = 0;
+    ssize_t byte_span_end = 0;
+    bool has_element = true;
+    for (ssize_t i = 0; i < arr_in.ndim(); ++i)
+    {
+        shape.push_back(arr_in.shape(i));
+        ssize_t const byte_stride = arr_in.strides(i);
+        if (byte_stride % itemsize != 0)
+        {
+            throw std::runtime_error(
+                std::format("NumPy byte stride {} in dimension {} is not divisible by item size {}",
+                            byte_stride,
+                            i,
+                            itemsize));
+        }
+        stride.push_back(byte_stride / itemsize);
+        if (shape[i] == 0)
+        {
+            has_element = false;
+            continue;
+        }
+        ssize_t const axis_byte_offset = (shape[i] - 1) * byte_stride;
+        if (axis_byte_offset < 0)
+        {
+            byte_span_begin += axis_byte_offset;
+        }
+        else
+        {
+            byte_span_end += axis_byte_offset;
+        }
+    }
+    if (!has_element)
+    {
+        byte_span_begin = 0;
+        byte_span_end = 0;
+    }
+
+    array_order_type array_order = array_order_type::Unspecified;
+    if ((arr_in.flags() & py::array::c_style) == py::array::c_style)
+    {
+        array_order |= array_order_type::CType;
+    }
+    if ((arr_in.flags() & py::array::f_style) == py::array::f_style)
+    {
+        array_order |= array_order_type::FType;
+    }
+
+    py::array owner = arr_in;
+    /*
+     * In the following document, it introduces the base object in ndarray.
+     * https://numpy.org/doc/2.2/reference/generated/numpy.ndarray.base.html
+     * The `array.base` is base object if memory is from some other object.
+     * If object owns its memory, base is None.
+     */
+    while (true)
+    {
+        const py::object b = owner.attr("base");
+        if (b.is_none() || !py::isinstance<py::array>(b))
+        {
+            break;
+        }
+        auto next = b.cast<py::array>();
+        /*
+         * Prevent the infinite loop.
+         * For example, the following code will create a loop:
+         * nparr = np.arange(24, dtype='float64').reshape((2, 3, 4))
+         * nparr = nparr[::2, ::2, ::2]
+         */
+        if (next.ptr() == owner.ptr())
+        {
+            break;
+        }
+        owner = next;
+    }
+
+    char * view_ptr = static_cast<char *>(arr_in.mutable_data());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    if (reinterpret_cast<std::uintptr_t>(view_ptr) % alignof(value_type) != 0)
+    {
+        throw std::runtime_error(
+            std::format("NumPy data pointer is not aligned for item alignment {}", alignof(value_type)));
+    }
+    char * storage_ptr = view_ptr + byte_span_begin;
+    const size_t storage_nbytes = has_element
+                                      ? static_cast<size_t>(byte_span_end - byte_span_begin + itemsize)
+                                      : 0;
+    const auto data_offset = static_cast<size_t>(-byte_span_begin);
+    auto remover = std::make_unique<ConcreteBufferNdarrayRemover>(owner);
+    const auto buffer = ConcreteBuffer::construct(storage_nbytes, storage_ptr, std::move(remover));
+    return SimpleArray<T>(shape, stride, buffer, data_offset, array_order);
+}
+
 } /* end namespace python */
 } /* end namespace solvcon */
 

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -56,8 +56,6 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
 
     friend root_base_type;
 
-    static wrapped_type make_array_from_numpy(pybind11::array & arr_in);
-
     WrapSimpleArray(pybind11::module & mod, char const * pyname, char const * pydoc)
         : root_base_type(mod, pyname, pydoc, pybind11::buffer_protocol())
     {
@@ -88,7 +86,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 py::arg("shape"),
                 py::arg("value"),
                 py::arg("alignment"))
-            .def(py::init(&WrapSimpleArray::make_array_from_numpy), py::arg("array"))
+            .def(py::init(&make_array_from_numpy<T>), py::arg("array"))
             .def_buffer(&property_helper::get_buffer_info)
             .def("clone",
                  [](wrapped_type const & self)
@@ -753,112 +751,6 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
         throw std::invalid_argument("SimpleArray::where(): unsupported dtype");
     }
 }; /* end class WrapSimpleArray */
-
-template <typename T>
-typename WrapSimpleArray<T>::wrapped_type
-WrapSimpleArray<T>::make_array_from_numpy(pybind11::array & arr_in)
-{
-    namespace py = pybind11;
-
-    if (!dtype_is_type<T>(arr_in))
-    {
-        throw std::runtime_error("dtype mismatch");
-    }
-
-    solvcon::detail::shape_type shape;
-    solvcon::detail::shape_type stride;
-    constexpr auto itemsize = static_cast<ssize_t>(sizeof(value_type));
-    ssize_t byte_span_begin = 0;
-    ssize_t byte_span_end = 0;
-    bool has_element = true;
-    for (ssize_t i = 0; i < arr_in.ndim(); ++i)
-    {
-        shape.push_back(arr_in.shape(i));
-        ssize_t const byte_stride = arr_in.strides(i);
-        if (byte_stride % itemsize != 0)
-        {
-            throw std::runtime_error(
-                std::format("NumPy byte stride {} in dimension {} is not divisible by item size {}",
-                            byte_stride,
-                            i,
-                            itemsize));
-        }
-        stride.push_back(byte_stride / itemsize);
-        if (shape[i] == 0)
-        {
-            has_element = false;
-            continue;
-        }
-        ssize_t const axis_byte_offset = (shape[i] - 1) * byte_stride;
-        if (axis_byte_offset < 0)
-        {
-            byte_span_begin += axis_byte_offset;
-        }
-        else
-        {
-            byte_span_end += axis_byte_offset;
-        }
-    }
-    if (!has_element)
-    {
-        byte_span_begin = 0;
-        byte_span_end = 0;
-    }
-
-    array_order_type array_order = array_order_type::Unspecified;
-    if ((arr_in.flags() & py::array::c_style) == py::array::c_style)
-    {
-        array_order |= array_order_type::CType;
-    }
-    if ((arr_in.flags() & py::array::f_style) == py::array::f_style)
-    {
-        array_order |= array_order_type::FType;
-    }
-
-    py::array owner = arr_in;
-    /*
-     * In the following document, it introduces the base object in ndarray.
-     * https://numpy.org/doc/2.2/reference/generated/numpy.ndarray.base.html
-     * The `array.base` is base object if memory is from some other object.
-     * If object owns its memory, base is None.
-     */
-    while (true)
-    {
-        const py::object b = owner.attr("base");
-        if (b.is_none() || !py::isinstance<py::array>(b))
-        {
-            break;
-        }
-        auto next = b.cast<py::array>();
-        /*
-         * Prevent the infinite loop.
-         * For example, the following code will create a loop:
-         * nparr = np.arange(24, dtype='float64').reshape((2, 3, 4))
-         * nparr = nparr[::2, ::2, ::2]
-         */
-        if (next.ptr() == owner.ptr())
-        {
-            break;
-        }
-        owner = next;
-    }
-
-    char * view_ptr = static_cast<char *>(arr_in.mutable_data());
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    if (reinterpret_cast<std::uintptr_t>(view_ptr) % alignof(value_type) != 0)
-    {
-        throw std::runtime_error(
-            std::format("NumPy data pointer is not aligned for item alignment {}", alignof(value_type)));
-    }
-    char * storage_ptr = view_ptr + byte_span_begin;
-    const size_t storage_nbytes = has_element
-                                      ? static_cast<size_t>(byte_span_end - byte_span_begin + itemsize)
-                                      : 0;
-    const auto data_offset = static_cast<size_t>(-byte_span_begin);
-    auto remover = std::make_unique<ConcreteBufferNdarrayRemover>(owner);
-    const auto buffer = ConcreteBuffer::construct(storage_nbytes, storage_ptr, std::move(remover));
-    return wrapped_type(shape, stride, buffer, data_offset, array_order);
-}
 
 template <typename T>
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleCollector

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -189,6 +189,33 @@ static pybind11::object get_typed_array(const SimpleArrayPlex & array_plex)
 #undef SC_DECL_GET_TYPED_ARRAY
 }
 
+// NOLINTNEXTLINE(misc-use-anonymous-namespace)
+static SimpleArrayPlex make_arrayplex_from_numpy(pybind11::array & arr_in)
+{
+#define SC_DECL_MAKE_ARRAYPLEX(DataTypeName, ValueType) \
+    case DataType::DataTypeName: return SimpleArrayPlex(make_array_from_numpy<ValueType>(arr_in));
+
+    switch (DataType(pybind11::str(arr_in.dtype()).cast<std::string>()))
+    {
+        SC_DECL_MAKE_ARRAYPLEX(Bool, bool)
+        SC_DECL_MAKE_ARRAYPLEX(Int8, int8_t)
+        SC_DECL_MAKE_ARRAYPLEX(Int16, int16_t)
+        SC_DECL_MAKE_ARRAYPLEX(Int32, int32_t)
+        SC_DECL_MAKE_ARRAYPLEX(Int64, int64_t)
+        SC_DECL_MAKE_ARRAYPLEX(Uint8, uint8_t)
+        SC_DECL_MAKE_ARRAYPLEX(Uint16, uint16_t)
+        SC_DECL_MAKE_ARRAYPLEX(Uint32, uint32_t)
+        SC_DECL_MAKE_ARRAYPLEX(Uint64, uint64_t)
+        SC_DECL_MAKE_ARRAYPLEX(Float32, float)
+        SC_DECL_MAKE_ARRAYPLEX(Float64, double)
+        SC_DECL_MAKE_ARRAYPLEX(Complex64, Complex<float>)
+        SC_DECL_MAKE_ARRAYPLEX(Complex128, Complex<double>)
+    default: throw std::invalid_argument("Unsupported datatype");
+    }
+
+#undef SC_DECL_MAKE_ARRAYPLEX
+}
+
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<WrapSimpleArrayPlex, SimpleArrayPlex>
 {
     using root_base_type = WrapBase<WrapSimpleArrayPlex, SimpleArrayPlex>;
@@ -230,21 +257,12 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
                 pybind11::arg("dtype"),
                 pybind11::arg("alignment"))
             .def(
-                pybind11::init(
-                    [](pybind11::array & arr_in)
-                    {
-                        solvcon::detail::shape_type shape;
-                        for (ssize_t i = 0; i < arr_in.ndim(); ++i)
-                        {
-                            shape.push_back(arr_in.shape(i));
-                        }
-                        std::shared_ptr<ConcreteBuffer> const buffer = ConcreteBuffer::construct(
-                            arr_in.nbytes(),
-                            arr_in.mutable_data(),
-                            std::make_unique<ConcreteBufferNdarrayRemover>(arr_in));
-                        return wrapped_type(shape, buffer, pybind11::str(arr_in.dtype()));
-                    }),
+                pybind11::init(&make_arrayplex_from_numpy),
                 pybind11::arg("array"))
+            //
+            ;
+
+        (*this)
             .def("clone",
                  [](wrapped_type const & self)
                  { return wrapped_type(self); }) // cloning the object using the copy constructor. never add the clone method to the C++ class.

--- a/cpp/solvcon/timeseries/pymod/wrap_timeseries.cpp
+++ b/cpp/solvcon/timeseries/pymod/wrap_timeseries.cpp
@@ -7,6 +7,8 @@
 
 #include <pybind11/stl.h>
 
+#include <solvcon/buffer/pymod/SimpleArrayCaster.hpp>
+
 namespace solvcon
 {
 
@@ -24,13 +26,14 @@ void wrap_timeseries(pybind11::module & mod)
             small_vector<SimpleArray<uint64_t> const *> arrays;
             for (py::handle const arg : args)
             {
-                if (!py::isinstance<SimpleArray<uint64_t>>(arg))
+                py::detail::make_caster<SimpleArray<uint64_t>> caster;
+                if (!caster.load(arg, true)) // implicit conversion
                 {
                     throw py::type_error(std::format(
                         "timeseries::merge_sorted_unique(): every array must be SimpleArrayUint64 but got {}",
                         py::str(py::type::of(arg).attr("__name__")).cast<std::string>()));
                 }
-                arrays.push_back(&arg.cast<SimpleArray<uint64_t> const &>());
+                arrays.push_back(&py::detail::cast_op<SimpleArray<uint64_t> const &>(caster));
             }
             return timeseries::merge_sorted_unique(arrays);
         },

--- a/solvcon/timeseries.py
+++ b/solvcon/timeseries.py
@@ -8,12 +8,17 @@ paired with the values sampled at them.
 """
 
 
-try:
-    from _solvcon import timeseries as _impl  # noqa: F401
-except ImportError:
-    from ._solvcon import timeseries as _impl  # noqa: F401
+import numpy as np
 
-_toload = [
+from . import core
+
+try:
+    from _solvcon import timeseries as _impl
+except ImportError:
+    from ._solvcon import timeseries as _impl
+
+
+__all__ = [
     'merge_sorted_unique',
     'dedup_last',
     'deriv',
@@ -23,16 +28,61 @@ _toload = [
 ]
 
 
-def _load():
-    for name in _toload:  # noqa: F821
-        globals()[name] = getattr(_impl, name)
+def _as_arrays(*arrays):
+    return tuple(core.SimpleArray(array=array)
+                 if isinstance(array, np.ndarray) else array
+                 for array in arrays)
 
 
-__all__ = _toload
+def merge_sorted_unique(*arrays):
+    """Merge sorted timestamp arrays into one sorted array of the distinct
+    timestamps.
+
+    Every input must already be sorted.
+    """
+    return _impl.merge_sorted_unique(*_as_arrays(*arrays))
 
 
-_load()
-del _load
-del _toload
+def dedup_last(times, values):
+    """Keep the last sample of every group of equal timestamps.
+
+    Returns (times, values).
+    """
+    return _impl.dedup_last(*_as_arrays(times, values))
+
+
+def deriv(times, values):
+    """Differentiate a series by the backward difference.
+
+    Returns (times[1:], derivatives).
+    """
+    return _impl.deriv(*_as_arrays(times, values))
+
+
+def movavg(times, values, span):
+    """Average a series over the trailing half-open window (t - span, t].
+
+    Returns (times, means).
+    """
+    return _impl.movavg(*_as_arrays(times, values), span)
+
+
+def held(times, values, span):
+    """Report whether a boolean series was true over the trailing half-open
+    window (t - span, t].
+
+    The last sample at or before t - span must be true as well.  Returns
+    (times, answers).
+    """
+    return _impl.held(*_as_arrays(times, values), span)
+
+
+def true_intervals(times, values):
+    """Run-length encode the true stretches of a boolean series into rows of
+    (start, end, duration).
+
+    A run still open at the last sample ends there.
+    """
+    return _impl.true_intervals(*_as_arrays(times, values))
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/track/dataframe.py
+++ b/solvcon/track/dataframe.py
@@ -6,9 +6,26 @@ import os
 import contextlib
 import numpy as np
 
-from solvcon import SimpleArrayUint64, SimpleArrayFloat64
+import solvcon as sc
 
 all = ['DataFrame']
+
+_SIMPLE_ARRAY_BY_DTYPE = {
+    np.dtype('bool'): sc.SimpleArrayBool,
+    np.dtype('int8'): sc.SimpleArrayInt8,
+    np.dtype('int16'): sc.SimpleArrayInt16,
+    np.dtype('int32'): sc.SimpleArrayInt32,
+    np.dtype('int64'): sc.SimpleArrayInt64,
+    np.dtype('uint8'): sc.SimpleArrayUint8,
+    np.dtype('uint16'): sc.SimpleArrayUint16,
+    np.dtype('uint32'): sc.SimpleArrayUint32,
+    np.dtype('uint64'): sc.SimpleArrayUint64,
+    np.dtype('float32'): sc.SimpleArrayFloat32,
+    np.dtype('float64'): sc.SimpleArrayFloat64,
+    np.dtype('complex64'): sc.SimpleArrayComplex64,
+    np.dtype('complex128'): sc.SimpleArrayComplex128,
+}
+_ARRAY_TYPES = (sc.SimpleArray,) + tuple(_SIMPLE_ARRAY_BY_DTYPE.values())
 
 
 class DataFrame(object):
@@ -21,6 +38,67 @@ class DataFrame(object):
         self._index_data = None
         self._index_name = None
         self._data = list()
+
+    def _require_index(self):
+        if self._index_data is None:
+            raise ValueError("data frame has no index")
+
+    @classmethod
+    def _normalize_array(cls, name, array, size=None, size_name='index'):
+        if isinstance(array, _ARRAY_TYPES):
+            array = np.asarray(array)
+        if not isinstance(array, np.ndarray):
+            raise TypeError(
+                "{} must be a numpy.ndarray or SimpleArray".format(name))
+
+        if array.ndim != 1:
+            raise ValueError("{} must be one-dimensional".format(name))
+        if size is not None and array.shape[0] != size:
+            raise ValueError(
+                "{} length {} does not match {} length {}".format(
+                    name, array.shape[0], size_name, size))
+
+        return cls._typed_from_ndarray(name, array)
+
+    @staticmethod
+    def _typed_from_ndarray(name, ndarray):
+        typ = _SIMPLE_ARRAY_BY_DTYPE.get(ndarray.dtype)
+        if typ is None:
+            raise TypeError(
+                "{} has unsupported dtype {}".format(name, ndarray.dtype))
+        return typ(array=ndarray)
+
+    @staticmethod
+    def _require_sorted(name, array):
+        ndarray = np.asarray(array)
+        if ndarray.shape[0] > 1 and np.any(ndarray[1:] < ndarray[:-1]):
+            raise ValueError("{} must be sorted".format(name))
+
+    @staticmethod
+    def _slice(array, begin, end):
+        return type(array)(array=np.asarray(array)[begin:end])
+
+    @classmethod
+    def _from_parts(cls, index, index_name, names=(), data=()):
+        """Build a frame from parts that are already normalized."""
+        ret = cls()
+        ret._index_data = index
+        ret._index_name = index_name
+        ret._columns = list(names)
+        ret._data = list(data)
+        return ret
+
+    @classmethod
+    def from_columns(cls, index, **columns):
+        """Construct a data frame from existing array columns."""
+        index = cls._normalize_array('index', index)
+        if index.ndarray.dtype != np.dtype('uint64'):
+            raise TypeError("index must have dtype uint64")
+
+        ret = cls._from_parts(index, 'Index')
+        for name, column in columns.items():
+            ret[name] = column
+        return ret
 
     def read_from_text_file(
         self,
@@ -70,12 +148,12 @@ class DataFrame(object):
             if timestamp_in_file:
                 if timestamp_column in table_header:
                     idx_col_num = table_header.index(timestamp_column)
-                self._index_data = SimpleArrayUint64(
+                self._index_data = sc.SimpleArrayUint64(
                     array=nd_arr[:, idx_col_num].astype(np.uint64)
                 )
                 self._index_name = table_header[idx_col_num]
             else:
-                self._index_data = SimpleArrayUint64(
+                self._index_data = sc.SimpleArrayUint64(
                     array=np.arange(nd_arr.shape[0]).astype(np.uint64)
                 )
                 self._index_name = "Index"
@@ -87,13 +165,22 @@ class DataFrame(object):
             for i in range(nd_arr.shape[1]):
                 if i != idx_col_num:
                     self._data.append(
-                        SimpleArrayFloat64(array=nd_arr[:, i].copy())
+                        sc.SimpleArrayFloat64(array=nd_arr[:, i].copy())
                     )
 
     def __getitem__(self, name):
         if name not in self._columns:
             raise Exception("Column '{}' does not exist".format(name))
-        return self._data[self._columns.index(name)].ndarray
+        return np.asarray(self._data[self._columns.index(name)])
+
+    def __setitem__(self, name, column):
+        self._require_index()
+        column = self._normalize_array(name, column, self.shape[0])
+        if name in self._columns:
+            self._data[self._columns.index(name)] = column
+        else:
+            self._columns.append(name)
+            self._data.append(column)
 
     @property
     def columns(self):
@@ -101,11 +188,59 @@ class DataFrame(object):
 
     @property
     def shape(self):
-        return (self._index_data.ndarray.shape[0], len(self._data))
+        rows = 0 if self._index_data is None else self.index.shape[0]
+        return (rows, len(self._data))
 
     @property
     def index(self):
-        return self._index_data.ndarray
+        return np.asarray(self._index_data)
+
+    @property
+    def empty(self):
+        return self.shape[0] == 0
+
+    def asof(self, times, values):
+        """Align values causally onto this frame's index.
+
+        The value at each index timestamp is the last source sample at or
+        before it.  The returned mask is false where the timestamp precedes
+        the first source sample; what the value reads there is unspecified.
+        The values are a copy, unlike the views window() returns.
+        """
+        self._require_index()
+        times = self._normalize_array('times', times)
+        if times.ndarray.dtype != np.dtype('uint64'):
+            raise TypeError("times must have dtype uint64")
+        values = self._normalize_array(
+            'values', values, times.shape[0], 'times')
+        self._require_sorted('frame index', self._index_data)
+        self._require_sorted('times', times)
+
+        found = times.searchsorted(self._index_data, side='right').ndarray
+        valid = sc.SimpleArrayBool(array=found > 0)
+        source = values.ndarray
+        if source.shape[0] == 0:
+            source = np.zeros(1, dtype=source.dtype)
+
+        output = source[np.maximum(found - 1, 0)]
+        return self._typed_from_ndarray('values', output), valid
+
+    def window(self, start, end):
+        """Return a zero-copy view over the half-open interval [start, end)."""
+        self._require_index()
+        if start > end:
+            raise ValueError("window start must not exceed end")
+        self._require_sorted('frame index', self._index_data)
+
+        # SimpleArray compares the bound in the index type.  numpy has no
+        # integer type holding both uint64 and int64, so it would search
+        # through float64, which cannot tell nanosecond timestamps apart.
+        begin = self._index_data.searchsorted(start, side='left')
+        finish = self._index_data.searchsorted(end, side='left')
+        return self._from_parts(
+            self._slice(self._index_data, begin, finish), self._index_name,
+            self._columns,
+            [self._slice(column, begin, finish) for column in self._data])
 
     def sort(self, columns=None, index_column=None, inplace=True):
         """

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -33,6 +33,73 @@ ALL_DTYPES = ('bool',) + INT_DTYPES + ('float32', 'float64',
                                        'complex64', 'complex128')
 
 
+class NumpyInputTC(unittest.TestCase):
+
+    def test_every_kernel_accepts_ndarrays(self):
+        times = np.array([0, 10, 20], dtype='uint64')
+        values = np.array([1.0, 3.0, 5.0], dtype='float64')
+        flags = np.array([False, True, True], dtype='bool')
+
+        self.assertEqual(
+            ts.merge_sorted_unique(times).ndarray.tolist(), [0, 10, 20])
+        self.assertEqual(
+            ts.dedup_last(times, values)[1].ndarray.tolist(), [1.0, 3.0, 5.0])
+        self.assertEqual(
+            ts.deriv(times, values)[1].ndarray.tolist(), [0.2, 0.2])
+        self.assertEqual(
+            ts.movavg(times, values, span=10)[1].ndarray.tolist(),
+            [1.0, 3.0, 5.0])
+        self.assertEqual(
+            ts.held(times, flags, span=10)[1].ndarray.tolist(),
+            [False, False, True])
+        self.assertEqual(
+            ts.true_intervals(times, flags).ndarray.tolist(), [[10, 20, 10]])
+
+    def test_strided_ndarrays_keep_their_logical_order(self):
+        times = np.arange(0, 60, 10, dtype='uint64')[::2]
+        values = np.arange(6, dtype='float64')[::2]
+
+        output_times, output_values = ts.deriv(times, values)
+
+        self.assertEqual(output_times.ndarray.tolist(), [20, 40])
+        self.assertEqual(output_values.ndarray.tolist(), [0.1, 0.1])
+
+    def test_arrayplex_inputs_alias_their_ndarray(self):
+        ntimes = np.array([0, 10, 20], dtype='uint64')
+        nvalues = np.array([1.0, 3.0, 5.0], dtype='float64')
+        times = solvcon.SimpleArray(array=ntimes)
+        values = solvcon.SimpleArray(array=nvalues)
+        nvalues[1] = 5.0
+
+        output_times, output_values = ts.deriv(times, values)
+
+        self.assertIs(type(output_values), solvcon.SimpleArrayFloat64)
+        self.assertEqual(output_times.ndarray.tolist(), [10, 20])
+        self.assertEqual(output_values.ndarray.tolist(), [0.4, 0.0])
+
+    def test_arrayplex_inputs_reach_merge_sorted_unique(self):
+        times = solvcon.SimpleArray(array=np.array([0, 10, 20],
+                                                   dtype='uint64'))
+
+        merged = ts.merge_sorted_unique(times)
+
+        self.assertEqual(merged.ndarray.tolist(), [0, 10, 20])
+
+    def test_strided_arrayplex_inputs_keep_their_logical_order(self):
+        ntimes = np.arange(0, 60, 10, dtype='uint64')[::2]
+        nvalues = np.arange(6, dtype='float64')[::2]
+        times = solvcon.SimpleArray(array=ntimes)
+        values = solvcon.SimpleArray(array=nvalues)
+
+        nvalues[1] = 6.0
+        output_times, output_values = ts.deriv(times, values)
+
+        self.assertEqual(list(times), [0, 20, 40])
+        self.assertEqual(list(values), [0.0, 6.0, 4.0])
+        self.assertEqual(output_times.ndarray.tolist(), [20, 40])
+        self.assertEqual(output_values.ndarray.tolist(), [0.3, -0.1])
+
+
 class MergeSortedUniqueTC(unittest.TestCase):
 
     def test_union_grid(self):
@@ -143,9 +210,9 @@ class DedupLastTC(unittest.TestCase):
     def test_output_keeps_the_value_dtype(self):
         times = u64([1, 1, 2])
         for dtype in ALL_DTYPES:
-            values = arr(dtype, [1, 0, 1])
+            values = np.array([1, 0, 1], dtype=dtype)
             otimes, ovalues = ts.dedup_last(times, values)
-            self.assertIs(type(ovalues), type(values), dtype)
+            self.assertIs(type(ovalues), type(arr(dtype, [])), dtype)
             self.assertEqual(otimes.ndarray.tolist(), [1, 2], dtype)
             self.assertEqual(ovalues.ndarray.tolist(), [0, 1], dtype)
 

--- a/tests/test_timeseries_dataframe.py
+++ b/tests/test_timeseries_dataframe.py
@@ -10,6 +10,8 @@ import unittest
 
 import numpy as np
 
+import solvcon as sc
+from solvcon import timeseries
 from solvcon.track import dataframe
 
 
@@ -54,6 +56,16 @@ class TimeSeriesDataFrameTC(unittest.TestCase):
 1.60259601028932e+18,-0.18927001953125,-0.0009765625,-0.04840087890625
 1.60259601038931e+18,-0.18841552734375,6.103515625e-05,-0.0489501953125
 """
+
+    @staticmethod
+    def _u64(values):
+        return sc.SimpleArrayUint64(
+            array=np.array(values, dtype='uint64'))
+
+    @staticmethod
+    def _f64(values):
+        return sc.SimpleArrayFloat64(
+            array=np.array(values, dtype='float64'))
 
     def test_read_from_text_file_basic(self):
         tsdf = dataframe.DataFrame()
@@ -107,6 +119,7 @@ class TimeSeriesDataFrameTC(unittest.TestCase):
         self.assertEqual(
             list(tsdf.index), list(nd_arr[:, 0].astype(np.uint64))
         )
+        self.assertIsInstance(tsdf.index, np.ndarray)
 
     def test_dataframe_get_column(self):
         tsdf = dataframe.DataFrame()
@@ -117,6 +130,7 @@ class TimeSeriesDataFrameTC(unittest.TestCase):
         nd_arr = np.genfromtxt(io.StringIO(self.dlc_data), delimiter=',')[1:]
 
         self.assertEqual(list(col_data), list(nd_arr[:, 1]))
+        self.assertIsInstance(col_data, np.ndarray)
 
     def test_dataframe_sort(self):
         tsdf = dataframe.DataFrame()
@@ -181,5 +195,191 @@ class TimeSeriesDataFrameTC(unittest.TestCase):
         )
         with self.assertRaisesRegex(FileNotFoundError, expected_pattern):
             tsdf.read_from_text_file(missing)
+
+    def test_from_columns_accepts_arrayplex(self):
+        nindex = np.array([10, 20, 30], dtype='uint64')
+        nspeed = np.array([1.0, 2.0, 3.0], dtype='float64')
+        index = sc.SimpleArray(array=nindex)
+        speed = sc.SimpleArray(array=nspeed)
+
+        frame = dataframe.DataFrame.from_columns(index=index, speed=speed)
+
+        self.assertTrue(np.shares_memory(frame.index, nindex))
+        self.assertTrue(np.shares_memory(frame['speed'], nspeed))
+        nindex[0] = 5
+        nspeed[1] = 9.0
+        self.assertEqual(frame.index.tolist(), [5, 20, 30])
+        self.assertEqual(frame['speed'].tolist(), [1.0, 9.0, 3.0])
+
+    def test_from_columns_rejects_incompatible_arrays(self):
+        index = self._u64([10, 20, 30])
+        with self.assertRaisesRegex(
+                ValueError, "speed length 2 does not match index length 3"):
+            dataframe.DataFrame.from_columns(
+                index=index, speed=self._f64([1.0, 2.0]))
+        with self.assertRaisesRegex(
+                TypeError, "index must have dtype uint64"):
+            dataframe.DataFrame.from_columns(
+                index=self._f64([10.0]), speed=self._f64([1.0]))
+        with self.assertRaisesRegex(
+                TypeError, "index must be a numpy.ndarray or SimpleArray"):
+            dataframe.DataFrame.from_columns(index=[10, 20])
+        with self.assertRaisesRegex(
+                ValueError, "index must be one-dimensional"):
+            dataframe.DataFrame.from_columns(
+                index=np.zeros((2, 2), dtype='uint64'))
+        with self.assertRaisesRegex(
+                TypeError, "index has unsupported dtype"):
+            dataframe.DataFrame.from_columns(
+                index=np.array(['a'], dtype='U1'))
+
+    def test_setitem_replaces_an_existing_column(self):
+        frame = dataframe.DataFrame.from_columns(
+            index=self._u64([10, 20]), speed=self._f64([1.0, 2.0]))
+
+        frame['speed'] = self._f64([3.0, 4.0])
+
+        self.assertEqual(frame.columns, ['speed'])
+        self.assertEqual(frame['speed'].tolist(), [3.0, 4.0])
+
+    def test_operations_require_an_index(self):
+        frame = dataframe.DataFrame()
+        message = "data frame has no index"
+
+        with self.assertRaisesRegex(ValueError, message):
+            frame['speed'] = self._f64([])
+        with self.assertRaisesRegex(ValueError, message):
+            frame.asof(self._u64([]), self._f64([]))
+        with self.assertRaisesRegex(ValueError, message):
+            frame.window(0, 1)
+
+    def test_asof_is_causal_and_uses_last_duplicate(self):
+        frame = dataframe.DataFrame.from_columns(
+            index=self._u64([5, 10, 15, 20, 25, 30, 35]))
+        times = self._u64([10, 20, 20, 30])
+        values = self._f64([1.0, 2.0, 3.0, 4.0])
+
+        aligned, valid = frame.asof(times, values)
+
+        self.assertEqual(valid.ndarray.tolist(),
+                         [False, True, True, True, True, True, True])
+        self.assertEqual(aligned.ndarray[valid.ndarray].tolist(),
+                         [1.0, 1.0, 3.0, 3.0, 4.0, 4.0])
+        values[3] = 99.0
+        realigned, _ = frame.asof(times, values)
+        self.assertEqual(realigned.ndarray[5], 99.0)
+
+    def test_asof_empty_source_has_no_valid_values(self):
+        frame = dataframe.DataFrame.from_columns(
+            index=self._u64([10, 20, 30]))
+
+        aligned, valid = frame.asof(self._u64([]), self._f64([]))
+
+        self.assertIs(type(aligned), sc.SimpleArrayFloat64)
+        self.assertEqual(aligned.ndarray.tolist(), [0.0, 0.0, 0.0])
+        self.assertEqual(valid.ndarray.tolist(), [False, False, False])
+
+    def test_asof_requires_sorted_indices(self):
+        frame = dataframe.DataFrame.from_columns(
+            index=self._u64([10, 30, 20]))
+        with self.assertRaisesRegex(ValueError, "frame index must be sorted"):
+            frame.asof(self._u64([10, 20]), self._f64([1.0, 2.0]))
+
+        frame = dataframe.DataFrame.from_columns(
+            index=self._u64([10, 20, 30]))
+        with self.assertRaisesRegex(ValueError, "times must be sorted"):
+            frame.asof(self._u64([20, 10]), self._f64([2.0, 1.0]))
+
+    def test_window_is_half_open_and_zero_copy(self):
+        frame = dataframe.DataFrame.from_columns(
+            index=self._u64([0, 10, 20, 20, 30, 40]),
+            value=self._f64([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]))
+
+        window = frame.window(10, 30)
+
+        self.assertEqual(window.index.tolist(), [10, 20, 20])
+        self.assertEqual(window['value'].tolist(), [1.0, 2.0, 3.0])
+        self.assertTrue(np.shares_memory(window.index, frame.index))
+        self.assertTrue(np.shares_memory(window['value'], frame['value']))
+        window['value'][0] = 99.0
+        self.assertEqual(frame['value'][1], 99.0)
+
+    def test_window_cuts_on_epoch_nanosecond_bounds(self):
+        # A uint64 index and a plain int bound have no common integer type,
+        # so an unguarded search compares them as float64, which cannot tell
+        # neighbouring nanosecond timestamps apart.
+        base = 1602596010389310000
+        frame = dataframe.DataFrame.from_columns(
+            index=self._u64([base, base + 1, base + 2, base + 3]),
+            value=self._f64([0.0, 1.0, 2.0, 3.0]))
+
+        window = frame.window(base + 1, base + 3)
+
+        self.assertEqual(window.index.tolist(), [base + 1, base + 2])
+        self.assertEqual(window['value'].tolist(), [1.0, 2.0])
+
+    def test_window_keeps_a_column_named_index(self):
+        frame = dataframe.DataFrame.from_columns(index=self._u64([10, 20, 30]))
+        frame['index'] = self._f64([4.0, 5.0, 6.0])
+
+        window = frame.window(10, 30)
+
+        self.assertEqual(window['index'].tolist(), [4.0, 5.0])
+
+    def test_an_index_less_frame_is_empty(self):
+        self.assertTrue(dataframe.DataFrame().empty)
+
+    def test_window_is_empty_when_no_sample_falls_inside(self):
+        frame = dataframe.DataFrame.from_columns(
+            index=self._u64([10, 20]), value=self._f64([1.0, 2.0]))
+
+        window = frame.window(20, 20)
+
+        self.assertTrue(window.empty)
+        self.assertEqual(window.columns, ['value'])
+
+    def test_window_rejects_a_reversed_interval(self):
+        frame = dataframe.DataFrame.from_columns(
+            index=self._u64([10, 20]), value=self._f64([1.0, 2.0]))
+
+        with self.assertRaisesRegex(
+                ValueError, "window start must not exceed end"):
+            frame.window(30, 20)
+
+    def test_window_keeps_the_index_name(self):
+        frame = dataframe.DataFrame.from_columns(index=self._u64([10, 20]))
+        frame._index_name = 'Timestamp'
+
+        self.assertEqual(frame.window(10, 20)._index_name, 'Timestamp')
+
+    def test_sort_keeps_equal_timestamps_in_recorded_order(self):
+        # asof and dedup_last both let the last row of a duplicate group win,
+        # so an unstable sort would make them answer differently every run.
+        frame = dataframe.DataFrame.from_columns(
+            index=self._u64([1, 0] * 20),
+            value=self._f64(list(range(40))))
+
+        frame.sort()
+
+        self.assertEqual(frame['value'].tolist()[:3], [1.0, 3.0, 5.0])
+
+    def test_timeseries_pipeline_composes_with_frame(self):
+        source = dataframe.DataFrame.from_columns(
+            index=np.array([0, 10, 20, 30], dtype='uint64'),
+            speed=np.array([0.0, 10.0, 30.0, 60.0], dtype='float64'),
+            brake=np.array([False, True, True, False], dtype='bool'))
+
+        output_times, acceleration = timeseries.deriv(
+            source.index, source['speed'])
+        frame = dataframe.DataFrame.from_columns(
+            index=output_times, acceleration=acceleration)
+        brake, valid = frame.asof(source.index, source['brake'])
+        frame['brake'] = brake
+        window = frame.window(10, 30)
+
+        self.assertTrue(valid.ndarray.all())
+        self.assertEqual(window.index.tolist(), [10, 20])
+        self.assertEqual(window['acceleration'].tolist(), [1.0, 2.0])
+        self.assertEqual(window['brake'].tolist(), [True, True])
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:


### PR DESCRIPTION
Grow `solvcon/track/DataFrame` into the container that holds extracted signal columns, the first of two pull requests for issue #1287. `from_columns` builds a frame from arrays that are already in memory, the shape a signal extractor produces. `asof` aligns a series recorded on another sample grid onto the frame index with a strictly causal zero-order hold, and returns the aligned values together with a mask that is false where there was no sample to hold. `window` cuts the half-open interval `[start, end)` as views over the same buffers. A column may now carry any SimpleArray element type rather than float64 alone, because a signal log records flags and counters beside its measurements.

`window` and `asof` search through `SimpleArray::searchsorted` rather than numpy. For `window` numpy is not merely slower but wrong: it has no integer type holding both uint64 and int64, so it compares a uint64 index against a plain Python int through float64, which cannot tell apart the epoch nanoseconds this index exists to carry.

The binding work the container needs comes with it, and is the part to review first. Casting a SimpleArray out of a plex took the plex by value. Copying a plex allocates a fresh SimpleArray and clones the whole buffer, and the caster then pointed into that copy and let it die at the end of the load, so a binding handed a plex read freed memory after paying a deep copy of its argument. Binding the plex by reference removes both. It also changes aliasing: a loaded SimpleArray now points at the caller's data rather than a private copy, so a binding that writes to its argument writes through to the caller.

A plex also builds from a numpy array through the maker that already serves the typed constructor, so it honors the strides and the offset of its source instead of reading the buffer as one flat block. That maker moves out of `WrapSimpleArray` into `array_common.hpp` as a free function template, so neither binding unit has to reach into the other. The constructor consequently rejects what the flat-block path accepted: a dtype mismatch, a stride that is not a multiple of the item size, and an underaligned data pointer.

`solvcon/timeseries.py` gains one Python wrapper per kernel, so the kernels take a numpy array or a plex as well as a typed array. The module's six names become real functions rather than objects forwarded from the extension.

Related to #1287, #1285, and #1286.

Left for follow-up: `asof` and `window` each rescan the index for order on every call, which dominates a windowed sweep over a large log; the caster could accept a numpy array directly and retire the Python wrappers in `solvcon/timeseries.py`; and the dtype table in `dataframe.py` duplicates a dispatch C++ already carries.
