### PR TITLE
Add shared Metal buffer storage

### DIFF
--- a/cpp/solvcon/buffer/BufferBase.hpp
+++ b/cpp/solvcon/buffer/BufferBase.hpp
@@ -49,7 +49,7 @@ public:
     explicit operator bool() const { return static_cast<bool>(m_begin); }
     size_type size() const
     {
-        return static_cast<size_type>(this->m_end - this->m_begin);
+        return this->m_begin == this->m_end ? 0 : static_cast<size_type>(this->m_end - this->m_begin);
     }
     size_t nbytes() const { return size() * sizeof(int8_t); }
 

--- a/cpp/solvcon/buffer/BufferStorage.hpp
+++ b/cpp/solvcon/buffer/BufferStorage.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Ownership contracts for ConcreteBuffer storage.
+ *
+ * @ingroup group_core
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+
+#ifdef _WIN32
+#include <malloc.h>
+#endif
+
+namespace solvcon
+{
+
+namespace detail
+{
+
+/**
+ * Base class for buffer-storage deallocation.
+ *
+ * ConcreteBuffer's data deleter calls this object to release the backing
+ * storage. A derived remover may instead release its owner when the remover
+ * itself is destroyed.
+ */
+struct ConcreteBufferRemover
+{
+
+    ConcreteBufferRemover() = default;
+    ConcreteBufferRemover(ConcreteBufferRemover const &) = default;
+    ConcreteBufferRemover(ConcreteBufferRemover &&) = default;
+    ConcreteBufferRemover & operator=(ConcreteBufferRemover const &) = default;
+    ConcreteBufferRemover & operator=(ConcreteBufferRemover &&) = default;
+    virtual ~ConcreteBufferRemover() = default;
+
+    /**
+     * Release heap storage with its original alignment.
+     * @param p Storage to release.
+     * @param alignment Original alignment; 0 means no explicit alignment.
+     */
+    static void deallocate_memory(int8_t * p, size_t alignment);
+
+    /**
+     * Release storage or its backing resource.
+     * @param p CPU-visible storage pointer.
+     * @param alignment Storage alignment; 0 means no explicit alignment.
+     */
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays,readability-non-const-parameter)
+    virtual void operator()(int8_t * p, size_t alignment) const { deallocate_memory(p, alignment); }
+
+}; /* end struct ConcreteBufferRemover */
+
+inline void ConcreteBufferRemover::deallocate_memory(int8_t * p, size_t alignment)
+{
+    if (alignment > 0) // NOLINT(bugprone-branch-clone)
+    {
+#ifdef _WIN32
+        _aligned_free(p); // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+#else
+        std::free(p); // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+#endif
+    }
+    else
+    {
+        std::free(p); // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+    }
+}
+
+/**
+ * Transfer object for CPU-visible device-backed storage.
+ *
+ * The remover moves into ConcreteBuffer, where it keeps the backing resource
+ * alive and handles release. A successful allocation has a non-null remover;
+ * its data pointer is null only for zero-byte storage.
+ */
+struct DeviceBufferStorage
+{
+
+    int8_t * m_data = nullptr; ///< CPU-visible pointer, or nullptr for zero-byte storage.
+    std::unique_ptr<ConcreteBufferRemover> m_remover; ///< Keeps the backing resource alive until destruction.
+
+}; /* end struct DeviceBufferStorage */
+
+} /* end namespace detail */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/buffer/CMakeLists.txt
+++ b/cpp/solvcon/buffer/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOLVCON_BUFFER_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/buffer.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BufferBase.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BufferDevice.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/BufferStorage.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/small_vector.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/signed_stride_layout.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ConcreteBuffer.hpp

--- a/cpp/solvcon/buffer/ConcreteBuffer.cpp
+++ b/cpp/solvcon/buffer/ConcreteBuffer.cpp
@@ -5,6 +5,10 @@
 
 #include <solvcon/buffer/ConcreteBuffer.hpp>
 
+#ifdef SOLVCON_METAL
+#include <solvcon/device/metal/metal.hpp>
+#endif
+
 namespace solvcon
 {
 
@@ -18,7 +22,14 @@ std::shared_ptr<ConcreteBuffer> ConcreteBuffer::construct(size_t nbytes, size_t 
     case BufferDevice::Cpu:
         return construct(nbytes, alignment);
     case BufferDevice::Metal:
+#ifdef SOLVCON_METAL
+    {
+        detail::DeviceBufferStorage device_storage = device::MetalManager::instance().allocate_buffer(nbytes, alignment);
+        return construct(nbytes, device_storage.m_data, std::move(device_storage.m_remover), alignment);
+    }
+#else
         throw std::runtime_error("ConcreteBuffer::construct: Metal storage is unavailable");
+#endif
     }
     throw std::invalid_argument("ConcreteBuffer::construct: unknown buffer device");
 }

--- a/cpp/solvcon/buffer/ConcreteBuffer.hpp
+++ b/cpp/solvcon/buffer/ConcreteBuffer.hpp
@@ -15,6 +15,7 @@
 #include <solvcon/base.hpp>
 #include <solvcon/buffer/BufferBase.hpp>
 #include <solvcon/buffer/BufferDevice.hpp>
+#include <solvcon/buffer/BufferStorage.hpp>
 #include <solvcon/buffer/small_vector.hpp>
 
 #include <algorithm>
@@ -28,47 +29,8 @@ namespace solvcon
 namespace detail
 {
 
-// Take the remover and deleter classes outside ConcreteBuffer to work around
+// Keep the remover and deleter types outside ConcreteBuffer to work around
 // https://bugzilla.redhat.com/show_bug.cgi?id=1569374
-
-/**
- * The base class of memory deallocator for ConcreteBuffer.  When the object
- * exists in ConcreteBufferDataDeleter (the unique_ptr deleter), the deleter
- * calls it to release the memory of the ConcreteBuffer data buffer.
- */
-struct ConcreteBufferRemover
-{
-
-    ConcreteBufferRemover() = default;
-    ConcreteBufferRemover(ConcreteBufferRemover const &) = default;
-    ConcreteBufferRemover(ConcreteBufferRemover &&) = default;
-    ConcreteBufferRemover & operator=(ConcreteBufferRemover const &) = default;
-    ConcreteBufferRemover & operator=(ConcreteBufferRemover &&) = default;
-    virtual ~ConcreteBufferRemover() = default;
-
-    static void deallocate_memory(int8_t * p, size_t alignment)
-    {
-        if (alignment > 0) // NOLINT(bugprone-branch-clone)
-        {
-#ifdef _WIN32
-            _aligned_free(p); // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
-#else
-            std::free(p); // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
-#endif
-        }
-        else
-        {
-            std::free(p); // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
-        }
-    }
-
-    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays,readability-non-const-parameter)
-    virtual void operator()(int8_t * p, size_t alignment) const
-    {
-        deallocate_memory(p, alignment);
-    }
-
-}; /* end struct ConcreteBufferRemover */
 
 struct ConcreteBufferNoRemove : public ConcreteBufferRemover
 {
@@ -148,9 +110,10 @@ public:
      * @param nbytes Size in bytes.
      * @param alignment Alignment in bytes: 0, 16, 32, or 64. An aligned size
      * must be a multiple of the alignment.
-     * @param device Device that owns the storage.
+     * @param device Backend used to allocate the storage.
      * @return A new owning buffer.
      * @throw std::invalid_argument If the alignment, size, or device is invalid.
+     * @throw std::length_error If the requested storage exceeds the device limit.
      * @throw std::runtime_error If the requested device is unavailable.
      * @throw std::bad_alloc If storage allocation fails. */
     static std::shared_ptr<ConcreteBuffer> construct(size_t nbytes, size_t alignment, BufferDevice device);
@@ -195,7 +158,7 @@ public:
         , m_data(allocate(nbytes, m_alignment))
     {
         m_begin = m_data.get(); // overwrite m_begin and m_end once we have the data
-        m_end = m_begin + m_nbytes;
+        m_end = m_nbytes == 0 ? m_begin : m_begin + m_nbytes;
     }
 
     /**
@@ -218,7 +181,7 @@ public:
         , m_data(data, data_deleter_type(std::move(remover), m_alignment))
     {
         m_begin = m_data.get(); // overwrite m_begin and m_end once we have the data
-        m_end = m_begin + m_nbytes;
+        m_end = m_nbytes == 0 ? m_begin : m_begin + m_nbytes;
     }
 
     ~ConcreteBuffer() = default;
@@ -239,7 +202,7 @@ public:
         , m_data(allocate(other.m_nbytes, other.m_alignment))
     {
         m_begin = m_data.get(); // overwrite m_begin and m_end once we have the data
-        m_end = m_begin + m_nbytes;
+        m_end = m_nbytes == 0 ? m_begin : m_begin + m_nbytes;
         if (size() != other.size())
         {
             throw std::out_of_range("Buffer size mismatch");

--- a/cpp/solvcon/device/metal/metal.hpp
+++ b/cpp/solvcon/device/metal/metal.hpp
@@ -13,6 +13,9 @@
  * @ingroup group_core
  */
 
+#include <solvcon/buffer/BufferStorage.hpp>
+
+#include <cstddef>
 #include <memory>
 
 namespace solvcon
@@ -22,7 +25,7 @@ namespace device
 {
 
 /**
- * Process-wide owner of the single Metal device handle.
+ * Process-wide owner of a unified-memory Metal device handle.
  *
  * The instance is created on first access and acquires the Metal device in
  * startup(); shutdown() releases it. Copy and move are deleted so the device
@@ -46,6 +49,19 @@ public:
     void startup();
     bool started() { return nullptr != m_impl; }
     void shutdown();
+
+    /**
+     * Allocate CPU-visible shared Metal storage.
+     * @internal
+     * @param nbytes Size of the storage in bytes.
+     * @param alignment Alignment in bytes: 0, 16, 32, or 64; nbytes must be a multiple of a nonzero alignment.
+     * @return Storage and the owner of its Metal resource.
+     * @throw std::invalid_argument If the alignment or size is invalid.
+     * @throw std::length_error If the requested storage exceeds the device limit.
+     * @throw std::runtime_error If Metal storage is unavailable.
+     * @throw std::bad_alloc If storage allocation fails.
+     */
+    detail::DeviceBufferStorage allocate_buffer(std::size_t nbytes, std::size_t alignment);
 
 private:
 

--- a/cpp/solvcon/device/metal/metal.mm
+++ b/cpp/solvcon/device/metal/metal.mm
@@ -5,15 +5,74 @@
 
 #import <Metal/Metal.h>
 
+#include <solvcon/buffer/BufferBase.hpp>
 #include <solvcon/device/metal/metal.hpp>
 
 #include <memory>
+#include <new>
+#include <stdexcept>
+#include <utility>
 
 namespace solvcon
 {
 
 namespace device
 {
+
+static id<MTLDevice> select_unified_device()
+{
+    id<MTLDevice> const default_device = MTLCreateSystemDefaultDevice();
+    if (default_device != nil && default_device.hasUnifiedMemory)
+    {
+        return default_device;
+    }
+    for (id<MTLDevice> device in MTLCopyAllDevices())
+    {
+        if (device.hasUnifiedMemory)
+        {
+            return device;
+        }
+    }
+    return nil;
+}
+
+namespace
+{
+
+class MetalBufferRemover final : public detail::ConcreteBufferRemover
+{
+
+public:
+
+    explicit MetalBufferRemover(id<MTLBuffer> buffer)
+        : m_buffer(buffer)
+    {
+    }
+
+    MetalBufferRemover(MetalBufferRemover const &) = delete;
+    MetalBufferRemover(MetalBufferRemover &&) = delete;
+    MetalBufferRemover & operator=(MetalBufferRemover const &) = delete;
+    MetalBufferRemover & operator=(MetalBufferRemover &&) = delete;
+
+    ~MetalBufferRemover() override
+    {
+        // Metal may autorelease related resources while releasing the buffer.
+        @autoreleasepool
+        {
+            m_buffer = nil;
+        }
+    }
+
+    void operator()(int8_t *, size_t) const override {}
+    void reset(id<MTLBuffer> buffer) noexcept { m_buffer = buffer; }
+
+private:
+
+    id<MTLBuffer> m_buffer;
+
+}; /* end class MetalBufferRemover */
+
+} /* end namespace */
 
 class MetalManager::Impl
 {
@@ -22,6 +81,7 @@ public:
 
     Impl();
     bool started() const { return nil != m_device; }
+    detail::DeviceBufferStorage allocate_buffer(size_t nbytes, size_t alignment) const;
 
 private:
 
@@ -33,8 +93,54 @@ MetalManager::Impl::Impl()
 {
     @autoreleasepool
     {
-        m_device = MTLCreateSystemDefaultDevice();
+        m_device = select_unified_device();
     }
+}
+
+detail::DeviceBufferStorage MetalManager::Impl::allocate_buffer(size_t nbytes, size_t alignment) const
+{
+    if (nbytes == 0)
+    {
+        return {.m_data = nullptr, .m_remover = std::make_unique<MetalBufferRemover>(nil)};
+    }
+
+    size_t const padding = alignment == 0 ? 0 : alignment - 1;
+    size_t const capacity = nbytes + padding;
+
+    // Metal calls may autorelease objects; leave each local pool before throwing.
+    size_t max_buffer_length = 0;
+    @autoreleasepool
+    {
+        max_buffer_length = m_device.maxBufferLength;
+    }
+    if (capacity > max_buffer_length)
+    {
+        throw std::length_error("MetalManager::allocate_buffer: Metal storage exceeds maxBufferLength");
+    }
+
+    auto remover = std::make_unique<MetalBufferRemover>(nil);
+    id<MTLBuffer> buffer = nil;
+    void * data = nullptr;
+    @autoreleasepool
+    {
+        buffer = [m_device newBufferWithLength:capacity options:MTLResourceStorageModeShared];
+        remover->reset(buffer);
+        data = buffer.contents;
+    }
+    if (buffer == nil || data == nullptr)
+    {
+        throw std::bad_alloc();
+    }
+
+    size_t space = capacity;
+    if (alignment != 0 && std::align(alignment, nbytes, data, space) == nullptr)
+    {
+        throw std::bad_alloc();
+    }
+    return {
+        .m_data = static_cast<int8_t *>(data),
+        .m_remover = std::move(remover),
+    };
 }
 
 MetalManager::MetalManager() { startup(); }
@@ -60,6 +166,19 @@ void MetalManager::startup()
 }
 
 void MetalManager::shutdown() { m_impl.reset(); }
+
+detail::DeviceBufferStorage MetalManager::allocate_buffer(std::size_t nbytes, std::size_t alignment)
+{
+    validate_alignment(alignment, "MetalManager::allocate_buffer");
+    validate_size_alignment(nbytes, alignment, "MetalManager::allocate_buffer");
+
+    if (!m_impl)
+    {
+        throw std::runtime_error("MetalManager::allocate_buffer: Metal storage is unavailable");
+    }
+
+    return m_impl->allocate_buffer(nbytes, alignment);
+}
 
 } /* end namespace device */
 

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -25,12 +25,24 @@ TEST(ConcreteBuffer, construct_cpu_device)
     EXPECT_EQ(size_t{32}, buffer->alignment());
 }
 
+TEST(ConcreteBuffer, construct_empty)
+{
+    namespace sc = solvcon;
+
+    auto buffer = sc::ConcreteBuffer::construct();
+    EXPECT_EQ(nullptr, buffer->data());
+    EXPECT_EQ(buffer->begin(), buffer->end());
+    EXPECT_EQ(size_t{0}, buffer->size());
+}
+
+#ifndef SOLVCON_METAL
 TEST(ConcreteBuffer, construct_unavailable_metal)
 {
     namespace sc = solvcon;
 
     EXPECT_THROW(sc::ConcreteBuffer::construct(16, 0, sc::BufferDevice::Metal), std::runtime_error);
 }
+#endif
 
 TEST(ConcreteBuffer, construct_invalid_metal_request)
 {

--- a/gtests/test_nopython_metal.cpp
+++ b/gtests/test_nopython_metal.cpp
@@ -1,6 +1,12 @@
+#include <solvcon/buffer/ConcreteBuffer.hpp>
 #include <solvcon/device/metal/metal.hpp>
 
 #include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
 
 #ifdef Py_PYTHON_H
 #error "Python.h should not be included."
@@ -24,9 +30,86 @@ TEST(MetalManager, repeated_lifecycle_calls_preserve_state)
     EXPECT_FALSE(manager.started());
     manager.shutdown();
     EXPECT_FALSE(manager.started());
+    EXPECT_THROW(ConcreteBuffer::construct(16, 0, BufferDevice::Metal), std::runtime_error);
 
     manager.startup();
     EXPECT_EQ(available, manager.started());
+}
+
+TEST(MetalManager, allocate_shared_buffer)
+{
+    MetalManager & manager = MetalManager::instance();
+    if (!manager.started())
+    {
+        GTEST_SKIP() << "No unified-memory Metal device is available";
+    }
+
+    for (size_t const alignment : std::array<size_t, 4>{0, 16, 32, 64})
+    {
+        auto buffer = ConcreteBuffer::construct(64, alignment, BufferDevice::Metal);
+        ASSERT_NE(nullptr, buffer->data());
+        EXPECT_EQ(size_t{64}, buffer->size());
+        EXPECT_EQ(alignment, buffer->alignment());
+        EXPECT_TRUE(buffer->has_remover());
+        if (alignment != 0)
+        {
+            auto const address = reinterpret_cast<std::uintptr_t>(buffer->data());
+            EXPECT_EQ(std::uintptr_t{0}, address % alignment);
+        }
+
+        (*buffer)[0] = 12;
+        (*buffer)[63] = 34;
+        EXPECT_EQ(12, (*buffer)[0]);
+        EXPECT_EQ(34, (*buffer)[63]);
+    }
+}
+
+TEST(MetalManager, allocate_empty_shared_buffer)
+{
+    MetalManager & manager = MetalManager::instance();
+    if (!manager.started())
+    {
+        GTEST_SKIP() << "No unified-memory Metal device is available";
+    }
+
+    auto buffer = ConcreteBuffer::construct(0, 64, BufferDevice::Metal);
+    EXPECT_EQ(nullptr, buffer->data());
+    EXPECT_EQ(size_t{0}, buffer->size());
+    EXPECT_EQ(size_t{64}, buffer->alignment());
+    EXPECT_TRUE(buffer->has_remover());
+}
+
+TEST(MetalManager, reject_oversized_shared_buffer)
+{
+    MetalManager & manager = MetalManager::instance();
+    if (!manager.started())
+    {
+        GTEST_SKIP() << "No unified-memory Metal device is available";
+    }
+
+    EXPECT_THROW(
+        ConcreteBuffer::construct(std::numeric_limits<size_t>::max(), 0, BufferDevice::Metal),
+        std::length_error);
+}
+
+TEST(MetalManager, shared_buffer_owns_resource)
+{
+    MetalManager & manager = MetalManager::instance();
+    if (!manager.started())
+    {
+        GTEST_SKIP() << "No unified-memory Metal device is available";
+    }
+
+    auto buffer = ConcreteBuffer::construct(16, 0, BufferDevice::Metal);
+    (*buffer)[0] = 12;
+
+    manager.shutdown();
+    EXPECT_FALSE(manager.started());
+    EXPECT_EQ(12, (*buffer)[0]);
+    buffer.reset();
+
+    manager.startup();
+    EXPECT_TRUE(manager.started());
 }
 
 } /* end namespace device */


### PR DESCRIPTION
Metal construction allocates CPU-visible shared `MTLBuffer` storage on a unified-memory device. The Metal layer returns storage and its owner; `ConcreteBuffer` remains the only buffer factory.

Alignment, empty buffers, device limits, and unavailable build or runtime configurations are handled explicitly. Synchronization, `SimpleArray` device APIs, and MPS execution remain in later tasks.

Related to #1397.