### PR TITLE
Share the bounds-checked byte cursor of the MCAP reader

### DIFF
--- a/cpp/solvcon/mcap/CMakeLists.txt
+++ b/cpp/solvcon/mcap/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 4.0.1)
 
 set(SOLVCON_MCAP_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/mcap.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mcap_cursor.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mcap_reader.hpp
     CACHE FILEPATH "" FORCE)
 

--- a/cpp/solvcon/mcap/mcap_cursor.hpp
+++ b/cpp/solvcon/mcap/mcap_cursor.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Bounds-checked cursor over the bytes of an MCAP record or message.
+ *
+ * @ingroup group_inout
+ */
+
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string_view>
+
+namespace solvcon
+{
+
+namespace mcap
+{
+
+namespace detail
+{
+
+/**
+ * @internal
+ * Cursor over a run of bytes.  MCAP writes its integers little-endian, and
+ * so does every platform solvcon builds for, so a value is a plain copy out
+ * of the buffer.
+ */
+class ByteCursor
+{
+
+public:
+
+    /**
+     * Wrap a run of bytes.
+     *
+     * @param data Bytes to read.
+     * @param truncated Message of the std::runtime_error that a read past
+     *                  the end throws.  The string must outlive the cursor.
+     */
+    ByteCursor(std::string_view data, char const * truncated)
+        : m_data(data)
+        , m_truncated(truncated)
+    {
+    }
+
+    size_t position() const { return m_pos; }
+
+    void skip(size_t length)
+    {
+        require(length);
+        m_pos += length;
+    }
+
+    template <typename T>
+    T read()
+    {
+        require(sizeof(T));
+        T value = T();
+        std::memcpy(&value, m_data.data() + m_pos, sizeof(T));
+        m_pos += sizeof(T);
+        return value;
+    }
+
+protected:
+
+    void require(size_t length) const
+    {
+        // The cursor never passes the end, so the room left is a subtraction.
+        // Adding the length to the position instead would wrap for a length
+        // the data states.
+        if (length > m_data.size() - m_pos)
+        {
+            throw std::runtime_error(m_truncated);
+        }
+    }
+
+    std::string_view m_data;
+    size_t m_pos = 0;
+
+private:
+
+    char const * m_truncated;
+}; /* end class ByteCursor */
+
+} /* end namespace detail */
+
+} /* end namespace mcap */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/mcap/mcap_reader.cpp
+++ b/cpp/solvcon/mcap/mcap_reader.cpp
@@ -13,6 +13,8 @@
 #include <lz4frame.h>
 #include <zstd.h>
 
+#include <solvcon/mcap/mcap_cursor.hpp>
+
 namespace solvcon
 {
 
@@ -42,17 +44,16 @@ enum Opcode : uint8_t
 
 /**
  * @internal
- * Cursor reading the fields of one record content.  MCAP writes its integers
- * little-endian, and so does every platform solvcon builds for, so a field is
- * a plain copy out of the buffer.
+ * Cursor reading the fields of one record content.
  */
 class FieldReader
+    : public detail::ByteCursor
 {
 
 public:
 
     explicit FieldReader(std::string_view data)
-        : m_data(data)
+        : ByteCursor(data, "MCAP record is truncated")
     {
     }
 
@@ -71,38 +72,10 @@ public:
         return out;
     }
 
-    void skip(uint64_t length) { bytes(length); }
-
     /// The bytes after the cursor.
     std::string_view rest() { return bytes(m_data.size() - m_pos); }
 
     bool done() const { return m_pos >= m_data.size(); }
-
-private:
-
-    template <typename T>
-    T read()
-    {
-        require(sizeof(T));
-        T value = 0;
-        std::memcpy(&value, m_data.data() + m_pos, sizeof(T));
-        m_pos += sizeof(T);
-        return value;
-    }
-
-    void require(uint64_t length) const
-    {
-        // The cursor never passes the end, so the room left is a subtraction.
-        // Adding the length to the position instead would wrap for a length
-        // the file states.
-        if (length > m_data.size() - m_pos)
-        {
-            throw std::runtime_error("MCAP record is truncated");
-        }
-    }
-
-    std::string_view m_data;
-    uint64_t m_pos = 0;
 }; /* end class FieldReader */
 
 } /* end namespace */

--- a/solvcon/mcap/_decode_plan.py
+++ b/solvcon/mcap/_decode_plan.py
@@ -14,10 +14,10 @@ Each instruction is a tuple whose first item names it:
 - ``("align", n)`` advances to the next multiple of ``n`` bytes.
 - ``("skip", n)`` advances ``n`` bytes.
 - ``("skip_string", )`` reads a 4-byte length and advances past the text.
-- ``("skip_sequence", name)`` reads a 4-byte count and advances past that
-  many primitives of type ``name``.  CDR pads between the count and the
-  elements, so a nonzero count aligns to the width of ``name`` first.  An
-  empty sequence carries no padding.
+- ``("skip_sequence", width)`` reads a 4-byte count and advances past that
+  many primitives of ``width`` bytes.  CDR pads between the count and the
+  elements, so when the count is nonzero the walk aligns to ``width``
+  first.  An empty sequence carries no padding.
 - ``("skip_sequence_body", n)`` reads a 4-byte count and runs the ``n``
   instructions that follow it that many times.
 - ``("skip_array_body", count, n)`` runs the ``n`` instructions that follow
@@ -331,7 +331,7 @@ class _Compiler:
         else:
             _align(self.instructions, 4)
             if element.kind == "primitive":
-                self.instructions.append(("skip_sequence", element.name))
+                self.instructions.append(("skip_sequence", element.size))
             else:
                 self.skip_container("skip_sequence_body", element)
 

--- a/tests/test_mcap_decode_plan.py
+++ b/tests/test_mcap_decode_plan.py
@@ -81,7 +81,7 @@ module vhclsim_msgs { module msg {
                 ("align", 8), ("skip", 8),
                 ("align", 8), ("skip", 8),
                 ("skip", 1),
-                ("align", 4), ("skip_sequence", "float32"),
+                ("align", 4), ("skip_sequence", 4),
                 ("align", 4), ("skip_string",),
                 ("align", 4), ("skip", 4),
                 ("align", 4), ("read", "int32", 0),
@@ -142,7 +142,7 @@ module p { module msg {
                 ("align", 4), ("skip_string",),
                 ("align", 4), ("skip_sequence_body", 2),
                 ("align", 4), ("skip_string",),
-                ("align", 4), ("skip_sequence", "float64"),
+                ("align", 4), ("skip_sequence", 8),
                 ("align", 4), ("read", "int32", 0),
             ),
         )


### PR DESCRIPTION
`detail::ByteCursor` in `mcap_cursor.hpp` carries the bounds-checked read and skip that `FieldReader` used over one record. The cursor over a CDR message body that the decode plan executor needs derives from it, so the two share one bounds check instead of repeating it.

`("skip_sequence", ...)` now carries the element width instead of the type name. The executor aligns to the width and skips past the elements, so the width is all it reads from the instruction.

This is the first of four stacked PRs that split the executor step of issue #1286 (the former single PR here). The next three are pushed as `worktree-issue-1286-pr3b-decode-plan` (the plan check, `core.McapDecodePlan`), `worktree-issue-1286-pr3c-executor` (the walk and `McapReader.extract`), and `worktree-issue-1286-pr3d-python-extract` (`Reader.extract` and `ColumnSet`); each opens once the one before it merges. #1381, #1386, and #1401 built the container reader, and #1402 built the plan compiler.

Related to #1286.
