### PR TITLE
Add CUDA backend for FFT and IFFT

### DIFF
--- a/.github/actions/setup_linux/action.yml
+++ b/.github/actions/setup_linux/action.yml
@@ -183,6 +183,17 @@ runs:
         sudo pip3 install numpy pytest flake8
         echo "::endgroup::"
 
+    # The transform tests this lane runs collect all of tests/ outside
+    # tests/gui/, and a few of those modules import jsonschema at module
+    # level, which is a collection error rather than a skip.
+    - name: dependency by pip (cuda)
+      if: ${{ inputs.workflow == 'build_cuda' }}
+      shell: bash
+      run: |
+        echo "::group::dependency by pip (cuda)"
+        sudo pip3 install jsonschema
+        echo "::endgroup::"
+
     - name: dependency by pip (lint & build)
       if: "${{ inputs.workflow == 'lint' || inputs.workflow == 'build' }}"
       shell: bash

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -285,6 +285,11 @@ jobs:
 
   build_cuda:
 
+    # CUDA lane, Linux only. The hosted runners have no GPU, so the kernels
+    # cannot execute here and the CUDA tests detect the missing device and
+    # skip. The lane still proves the nvcc unit and the BUILD_CUDA=ON
+    # configuration keep building, which no other lane exercises because they
+    # all compile the stub.
     needs: [check_skip, standalone_buffer]
 
     if: |
@@ -328,17 +333,38 @@ jobs:
         key: ${{ runner.os }}-cuda-Release
         restore-keys: ${{ runner.os }}-cuda-Release
         save: ${{ github.event_name != 'pull_request' }}
+        # Bound the cache so it does not grow without limit across the rolling
+        # key. A master push saves this cache; pull requests restore it (a PR
+        # on a non-default base branch cannot, so it runs cold).
         max-size: 1500M
 
-    - name: make buildext BUILD_CUDA=ON
+    - name: make gtest BUILD_CUDA=ON
       run: |
-        echo "::group::make buildext BUILD_CUDA=ON"
+        echo "::group::make gtest BUILD_CUDA=ON"
         nvcc --version
+        make gtest \
+          VERBOSE=1 USE_CLANG_TIDY=OFF \
+          BUILD_QT=OFF BUILD_CUDA=ON \
+          CMAKE_CUDA_ARCHITECTURES=all-major \
+          CMAKE_CUDA_HOST_COMPILER=g++-14 \
+          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+        echo "::endgroup::"
+
+    - name: make pytest BUILD_CUDA=ON
+      run: |
+        echo "::group::make pytest BUILD_CUDA=ON"
         make buildext \
           VERBOSE=1 USE_CLANG_TIDY=OFF \
           BUILD_QT=OFF BUILD_CUDA=ON \
           CMAKE_CUDA_ARCHITECTURES=all-major \
-          CMAKE_CUDA_HOST_COMPILER=g++-14
+          CMAKE_CUDA_HOST_COMPILER=g++-14 \
+          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3)"
+        PYTHONPATH=$(pwd) python3 contrib/ci/check-cuda-backend.py
+        # pytest-fast, not pytest: this lane installs no Qt, and the tests
+        # under tests/gui/ import PySide6 unguarded, which is a collection
+        # error rather than a skip. -k then narrows the run to the transform
+        # tests; the other lanes cover the rest against the stub.
+        make pytest-fast VERBOSE=1 PYTEST_OPTS="-k test_transform"
         echo "::endgroup::"
 
   send_email_on_failure:

--- a/contrib/ci/check-cuda-backend.py
+++ b/contrib/ci/check-cuda-backend.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""Make sure the build under test carries the real CUDA FFT backend.
+
+`FourierTransform.cuda_available()` returns False on a host without a GPU
+in the real backend and in the stub alike, so the two look the same to the
+test suite: every CUDA test skips either way, and a stub build keeps the
+CUDA lane green while proving nothing. Tell them apart by the failure
+message, which only the real backend blames on the missing device.
+
+Run this from the repository root after the extension is built. It exits
+0 when the build is the real backend, or when a GPU is present and the
+backend works.
+"""
+
+import sys
+
+import solvcon as sc
+
+DEVICE_MESSAGE = "no usable CUDA device"
+
+
+def main():
+    if sc.FourierTransform.cuda_available():
+        print("CUDA device present; the backend is the real one.")
+        return 0
+
+    inp = sc.SimpleArrayComplex128(8, sc.complex128())
+    out = sc.SimpleArrayComplex128(8, sc.complex128())
+    try:
+        sc.FourierTransform.fft(inp, out, backend=sc.FourierBackend.cuda)
+    except RuntimeError as err:
+        if DEVICE_MESSAGE not in str(err):
+            print("CUDA fft raised %r; expected %r. The build compiled the "
+                  "stub instead of the CUDA backend."
+                  % (str(err), DEVICE_MESSAGE), file=sys.stderr)
+            return 1
+    else:
+        print("CUDA fft did not raise without a device.", file=sys.stderr)
+        return 1
+
+    print("No CUDA device; the backend is the real one and reports it.")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/cpp/solvcon/CMakeLists.txt
+++ b/cpp/solvcon/CMakeLists.txt
@@ -59,14 +59,16 @@ set(SOLVCON_ROOT_FILES
     ${SOLVCON_ROOT_HEADERS}
     CACHE FILEPATH "" FORCE)
 
+# The cuda subdirectory always contributes sources: the real CUDA FFT
+# implementation under BUILD_CUDA, and otherwise a stub that throws.
+add_subdirectory(device/cuda)
+
 set(SOLVCON_DEVICE_HEADERS
+    ${SOLVCON_CUDA_HEADERS}
     CACHE FILEPATH "" FORCE)
 set(SOLVCON_DEVICE_SOURCES
+    ${SOLVCON_CUDA_SOURCES}
     CACHE FILEPATH "" FORCE)
-
-if (BUILD_CUDA)
-    add_subdirectory(device/cuda)
-endif () # BUILD_CUDA
 
 if (BUILD_METAL)
     add_subdirectory(device/metal)
@@ -139,6 +141,7 @@ if (BUILD_CUDA)
     # Keep the probe out of the core link because CUDA may need a different
     # host compiler from the C++ sources.
     add_dependencies(solvcon_primary solvcon_cuda_probe)
+    target_link_libraries(solvcon_primary PRIVATE CUDA::cudart)
 endif () # BUILD_CUDA
 
 if (BUILD_QT)
@@ -360,26 +363,26 @@ endif () # NOT APPLE
 # pilot sources and `module.cpp` are the units that need the pybind11 and
 # Accelerate suppressions most, and `wrap_pilot.cpp` is the one most likely
 # to want /bigobj.
+# Every option below is scoped to CXX. A CUDA unit under BUILD_CUDA joins
+# the same target, and nvcc takes neither the gcc-style warning flags nor
+# the MSVC ones: it reads an unprefixed /W4 as a second input file and
+# stops with "a single input file is required for a non-link phase".
 foreach (SOLVCON_LIBRARY IN LISTS SOLVCON_LIBRARIES)
     if (MSVC)
         target_compile_options(
             ${SOLVCON_LIBRARY} PRIVATE
-            ${COMMON_COMPILER_OPTIONS}
-            /bigobj # C1128: number of sections exceeded object file format limit
-            # This is the last suppression left from issue #1324. It fires in
-            # the SimpleArray<bool> reductions, where clearing it means
-            # deciding what mean, average and variance mean for bool rather
-            # than rewriting an expression. Issue #1332 tracks that.
-            /wd4804 # bool in an arithmetic operation, from reductions over SimpleArray<bool>
-            /external:W0 # do not apply /W4 to a SYSTEM include such as numpy
+            # /bigobj: C1128, number of sections exceeded object file format limit.
+            # /wd4804 is the last suppression left from issue #1324. It fires in
+            # the SimpleArray<bool> reductions, where clearing it means deciding
+            # what mean, average and variance mean for bool rather than rewriting
+            # an expression. Issue #1332 tracks that.
+            # /external:W0 keeps /W4 off a SYSTEM include such as numpy.
+            "$<$<COMPILE_LANGUAGE:CXX>:${COMMON_COMPILER_OPTIONS};/bigobj;/wd4804;/external:W0>"
         )
     else () # MSVC
         target_compile_options(
             ${SOLVCON_LIBRARY} PRIVATE
-            ${COMMON_COMPILER_OPTIONS}
-            -Wno-unused-value # for PYBIND11_EXPAND_SIDE_EFFECTS in pybind11.h
-            -Wno-noexcept-type # GCC
-            -Wno-elaborated-enum-base # for apple accelerate/veclib
+            "$<$<COMPILE_LANGUAGE:CXX>:${COMMON_COMPILER_OPTIONS};-Wno-unused-value;-Wno-noexcept-type;-Wno-elaborated-enum-base>"
         )
     endif () # MSVC
 endforeach ()

--- a/cpp/solvcon/device/cuda/CMakeLists.txt
+++ b/cpp/solvcon/device/cuda/CMakeLists.txt
@@ -3,11 +3,33 @@
 
 cmake_minimum_required(VERSION 4.0.1)
 
-add_library(
-    solvcon_cuda_probe
-    STATIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/cuda.cu
-)
-target_link_libraries(solvcon_cuda_probe PRIVATE CUDA::cudart)
+if (BUILD_CUDA)
+    add_library(
+        solvcon_cuda_probe
+        STATIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/cuda.cu
+    )
+    target_link_libraries(solvcon_cuda_probe PRIVATE CUDA::cudart)
+endif () # BUILD_CUDA
+
+set(SOLVCON_CUDA_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/fft.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fft_impl.hpp
+    CACHE FILEPATH "" FORCE)
+
+# fft.hpp declares the CUDA entry points unconditionally. A CUDA build
+# defines them in fft.cpp (host-compiled adapter) over fft_kernel.cu (the
+# nvcc unit); any other build compiles the stub that throws, so no other
+# directory needs to know whether CUDA is on.
+if (BUILD_CUDA)
+    set(SOLVCON_CUDA_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/fft.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/fft_kernel.cu
+        CACHE FILEPATH "" FORCE)
+else () # BUILD_CUDA
+    set(SOLVCON_CUDA_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/fft_stub.cpp
+        CACHE FILEPATH "" FORCE)
+endif () # BUILD_CUDA
 
 # vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/device/cuda/fft.cpp
+++ b/cpp/solvcon/device/cuda/fft.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/device/cuda/fft.hpp>
+#include <solvcon/device/cuda/fft_impl.hpp>
+
+#include <cstddef>
+#include <format>
+#include <stdexcept>
+
+namespace solvcon
+{
+
+namespace device
+{
+
+namespace cuda
+{
+
+namespace
+{
+
+// The Bluestein path pads to the next power of two at or above 2n-1 and
+// carries that length in an int, so cap n where the padded length still
+// fits. The cap is far above any length a device can hold.
+constexpr size_t MAX_SIZE = size_t(1) << 29;
+
+template <typename T>
+void fft_checked(SimpleArray<Complex<T>> const & in, SimpleArray<Complex<T>> & out, void (*impl)(void const *, void *, int))
+{
+    static_assert(is_std_complex_layout_compatible_v<T> && sizeof(Complex<T>) == 2 * sizeof(T));
+
+    if (!available())
+    {
+        throw std::runtime_error("CUDA FFT is not available: no usable CUDA device");
+    }
+    if (in.size() != out.size())
+    {
+        throw std::invalid_argument(std::format(
+            "CUDA FFT input size {} does not match output size {}", in.size(), out.size()));
+    }
+    if (in.size() > MAX_SIZE)
+    {
+        throw std::invalid_argument(std::format("CUDA FFT size {} exceeds the supported limit {}", in.size(), MAX_SIZE));
+    }
+
+    impl(in.data(), out.data(), static_cast<int>(in.size()));
+}
+
+} /* end namespace */
+
+bool available()
+{
+    // Probed once and latched: the device set does not change under a
+    // running process, and the probe initializes the CUDA runtime.
+    static bool const ok = detail::device_available();
+    return ok;
+}
+
+void fft(SimpleArray<Complex<float>> const & in, SimpleArray<Complex<float>> & out)
+{
+    fft_checked(in, out, detail::fft_float);
+}
+
+void fft(SimpleArray<Complex<double>> const & in, SimpleArray<Complex<double>> & out)
+{
+    fft_checked(in, out, detail::fft_double);
+}
+
+} /* end namespace cuda */
+
+} /* end namespace device */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/device/cuda/fft.hpp
+++ b/cpp/solvcon/device/cuda/fft.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * CUDA fast Fourier transform entry points, implemented by in-house
+ * kernels. The declarations are always visible; a CUDA build defines them
+ * in fft.cpp (backed by the nvcc unit fft_kernel.cu) and any other build
+ * defines them in fft_stub.cpp, so callers never need a build-time macro.
+ *
+ * @ingroup group_numerics
+ */
+
+#include <solvcon/buffer/SimpleArray.hpp>
+#include <solvcon/math/Complex.hpp>
+
+namespace solvcon
+{
+
+namespace device
+{
+
+namespace cuda
+{
+
+/**
+ * Report whether a CUDA device is usable at runtime. Always false in a
+ * build without CUDA support.
+ */
+bool available();
+
+/**
+ * Forward FFT of a one-dimensional complex signal on the CUDA device.
+ * Throws std::runtime_error when CUDA is unusable or a CUDA call fails,
+ * and std::invalid_argument when the two arrays differ in size or the
+ * size exceeds what the device path supports.
+ */
+void fft(SimpleArray<Complex<float>> const & in, SimpleArray<Complex<float>> & out);
+void fft(SimpleArray<Complex<double>> const & in, SimpleArray<Complex<double>> & out);
+
+} /* end namespace cuda */
+
+} /* end namespace device */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/device/cuda/fft_impl.hpp
+++ b/cpp/solvcon/device/cuda/fft_impl.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Raw-pointer interface between the host-compiled CUDA FFT adapter
+ * (fft.cpp) and the nvcc-compiled kernel unit (fft_kernel.cu). The
+ * interface names no solvcon or CUDA type so the kernel unit stays free
+ * of the C++23 core headers, which nvcc may not parse.
+ *
+ * @ingroup group_numerics
+ */
+
+namespace solvcon
+{
+
+namespace device
+{
+
+namespace cuda
+{
+
+namespace detail
+{
+
+bool device_available();
+
+/**
+ * Forward complex-to-complex FFT of n interleaved (real, imag) pairs of
+ * float or double. Throws std::runtime_error on any CUDA failure.
+ */
+void fft_float(void const * in, void * out, int n);
+void fft_double(void const * in, void * out, int n);
+
+} /* end namespace detail */
+
+} /* end namespace cuda */
+
+} /* end namespace device */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/device/cuda/fft_kernel.cu
+++ b/cpp/solvcon/device/cuda/fft_kernel.cu
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+// In-house CUDA FFT: radix-2 Cooley-Tukey for power-of-two lengths and the
+// Bluestein algorithm otherwise, mirroring the CPU implementation in
+// transform/fourier.hpp so both backends share the same numerics.
+//
+// This unit is compiled by nvcc and deliberately includes no solvcon core
+// header: nvcc may not parse the C++23 the core requires. fft.cpp adapts
+// SimpleArray to the raw-pointer interface in fft_impl.hpp.
+#include <solvcon/device/cuda/fft_impl.hpp>
+
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace solvcon
+{
+
+namespace device
+{
+
+namespace cuda
+{
+
+namespace detail
+{
+
+namespace
+{
+
+void check(cudaError_t err, char const * what)
+{
+    if (cudaSuccess != err)
+    {
+        throw std::runtime_error(std::string(what) + " failed with CUDA error " +
+                                 std::to_string(static_cast<int>(err)) + ": " + cudaGetErrorString(err));
+    }
+}
+
+struct DeviceBuffer
+{
+    explicit DeviceBuffer(size_t nbytes) { check(cudaMalloc(&m_ptr, nbytes), "cudaMalloc"); }
+    ~DeviceBuffer() { cudaFree(m_ptr); }
+    DeviceBuffer(DeviceBuffer const &) = delete;
+    DeviceBuffer(DeviceBuffer &&) = delete;
+    DeviceBuffer & operator=(DeviceBuffer const &) = delete;
+    DeviceBuffer & operator=(DeviceBuffer &&) = delete;
+
+    template <typename T>
+    T * as() const { return static_cast<T *>(m_ptr); }
+    void * ptr() const { return m_ptr; }
+
+private:
+
+    void * m_ptr = nullptr;
+}; /* end struct DeviceBuffer */
+
+template <typename T>
+struct DevComplex
+{
+    T r;
+    T i;
+}; /* end struct DevComplex */
+
+template <typename T>
+__host__ __device__ constexpr T pi()
+{
+    return static_cast<T>(3.14159265358979323846);
+}
+
+__device__ inline void sincos_t(float a, float * s, float * c) { sincosf(a, s, c); }
+__device__ inline void sincos_t(double a, double * s, double * c) { sincos(a, s, c); }
+
+template <typename T>
+__device__ inline DevComplex<T> cmul(DevComplex<T> a, DevComplex<T> b)
+{
+    return {a.r * b.r - a.i * b.i, a.r * b.i + a.i * b.r};
+}
+
+template <typename T>
+__global__ void bit_reverse_kernel(DevComplex<T> const * in, DevComplex<T> * out, int n, int bits)
+{
+    int const idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n)
+    {
+        return;
+    }
+    int rev = 0;
+    for (int b = 0; b < bits; ++b)
+    {
+        if (idx & (1 << b))
+        {
+            rev |= 1 << (bits - 1 - b);
+        }
+    }
+    out[rev] = in[idx];
+}
+
+// One radix-2 stage: threads pair up the elements `half` apart inside each
+// block of `size` and apply the twiddle exp(-2 pi i k / size).
+template <typename T>
+__global__ void butterfly_kernel(DevComplex<T> * data, int n, int size)
+{
+    int const t = blockIdx.x * blockDim.x + threadIdx.x;
+    if (t >= n / 2)
+    {
+        return;
+    }
+    int const half = size / 2;
+    int const base = (t / half) * size;
+    int const k = t % half;
+
+    T s, c;
+    T const angle = T(-2.0) * pi<T>() / static_cast<T>(size) * static_cast<T>(k);
+    sincos_t(angle, &s, &c);
+    DevComplex<T> const even = data[base + k];
+    DevComplex<T> const odd = cmul(data[base + k + half], DevComplex<T>{c, s});
+
+    data[base + k] = {even.r + odd.r, even.i + odd.i};
+    data[base + k + half] = {even.r - odd.r, even.i - odd.i};
+}
+
+template <typename T>
+__global__ void pointwise_mul_kernel(DevComplex<T> * a, DevComplex<T> const * b, int n)
+{
+    int const idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n)
+    {
+        a[idx] = cmul(a[idx], b[idx]);
+    }
+}
+
+template <typename T>
+__global__ void conj_kernel(DevComplex<T> * a, int n)
+{
+    int const idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n)
+    {
+        a[idx].i = -a[idx].i;
+    }
+}
+
+template <typename T>
+__global__ void conj_scale_kernel(DevComplex<T> * a, int n, T scale)
+{
+    int const idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n)
+    {
+        a[idx] = {a[idx].r * scale, -a[idx].i * scale};
+    }
+}
+
+constexpr int BLOCK = 256;
+
+int grid(int n)
+{
+    return (n + BLOCK - 1) / BLOCK;
+}
+
+int ilog2(int n)
+{
+    int bits = 0;
+    while ((1 << bits) < n)
+    {
+        ++bits;
+    }
+    return bits;
+}
+
+bool is_pow2(int n)
+{
+    return n > 0 && 0 == (n & (n - 1));
+}
+
+int next_pow2(int n)
+{
+    int power = 1;
+    while (power < n)
+    {
+        power <<= 1;
+    }
+    return power;
+}
+
+// Forward FFT of `in` into `out`, both device pointers, n a power of two.
+// TODO: One global-memory kernel launch per stage; fuse stages through
+// shared memory to cut launch and bandwidth overhead.
+template <typename T>
+void fft_pow2_device(DevComplex<T> const * in, DevComplex<T> * out, int n)
+{
+    bit_reverse_kernel<<<grid(n), BLOCK>>>(in, out, n, ilog2(n));
+    for (int size = 2; size <= n; size *= 2)
+    {
+        butterfly_kernel<<<grid(n / 2), BLOCK>>>(out, n, size);
+    }
+    check(cudaGetLastError(), "fft kernel launch");
+}
+
+// Inverse FFT in place through the conjugation identity, matching
+// FourierTransform::ifft() on the CPU: conj, forward FFT, conj and 1/n.
+template <typename T>
+void ifft_pow2_device(DevComplex<T> * data, DevComplex<T> * scratch, int n)
+{
+    conj_kernel<<<grid(n), BLOCK>>>(data, n);
+    check(cudaGetLastError(), "conj kernel launch");
+    fft_pow2_device<T>(data, scratch, n);
+    conj_scale_kernel<<<grid(n), BLOCK>>>(scratch, n, T(1.0) / static_cast<T>(n));
+    check(cudaGetLastError(), "conj scale kernel launch");
+    check(cudaMemcpy(data, scratch, sizeof(DevComplex<T>) * n, cudaMemcpyDeviceToDevice), "cudaMemcpy");
+}
+
+template <typename T>
+void fft_bluestein(DevComplex<T> const * in, DevComplex<T> * out, int n)
+{
+    int const K = next_pow2(2 * n - 1);
+
+    // Build the Bluestein sequences on the host exactly as the CPU
+    // fft_bluestein() does: a[i] = in[i] * w(i) and the circular kernel b,
+    // with w(i) = exp(-pi i^2 / n).
+    std::vector<DevComplex<T>> a(K, DevComplex<T>{T(0.0), T(0.0)});
+    std::vector<DevComplex<T>> b(K, DevComplex<T>{T(0.0), T(0.0)});
+    std::vector<DevComplex<T>> w(n);
+    w[0] = {T(1.0), T(0.0)};
+    a[0] = in[0];
+    b[0] = {T(1.0), T(0.0)};
+    for (int i = 1; i < n; ++i)
+    {
+        T const tmp = -pi<T>() * static_cast<T>(i) * static_cast<T>(i) / static_cast<T>(n);
+        DevComplex<T> const tw{std::cos(tmp), std::sin(tmp)};
+        w[i] = tw;
+        a[i] = {in[i].r * tw.r - in[i].i * tw.i, in[i].r * tw.i + in[i].i * tw.r};
+        b[i] = {tw.r, -tw.i};
+        b[K - i] = b[i];
+    }
+
+    size_t const kbytes = sizeof(DevComplex<T>) * K;
+    DeviceBuffer dev_a(kbytes), dev_fa(kbytes), dev_b(kbytes), dev_fb(kbytes);
+    check(cudaMemcpy(dev_a.ptr(), a.data(), kbytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+    check(cudaMemcpy(dev_b.ptr(), b.data(), kbytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+
+    // Linear convolution as pointwise product in the frequency domain.
+    fft_pow2_device<T>(dev_a.as<DevComplex<T>>(), dev_fa.as<DevComplex<T>>(), K);
+    fft_pow2_device<T>(dev_b.as<DevComplex<T>>(), dev_fb.as<DevComplex<T>>(), K);
+    pointwise_mul_kernel<<<grid(K), BLOCK>>>(dev_fa.as<DevComplex<T>>(), dev_fb.as<DevComplex<T>>(), K);
+    check(cudaGetLastError(), "pointwise multiply kernel launch");
+    ifft_pow2_device<T>(dev_fa.as<DevComplex<T>>(), dev_a.as<DevComplex<T>>(), K);
+
+    std::vector<DevComplex<T>> conv(n);
+    check(cudaMemcpy(conv.data(), dev_fa.ptr(), sizeof(DevComplex<T>) * n, cudaMemcpyDeviceToHost), "cudaMemcpy");
+    for (int i = 0; i < n; ++i)
+    {
+        out[i] = {conv[i].r * w[i].r - conv[i].i * w[i].i, conv[i].r * w[i].i + conv[i].i * w[i].r};
+    }
+}
+
+template <typename T>
+void fft_impl(void const * in, void * out, int n)
+{
+    if (n <= 0)
+    {
+        return;
+    }
+
+    auto const * host_in = static_cast<DevComplex<T> const *>(in);
+    auto * host_out = static_cast<DevComplex<T> *>(out);
+
+    if (is_pow2(n))
+    {
+        size_t const nbytes = sizeof(DevComplex<T>) * n;
+        DeviceBuffer dev_in(nbytes), dev_out(nbytes);
+        check(cudaMemcpy(dev_in.ptr(), host_in, nbytes, cudaMemcpyHostToDevice), "cudaMemcpy");
+        fft_pow2_device<T>(dev_in.as<DevComplex<T>>(), dev_out.as<DevComplex<T>>(), n);
+        check(cudaMemcpy(host_out, dev_out.ptr(), nbytes, cudaMemcpyDeviceToHost), "cudaMemcpy");
+    }
+    else
+    {
+        fft_bluestein<T>(host_in, host_out, n);
+    }
+}
+
+} /* end namespace */
+
+bool device_available()
+{
+    int count = 0;
+    return cudaSuccess == cudaGetDeviceCount(&count) && count > 0;
+}
+
+void fft_float(void const * in, void * out, int n)
+{
+    fft_impl<float>(in, out, n);
+}
+
+void fft_double(void const * in, void * out, int n)
+{
+    fft_impl<double>(in, out, n);
+}
+
+} /* end namespace detail */
+
+} /* end namespace cuda */
+
+} /* end namespace device */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/device/cuda/fft_stub.cpp
+++ b/cpp/solvcon/device/cuda/fft_stub.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/device/cuda/fft.hpp>
+
+#include <stdexcept>
+
+namespace solvcon
+{
+
+namespace device
+{
+
+namespace cuda
+{
+
+[[noreturn]] static void unavailable()
+{
+    throw std::runtime_error("CUDA FFT is not available; rebuild with BUILD_CUDA=ON");
+}
+
+bool available()
+{
+    return false;
+}
+
+void fft(SimpleArray<Complex<float>> const &, SimpleArray<Complex<float>> &)
+{
+    unavailable();
+}
+
+void fft(SimpleArray<Complex<double>> const &, SimpleArray<Complex<double>> &)
+{
+    unavailable();
+}
+
+} /* end namespace cuda */
+
+} /* end namespace device */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/transform/fourier.hpp
+++ b/cpp/solvcon/transform/fourier.hpp
@@ -10,9 +10,24 @@
 
 #include <solvcon/math/math.hpp>
 #include <solvcon/buffer/buffer.hpp>
+#include <solvcon/device/cuda/fft.hpp>
+
+#include <cstdint>
 
 namespace solvcon
 {
+
+/**
+ * Computing backend for the Fourier transforms. The backend is selected as
+ * a template argument so that an unsupported value fails at compile time.
+ *
+ * @ingroup group_numerics
+ */
+enum class FourierBackend : std::uint8_t
+{
+    cpu,
+    cuda
+}; /* end enum class FourierBackend */
 
 namespace detail
 {
@@ -70,7 +85,10 @@ void fft_radix_2(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
  * Bluestein algorithm otherwise. ifft() computes the inverse by
  * conjugating the input, reusing fft(), and scaling by 1/N. dft()
  * evaluates the direct O(N^2) sum. The forward transform uses the
- * twiddle factor exp(-2 * pi * i * k / N).
+ * twiddle factor exp(-2 * pi * i * k / N). fft() and ifft() take the
+ * computing backend as a FourierBackend template argument defaulting to
+ * the CPU; the CUDA backend runs through device::cuda::fft() and throws
+ * at runtime when CUDA is unavailable.
  *
  * @ingroup group_numerics
  */
@@ -84,23 +102,31 @@ public:
     FourierTransform & operator=(const FourierTransform & other) = delete;
     FourierTransform & operator=(FourierTransform && other) = delete;
 
-    template <template <typename> class T1, typename T2>
+    template <FourierBackend Backend = FourierBackend::cpu, template <typename> class T1, typename T2>
     // FIXME: NOLINTNEXTLINE(misc-no-recursion)
     static void fft(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
     {
-        const size_t N = in.size();
-
-        if ((N & (N - 1)) == 0)
+        static_assert(FourierBackend::cpu == Backend || FourierBackend::cuda == Backend,
+                      "unsupported FourierBackend");
+        if constexpr (FourierBackend::cuda == Backend)
         {
-            detail::fft_radix_2<T1, T2>(in, out);
+            device::cuda::fft(in, out);
         }
         else
         {
-            detail::fft_bluestein<T1, T2>(in, out);
+            const size_t N = in.size();
+            if ((N & (N - 1)) == 0)
+            {
+                detail::fft_radix_2<T1, T2>(in, out);
+            }
+            else
+            {
+                detail::fft_bluestein<T1, T2>(in, out);
+            }
         }
     }
 
-    template <template <typename> class T1, typename T2>
+    template <FourierBackend Backend = FourierBackend::cpu, template <typename> class T1, typename T2>
     // FIXME: NOLINTNEXTLINE(misc-no-recursion)
     static void ifft(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
     {
@@ -112,7 +138,7 @@ public:
             in_conj[i] = in[i].conj();
         }
 
-        fft<T1, T2>(in_conj, out);
+        fft<Backend, T1, T2>(in_conj, out);
 
         for (size_t i = 0; i < N; ++i)
         {
@@ -178,7 +204,7 @@ void fft_bluestein(SimpleArray<T1<T2>> const & in, SimpleArray<T1<T2>> & out)
         A[i] *= B[i];
     }
 
-    FourierTransform::ifft<T1, T2>(A, a);
+    FourierTransform::ifft(A, a);
 
     for (size_t i = 0; i < N; ++i)
     {

--- a/cpp/solvcon/transform/pymod/wrap_fourier.cpp
+++ b/cpp/solvcon/transform/pymod/wrap_fourier.cpp
@@ -24,24 +24,78 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapFourierTransform
 
     friend base_type;
 
+    // Python picks the backend at runtime, so the dispatchers below map the
+    // enum value onto the compile-time backend instantiations.
+    template <template <typename> class T1, typename T2>
+    static void fft_dispatch(
+        solvcon::SimpleArray<T1<T2>> const & in, solvcon::SimpleArray<T1<T2>> & out, solvcon::FourierBackend backend)
+    {
+        if (solvcon::FourierBackend::cuda == backend)
+        {
+            wrapped_type::fft<solvcon::FourierBackend::cuda>(in, out);
+        }
+        else
+        {
+            wrapped_type::fft<solvcon::FourierBackend::cpu>(in, out);
+        }
+    }
+
+    template <template <typename> class T1, typename T2>
+    static void ifft_dispatch(
+        solvcon::SimpleArray<T1<T2>> const & in, solvcon::SimpleArray<T1<T2>> & out, solvcon::FourierBackend backend)
+    {
+        if (solvcon::FourierBackend::cuda == backend)
+        {
+            wrapped_type::ifft<solvcon::FourierBackend::cuda>(in, out);
+        }
+        else
+        {
+            wrapped_type::ifft<solvcon::FourierBackend::cpu>(in, out);
+        }
+    }
+
     WrapFourierTransform(pybind11::module & mod, char const * pyname, char const * pydoc)
         : WrapBase<WrapFourierTransform, solvcon::FourierTransform, std::shared_ptr<solvcon::FourierTransform>>(mod, pyname, pydoc)
     {
         namespace py = pybind11; // NOLINT(misc-unused-alias-decls)
 
         (*this)
-            .def_static("fft", &wrapped_type::fft<solvcon::Complex, double>, py::arg("input"), py::arg("output"))
-            .def_static("fft", &wrapped_type::fft<solvcon::Complex, float>, py::arg("input"), py::arg("output"))
-            .def_static("ifft", &wrapped_type::ifft<solvcon::Complex, double>, py::arg("input"), py::arg("output"))
-            .def_static("ifft", &wrapped_type::ifft<solvcon::Complex, float>, py::arg("input"), py::arg("output"))
+            .def_static(
+                "fft",
+                &fft_dispatch<solvcon::Complex, double>,
+                py::arg("input"),
+                py::arg("output"),
+                py::arg("backend") = solvcon::FourierBackend::cpu)
+            .def_static(
+                "fft",
+                &fft_dispatch<solvcon::Complex, float>,
+                py::arg("input"),
+                py::arg("output"),
+                py::arg("backend") = solvcon::FourierBackend::cpu)
+            .def_static(
+                "ifft",
+                &ifft_dispatch<solvcon::Complex, double>,
+                py::arg("input"),
+                py::arg("output"),
+                py::arg("backend") = solvcon::FourierBackend::cpu)
+            .def_static(
+                "ifft",
+                &ifft_dispatch<solvcon::Complex, float>,
+                py::arg("input"),
+                py::arg("output"),
+                py::arg("backend") = solvcon::FourierBackend::cpu)
             .def_static("dft", &wrapped_type::dft<solvcon::Complex, double>, py::arg("input"), py::arg("output"))
-            .def_static("dft", &wrapped_type::dft<solvcon::Complex, float>, py::arg("input"), py::arg("output"));
+            .def_static("dft", &wrapped_type::dft<solvcon::Complex, float>, py::arg("input"), py::arg("output"))
+            .def_static("cuda_available", &solvcon::device::cuda::available);
     }
 
 }; /* end class WrapFourierTransform */
 
 void wrap_FourierTransform(pybind11::module & mod)
 {
+    pybind11::enum_<solvcon::FourierBackend>(mod, "FourierBackend")
+        .value("cpu", solvcon::FourierBackend::cpu)
+        .value("cuda", solvcon::FourierBackend::cuda);
     WrapFourierTransform::commit(mod, "FourierTransform", "Fourier transform library");
 }
 

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -120,6 +120,10 @@ target_link_libraries(
     $<$<BOOL:${BUILD_METAL}>:${APPLE_FWK_METAL}>
 )
 
+if (BUILD_CUDA)
+    target_link_libraries(test_nopython CUDA::cudart)
+endif () # BUILD_CUDA
+
 include(GoogleTest)
 gtest_discover_tests(test_nopython PROPERTIES LABELS "cpp")
 

--- a/gtests/test_nopython_transform.cpp
+++ b/gtests/test_nopython_transform.cpp
@@ -148,7 +148,18 @@ TYPED_TEST_SUITE(InverseTest, TestTypes);
 
 TYPED_TEST(ParsevalTest, fft)
 {
-    solvcon::FourierTransform::fft<solvcon::Complex, typename TypeParam::Type>(this->signal, this->out);
+    solvcon::FourierTransform::fft(this->signal, this->out);
+
+    this->verify_parseval();
+}
+
+TYPED_TEST(ParsevalTest, fft_cuda)
+{
+    if (!solvcon::device::cuda::available())
+    {
+        GTEST_SKIP() << "CUDA is not available";
+    }
+    solvcon::FourierTransform::fft<solvcon::FourierBackend::cuda>(this->signal, this->out);
 
     this->verify_parseval();
 }
@@ -162,7 +173,18 @@ TYPED_TEST(ParsevalTest, dft)
 
 TYPED_TEST(DeltaFunctionTest, fft)
 {
-    solvcon::FourierTransform::fft<solvcon::Complex, typename TypeParam::Type>(this->signal, this->out);
+    solvcon::FourierTransform::fft(this->signal, this->out);
+
+    this->verify_delta_function();
+}
+
+TYPED_TEST(DeltaFunctionTest, fft_cuda)
+{
+    if (!solvcon::device::cuda::available())
+    {
+        GTEST_SKIP() << "CUDA is not available";
+    }
+    solvcon::FourierTransform::fft<solvcon::FourierBackend::cuda>(this->signal, this->out);
 
     this->verify_delta_function();
 }
@@ -176,8 +198,20 @@ TYPED_TEST(DeltaFunctionTest, dft)
 
 TYPED_TEST(InverseTest, fft)
 {
-    solvcon::FourierTransform::fft<solvcon::Complex, typename TypeParam::Type>(this->signal, this->freq_domain);
-    solvcon::FourierTransform::ifft<solvcon::Complex, typename TypeParam::Type>(this->freq_domain, this->time_domain);
+    solvcon::FourierTransform::fft(this->signal, this->freq_domain);
+    solvcon::FourierTransform::ifft(this->freq_domain, this->time_domain);
+
+    this->verify_inverse_fft_function();
+}
+
+TYPED_TEST(InverseTest, fft_cuda)
+{
+    if (!solvcon::device::cuda::available())
+    {
+        GTEST_SKIP() << "CUDA is not available";
+    }
+    solvcon::FourierTransform::fft<solvcon::FourierBackend::cuda>(this->signal, this->freq_domain);
+    solvcon::FourierTransform::ifft<solvcon::FourierBackend::cuda>(this->freq_domain, this->time_domain);
 
     this->verify_inverse_fft_function();
 }
@@ -185,7 +219,7 @@ TYPED_TEST(InverseTest, fft)
 TYPED_TEST(InverseTest, dft)
 {
     solvcon::FourierTransform::dft<solvcon::Complex, typename TypeParam::Type>(this->signal, this->freq_domain);
-    solvcon::FourierTransform::ifft<solvcon::Complex, typename TypeParam::Type>(this->freq_domain, this->time_domain);
+    solvcon::FourierTransform::ifft(this->freq_domain, this->time_domain);
 
     this->verify_inverse_fft_function();
 }

--- a/solvcon/core.py
+++ b/solvcon/core.py
@@ -103,6 +103,7 @@ list_of_toggle = [
 
 # transform directory symbols
 list_of_transform = [
+    'FourierBackend',
     'FourierTransform',
 ]
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -56,7 +56,7 @@ class FourierTransformTB(sc.testing.TestBase):
             self.assert_allclose(sc_output[i].real, np_output[i].real)
             self.assert_allclose(sc_output[i].imag, np_output[i].imag)
 
-    def test_numpy_fft_comparison(self):
+    def check_fft_against_numpy(self, **kw):
         input_size = 100
 
         sc_input = self.SimpleArray(input_size)
@@ -66,7 +66,7 @@ class FourierTransformTB(sc.testing.TestBase):
         np_input = np.array(sc_input, copy=False)
 
         sc_output = self.SimpleArray(input_size, self.complex())
-        sc.FourierTransform.fft(sc_input, sc_output)
+        sc.FourierTransform.fft(sc_input, sc_output, **kw)
 
         np_output = np.fft.fft(np_input)
 
@@ -74,7 +74,10 @@ class FourierTransformTB(sc.testing.TestBase):
             self.assert_allclose(sc_output[i].real, np_output[i].real)
             self.assert_allclose(sc_output[i].imag, np_output[i].imag)
 
-    def test_numpy_ifft_comparison(self):
+    def test_numpy_fft_comparison(self):
+        self.check_fft_against_numpy()
+
+    def check_ifft_against_numpy(self, **kw):
         input_size = 100
 
         sc_input = self.SimpleArray(input_size)
@@ -84,13 +87,39 @@ class FourierTransformTB(sc.testing.TestBase):
         np_input = np.array(sc_input, copy=False)
 
         sc_output = self.SimpleArray(input_size, self.complex())
-        sc.FourierTransform.ifft(sc_input, sc_output)
+        sc.FourierTransform.ifft(sc_input, sc_output, **kw)
 
         np_output = np.fft.ifft(np_input)
 
         for i in range(input_size):
             self.assert_allclose(sc_output[i].real, np_output[i].real)
             self.assert_allclose(sc_output[i].imag, np_output[i].imag)
+
+    def test_numpy_ifft_comparison(self):
+        self.check_ifft_against_numpy()
+
+    def test_fft_cuda_backend(self):
+        if not sc.FourierTransform.cuda_available():
+            self.skipTest("CUDA is not available")
+        self.check_fft_against_numpy(backend=sc.FourierBackend.cuda)
+
+    def test_ifft_cuda_backend(self):
+        if not sc.FourierTransform.cuda_available():
+            self.skipTest("CUDA is not available")
+        self.check_ifft_against_numpy(backend=sc.FourierBackend.cuda)
+
+    def test_fft_cuda_backend_unavailable(self):
+        if sc.FourierTransform.cuda_available():
+            self.skipTest("CUDA is available")
+        input_size = 8
+
+        sc_input = self.SimpleArray(input_size, self.complex())
+        sc_output = self.SimpleArray(input_size, self.complex())
+
+        with self.assertRaisesRegex(RuntimeError,
+                                    "CUDA FFT is not available"):
+            sc.FourierTransform.fft(sc_input, sc_output,
+                                    backend=sc.FourierBackend.cuda)
 
 
 class TransformFp32TC(FourierTransformTB, unittest.TestCase):


### PR DESCRIPTION
This PR reworks #548 to add a CUDA backend for the FFT, following the review there and the request for an in-house implementation. The kernels implement radix-2 Cooley-Tukey and Bluestein directly and mirror the CPU algorithms in `transform/fourier.hpp`, so the backend adds no cuFFT dependency.

`FourierTransform::fft` and `ifft` take the backend as a `FourierBackend` template argument, so an unsupported value fails at compile time. The default stays the CPU. The CPU path runs the same statements as before, now inside the `if constexpr` else. Python passes `backend` as an optional run-time argument.

The CUDA code stays under `cpp/solvcon/device/cuda/`, and no `BUILD_CUDA` macro reaches any C++ source: CMake selects between the real implementation and a throwing stub. A build without `BUILD_CUDA` therefore needs no CUDA toolkit. Master already defines `BUILD_CUDA`, and it stays `OFF` by default.

The `build_cuda` lane already compiles the extension with CUDA, so this PR adds `gtest` and `pytest` steps to it. The hosted runners have no GPU, so the CUDA tests skip themselves there. `contrib/ci/check-cuda-backend.py` then asserts that the backend blames the missing device rather than the stub. A stub build therefore cannot keep the lane green.

Verified on an RTX 5070 Ti with CUDA 13.0. The C++ suite and the Python suite pass, with the CUDA backend exercised for both precisions and both algorithms. The GUI tests under `tests/gui/` need a desktop and did not run. Without CUDA the suites pass and the CUDA tests skip. Benchmark of `FourierTransform.fft` (fp64, best-of timings, numpy for reference):

| Case | CPU backend | CUDA backend | numpy |
|---|---|---|---|
| radix-2, N=4096 | 155 us | 99.1 us | 20.7 us |
| radix-2, N=65536 | 3.40 ms | 0.32 ms | 0.42 ms |
| radix-2, N=1048576 | 69.5 ms | 3.82 ms | 17.1 ms |
| Bluestein, N=10000 | 5.08 ms | 0.49 ms | 0.06 ms |
| Bluestein, N=100000 | 50.7 ms | 3.28 ms | 0.75 ms |
| per call, N=16 | 0.45 us | 52.7 us | 1.78 us |

The CUDA backend runs 10 to 18 times faster than the CPU backend at the large sizes. A fixed per-call cost of about 50 us (device allocation, transfers, and kernel launches) dominates the small sizes. A TODO in `fft_kernel.cu` records the follow-up optimizations.

Related to #548.
