### PR TITLE
Ignore worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/worktrees/
 CLAUDE.local.md
 .DS_Store
 .claude/worktrees/


### PR DESCRIPTION
Use `/worktrees/` as the designated directory to host worktrees.