### PR TITLE
Stop MSVC from compiling the matmul `if constexpr` fallbacks

### DIFF
--- a/cpp/solvcon/buffer/matmul.hpp
+++ b/cpp/solvcon/buffer/matmul.hpp
@@ -364,6 +364,7 @@ private:
 
     MatmulSelection select() const;
     std::optional<MatmulSelection> select(MatmulKernel kernel) const;
+    std::optional<MatmulSelection> select_blas(MatmulKernel kernel) const;
     MatmulSelection select_dot() const;
     MatmulSelection select_gevm() const;
     MatmulSelection select_gemv() const;
@@ -764,7 +765,10 @@ MatmulSelection MatmulExecutor<Array>::select() const
         }
         return select_gemm();
     }
-    return MatmulSelection{};
+    else
+    {
+        return MatmulSelection{};
+    }
 }
 
 template <typename Array>
@@ -894,10 +898,20 @@ std::optional<MatmulSelection> MatmulExecutor<Array>::select(MatmulKernel kernel
     {
         return MatmulSelection{};
     }
-    if constexpr (!use_matmul_blas_v<value_type>)
+
+    if constexpr (use_matmul_blas_v<value_type>)
+    {
+        return select_blas(kernel);
+    }
+    else
     {
         return std::nullopt;
     }
+}
+
+template <typename Array>
+std::optional<MatmulSelection> MatmulExecutor<Array>::select_blas(MatmulKernel kernel) const
+{
     if (m_plan.rows() <= 0 || m_plan.columns() <= 0 || m_plan.inner_size() <= 0)
     {
         return std::nullopt;


### PR DESCRIPTION
`MatmulExecutor::select()` and `MatmulExecutor::select(kernel)` each put a fallback `return` after an `if constexpr` block that always returns. MSVC reports that fallback as C4702, unreachable code. The Windows Debug build compiles the core with `/W4 /WX`, so the warning failed five `wrap_SimpleArray_*` translation units and broke the nightly build.

Each fallback now sits in an `else`, so the compiler discards the branch instead of compiling it. The kernel switch moves to a new `select_blas()`, because the added `else` costs one nesting level and that pushed the merged `select(kernel)` past the clang-tidy cognitive complexity threshold of 25. Both functions arrived after #1324 closed, so C4702 is a new code rather than one of the four that issue lists.

Clang and GCC never report this warning. Clang stays silent even under `-Wunreachable-code-aggressive`, because it suppresses the diagnostic inside a template instantiation. A Windows build is the only way to see the failure, as #1324 also notes.

A manual `nightly_build_windows` run on this branch builds Windows Debug to completion, 305 of 305 targets, with no C4702. The failed nightly stopped at 104 targets, so this run also covers the translation units that the early exit hid. On macOS the branch passes `make lint`, `pilot_clang_tidy_diff`, `make gtest` with 253 tests, and `make pytest` with 2301 passed and 40 skipped.

Related to #1324.
