### PR TITLE
update /create-pr and /worktree

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,124 +1,88 @@
 ---
 name: create-pr
-description: Open a solvcon pull request that follows the project PR protocol (concise subject, clear description, "related to #xxx" wording, draft by default, ready-for-review via global comment). Use when the user asks to create, open, or draft a pull request.
+description: Open a solvcon pull request that follows the project PR protocol. Use when the user asks to create, open, or draft a pull request.
 ---
 
 # Create Pull Request (solvcon)
 
-This file is the authoritative reference for the solvcon PR protocol.
-The "Pull Request Guidelines" section of `CLAUDE.md` is the project-wide
-cross-reference; flag any drift between the two.
+Authoritative reference for the solvcon PR protocol. The "Pull Request
+Guidelines" section of `AGENTS.md` is the cross-reference; flag drift.
 
-## Protocol the PR must satisfy
+## Protocol
 
-1. **Subject** -- concise and informative.
-2. **Description** -- clear, short, human-readable global description.
-   Write it as prose paragraphs that a person would actually want to
-   read. Avoid bullet lists; only fall back to a short bulleted list or
-   a table when prose would genuinely be unreadable (e.g. a benchmark
-   matrix with many rows). State *what* changed and *why*.
-   **Do not hard-wrap paragraphs.** Each paragraph is a single
-   unbroken line; separate paragraphs with one blank line. GitHub
-   reflows the text to the viewer's width, and mid-sentence line
-   breaks at 79/80 columns render as ragged prose in the PR view.
-   The 79-char source-code limit does not apply to PR descriptions.
-3. **Issue reference** -- end with "Related to #xxx" or "For issue #xxx".
-   **Never** use "close #xxx", "closes #xxx", "fixes #xxx", or any closing
-   keyword. We do not let PR/commit text drive issue management.
-   *Exception:* a private or fork-based prototype PR (see
-   `prototype-with-devplan`) omits the issue reference and any upstream link
-   entirely, so the draft does not spray backlinks onto the upstream issue.
-4. **Draft by default** -- open as draft unless the user explicitly says it
-   is ready for review. Pushing the "ready for review" button alone is
-   *not* a review request in this project.
-5. **Request review with a global comment** -- when the PR is ready, the
-   author posts a global PR comment that explicitly asks for review. The
-   button push is not quotable in follow-ups, so the comment is required.
-6. **Inline annotations** -- the author is expected to add inline review
-   annotations to guide the reviewer, unless the diff is one-liner-ish.
-   The skill should remind the user; it does not write the annotations.
-7. **Human authorship** -- all PR comments are written by humans. Tool
-   assistance is OK, but the user must know what the text says. When the
-   skill drafts text, present it for the user's review and edits before
-   posting.
-8. **Skip CI for agent-only changes.** When the diff touches *only*
-   agent tooling (the `.claude/` and `.cursor/` trees, root `CLAUDE.md` /
-   `AGENTS.md`, and `contrib/prompt/`), end the body with `[skip-ci]` on
-   its own line so the `check_skip_ci` workflow skips the heavy CI jobs.
-   Omit it if the diff touches any other file. The control string works
-   only on its own line and only for a PR opened by a repository owner,
-   member, or collaborator.
+1. **Subject** -- imperative, concrete, informative.
+2. **Body** -- the shortest prose that covers, in this order:
+   what the change does (one or two sentences, present tense); why
+   (the problem or issue); how, only when the diff does not make it
+   obvious; what was tested and the actual result, when tests were
+   run. Describe only what the diff contains. Do not pad with file
+   lists the diff already shows. Prefer one to three short paragraphs;
+   bullets only when prose is genuinely unreadable (e.g. a benchmark
+   matrix).
+3. **Sentence style** -- a non-native reader must parse each sentence
+   exactly one way:
+   - Under 25 words, one claim per sentence, at most 6 sentences per
+     paragraph, one topic per paragraph.
+   - Active voice and simple tenses. "The hook rejects the commit",
+     not "the commit is rejected"; "adds", not "has added".
+   - Short common words: "use" not "utilize", "start" not "initiate".
+     Plain verbs, no metaphors and no phrasal-verb idioms.
+   - One term per thing, everywhere. Do not rotate synonyms.
+   - Name the observable effect ("closes the interval", "returns the
+     pybind11 type"), not a vague verb ("handles", "manages").
+   - No hedges. State what the change does; drop "should", "might",
+     "essentially", "some", "several" when a fact or number is known.
+   - Keep the article and the "that"; every "it"/"this" needs an
+     adjacent referent.
+4. **No hard wrap** -- each paragraph is one unbroken line; blank line
+   between paragraphs. GitHub reflows; the 79-char source limit does
+   not apply.
+5. **Issue reference** -- end with "Related to #xxx." or
+   "For issue #xxx.". **Never** "close/closes/fixes/resolves #xxx";
+   PR text does not drive issue management. *Exception:* a fork
+   prototype PR (see `prototype-with-devplan`) omits the reference
+   and any upstream link.
+6. **Draft by default** -- open as draft unless the user says it is
+   ready for review.
+7. **Review request is a global comment** -- when ready, the author
+   posts a PR comment asking for review. The ready-for-review button
+   alone is not a request.
+8. **Human authorship** -- present drafted text for the user's review
+   before posting. No `Co-Authored-By:` or "Generated with Claude
+   Code" trailers.
+9. **`[skip-ci]` for agent-only diffs** -- when the diff touches only
+   `.claude/`, `.cursor/`, root `CLAUDE.md`/`AGENTS.md`, or
+   `contrib/prompt/`, end the body with `[skip-ci]` on its own line
+   (works only on its own line, only for repo members). Omit
+   otherwise.
 
 ## Workflow
 
-1. **Confirm scope with the user.** Ask directly when unclear from
-   context:
-   - Which issue does this PR relate to? (issue number)
-   - Is this ready for review, or should it be opened as draft?
-   - One-line gist of the change.
+1. **Confirm scope** when unclear: issue number, draft or ready,
+   one-line gist.
 
-2. **Verify branch state.** solvcon's main branch is `master`. Run in
-   parallel:
-   - `git status --porcelain` -- check for staged or unstaged changes
-     and untracked files.
-   - `git log --oneline origin/master..HEAD` -- list the commits the PR
-     will carry.
-   - `git diff --stat origin/master...HEAD` -- summarize the diff
-     (three-dot uses the merge base).
-   - `git rev-parse --abbrev-ref --symbolic-full-name @{u}` -- check if
-     the branch tracks a remote.
+2. **Verify branch state** (main branch is `master`). Run in parallel:
+   `git status --porcelain`, `git log --oneline origin/master..HEAD`,
+   `git diff --stat origin/master...HEAD`, and
+   `git rev-parse --abbrev-ref --symbolic-full-name @{u}`.
+   - Dirty tree: show staged/unstaged/untracked. Commit and push
+     clearly in-scope files without another staging question. Stop and
+     ask about unrelated or ambiguous files. Never `git add -A` or
+     `git add .`; stage exact paths.
+   - After handling the dirty tree, no commits ahead: abort, the PR
+     would be empty.
+   - Unpushed: push without repeating confirmation. If behind its
+     remote, stop and reconcile before pushing.
+   - Fork prototype PR: base and remote are the fork, not `origin`.
 
-   If `git status --porcelain` shows any output, the working tree is
-   not clean. Show the user the list (staged, unstaged, and untracked
-   separately) and ask explicitly how to proceed: stage and commit
-   selected files, stash, or abort. Never run `git add -A` or
-   `git add .` without confirmation -- pick specific paths so that
-   stray files (local settings, generated artifacts) are not pulled
-   into the PR.
+3. **Draft subject and body** from the diff and the gist, following
+   the protocol above. Cut every sentence the reader does not need.
+   End with the issue reference (omit for a fork prototype PR), then
+   `[skip-ci]` if protocol item 9 applies. Show the draft in a fenced
+   block and wait for approval.
 
-   If the branch has no commits ahead of `origin/master`, abort -- the
-   PR would be empty.
-
-   If the branch is not pushed (or is behind its remote), push after
-   confirming with the user.
-
-   For a private/fork prototype PR (see `prototype-with-devplan`), the base
-   is the fork's own default branch and the tracked remote is the fork, not
-   `origin`/upstream; compare against and open the PR on that repository.
-
-3. **Draft the subject and body.** Inspect the diff and the user's
-   gist, then propose a subject and a body. The body should be **short
-   prose** -- a person reading it should understand what changed and
-   why without scanning a checklist. Prefer one to three paragraphs.
-   Reserve bullets for cases where prose would genuinely be unreadable
-   (long enumerations, benchmark matrices). End with the closing line
-   `Related to #xxx.` or `For issue #xxx.` -- but omit that line, and any
-   upstream reference, for a private/fork prototype PR (see
-   `prototype-with-devplan`).
-
-   If the diff is agent-tooling-only (protocol item 8), add `[skip-ci]`
-   on its own line at the very end of the body, one blank line below the
-   `Related to #xxx.` closing line.
-
-   **Write each paragraph as one continuous line.** Do not insert
-   hard line breaks inside a paragraph -- not at 79 columns, not at
-   any column. Paragraphs are separated by exactly one blank line.
-   GitHub wraps to the viewer's width; pre-wrapped prose looks
-   ragged in the rendered PR. This applies to the draft you show
-   the user and to the text written into `$body_file` in step 4.
-
-   Present the draft to the user (subject and body) and wait for edits
-   or approval before opening the PR. Do not post Claude-Code
-   attribution trailers in the PR body -- this project treats PR text
-   as human-authored.
-
-4. **Open the PR.** Load the approved title and body into shell
-   variables using **quoted heredocs** -- the single-quoted delimiter
-   suppresses every form of shell expansion, so the placeholder text
-   can contain backticks, `$`, `"`, or apostrophes without escaping.
-   Then pass the title as a double-quoted variable expansion (safe
-   because the value is already in memory) and the body via a temp
-   file:
+4. **Open the PR.** Quoted heredocs suppress shell expansion, so the
+   text needs no escaping:
 
    ```bash
    title=$(cat <<'TITLE'
@@ -129,9 +93,7 @@ cross-reference; flag any drift between the two.
    body_file=$(mktemp)
    trap 'rm -f "$body_file"' EXIT
    cat >"$body_file" <<'BODY'
-   <approved body, already ending with "Related to #xxx." or
-   "For issue #xxx." from step 3, plus a trailing "[skip-ci]" line for
-   agent-only changes>
+   <approved body>
    BODY
 
    gh pr create --draft \
@@ -139,60 +101,33 @@ cross-reference; flag any drift between the two.
      --body-file "$body_file"
    ```
 
-   Drop `--draft` only when the user has explicitly said the PR is
-   ready for review. Do not append a second issue-reference footer here;
-   the body from step 3 already has one. The `trap` ensures the temp
-   file is removed on any exit path. If the approved body would itself
-   contain the literal token `BODY` on its own line, swap the delimiter
-   to something unique (e.g. `BODY_EOF_811`).
+   Drop `--draft` only when the user said ready. If the body contains
+   a literal `BODY` line, use a unique delimiter. For a fork prototype
+   PR, add `--repo <fork> --base <fork-default>`.
 
-   For a fork prototype PR, pass `--repo <fork> --base <fork-default>` so the
-   PR opens on the fork; `gh pr create` otherwise defaults to the parent
-   (upstream) repository.
-
-5. **After creation.** Report the PR URL back to the user. Then:
-   - Remind the user that the global review-request comment is the
-     author's responsibility -- the skill does **not** post it. When
-     the PR is ready (now, or later after leaving draft), the author
-     must open a global PR comment that explicitly asks the
-     maintainer to review. Point the user at the PR URL and let them
-     write and post the comment themselves; do not draft text for it
-     and do not call `gh pr comment`.
-   - Remind the user to add inline annotations on the diff (the skill
-     does not write them). Recommend the user focus on the points
-     that help the reviewer most:
-     - non-obvious design choices and the alternatives considered;
-     - subtle logic, invariants, or ordering constraints a reader
-       might overlook;
-     - changes that look like dead code or accidental edits but are
-       intentional, so the reviewer does not "fix" them;
-     - known limitations, follow-up work, and test-coverage gaps;
-     - tricky diffs (large reformatting next to substantive edits,
-       cross-file renames) where the reviewer needs guidance on what
-       to inspect carefully versus what is mechanical.
-     Skip the reminder when the diff is genuinely one-liner-ish.
+5. **After creation.** Report the URL. Remind the user:
+   - The global review-request comment is theirs to write and post;
+     do not draft it and do not call `gh pr comment`.
+   - Add inline annotations on the diff (skip when one-liner-ish):
+     non-obvious choices, subtle invariants, intentional edits that
+     look accidental, known limitations, and where a tricky diff needs
+     careful reading versus mechanical.
 
 ## Guardrails
 
-- **Closing keywords.** After loading `$title` and writing `$body_file`
-  in step 4, but **before** the `gh pr create` call, scan title and
-  body together with a single case-insensitive check:
+Run both checks after writing `$body_file`, before `gh pr create`.
+
+- **Closing keywords:**
 
   ```bash
   { printf '%s\n' "$title"; cat "$body_file"; } \
       | grep -iEn '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+'
   ```
 
-  Any hit means the text uses a banned closing keyword (close/closes/
-  closed/fix/fixes/fixed/resolve/resolves/resolved followed by `#nnn`).
-  Rewrite the offending line to "Related to #xxx" or "For issue #xxx"
-  and re-confirm with the user before retrying.
-- **Hard-wrapped prose.** The 79-char source limit does NOT apply to a
-  PR body; each paragraph must be one unbroken line. This is easy to
-  violate by reflex after editing wrapped source all session, so treat
-  it as a mechanical gate, not a preference. After writing `$body_file`
-  in step 4, but **before** `gh pr create`, scan for a paragraph split
-  across lines -- any two consecutive non-blank prose lines:
+  Any hit: rewrite to "Related to #xxx" and re-confirm with the user.
+
+- **Hard-wrapped prose** (easy to violate by reflex after editing
+  wrapped source; treat as a mechanical gate):
 
   ```bash
   awk '
@@ -206,31 +141,21 @@ cross-reference; flag any drift between the two.
   ' "$body_file"
   ```
 
-  A non-zero exit means a paragraph was wrapped. Rejoin it into a single
-  line (fenced code blocks, list items, and table rows are exempt and
-  the check skips them) and re-run before creating the PR. Apply the
-  same one-line-per-paragraph rule to the draft shown in step 3, not
-  only to `$body_file`.
-- **Branch protection.** Never push directly to `master`/`main`, never
-  `--no-verify`. If `gh pr create` fails, surface the error and stop --
-  do not work around it.
-- **No fabricated context.** Do not invent benchmark numbers, test
-  results, or verification claims. Only include what the user has stated
-  or what is visible in the diff/commits.
-- **Diff accuracy.** Before presenting the draft, re-read
-  `git diff origin/master...HEAD` and confirm every claim in the subject
-  and body corresponds to a hunk in the diff. Drop claims about behavior
-  that already exists upstream or that the diff does not change.
-- **Trailers.** Do not append `Co-Authored-By:` or "Generated with Claude
-  Code" trailers to the PR body. Commits in this project are
-  human-authored by convention.
+  Non-zero exit: rejoin the paragraph into one line and re-run.
+  Code fences, list items, and table rows are exempt.
+
+- **Branch protection.** Never push to `master`/`main`, never
+  `--no-verify`. If `gh pr create` fails, surface the error and stop.
+- **No fabricated context.** No invented benchmarks, test results, or
+  verification claims; only what the user stated or the diff shows.
+- **Diff accuracy.** Re-read `git diff origin/master...HEAD` and
+  confirm every claim in subject and body matches a hunk.
 
 ## Output
 
-- Show the draft subject and body to the user before calling `gh pr
-  create`. Use a fenced block so it is easy to edit.
-- After creation, output a single line: `opened: <PR URL> (draft|ready)`.
-- If guardrails block the action (closing keyword, dirty tree, unpushed
-  branch), output `blocked: <reason>` and stop. Do not retry silently.
+- Show the draft in a fenced block before `gh pr create`.
+- After creation: `opened: <PR URL> (draft|ready)`.
+- If blocked (closing keyword, dirty tree, unpushed branch):
+  `blocked: <reason>` and stop.
 
 <!-- vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: -->

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -9,13 +9,13 @@ Use an automatically provided worktree. Otherwise create one, then do the task. 
 
 ## 1. Enter or create
 
-If the agent or session already provides a worktree, enter it. Otherwise derive a short kebab-case `name` from `<description>`, or omit it and let the tool pick one.
+If the agent or session already provides a worktree, enter it. Otherwise derive a short kebab-case `name` from `<description>`, or omit it and let the tool pick one. Name it for what the task does, e.g. `mcap-topic-walk`, not for its tracking number: when `<description>` gives only an issue or PR number, append a few words that say what the work is (`1206-agent-panel`, not `1206`).
 
 Based on the agent type, do one of the following:
 
 - **Claude Code:** use Claude's builtin `EnterWorktree` with that `name`. If the worktree does not exist, it will be created automatically.
-- **Cursor:**  use Cursors's builtin `/worktree` command instead. If the built-in command is unavailable, fall back like Codex below.
-- **Codex, otherwise:** run `git worktree add -b worktree-<name> .claude/worktrees/<name> origin/master`, then run all commands from it.
+- **Cursor:** use Cursor's builtin `/worktree` command instead. If the built-in command is unavailable, fall back like Codex below.
+- **Codex, otherwise:** run `git worktree add -b worktree-<name> .claude/worktrees/<name> HEAD`, then run all commands from it.
 
 ## 2. Do the task
 


### PR DESCRIPTION
Update two skills. Make `/worktree` to have more clear naming for the worktree. Make `/create-pr` be more concise and simple.