### PR TITLE
Build and run solvcon on Windows without make or python3-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ CMakeUserPresets.json
 *.tlog
 *.obj
 *.pdb
+*.ilk
 *.env

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,7 @@ set(SOLVCON_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/cpp" CACHE INTERNAL "")
 
 include_directories(${SOLVCON_INCLUDE_DIR})
 
+if(BUILD_QT)
 # Discovery has to use PYTHON_EXECUTABLE rather than a bare python3.
 execute_process(
     COMMAND "${PYTHON_EXECUTABLE}" -c "import os, PySide6; print(os.path.dirname(PySide6.__file__))"
@@ -351,13 +352,6 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 message(STATUS "SHIBOKEN6_FALLBACK_LIBDIR: ${SHIBOKEN6_FALLBACK_LIBDIR}")
-execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}" -c "import os, shiboken6_generator; print(os.path.dirname(shiboken6_generator.__file__))"
-    OUTPUT_VARIABLE SHIBOKEN6_GENERATOR_PYTHON_PACKAGE_PATH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-message(STATUS "SHIBOKEN6_GENERATOR_PYTHON_PACKAGE_PATH: ${SHIBOKEN6_GENERATOR_PYTHON_PACKAGE_PATH}")
-
 if(NOT "${PYSIDE6_PYTHON_PACKAGE_PATH}" STREQUAL "")
     include_directories("${PYSIDE6_PYTHON_PACKAGE_PATH}/include")
     link_directories("${PYSIDE6_PYTHON_PACKAGE_PATH}")
@@ -365,10 +359,8 @@ endif()
 if(NOT "${PYSIDE6_FALLBACK_LIBDIR}" STREQUAL "" AND IS_DIRECTORY "${PYSIDE6_FALLBACK_LIBDIR}")
     link_directories("${PYSIDE6_FALLBACK_LIBDIR}")
 endif()
-if(NOT "${SHIBOKEN6_GENERATOR_PYTHON_PACKAGE_PATH}" STREQUAL "")
-    include_directories("${SHIBOKEN6_GENERATOR_PYTHON_PACKAGE_PATH}/include")
-endif()
 if(NOT "${SHIBOKEN6_PYTHON_PACKAGE_PATH}" STREQUAL "")
+    include_directories("${SHIBOKEN6_PYTHON_PACKAGE_PATH}/include")
     link_directories("${SHIBOKEN6_PYTHON_PACKAGE_PATH}")
 endif()
 if(NOT "${SHIBOKEN6_FALLBACK_LIBDIR}" STREQUAL "" AND IS_DIRECTORY "${SHIBOKEN6_FALLBACK_LIBDIR}")
@@ -401,12 +393,16 @@ if(BUILD_QT AND "${PYSIDE6_LIBFILE}" STREQUAL "")
         "PYTHON_EXECUTABLE at an interpreter that can import PySide6, or "
         "configure with BUILD_QT=OFF.")
 endif()
+endif() # BUILD_QT
 
 # add_subdirectory() copies this scope's variables into the subdirectory as it
 # is called, so this must stay above every add_subdirectory() that consumes it.
 # Set it below one and the subdirectory sees nothing, with no diagnostic.
 if(MSVC)
-    set(COMMON_COMPILER_OPTIONS /W4 /bigobj /WX)
+    # /guard:cf covers _solvcon as well as the pilot: the file parsers under
+    # cpp/solvcon/{mcap,inout,serialization} are the untrusted-input surface.
+    set(COMMON_COMPILER_OPTIONS /W4 /bigobj /guard:cf /WX)
+    add_link_options(/guard:cf)
 else()
     set(COMMON_COMPILER_OPTIONS -Wall -Wextra)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -331,7 +331,7 @@
       "configurePreset": "win-reldbg",
       "displayName": "Windows Release with Debug Info",
       "description": "Build the extension module and the pilot, RelWithDebInfo.",
-      "targets": ["_solvcon", "pilot"]
+      "targets": ["_solvcon_py", "pilot"]
     },
     {
       "name": "win-reldbg-module",
@@ -339,7 +339,7 @@
       "configurePreset": "win-reldbg",
       "displayName": "Windows Release with Debug Info, module only",
       "description": "Build the extension module alone, RelWithDebInfo.",
-      "targets": ["_solvcon"]
+      "targets": ["_solvcon_py"]
     },
     {
       "name": "win-reldbg-gtest",
@@ -355,7 +355,7 @@
       "configurePreset": "win-rel",
       "displayName": "Windows Release",
       "description": "Build the extension module and the pilot, Release.",
-      "targets": ["_solvcon", "pilot"]
+      "targets": ["_solvcon_py", "pilot"]
     },
     {
       "name": "win-rel-module",
@@ -363,7 +363,7 @@
       "configurePreset": "win-rel",
       "displayName": "Windows Release, module only",
       "description": "Build the extension module alone, Release.",
-      "targets": ["_solvcon"]
+      "targets": ["_solvcon_py"]
     },
     {
       "name": "win-rel-gtest",
@@ -379,7 +379,7 @@
       "configurePreset": "win-dbg",
       "displayName": "Windows Debug",
       "description": "Build the extension module and the pilot, Debug.",
-      "targets": ["_solvcon", "pilot"]
+      "targets": ["_solvcon_py", "pilot"]
     },
     {
       "name": "win-dbg-module",
@@ -387,7 +387,7 @@
       "configurePreset": "win-dbg",
       "displayName": "Windows Debug, module only",
       "description": "Build the extension module alone, Debug.",
-      "targets": ["_solvcon"]
+      "targets": ["_solvcon_py"]
     },
     {
       "name": "win-dbg-gtest",

--- a/build.ps1
+++ b/build.ps1
@@ -5,10 +5,10 @@
 # Build solvcon (the _solvcon extension and, by default, the Qt pilot) on
 # Windows against a scdv produced by
 # contrib/dependency/windows/build-scdv-windows.ps1.  solvcon's Makefile and
-# setup.py shell out to "make", and its module-copy target runs
-# "python3-config"; neither exists on Windows.  This drives CMake directly
-# through the win-reldbg / win-rel / win-dbg presets in CMakePresets.json,
-# adding only the scdv-specific cache variables, and places the module by hand.
+# its Unix development workflow require "make", which is not a standard
+# Windows tool.  This drives CMake directly through the win-reldbg / win-rel /
+# win-dbg presets in CMakePresets.json, adding only the scdv-specific cache
+# variables.
 # Those three path variables belong in CMakeUserPresets.json; pass -Preset
 # <name> to build such a preset and the script leaves them to it.  Start from
 # contrib/cmake/CMakeUserPresets.win-example.json: the other template inherits
@@ -95,6 +95,10 @@ if ($Sanitize) {
         throw '-Sanitize cannot use the Debug preset: MSVC ASan rejects the ' +
             "Debug /RTC1 runtime checks. Drop -BuildType Debug."
     }
+    if ($Test) {
+        throw '-Sanitize cannot run -Test through stock python.exe; use ' +
+            '-Gtest or -PilotTest so AddressSanitizer starts with the process'
+    }
     if (-not $PilotTest) {
         $Gtest = $true
         $NoQt = $true
@@ -156,12 +160,14 @@ function Get-ConfigurePresetBinaryDir {
     if (-not $raw) { throw "preset '$Name' states no binaryDir" }
     $raw = $raw.Replace('${sourceDir}', $Root).Replace('${presetName}', $Name)
     if ($raw -match '\$\{') { throw "unsupported macro in binaryDir '$raw'" }
-    return $raw.Replace('/', '\')
+    $raw = $raw.Replace('/', '\')
+    if (-not [IO.Path]::IsPathRooted($raw)) {
+        $raw = Join-Path $Root $raw
+    }
+    return [IO.Path]::GetFullPath($raw)
 }
 
 $bld = Get-ConfigurePresetBinaryDir $Repo $presetName
-$solvconDir = Join-Path $Repo 'solvcon'
-
 # --- MSVC environment -------------------------------------------------------
 
 if (-not (Get-Command cl.exe -ErrorAction SilentlyContinue)) {
@@ -229,23 +235,26 @@ Write-Host "using cmake: $cmake"
 
 # --- Activate the scdv ------------------------------------------------------
 
-if (-not $env:SCDV_USRDIR) {
-    if (-not $ScdvBase) { $ScdvBase = $env:SCDV_BASE }
-    if (-not $ScdvBase) {
-        throw ('no active scdv: activate one (". <scdv>\Activate.ps1") or pass ' +
-            '-ScdvBase <scdv dir>')
+$py = $null
+if (-not $Preset) {
+    if (-not $env:SCDV_USRDIR) {
+        if (-not $ScdvBase) { $ScdvBase = $env:SCDV_BASE }
+        if (-not $ScdvBase) {
+            throw ('no active scdv: activate one (". <scdv>\Activate.ps1") ' +
+                'or pass -ScdvBase <scdv dir>')
+        }
+        $activate = Join-Path $ScdvBase 'Activate.ps1'
+        if (-not (Test-Path -LiteralPath $activate)) {
+            throw "Activate.ps1 not found under -ScdvBase '$ScdvBase'"
+        }
+        Write-Host "activating scdv: $ScdvBase"
+        . $activate
     }
-    $activate = Join-Path $ScdvBase 'Activate.ps1'
-    if (-not (Test-Path -LiteralPath $activate)) {
-        throw "Activate.ps1 not found under -ScdvBase '$ScdvBase'"
+    $usr = $env:SCDV_USRDIR
+    $py = Join-Path $usr 'python3.exe'
+    if (-not (Test-Path -LiteralPath $py)) {
+        throw "scdv python3.exe not found at $py"
     }
-    Write-Host "activating scdv: $ScdvBase"
-    . $activate
-}
-$usr = $env:SCDV_USRDIR
-$py = Join-Path $usr 'python3.exe'
-if (-not (Test-Path -LiteralPath $py)) {
-    throw "scdv python3.exe not found at $py"
 }
 
 # --- Configure and build via the preset -------------------------------------
@@ -276,11 +285,32 @@ if ($NoQt) { $extra += '-DBUILD_QT=OFF' }
 # instrumented .pyd into a stock python.exe.
 if ($Sanitize) { $extra += '-DUSE_SANITIZER=ON' }
 
+# Timestamps preserved from Python wheels can appear ahead of the local clock
+# and make Ninja's automatic CMake regeneration loop.  Suppress it only for
+# this scripted build, then regenerate the tree with the normal rule restored.
+$configureExtra = @($extra) + '-DCMAKE_SUPPRESS_REGENERATION=ON'
+$restoreExtra = @($extra) + '-DCMAKE_SUPPRESS_REGENERATION=OFF'
+$cachePath = Join-Path $bld 'CMakeCache.txt'
+$operationFailure = $null
+
 Push-Location $Repo
 try {
     Write-Host "configuring solvcon (preset $presetName, BUILD_QT=$(if ($NoQt) {'OFF'} else {'ON'})) ..."
-    & $cmake --preset $presetName @extra
+    & $cmake --preset $presetName @configureExtra
     Assert-LastExit 'cmake configure'
+
+    if (-not $py) {
+        $cacheEntry = Get-Content -LiteralPath $cachePath |
+            Select-String -Pattern '^PYTHON_EXECUTABLE:[^=]+=(.*)$' |
+            Select-Object -First 1
+        if (-not $cacheEntry) {
+            throw "preset '$presetName' did not configure PYTHON_EXECUTABLE"
+        }
+        $py = $cacheEntry.Matches[0].Groups[1].Value
+        if (-not (Test-Path -LiteralPath $py)) {
+            throw "preset '$presetName' configured missing Python at $py"
+        }
+    }
 
     # The build presets carry the target lists: <preset> builds the module and
     # the pilot, <preset>-module the module alone, <preset>-gtest the C++ test
@@ -297,19 +327,36 @@ try {
         & $cmake --build --preset $buildPreset
         Assert-LastExit "cmake build --preset $buildPreset"
     }
+} catch {
+    $operationFailure = $_
 } finally {
+    # A tree left suppressed only inconveniences other tools, so warn rather
+    # than fail a build that already succeeded.
+    try {
+        $suppressed = (Test-Path -LiteralPath $cachePath) -and
+            (Select-String -LiteralPath $cachePath -Quiet `
+                -Pattern '^CMAKE_SUPPRESS_REGENERATION:[^=]+=ON$')
+        if ($suppressed) {
+            Write-Host 'restoring automatic CMake regeneration ...'
+            & $cmake --preset $presetName @restoreExtra
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning ('automatic CMake regeneration could not be ' +
+                    "restored; reconfigure $bld before building again")
+            }
+        }
+    } catch {
+        Write-Warning "regeneration cleanup failed: $_"
+    }
     Pop-Location
 }
+if ($operationFailure) { throw $operationFailure }
 
-# _solvcon.pyd is a LIBRARY artifact (-> solvcon\, per the preset); pilot.exe is
-# a RUNTIME artifact (-> the binary directory the preset states, read above).
-# Copy the module to the repo root as the top-level _solvcon: solvcon.core
-# imports it there first, and the tests' qualified type names assume that name.
-$pyd = Get-ChildItem -LiteralPath $solvconDir -Filter '_solvcon*.pyd' |
-    Select-Object -First 1
-if (-not $pyd) { throw "no _solvcon*.pyd produced under $solvconDir" }
-Copy-Item $pyd.FullName (Join-Path $Repo $pyd.Name) -Force
-Write-Host "placed module: $(Join-Path $Repo $pyd.Name)"
+# The _solvcon_py target places the module at the repository root, where
+# solvcon.core imports it.
+$pyd = Get-ChildItem -LiteralPath $Repo -Filter '_solvcon*.pyd' |
+    Sort-Object LastWriteTime -Descending | Select-Object -First 1
+if (-not $pyd) { throw "no _solvcon*.pyd produced under $Repo" }
+Write-Host "placed module: $($pyd.FullName)"
 if (-not $NoQt) {
     Write-Host "built pilot: $(Join-Path $bld 'pilot.exe')"
 }

--- a/cpp/binary/pymod_solvcon/CMakeLists.txt
+++ b/cpp/binary/pymod_solvcon/CMakeLists.txt
@@ -43,27 +43,19 @@ if (CLANG_TIDY_EXE AND USE_CLANG_TIDY)
     )
 endif ()
 
-include(CMakePrintHelpers)
-get_filename_component(REALPATH_PYTHON "${PYTHON_EXECUTABLE}" REALPATH)
-get_filename_component(PYTHON_VENV_BIN "${REALPATH_PYTHON}" DIRECTORY)
-cmake_print_variables(REALPATH_PYTHON)
-cmake_print_variables(PYTHON_VENV_BIN)
-
-execute_process(
-    COMMAND ${PYTHON_VENV_BIN}/python3-config --extension-suffix
-    OUTPUT_VARIABLE PYEXTSUFFIX
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-add_custom_target(_solvcon_py
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:_solvcon> ${SOLVCON_PY_DIR}/../_solvcon${PYEXTSUFFIX}
-    DEPENDS _solvcon)
+add_custom_target(_solvcon_py ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        $<TARGET_FILE:_solvcon>
+        ${SOLVCON_PY_DIR}/../$<TARGET_FILE_NAME:_solvcon>
+    DEPENDS _solvcon
+    VERBATIM)
 
 add_custom_target(remove_solvcon_py
     COMMAND ${CMAKE_COMMAND} -E rm -f
-        ${SOLVCON_PY_DIR}/_solvcon${PYEXTSUFFIX}
-        ${SOLVCON_PY_DIR}/../_solvcon${PYEXTSUFFIX}
-    COMMENT "removing the built _solvcon extension")
+        ${SOLVCON_PY_DIR}/$<TARGET_FILE_NAME:_solvcon>
+        ${SOLVCON_PY_DIR}/../$<TARGET_FILE_NAME:_solvcon>
+    COMMENT "removing the built _solvcon extension"
+    VERBATIM)
 
 message(STATUS "CMAKE_INSTALL_INCLUDEDIR: ${CMAKE_INSTALL_INCLUDEDIR}")
 install(DIRECTORY ${SOLVCON_INCLUDE_DIR}/solvcon DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/cpp/solvcon/pilot/theme/RWindowsThemeBackend.cpp
+++ b/cpp/solvcon/pilot/theme/RWindowsThemeBackend.cpp
@@ -105,7 +105,7 @@ void RWindowsThemeBackend::applyNativeChrome(QWidget * window, ThemeVariant vari
     }
 
     // dwmapi is loaded at runtime so the room needs no extra link dependency.
-    HMODULE const dwm = LoadLibraryW(L"dwmapi.dll");
+    HMODULE const dwm = LoadLibraryExW(L"dwmapi.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (dwm == nullptr)
     {
         return;

--- a/cpp/solvcon/profiling/profile.hpp
+++ b/cpp/solvcon/profiling/profile.hpp
@@ -19,7 +19,7 @@ namespace solvcon
 {
 
 /**
- * Simple timer for wall time using high-resolution clock.
+ * Simple timer for elapsed wall time using a monotonic clock.
  *
  * @ingroup group_core
  */
@@ -28,7 +28,7 @@ class StopWatch
 
 private:
 
-    using clock_type = std::chrono::high_resolution_clock;
+    using clock_type = std::chrono::steady_clock;
     using time_type = std::chrono::time_point<clock_type>;
 
 public:

--- a/gtests/test_nopython_formatter.cpp
+++ b/gtests/test_nopython_formatter.cpp
@@ -4,8 +4,10 @@
  */
 
 // Intended to use deprecated Formatter as the demo of comparison with std::format
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 #include <solvcon/base.hpp>
 
@@ -156,6 +158,8 @@ TEST(FormatterVsStdFormat, performance_std_format)
     EXPECT_FALSE(result.empty());
 }
 
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,11 @@
 # BSD 3-Clause License, see COPYING
 
 
+import os
 import pathlib
+import shlex
 import subprocess
+import sys
 
 import setuptools
 from setuptools.command import build_ext
@@ -13,6 +16,25 @@ from setuptools.command import build_ext
 class CMakeExtension(setuptools.Extension):
     def __init__(self, name, **kwa):
         super().__init__(name, sources=[])
+
+
+def split_command_args(value):
+
+    if os.name != 'nt':
+        return shlex.split(value)
+
+    # A Windows path argument (-DCMAKE_PREFIX_PATH=C:\scdv\usr) would lose
+    # its backslashes to shlex escape processing, so disable escapes there.
+    lexer = shlex.shlex(value, posix=True)
+    # A '#' is a legal character in a cmake argument, not a
+    # comment introducer.
+    lexer.commenters = ''
+    lexer.whitespace_split = True
+    lexer.escape = ''
+    # cmd.exe has no single-quote quoting, and an apostrophe is
+    # ordinary in a Windows path (C:\Users\O'Brien).
+    lexer.quotes = '"'
+    return list(lexer)
 
 
 class cmake_build_ext(build_ext.build_ext):
@@ -44,20 +66,32 @@ class cmake_build_ext(build_ext.build_ext):
         build_temp.mkdir(parents=True, exist_ok=True)
         extdir = pathlib.Path(self.get_ext_fullpath(ext.name)).parent
         extdir.mkdir(parents=True, exist_ok=True)
+        config = 'Debug' if self.debug else 'Release'
 
-        local_cmake_args = '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={}'.format(
-            str(extdir.absolute()))
+        local_cmake_args = [
+            '-DCMAKE_BUILD_TYPE={}'.format(config),
+            '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={}'.format(
+                str(extdir.absolute())),
+            '-DPYTHON_EXECUTABLE={}'.format(sys.executable),
+        ]
+        if os.name == 'nt':
+            local_cmake_args.append(
+                '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(
+                    config.upper(), str(extdir.absolute())))
 
-        cmd = 'cmake {} {} {}'.format(cwd, local_cmake_args, self.cmake_args)
-        proc = subprocess.run(cmd, shell=True, cwd=str(build_temp))
-        if 0 != proc.returncode:
-            raise RuntimeError('{} return {}'.format(cmd, proc.returncode))
+        cmd = ['cmake', '-S', str(cwd), '-B', '.'] + local_cmake_args
+        cmd.extend(split_command_args(self.cmake_args))
+        subprocess.run(cmd, check=True, cwd=str(build_temp))
 
         target_name = ext.name.split('.')[-1]
-        cmd = 'make {} {}'.format(target_name, self.make_args)
-        proc = subprocess.run(cmd, shell=True, cwd=str(build_temp))
-        if 0 != proc.returncode:
-            raise RuntimeError('{} return {}'.format(cmd, proc.returncode))
+        cmd = [
+            'cmake', '--build', '.', '--config', config,
+            '--target', target_name,
+        ]
+        make_args = split_command_args(self.make_args)
+        if make_args:
+            cmd.extend(['--'] + make_args)
+        subprocess.run(cmd, check=True, cwd=str(build_temp))
 
 
 def main():

--- a/solvcon/agent/_backends_impl.py
+++ b/solvcon/agent/_backends_impl.py
@@ -217,7 +217,9 @@ class SubprocessBackend(CancellableBackend, _backend.AgentBackend):
     #: The process basics every agent CLI receives.  A subclass extends this
     #: with only its own authentication variables.
     env_passthrough = (
-        "HOME", "USER", "LOGNAME", "PATH", "TMPDIR")
+        "HOME", "USER", "LOGNAME", "PATH", "TMPDIR", "USERPROFILE",
+        "SystemRoot", "ComSpec", "PATHEXT", "TEMP", "TMP", "APPDATA",
+        "LOCALAPPDATA")
 
     def __init__(self, timeout=120):
         super().__init__()
@@ -291,7 +293,8 @@ class SubprocessBackend(CancellableBackend, _backend.AgentBackend):
         try:
             proc = subprocess.Popen(
                 argv, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE, text=True, cwd=workdir, env=env)
+                stderr=subprocess.PIPE, text=True, encoding="utf-8",
+                errors="replace", cwd=workdir, env=env)
             self._proc = proc
             if self._cancelled:
                 # A cancel between spawning the child and publishing it here

--- a/solvcon/pstake.py
+++ b/solvcon/pstake.py
@@ -20,6 +20,7 @@ import argparse
 import tempfile
 import shutil
 import re
+import shlex
 import collections
 
 try:
@@ -55,40 +56,33 @@ def _remember_cwd():
 
 class ExternalCommand(object):
     def __init__(self, command, echo=True):
-        self.command = command
+        # A tuple names interchangeable spellings of one tool, tried in
+        # order: ImageMagick 7 installs "magick" and drops the "convert" it
+        # replaced, and Ghostscript is "gswin64c" on Windows.
+        if isinstance(command, str):
+            self.candidates = (command,)
+        else:
+            self.candidates = tuple(command)
         self.echo = echo
 
-    @staticmethod
-    def _which(program):
-        """
-        Taken from http://stackoverflow.com/a/377028
-        """
-
-        def is_exe(fpath):
-            return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-        fpath, fname = os.path.split(program)
-        if fpath:
-            if is_exe(program):
-                return os.path.abspath(program)
-        else:
-            for path in os.environ["PATH"].split(os.pathsep):
-                path = path.strip('"')
-                exe_file = os.path.join(path, program)
-                if is_exe(exe_file):
-                    return os.path.abspath(exe_file)
-
-        return None
+    @property
+    def command(self):
+        for name in self.candidates:
+            if shutil.which(name):
+                return name
+        return self.candidates[0]
 
     @property
     def command_abspath(self):
-        return self._which(self.command)
+        found = shutil.which(self.command)
+        return os.path.abspath(found) if found else None
 
     def __call__(self, *args, **kw):
         cmdout = kw.pop('cmdout', None)  # None is subprocess default.
         cmderr = kw.pop('cmderr', None)  # None is subprocess default.
-        param = " ".join(args)
-        cmd = " ".join([self.command, param])
+        argv = [self.command] + list(args)
+        cmd = (subprocess.list2cmdline(argv) if os.name == 'nt'
+               else shlex.join(argv))
         if self.echo:
             sys.stdout.write(cmd + '\n')
             sys.stdout.flush()
@@ -96,7 +90,7 @@ class ExternalCommand(object):
             cmdout.write(cmd + '\n')
             cmdout.flush()
         with _remember_cwd():
-            subprocess.call(cmd.split(), stdout=cmdout, stderr=cmderr)
+            subprocess.check_call(argv, stdout=cmdout, stderr=cmderr)
             if cmdout:
                 cmdout.flush()
 
@@ -126,8 +120,8 @@ class Pstricks(object):
         self.tex_template = _TEX_TEMPLATE
         self.cmd_latex = ExternalCommand("latex", echo=echo)
         self.cmd_dvips = ExternalCommand("dvips", echo=echo)
-        self.cmd_convert = ExternalCommand("convert", echo=echo)
-        self.cmd_gs = ExternalCommand("gs", echo=echo)
+        self.cmd_convert = ExternalCommand(("magick", "convert"), echo=echo)
+        self.cmd_gs = ExternalCommand(("gs", "gswin64c"), echo=echo)
 
     def write_tex(self, src, dst, cmbright=False, options=None, packages=None):
         # Sanitize options.
@@ -150,15 +144,15 @@ class Pstricks(object):
 
     def pst(self, srcmain, dst, cmdout=None):
         self.cmd_latex(srcmain + '.tex', cmdout=cmdout)
-        self.cmd_dvips(srcmain + '.dvi', '-q -E -o %s' % dst, cmdout=cmdout)
+        self.cmd_dvips(srcmain + '.dvi', '-q', '-E', '-o', dst, cmdout=cmdout)
 
     def imconvert(self, src, dst, dpi=300, cmdout=None):
         """
         Currently I only support PNG.
         """
         if self.cmd_convert.command_abspath:
-            self.cmd_convert('-density %d -units PixelsPerInch %s %s' % (
-                dpi, src, dst), cmdout=cmdout)
+            self.cmd_convert('-density', str(dpi), '-units', 'PixelsPerInch',
+                             src, dst, cmdout=cmdout)
         elif HAS_IMAGE:
             im = Image.open(src)
             size = tuple(float(dpi) / 72 * val for val in im.size)
@@ -172,6 +166,12 @@ class Pstricks(object):
 
     def __call__(self, fn, cmbright=None, keep_tmp=None, cmdout=None,
                  options=None, **kw):
+        try:
+            self._render(fn, cmbright, cmdout, options)
+        finally:
+            self._cleanup(fn, keep_tmp)
+
+    def _render(self, fn, cmbright, cmdout, options):
         with _remember_cwd():
             os.chdir(fn.tempdir)
             if not self.quiet:
@@ -193,6 +193,8 @@ class Pstricks(object):
                 if not self.quiet:
                     sys.stdout.write(
                         "Destination file type %s isn't supported.\n" % dstext)
+
+    def _cleanup(self, fn, keep_tmp):
         tempdir = os.path.abspath(fn.tempdir)
         if not keep_tmp:
             if not self.quiet:
@@ -534,7 +536,7 @@ def main():
     args = parser.parse_args()
 
     if args.quiet:
-        args.cmdout = '/dev/null'
+        args.cmdout = os.devnull
     if args.cmdout:
         args.cmdout = open(args.cmdout, 'a+')
     runner = Pstricks(**vars(args))

--- a/tests/test_agent_backends_impl.py
+++ b/tests/test_agent_backends_impl.py
@@ -411,6 +411,21 @@ class SubprocessBackendPinningTC(unittest.TestCase):
         seen = self._run({"PATH": "/bin"})
         self.assertEqual(seen["env"], {"PATH": "/bin"})
 
+    def test_windows_process_basics_reach_the_child(self):
+        basics = {
+            "PATH": r"C:\Windows\System32",
+            "USERPROFILE": r"C:\Users\user",
+            "SystemRoot": r"C:\Windows",
+            "ComSpec": r"C:\Windows\System32\cmd.exe",
+            "PATHEXT": ".COM;.EXE;.BAT;.CMD",
+            "TEMP": r"C:\Users\user\Temp",
+            "TMP": r"C:\Users\user\Temp",
+            "APPDATA": r"C:\Users\user\AppData\Roaming",
+            "LOCALAPPDATA": r"C:\Users\user\AppData\Local",
+        }
+        seen = self._run({**basics, **self._SECRETS})
+        self.assertEqual(seen["env"], basics)
+
     def test_each_supported_auth_mode_reaches_the_child(self):
         base = {"HOME": "/home/u", "PATH": "/bin"}
         modes = (
@@ -433,6 +448,12 @@ class SubprocessBackendPinningTC(unittest.TestCase):
     def test_child_cannot_read_the_parent_stdin(self):
         seen = self._run({"PATH": "/bin"})
         self.assertEqual(seen["stdin"], subprocess.DEVNULL)
+
+    def test_child_output_is_decoded_as_utf8(self):
+        seen = self._run({"PATH": "/bin"})
+        self.assertTrue(seen["text"])
+        self.assertEqual(seen["encoding"], "utf-8")
+        self.assertEqual(seen["errors"], "replace")
 
     def test_argv_pins_the_cli_sandbox(self):
         argv = self._run({"PATH": "/bin"})["argv"]

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -2,7 +2,6 @@
 # BSD 3-Clause License, see COPYING
 
 
-import os
 import unittest
 import time
 
@@ -20,8 +19,6 @@ class StopWatchTC(unittest.TestCase):
         sw = solvcon.stop_watch
         self.assertGreater(1.e-6, sw.resolution)
 
-    @unittest.skipUnless("nt" != os.name,
-                         "timing code on windows does not work yet")
     def test_lap_with_sleep(self):
 
         sw = solvcon.stop_watch
@@ -29,7 +26,7 @@ class StopWatchTC(unittest.TestCase):
         # Mark start
         sw.lap()
 
-        time.sleep(0.01)
+        time.sleep(0.05)
 
         elapsed = sw.lap()
         self.assertGreater(elapsed, 0.01)

--- a/tests/test_pstake.py
+++ b/tests/test_pstake.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import contextlib
+import io
+import os
+import types
+import unittest
+from unittest import mock
+
+from solvcon import pstake
+
+
+class ExternalCommandTC(unittest.TestCase):
+
+    def test_arguments_with_spaces_stay_separate(self):
+        command = pstake.ExternalCommand("tool", echo=False)
+        output = io.StringIO()
+        with mock.patch("solvcon.pstake.subprocess.check_call") as check:
+            command("input with space.tex", "-o", "output with space.eps",
+                    cmdout=output)
+        check.assert_called_once_with(
+            ["tool", "input with space.tex", "-o",
+             "output with space.eps"], stdout=output, stderr=None)
+
+    def test_image_tools_name_every_spelling(self):
+        renderer = pstake.Pstricks(quiet=True)
+        self.assertEqual(
+            renderer.cmd_convert.candidates, ("magick", "convert"))
+        self.assertEqual(renderer.cmd_gs.candidates, ("gs", "gswin64c"))
+
+    def test_command_takes_the_first_installed_candidate(self):
+        command = pstake.ExternalCommand(("magick", "convert"), echo=False)
+        with mock.patch("solvcon.pstake.shutil.which",
+                        side_effect=lambda name: "/usr/bin/convert"
+                        if name == "convert" else None):
+            self.assertEqual(command.command, "convert")
+
+    def test_command_falls_back_when_nothing_is_installed(self):
+        command = pstake.ExternalCommand(("gs", "gswin64c"), echo=False)
+        with mock.patch("solvcon.pstake.shutil.which", return_value=None):
+            self.assertEqual(command.command, "gs")
+            self.assertIsNone(command.command_abspath)
+
+    def test_echoed_command_is_quoted_for_the_platform(self):
+        command = pstake.ExternalCommand("tool", echo=False)
+        output = io.StringIO()
+        with mock.patch("solvcon.pstake.subprocess.check_call"):
+            with mock.patch("solvcon.pstake.os.name", "nt"):
+                command("a b.tex", cmdout=output)
+            with mock.patch("solvcon.pstake.os.name", "posix"):
+                command("a b.tex", cmdout=output)
+        windows, posix = output.getvalue().splitlines()
+        self.assertEqual(windows, 'tool "a b.tex"')
+        self.assertEqual(posix, "tool 'a b.tex'")
+
+    def test_command_abspath_is_absolute(self):
+        command = pstake.ExternalCommand("tool", echo=False)
+        with mock.patch("solvcon.pstake.shutil.which",
+                        return_value=os.path.join("rel", "tool")):
+            self.assertTrue(os.path.isabs(command.command_abspath))
+
+    def test_quiet_main_uses_platform_null_device(self):
+        args = types.SimpleNamespace(
+            quiet=True, cmdout=None, src="input.tex", dst=None,
+            dstext="png", font=None, options=False, keep_tmp=False,
+            tempdir=None)
+        opened = mock.mock_open()
+        patches = (
+            mock.patch("solvcon.pstake.argparse.ArgumentParser.parse_args",
+                       return_value=args),
+            mock.patch("builtins.open", opened),
+            mock.patch("solvcon.pstake.Pstricks"),
+            mock.patch("solvcon.pstake.Filename"),
+            mock.patch("solvcon.pstake.os.devnull", "<null-device>"),
+        )
+        with contextlib.ExitStack() as stack:
+            for patch in patches:
+                stack.enter_context(patch)
+            self.assertEqual(pstake.main(), 0)
+        opened.assert_called_once_with("<null-device>", "a+")
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/test_setup_args.py
+++ b/tests/test_setup_args.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import importlib.util
+import os
+import pathlib
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+_STUBBED = ("setuptools", "setuptools.command", "setuptools.command.build_ext")
+
+
+class _Extension:
+
+    def __init__(self, name, *args, **kw):
+        self.name = name
+
+
+class _BuildExt:
+    """Stand-in for setuptools' build_ext.
+
+    Only the hooks cmake_build_ext actually reaches are provided; each one
+    records or returns what the real command would.
+    """
+
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        pass
+
+
+def _load_setup():
+    # setup.py is not importable as a package module, and importing it runs
+    # only definitions: main() is guarded by __name__ == '__main__'.
+    # setuptools is stubbed so this works without a build backend installed.
+    setuptools = types.ModuleType("setuptools")
+    setuptools.Extension = _Extension
+    command = types.ModuleType("setuptools.command")
+    build_ext = types.ModuleType("setuptools.command.build_ext")
+    build_ext.build_ext = _BuildExt
+    command.build_ext = build_ext
+    setuptools.command = command
+    stubs = dict(zip(_STUBBED, (setuptools, command, build_ext)))
+    # Restore by key rather than mock.patch.dict, which rebuilds sys.modules
+    # wholesale and would evict anything imported inside the block.
+    saved = {name: sys.modules.get(name) for name in _STUBBED}
+    sys.modules.update(stubs)
+    try:
+        path = pathlib.Path(__file__).resolve().parent.parent / "setup.py"
+        spec = importlib.util.spec_from_file_location("solvcon_setup", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        for name, previous in saved.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+    return module
+
+
+class SplitCommandArgsTC(unittest.TestCase):
+
+    def setUp(self):
+        self.setup = _load_setup()
+
+    def test_posix_splitting_honours_quotes(self):
+        with mock.patch.object(os, "name", "posix"):
+            self.assertEqual(
+                self.setup.split_command_args('-j4 -DFOO="a b"'),
+                ["-j4", "-DFOO=a b"])
+
+    def test_windows_path_keeps_its_backslashes(self):
+        # The whole point of the nt branch: shlex would otherwise eat the
+        # backslashes of a Windows path as escape characters.
+        with mock.patch.object(os, "name", "nt"):
+            self.assertEqual(
+                self.setup.split_command_args(
+                    r"-DCMAKE_PREFIX_PATH=C:\scdv\usr -DBUILD_QT=OFF"),
+                [r"-DCMAKE_PREFIX_PATH=C:\scdv\usr", "-DBUILD_QT=OFF"])
+
+    def test_windows_path_may_contain_an_apostrophe(self):
+        # cmd.exe has no single-quote quoting, so an apostrophe is an
+        # ordinary character rather than an unterminated quote.
+        with mock.patch.object(os, "name", "nt"):
+            self.assertEqual(
+                self.setup.split_command_args(r"-DP=C:\Users\O'Brien -DQ=1"),
+                [r"-DP=C:\Users\O'Brien", "-DQ=1"])
+
+    def test_hash_is_an_argument_not_a_comment(self):
+        for name in ("posix", "nt"):
+            with self.subTest(os_name=name):
+                with mock.patch.object(os, "name", name):
+                    self.assertEqual(
+                        self.setup.split_command_args("-DX=a#b -DY=1"),
+                        ["-DX=a#b", "-DY=1"])
+
+    def test_empty_value_yields_no_arguments(self):
+        for name in ("posix", "nt"):
+            with self.subTest(os_name=name):
+                with mock.patch.object(os, "name", name):
+                    self.assertEqual(self.setup.split_command_args("   "), [])
+
+
+class BuildCmakeTC(unittest.TestCase):
+    """The argv cmake_build_ext hands to cmake, without running one."""
+
+    def setUp(self):
+        self.setup = _load_setup()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def _run(self, cmake_args="", make_args="", debug=False):
+        cmd = self.setup.cmake_build_ext.__new__(self.setup.cmake_build_ext)
+        cmd.build_temp = os.path.join(self.tmp.name, "build")
+        cmd.cmake_args = cmake_args
+        cmd.make_args = make_args
+        cmd.debug = debug
+        cmd.get_ext_fullpath = lambda name: os.path.join(
+            self.tmp.name, "out", name + ".pyd")
+        ext = _Extension("_solvcon")
+        with mock.patch.object(self.setup.subprocess, "run") as run:
+            cmd.build_cmake(ext)
+        self.calls = run.call_args_list
+        return [call.args[0] for call in self.calls]
+
+    def test_configure_and_build_are_both_invoked(self):
+        configure, build = self._run()
+        self.assertEqual(configure[:2], ["cmake", "-S"])
+        self.assertEqual(build[:4], ["cmake", "--build", ".", "--config"])
+        self.assertEqual(build[-2:], ["--target", "_solvcon"])
+
+    def test_configure_pins_the_running_interpreter(self):
+        configure, _ = self._run()
+        self.assertIn("-DPYTHON_EXECUTABLE={}".format(sys.executable),
+                      configure)
+
+    def test_debug_selects_the_debug_config(self):
+        configure, build = self._run(debug=True)
+        self.assertIn("-DCMAKE_BUILD_TYPE=Debug", configure)
+        self.assertEqual(build[build.index("--config") + 1], "Debug")
+
+    def test_subprocess_is_not_run_through_a_shell(self):
+        # The argv form is what keeps a path with spaces intact; a shell
+        # string would re-split it.
+        self._run()
+        for call in self.calls:
+            self.assertNotIn("shell", call.kwargs)
+            self.assertTrue(call.kwargs["check"])
+
+    def test_extra_make_args_go_after_the_separator(self):
+        _, build = self._run(make_args="-j4")
+        self.assertEqual(build[-2:], ["--", "-j4"])
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:


### PR DESCRIPTION
Lets the Windows build reach the same layout as Unix. `_solvcon_py` names the copied module with `$<TARGET_FILE_NAME:_solvcon>` instead of `python3-config`, the Windows presets build `_solvcon_py`, and `build.ps1` drops its hand copy. `setup.py` runs `cmake` and `cmake --build` as argv lists instead of `make` in a shell string. The top-level `CMakeLists.txt` runs the PySide6 lookups only when `BUILD_QT` is on and adds `/guard:cf` for MSVC.

Runtime fixes: `pstake` finds `magick` and `gswin64c` and passes argv lists; the agent `SubprocessBackend` forwards the Windows process basics and decodes child output as UTF-8; `StopWatch` uses `steady_clock`, so `test_lap_with_sleep` runs on Windows; the formatter gtest guards its GCC pragmas; the pilot loads `dwmapi.dll` from `System32` only.

`flake8` is clean on the changed Python files. `pytest tests/test_pstake.py tests/test_setup_args.py tests/test_agent_backends_impl.py tests/test_profile.py` passes on Windows with Python 3.14.7 (82 passed, 3 skipped).
