### PR TITLE
Let the user set the OpenAI backend URL and model

### DIFF
--- a/solvcon/agent/_backend.py
+++ b/solvcon/agent/_backend.py
@@ -532,7 +532,16 @@ class AgentBackend(abc.ABC):
     def set_setting(self, name, value):
         """Store ``value`` for the knob ``name``, raising :class:`KeyError` for
         an unknown knob and :class:`ValueError` for a value that is not a
-        string or falls outside the knob's choices."""
+        string or falls outside the knob's choices.
+
+        An emptied free-text knob stores the declared default instead.  A
+        backend reading a blank address or model would answer
+        :meth:`available` with False and drop out of the selector that is the
+        only way back to the settings editor.  Storing the default rather
+        than falling back on each read also keeps one value: what the editor
+        shows, what the configuration file records, and what the backend uses
+        cannot disagree.
+        """
         for setting in self.settings_spec():
             if setting.name != name:
                 continue
@@ -542,7 +551,7 @@ class AgentBackend(abc.ABC):
             if setting.choices and value not in setting.choices:
                 raise ValueError(
                     "%s: %r is not a valid %s" % (self.name, value, name))
-            self._settings[name] = value
+            self._settings[name] = value or setting.default
             return
         raise KeyError("%s has no setting %r" % (self.name, name))
 

--- a/solvcon/agent/_backends_impl.py
+++ b/solvcon/agent/_backends_impl.py
@@ -455,10 +455,19 @@ class OpenAIHttpBackend(CancellableBackend, _backend.AgentBackend):
 
     Uses only the stdlib (``http.client`` and ``urllib.parse``); no vendor
     SDK.  Point ``base_url`` at OpenAI, Ollama's ``/v1`` endpoint, or any
-    compatible server.  Defaults and the optional API key come from the
-    constructor or the ``SOLVCON_OPENAI_BASE_URL``, ``SOLVCON_OPENAI_MODEL``,
-    and ``SOLVCON_OPENAI_API_KEY`` environment variables.  The in-flight
-    connection is kept on the instance so a driver thread can :meth:`cancel`.
+    compatible server.
+
+    The base URL and the model name are user-tunable knobs; see
+    :meth:`settings_spec`.  The settings dialog edits them, and the
+    configuration file keeps them across runs.  The knobs start on what the
+    constructor or the ``SOLVCON_OPENAI_BASE_URL`` and
+    ``SOLVCON_OPENAI_MODEL`` environment variables give.  A stored value then
+    wins, because the user chose it in the dialog.
+
+    The API key stays out of the knobs.  It comes only from the constructor
+    or ``SOLVCON_OPENAI_API_KEY``.  The configuration file is plain text, and
+    a saved knob would write the secret into it.  The in-flight connection is
+    kept on the instance so a driver thread can :meth:`cancel`.
     """
 
     # Local Ollama's OpenAI-compatible root; override for a remote provider.
@@ -467,9 +476,9 @@ class OpenAIHttpBackend(CancellableBackend, _backend.AgentBackend):
 
     def __init__(self, base_url=None, model=None, api_key=None, timeout=120):
         super().__init__()
-        self._base_url = base_url if base_url is not None else self._env_or(
+        self._url_default = base_url if base_url is not None else self._env_or(
             "SOLVCON_OPENAI_BASE_URL", self._DEFAULT_BASE_URL)
-        self._model = model if model is not None else self._env_or(
+        self._model_default = model if model is not None else self._env_or(
             "SOLVCON_OPENAI_MODEL", self._DEFAULT_MODEL)
         self._api_key = api_key if api_key is not None else self._env_or(
             "SOLVCON_OPENAI_API_KEY", "")
@@ -486,18 +495,40 @@ class OpenAIHttpBackend(CancellableBackend, _backend.AgentBackend):
     def name(self):
         return "openai (http)"
 
+    def settings_spec(self):
+        """Return the free-text knobs for the server address and model name.
+
+        The defaults are per instance, not class constants.  That is what
+        carries the constructor arguments and the environment variables into
+        the value the dialog opens on.  Emptying either knob restores that
+        default, which
+        :meth:`~solvcon.agent.AgentBackend.set_setting` does for every
+        free-text knob.
+        """
+        return (
+            _backend.BackendSetting(
+                name="base_url", label="Base URL",
+                default=self._url_default,
+                tooltip="API root including the /v1 suffix, "
+                        "such as https://api.openai.com/v1."),
+            _backend.BackendSetting(
+                name="model", label="Model",
+                default=self._model_default,
+                tooltip="Model name sent in the request body."),
+        )
+
     @property
     def base_url(self):
         """API root including the ``/v1`` suffix, with no trailing slash."""
-        return (self._base_url or "").rstrip("/")
+        return self.get_setting("base_url").rstrip("/")
 
     @property
     def model(self):
-        return self._model
+        return self.get_setting("model")
 
     def available(self):
         """True when both a base URL and a model name are configured."""
-        return bool(self.base_url) and bool(self._model)
+        return bool(self.base_url) and bool(self.model)
 
     def send(self, prompt, scene_context, tool_surface, history=()):
         self.begin()
@@ -507,7 +538,7 @@ class OpenAIHttpBackend(CancellableBackend, _backend.AgentBackend):
         user_prompt = self._compose_user(
             prompt, scene_context, tool_surface, history)
         body = {
-            "model": self._model,
+            "model": self.model,
             "stream": False,
             "messages": [
                 {"role": "system", "content": self._INSTRUCTIONS},

--- a/solvcon/agent/_backends_impl.py
+++ b/solvcon/agent/_backends_impl.py
@@ -59,6 +59,36 @@ class ToolCallParser:
 
     NO_JSON = object()
 
+    #: The tag that closes a reasoning model's chain of thought.  A server
+    #: such as vLLM leaves the thinking in the message content.
+    REASONING_END = "</think>"
+
+    #: Every character a JSON value can start with.
+    VALUE_START = "{[\"-0123456789tfn"
+
+    @classmethod
+    def strip_reasoning(cls, text):
+        """Return the answer after a reasoning model's chain of thought.
+
+        The thinking argues with itself, so an array it tries out along the
+        way is not the reply and must not reach the runner.  Take what
+        follows the last :attr:`REASONING_END` outside a JSON string.  A
+        model cut off mid-thought leaves nothing after that tag, so the reply
+        yields no JSON and reads as prose.  Prose is the honest reading: an
+        empty batch would say the request is already done.
+
+        A command carries arbitrary text, a ``log`` message above all, so the
+        tag also turns up inside the payload.  An odd number of quotes before
+        it puts it in a string, where it is message text and cutting there
+        would throw the whole batch away.
+        """
+        marker = text.rfind(cls.REASONING_END)
+        while marker != -1:
+            if text.count('"', 0, marker) % 2 == 0:
+                return text[marker + len(cls.REASONING_END):]
+            marker = text.rfind(cls.REASONING_END, 0, marker)
+        return text
+
     @classmethod
     def strip_code_fences(cls, text):
         """Drop a surrounding triple-backtick fence (bare or tagged) if
@@ -74,33 +104,63 @@ class ToolCallParser:
         return "\n".join(lines)
 
     @classmethod
+    def opens_value(cls, text, index):
+        """Whether a JSON value can start at ``index``, skipping space.
+
+        The check is what keeps the cost of a bracket-heavy reply in hand.
+        Prose brackets such as ``[ref]`` fail it outright, and each decode
+        they would otherwise cost builds an exception that rescans the whole
+        reply to find its line and column.
+        """
+        while index < len(text) and text[index].isspace():
+            index += 1
+        return index < len(text) and text[index] in cls.VALUE_START
+
+    @classmethod
     def load_json_payload(cls, text):
-        """Parse the first JSON array or object out of a model reply,
-        tolerating a code fence or surrounding prose.
+        """Parse the JSON array or object a model reply ends with, tolerating
+        a chain of thought, a code fence, or surrounding prose.
 
         Return the parsed value, or :attr:`NO_JSON` when the reply has no
         JSON-looking span (plain prose).  Raise :class:`ValueError` when a
         ``[``/``{`` span is present but does not parse, so a truncated or
         invalid command batch is not mistaken for an empty one.
+
+        The payload is the value that closes on the reply's last bracket, and
+        the outermost one that does.  Each half of that rule answers its own
+        failure.  A model reasoning in prose tries batches out before it
+        answers.  An earlier value is therefore one the model rejected, and
+        it must not run in place of a malformed final batch.  A command can
+        nest an array, such as a polygon's vertices.  That array closes an
+        inner bracket last, so the innermost value is an argument, not the
+        batch.
+
+        A candidate must also pass :meth:`opens_value`, which bounds what a
+        bracket-heavy reply costs.
         """
-        text = cls.strip_code_fences(text).strip()
+        text = cls.strip_code_fences(cls.strip_reasoning(text)).strip()
         if not text:
             return cls.NO_JSON
         try:
             return json.loads(text)
         except json.JSONDecodeError:
             pass
-        saw_span = False
-        for opener, closer in (("[", "]"), ("{", "}")):
+        decoder = json.JSONDecoder()
+        end = max(text.rfind("]"), text.rfind("}"))
+        start, saw_span = -1, False
+        if end != -1:
+            opener = "[" if text[end] == "]" else "{"
             start = text.find(opener)
-            end = text.rfind(closer)
-            if start == -1 or end <= start:
-                continue
-            saw_span = True
-            try:
-                return json.loads(text[start:end + 1])
-            except json.JSONDecodeError:
-                continue
+        while -1 < start < end:
+            if cls.opens_value(text, start + 1):
+                saw_span = True
+                try:
+                    value, offset = decoder.raw_decode(text, start)
+                    if offset == end + 1:
+                        return value
+                except json.JSONDecodeError:
+                    pass
+            start = text.find(opener, start + 1)
         if saw_span or text[0] in "[{":
             raise ValueError("model reply has malformed JSON")
         return cls.NO_JSON

--- a/tests/gui/test_agent.py
+++ b/tests/gui/test_agent.py
@@ -321,5 +321,16 @@ class AgentPanelTC(unittest.TestCase):
         self.assertIn("--model=gpt-5.6-sol", argv)
         self.assertIn('--config=model_reasoning_effort="high"', argv)
 
+    def test_openai_http_settings_reach_the_request(self):
+        # A free-text knob gets a line edit rather than a combo box, and
+        # accepting the dialog is what lands the typed text on the backend.
+        backend = agent.OpenAIHttpBackend()
+        dialog = _agent_settings.AgentBackendSettingsDialog(backend)
+        dialog._editors["base_url"].setText("https://api.example.test/v1")
+        dialog._editors["model"].setText("gpt-4o-mini")
+        dialog.accept()
+        self.assertEqual(backend.base_url, "https://api.example.test/v1")
+        self.assertEqual(backend.model, "gpt-4o-mini")
+
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_backend.py
+++ b/tests/test_agent_backend.py
@@ -539,6 +539,40 @@ class RegistryTC(unittest.TestCase):
             agent.BackendRegistry.register(agent.ClaudeCliBackend())
 
 
+class FreeTextSettingTC(unittest.TestCase):
+    """The base class owns what an emptied free-text knob means."""
+
+    class Backend(agent.EchoBackend):
+        name = "free text"
+        SETTINGS = (
+            agent.BackendSetting(name="url", label="URL",
+                                 default="http://default.test"),
+            agent.BackendSetting(name="mode", label="Mode",
+                                 choices=("a", "b"), default="a"),
+        )
+
+        def settings_spec(self):
+            return self.SETTINGS
+
+    def setUp(self):
+        self.backend = self.Backend()
+
+    def test_emptying_a_knob_stores_the_declared_default(self):
+        # Storing the default rather than reading around a blank keeps one
+        # value: the editor, the configuration file, and the backend cannot
+        # disagree about what is configured.
+        self.backend.set_setting("url", "http://elsewhere.test")
+        self.backend.set_setting("url", "")
+        self.assertEqual(self.backend.get_setting("url"),
+                         "http://default.test")
+        self.assertEqual(self.backend.settings()["url"],
+                         "http://default.test")
+
+    def test_a_choice_knob_still_rejects_an_empty_value(self):
+        with self.assertRaises(ValueError):
+            self.backend.set_setting("mode", "")
+
+
 class BackendSettingsConfigTC(unittest.TestCase):
     def setUp(self):
         tmpdir = tempfile.mkdtemp()
@@ -591,6 +625,21 @@ class BackendSettingsConfigTC(unittest.TestCase):
         agent.BackendRegistry.load_settings(Config(self.path).load())
         self.assertEqual(backend.get_setting("model"), "gpt-5.6-terra")
         self.assertEqual(backend.get_setting("effort"), "high")
+
+    def test_openai_http_settings_survive_a_config_round_trip(self):
+        backend = agent.BackendRegistry.get(agent.OpenAIHttpBackend().name)
+        for knob, value in backend.settings().items():
+            self.addCleanup(backend.set_setting, knob, value)
+        backend.set_setting("base_url", "https://api.example.test/v1")
+        backend.set_setting("model", "gpt-4o-mini")
+        config = Config(self.path)
+        agent.BackendRegistry.save_settings(config)
+        config.save()
+        backend.set_setting("base_url", "http://elsewhere.test/v1")
+        backend.set_setting("model", "other")
+        agent.BackendRegistry.load_settings(Config(self.path).load())
+        self.assertEqual(backend.base_url, "https://api.example.test/v1")
+        self.assertEqual(backend.model, "gpt-4o-mini")
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_agent_backends_impl.py
+++ b/tests/test_agent_backends_impl.py
@@ -538,6 +538,42 @@ class OpenAIHttpBackendTC(unittest.TestCase):
         self.assertIn("add_circle", messages[1]["content"])
         self.assertNotIn("drive a 2D drawing canvas", messages[1]["content"])
 
+    def test_settings_drive_the_request(self):
+        # Editing the knobs redirects a turn: the request follows the new
+        # URL, and the body carries the new model name.
+        seen = {}
+
+        def _capture(body):
+            seen["body"] = body
+            seen["url"] = self.backend.base_url
+            return 200, self._chat_body("[]")
+
+        self.backend.set_setting("base_url", "https://api.example.test/v1/")
+        self.backend.set_setting("model", "gpt-4o-mini")
+        self.backend._post_chat = _capture
+        self.backend.send("hello", "one shape", _TOOLS)
+        self.assertEqual(seen["url"], "https://api.example.test/v1")
+        self.assertEqual(seen["body"]["model"], "gpt-4o-mini")
+
+    def test_settings_spec_starts_on_the_ctor_values(self):
+        knobs = {setting.name: setting.default
+                 for setting in self.backend.settings_spec()}
+        self.assertEqual(knobs, {"base_url": "http://127.0.0.1:11434/v1",
+                                 "model": "qwen2.5vl:7b"})
+        self.assertNotIn("api_key", knobs)
+
+    def test_a_cleared_knob_restores_the_default(self):
+        # Clearing the field must not drop the backend out of the selector:
+        # the selector is the only way back to the dialog that would repair
+        # it.  The restored value is what gets stored, so the editor and the
+        # configuration file cannot show something the backend is not using.
+        self.backend.set_setting("model", "")
+        self.backend.set_setting("base_url", "")
+        self.assertEqual(self.backend.model, "qwen2.5vl:7b")
+        self.assertEqual(self.backend.base_url, "http://127.0.0.1:11434/v1")
+        self.assertEqual(self.backend.get_setting("model"), "qwen2.5vl:7b")
+        self.assertTrue(self.backend.available())
+
     def test_send_http_error_status_is_error(self):
         self.backend._post_chat = lambda body: (500, b"boom")
         response = self.backend.send("draw", "scene", _TOOLS)

--- a/tests/test_agent_backends_impl.py
+++ b/tests/test_agent_backends_impl.py
@@ -77,6 +77,64 @@ class ParseToolCallsTC(unittest.TestCase):
         with self.assertRaises(ValueError):
             agent.ToolCallParser.parse('[{"op": ["a", "b"]}]')
 
+    def test_takes_the_last_array_not_the_first_bracket(self):
+        # What a reasoning model in prose mode does: it names a bracket, then
+        # answers.  Reading from the first bracket swallowed the real array
+        # into one unparseable span.
+        text = ('For a circle the parameters might be [x, y, r].\n'
+                'So the command is:\n[{"op": "add_circle", "r": 1.0}]')
+        self.assertEqual(agent.ToolCallParser.parse(text),
+                         [{"op": "add_circle", "r": 1.0}])
+
+    def test_ignores_json_inside_the_chain_of_thought(self):
+        # The thinking argues with itself, so an array it tries out there is
+        # not the answer and must not be run.
+        text = ('I could use [{"op": "delete_universe"}] here.\n'
+                'Actually no.\n</think>\n[{"op": "add_circle"}]')
+        self.assertEqual(agent.ToolCallParser.parse(text),
+                         [{"op": "add_circle"}])
+
+    def test_a_malformed_final_batch_does_not_run_an_earlier_one(self):
+        # The dangerous case: the model tried a batch, rejected it, and its
+        # real answer came out malformed.  Falling back to the rejected batch
+        # would run a command the model decided against.
+        text = ('Maybe [{"op": "delete_universe"}] would do it.\n'
+                'Final: [{"op": "add_circle",}]')
+        with self.assertRaises(ValueError):
+            agent.ToolCallParser.parse(text)
+
+    def test_takes_the_batch_not_a_nested_argument_array(self):
+        # A command whose arguments nest an array closes an inner bracket
+        # last, so the innermost value is an argument, never the batch.
+        text = ('Here you go:\n'
+                '[{"op": "add_polygon", "points": [[0, 0], [1, 1]]}]')
+        self.assertEqual(
+            agent.ToolCallParser.parse(text),
+            [{"op": "add_polygon", "points": [[0, 0], [1, 1]]}])
+
+    def test_keeps_an_end_of_thinking_tag_a_command_carries_as_text(self):
+        # The marker delimits the thinking.  Inside the payload it is message
+        # text, and cutting there would throw the whole batch away.  Prose
+        # around the payload must not change that.
+        command = {"op": "log", "message": "wrote </think> once"}
+        for text in ('[{"op": "log", "message": "wrote </think> once"}]',
+                     'Here you go:\n'
+                     '[{"op": "log", "message": "wrote </think> once"}]'):
+            self.assertEqual(agent.ToolCallParser.parse(text), [command], text)
+
+    def test_an_unclosed_bracket_in_prose_is_not_a_payload(self):
+        # A brace the model wrote as punctuation is the model talking, so the
+        # parser must not call it a command batch that failed to parse.
+        self.assertEqual(agent.ToolCallParser.parse("I cannot open a { here."),
+                         [])
+
+    def test_reasoning_with_no_answer_is_prose(self):
+        # A reply cut off mid-thought must read as the model talking, never as
+        # the empty batch that says the request is already done.
+        text = 'I should probably use [] for this.\n</think>\n   '
+        self.assertEqual(agent.ToolCallParser.parse_reply(text).status,
+                         agent.ParseStatus.PROSE)
+
     def test_unknown_op_survives_parsing(self):
         commands = agent.ToolCallParser.parse(
             '[{"op": "add_circle"}, {"op": "delete_universe"}]')


### PR DESCRIPTION
Add base URL and model name in the OpenAI API backend of Agent. Test with vllm hosted "Qwen/Qwen3.5-4B"


Related to #1206