### PR TITLE
Open the agent console with the 2D canvas it drives

### DIFF
--- a/solvcon/pilot/agent/_agent_gui.py
+++ b/solvcon/pilot/agent/_agent_gui.py
@@ -26,10 +26,17 @@ from ._agent_settings import AgentBackendSettingsDialog
 from ..base import _gui_common
 
 __all__ = [  # noqa: F822
+    'AUTO_OPEN_COMMANDS',
     'AgentBackendWorker',
     'AgentConsoleWidget',
     'AgentPanel',
 ]
+
+#: The commands that open the agent console together with their canvas.
+AUTO_OPEN_COMMANDS = (
+    "canvas.blank_2d",
+    "canvas.open_2d",
+)
 
 
 class AgentBackendWorker(QThread):
@@ -173,6 +180,9 @@ class AgentConsoleWidget(QWidget):
 class AgentPanel(_gui_common.PilotFeature):
     """Agent Console dock, toggled from the View "Panels" submenu.
 
+    The dock starts hidden.  The commands in :data:`AUTO_OPEN_COMMANDS`
+    open it together with the 2D canvas it drives.
+
     It holds one :class:`~solvcon.agent.AgentSession` reused across prompts
     (the "current session"), rebinding it to the active world and the selected
     backend on each turn.  The session runs a dispatcher over the Agent Draw,
@@ -205,11 +215,21 @@ class AgentPanel(_gui_common.PilotFeature):
         self._action = self.add_action(
             "View/Panels", "Agent Console", "Toggle the agent console panel",
             None, id="panel.agent_console", weight=40, checkable=True,
-            checked=True)
+            checked=False)
         self._action.toggled.connect(self._on_toggled)
-        # Shown by default, beside the Python console.
+
+    def bind_auto_open(self):
+        """Present the console from every command in"""
+        for command in AUTO_OPEN_COMMANDS:
+            action = self._mgr.menu_model.action(command)
+            if action is not None:
+                action.triggered.connect(self.present)
+
+    def present(self):
+        """Show the console dock and raise it over its neighbours. """
+        self._action.setChecked(True)
         self._ensure_panel()
-        self._dock.show()
+        self._dock.raise_()
 
     def _on_toggled(self, checked):
         """Show or hide the panel."""

--- a/solvcon/pilot/base/_gui.py
+++ b/solvcon/pilot/base/_gui.py
@@ -174,6 +174,7 @@ class _Controller(metaclass=_Singleton):
         self.agent.populate_menu()
         self.theme_menu.populate_menu()
         self.window_manager.populate_menu()
+        self.agent.bind_auto_open()  # need to be the last to bind all commands
 
         wm.menu_model.place(
             "File",

--- a/tests/gui/test_agent.py
+++ b/tests/gui/test_agent.py
@@ -159,12 +159,21 @@ class AgentPanelTC(unittest.TestCase):
         panels = self.mgr.menu_model.menu("View/Panels")
         self.assertIn(feature._action, panels.actions())
 
-    def test_appears_by_default_titled_agent(self):
+    def test_hidden_by_default(self):
+        # Pilot opens with no 2D canvas, so the console has nothing to act on
+        # and stays out of the way until a canvas opens.
         feature = _agent_gui.AgentPanel(mgr=self.mgr)
         feature.populate_menu()
+        self.assertFalse(feature._action.isChecked())
+        self.assertIsNone(feature._dock)
+
+    def test_present_opens_the_dock_titled_agent(self):
+        feature = _agent_gui.AgentPanel(mgr=self.mgr)
+        feature.populate_menu()
+        feature.present()
         self.assertTrue(feature._action.isChecked())
-        self.assertIsNotNone(feature._dock)
         self.assertEqual(feature._dock.windowTitle(), "Agent")
+        self.assertFalse(feature._dock.isHidden())
 
     def test_dock_sits_in_the_bottom_area(self):
         # The console owns the bottom-left; the agent takes the bottom-right.

--- a/tests/test_pilot_agent_panel.py
+++ b/tests/test_pilot_agent_panel.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Tests for when the pilot agent console opens.
+"""
+
+import unittest
+
+import solvcon
+
+try:
+    from solvcon.pilot.agent import _agent_gui
+    from solvcon.pilot.base import _gui
+except ImportError:
+    _agent_gui = _gui = None
+
+
+@unittest.skipIf(not solvcon.HAS_PILOT, "pilot is not built")
+class AgentAutoOpenTC(unittest.TestCase):
+    """The console opens with the canvas commands the table names."""
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.agent = _gui.controller.agent
+        self.model = self.mgr.menu_model
+        # The controller is a process-wide singleton, so an earlier test may
+        # leave the console open; start every case from the hidden state.
+        self.model.action("panel.agent_console").setChecked(False)
+
+    def tearDown(self):
+        self.mgr.mdiArea.closeAllSubWindows()
+        self.model.action("panel.agent_console").setChecked(False)
+
+    def test_every_table_id_is_a_registered_command(self):
+        # bind_auto_open skips a stale id, so nothing else reports one that
+        # no feature registers any more.
+        missing = [command for command in _agent_gui.AUTO_OPEN_COMMANDS
+                   if self.model.action(command) is None]
+        self.assertEqual(missing, [])
+
+    def test_new_2d_canvas_opens_the_console(self):
+        # trigger() is the single path the menu item and its New shortcut
+        # share, so one case covers both.
+        self.model.action("canvas.blank_2d").trigger()
+        self.assertFalse(self.agent._dock.isHidden())
+
+    def test_the_next_canvas_reopens_a_closed_console(self):
+        self.model.action("canvas.blank_2d").trigger()
+        self.model.action("panel.agent_console").setChecked(False)
+        self.assertTrue(self.agent._dock.isHidden())
+        self.model.action("canvas.open_2d").trigger()
+        self.assertFalse(self.agent._dock.isHidden())
+
+    def test_a_canvas_opened_outside_a_command_leaves_the_console_alone(self):
+        # The table binds menu commands, so a canvas the Python console or the
+        # agent itself opens does not drag the console along with it.
+        self.mgr.add2DWidget()
+        self.assertFalse(self.model.action("panel.agent_console").isChecked())
+        dock = self.agent._dock
+        self.assertTrue(dock is None or dock.isHidden())
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Pilot no longer shows the agent console at start-up.  Agent dock will only pop up while any command of `AUTO_OPEN_COMMANDS` is called.

Related to #1241.
