### PR TITLE
Check the MCAP decode plan at construction

### DIFF
--- a/cpp/solvcon/mcap/CMakeLists.txt
+++ b/cpp/solvcon/mcap/CMakeLists.txt
@@ -6,10 +6,12 @@ cmake_minimum_required(VERSION 4.0.1)
 set(SOLVCON_MCAP_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/mcap.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mcap_cursor.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mcap_decoder.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mcap_reader.hpp
     CACHE FILEPATH "" FORCE)
 
 set(SOLVCON_MCAP_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/mcap_decoder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mcap_reader.cpp
     CACHE FILEPATH "" FORCE)
 
@@ -19,6 +21,7 @@ set(SOLVCON_MCAP_PYMODHEADERS
 
 set(SOLVCON_MCAP_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/pymod/mcap_pymod.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_McapDecodePlan.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pymod/wrap_McapReader.cpp
     CACHE FILEPATH "" FORCE)
 

--- a/cpp/solvcon/mcap/mcap.hpp
+++ b/cpp/solvcon/mcap/mcap.hpp
@@ -5,6 +5,7 @@
  * BSD 3-Clause License, see COPYING
  */
 
+#include <solvcon/mcap/mcap_decoder.hpp>
 #include <solvcon/mcap/mcap_reader.hpp>
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/mcap/mcap_decoder.cpp
+++ b/cpp/solvcon/mcap/mcap_decoder.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/mcap/mcap_decoder.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace solvcon
+{
+
+namespace mcap
+{
+
+/// Number of instructions a container body runs per element; they follow the step.
+static size_t body_length(PlanStep const & step)
+{
+    return PlanOp::SkipArrayBody == step.op ? step.extra : step.operand;
+}
+
+static bool is_power_of_two(uint32_t value)
+{
+    return 0 != value && 0 == (value & (value - 1));
+}
+
+/**
+ * Whether a CDR primitive decodes into the type.  IDL declares no
+ * half-precision and no complex type, so a column is never of Float16,
+ * Complex64, or Complex128.
+ */
+static bool is_cdr_primitive(DataType type)
+{
+    switch (type)
+    {
+    case DataType::Bool:
+    case DataType::Int8:
+    case DataType::Int16:
+    case DataType::Int32:
+    case DataType::Int64:
+    case DataType::Uint8:
+    case DataType::Uint16:
+    case DataType::Uint32:
+    case DataType::Uint64:
+    case DataType::Float32:
+    case DataType::Float64:
+        return true;
+    default:
+        return false;
+    }
+}
+
+/**
+ * Check one range of instructions and recurse into each container body with
+ * the range of that body.
+ *
+ * @param steps Every instruction of the plan.
+ * @param begin Index of the first instruction of the range.
+ * @param end Index one past the last instruction of the range; a container body inside it must end by here.
+ * @param nested Whether the range is a container body, where a read is not allowed.
+ * @param types Type of every column, filled by the read into it; Undefined marks a column not read yet.
+ */
+// NOLINTNEXTLINE(misc-no-recursion)
+static void check_steps(
+    std::vector<PlanStep> const & steps, size_t begin, size_t end, bool nested, std::vector<DataType> & types)
+{
+    size_t it = begin;
+    while (it < end)
+    {
+        PlanStep const & step = steps[it];
+        ++it;
+        switch (step.op)
+        {
+        case PlanOp::Align:
+            // The cursor rounds the offset with a mask.
+            if (!is_power_of_two(step.operand))
+            {
+                throw std::invalid_argument("the MCAP decode plan aligns to a boundary that is not a power of two");
+            }
+            break;
+        case PlanOp::SkipSequence:
+            // The cursor aligns the elements to their own width, which CDR
+            // states only for a primitive.
+            if (!is_power_of_two(step.operand) || 8 < step.operand)
+            {
+                throw std::invalid_argument("the MCAP decode plan skips a sequence of no CDR primitive width");
+            }
+            break;
+        case PlanOp::SkipSequenceBody:
+        case PlanOp::SkipArrayBody:
+        {
+            size_t const body_end = it + body_length(step);
+            if (body_end > end)
+            {
+                throw std::invalid_argument("the MCAP decode plan states a container body that runs past its container");
+            }
+            check_steps(steps, it, body_end, true, types); // recursive here
+            it = body_end;
+            break;
+        }
+        case PlanOp::Read:
+        {
+            // A read inside a container appends one element per container
+            // element, not one per message.
+            if (nested)
+            {
+                throw std::invalid_argument("the MCAP decode plan reads a field inside a container");
+            }
+            DataType const type(static_cast<DataType::enum_type>(step.operand));
+            // The enum is a byte, so the cast alone would let a wider operand wrap onto a valid type.
+            if (step.operand != static_cast<uint32_t>(type.type()) || !is_cdr_primitive(type))
+            {
+                throw std::invalid_argument("the MCAP decode plan names a type CDR has no primitive for");
+            }
+            if (step.extra >= types.size() || DataType::Undefined != types[step.extra])
+            {
+                throw std::invalid_argument("the MCAP decode plan does not read every column exactly once");
+            }
+            types[step.extra] = type;
+            break;
+        }
+        default:
+            break;
+        }
+    }
+}
+
+DecodePlan::DecodePlan(std::vector<PlanStep> steps, size_t column_count)
+    : m_steps(std::move(steps))
+    , m_types(column_count, DataType::Undefined)
+{
+    if (0 == column_count)
+    {
+        throw std::invalid_argument("the MCAP decode plan reads no field");
+    }
+
+    check_steps(m_steps, 0, m_steps.size(), false, m_types);
+    if (std::ranges::any_of(m_types, [](DataType type)
+                            { return DataType::Undefined == type; }))
+    {
+        throw std::invalid_argument("the MCAP decode plan does not read every column exactly once");
+    }
+}
+
+} /* end namespace mcap */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/mcap/mcap_decoder.hpp
+++ b/cpp/solvcon/mcap/mcap_decoder.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * The flat CDR decode plan.
+ *
+ * @ingroup group_inout
+ */
+
+#include <cstdint>
+#include <vector>
+
+#include <solvcon/buffer/SimpleArray.hpp>
+
+namespace solvcon
+{
+
+namespace mcap
+{
+
+/**
+ * Kind of an instruction of a decode plan.  The compiler in
+ * solvcon/mcap/_decode_plan.py emits each one as a snake_case name and
+ * documents what it walks over.  plan_step() in pymod/wrap_McapDecodePlan.cpp
+ * maps the name onto this enum.
+ *
+ * @ingroup group_inout
+ */
+enum class PlanOp : uint8_t
+{
+    Align = 0,
+    Skip,
+    SkipString,
+    SkipSequence,
+    SkipSequenceBody,
+    SkipArrayBody,
+    Read,
+}; /* end enum class PlanOp */
+
+/**
+ * One instruction of a decode plan.  The operand and the extra hold what the
+ * tuple carries after the name, in the same order:
+ *
+ * - Align: the boundary.
+ * - Skip: the length.
+ * - SkipSequence: the element width.
+ * - SkipSequenceBody: the body length.
+ * - SkipArrayBody: the count, then the body length.
+ * - Read: the DataType value of the type the tuple names, then the column.
+ *
+ * @ingroup group_inout
+ */
+struct PlanStep
+{
+    PlanOp op = PlanOp::Align;
+    uint32_t operand = 0;
+    uint32_t extra = 0;
+}; /* end struct PlanStep */
+
+/**
+ * Decode plan over one CDR message.  Construction rejects a plan that reads a
+ * column inside a container, more than once, or not at all, so the columns
+ * share a row index.  Construction also rejects a read of a type no CDR
+ * primitive decodes into, a container body that runs past the range holding
+ * it, and an operand the cursor cannot align or skip by.
+ *
+ * @ingroup group_inout
+ */
+class DecodePlan
+{
+
+public:
+
+    /**
+     * Check and hold the instructions of a plan.
+     *
+     * @param steps Instructions in walk order.
+     * @param column_count Number of columns the reads fill; the reads must
+     *                     name each column from 0 to this count exactly once.
+     */
+    DecodePlan(std::vector<PlanStep> steps, size_t column_count);
+
+    std::vector<PlanStep> const & steps() const { return m_steps; }
+    /// Type of every column, as the read into it states.
+    std::vector<DataType> const & types() const { return m_types; }
+
+private:
+
+    // TODO: Once the buffer subsystem offers a collector of records, replace
+    // the STL containers below.  SimpleCollector is for fundamental types, and
+    // these hold instructions and column types (issue #1286).
+    std::vector<PlanStep> m_steps;
+    std::vector<DataType> m_types;
+}; /* end class DecodePlan */
+
+} /* end namespace mcap */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/mcap/pymod/mcap_pymod.cpp
+++ b/cpp/solvcon/mcap/pymod/mcap_pymod.cpp
@@ -24,6 +24,7 @@ void initialize_mcap(pybind11::module & mod)
 {
     auto initialize_impl = [](pybind11::module & mod)
     {
+        wrap_McapDecodePlan(mod);
         wrap_McapReader(mod);
     };
 

--- a/cpp/solvcon/mcap/pymod/mcap_pymod.hpp
+++ b/cpp/solvcon/mcap/pymod/mcap_pymod.hpp
@@ -19,6 +19,7 @@ namespace python
 {
 
 void initialize_mcap(pybind11::module & mod);
+void wrap_McapDecodePlan(pybind11::module & mod);
 void wrap_McapReader(pybind11::module & mod);
 
 } /* end namespace python */

--- a/cpp/solvcon/mcap/pymod/wrap_McapDecodePlan.cpp
+++ b/cpp/solvcon/mcap/pymod/wrap_McapDecodePlan.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/mcap/pymod/mcap_pymod.hpp>
+#include <solvcon/solvcon.hpp>
+
+#include <unordered_map>
+
+namespace solvcon
+{
+
+namespace python
+{
+
+/**
+ * Translate one instruction tuple that solvcon.mcap.DecodePlan compiled.  The
+ * Python side owns the schema grammar, so the instruction names it emits are
+ * the contract between the two halves.
+ */
+static mcap::PlanStep plan_step(pybind11::sequence const & item)
+{
+    static std::unordered_map<std::string, mcap::PlanOp> const ops = {
+        {"align", mcap::PlanOp::Align},
+        {"skip", mcap::PlanOp::Skip},
+        {"skip_string", mcap::PlanOp::SkipString},
+        {"skip_sequence", mcap::PlanOp::SkipSequence},
+        {"skip_sequence_body", mcap::PlanOp::SkipSequenceBody},
+        {"skip_array_body", mcap::PlanOp::SkipArrayBody},
+        {"read", mcap::PlanOp::Read},
+    };
+
+    auto const name = item[0].cast<std::string>();
+    auto const found = ops.find(name);
+    if (ops.end() == found)
+    {
+        throw std::invalid_argument("the MCAP decode plan states an unknown instruction: " + name);
+    }
+
+    mcap::PlanStep step{.op = found->second, .operand = 0, .extra = 0};
+    // A read names its type; every other operand is a number.
+    if (mcap::PlanOp::Read == step.op)
+    {
+        step.operand = static_cast<uint32_t>(DataType(item[1].cast<std::string>()).type());
+        step.extra = item[2].cast<uint32_t>();
+    }
+    else
+    {
+        step.operand = item.size() > 1 ? item[1].cast<uint32_t>() : 0;
+        step.extra = item.size() > 2 ? item[2].cast<uint32_t>() : 0;
+    }
+
+    return step;
+}
+
+class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapMcapDecodePlan
+    : public WrapBase<WrapMcapDecodePlan, mcap::DecodePlan>
+{
+
+public:
+
+    using base_type = WrapBase<WrapMcapDecodePlan, mcap::DecodePlan>;
+    using wrapped_type = typename base_type::wrapped_type;
+
+    friend root_base_type;
+
+protected:
+
+    WrapMcapDecodePlan(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : base_type(mod, pyname, pydoc)
+    {
+        namespace py = pybind11; // NOLINT(misc-unused-alias-decls)
+
+        (*this)
+            .def(
+                py::init(
+                    [](py::iterable const & instructions, size_t column_count)
+                    {
+                        std::vector<mcap::PlanStep> steps;
+                        for (py::handle const item : instructions)
+                        {
+                            steps.push_back(plan_step(item.cast<py::sequence>()));
+                        }
+                        return wrapped_type(std::move(steps), column_count);
+                    }),
+                py::arg("instructions"),
+                py::arg("column_count"))
+            //
+            ;
+    }
+
+}; /* end class WrapMcapDecodePlan */
+
+void wrap_McapDecodePlan(pybind11::module & mod)
+{
+    WrapMcapDecodePlan::commit(mod, "McapDecodePlan", "McapDecodePlan");
+}
+
+} /* end namespace python */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/core.py
+++ b/solvcon/core.py
@@ -85,6 +85,7 @@ list_of_python = [
 # mcap directory symbols, loaded only when the extension carries the
 # BUILD_MCAP subsystem.
 list_of_mcap = [
+    'McapDecodePlan',
     'McapReader',
     'McapSchema',
     'McapMessageIterator',

--- a/tests/test_mcap_decode_plan.py
+++ b/tests/test_mcap_decode_plan.py
@@ -274,4 +274,114 @@ module p { module msg { struct S {
                         self.schema(encoding), fields=["dt"])
 
 
+@unittest.skipUnless(sc.mcap.HAS_MCAP, "built without BUILD_MCAP")
+class CoreDecodePlanTC(unittest.TestCase):
+    """The check ``core.McapDecodePlan`` runs at construction.
+
+    The compiler emits only plans the check accepts, so the rejection cases
+    are written by hand.
+    """
+
+    def test_compiled_plan(self):
+        compiled = sc.mcap.DecodePlan(DecodePlanTC.SCHEMA_TEXT,
+                                      fields=["current.y", "sim_end"])
+        sc.core.McapDecodePlan(compiled.instructions, len(compiled.fields))
+
+    def test_no_column(self):
+        with self.assertRaisesRegex(
+                ValueError, "the MCAP decode plan reads no field"):
+            sc.core.McapDecodePlan((), 0)
+
+    def test_unknown_instruction(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                "the MCAP decode plan states an unknown instruction: rewind"):
+            sc.core.McapDecodePlan((("rewind", 4),), 1)
+
+    def test_unknown_type(self):
+        """The datatype lookup rejects a name no solvcon datatype has."""
+        with self.assertRaisesRegex(ValueError, "Unsupported datatype"):
+            sc.core.McapDecodePlan((("read", "float80", 0),), 1)
+
+    def test_type_no_cdr_primitive_has(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                "the MCAP decode plan names a type CDR has no primitive for"):
+            sc.core.McapDecodePlan((("read", "complex64", 0),), 1)
+
+    def test_alignment_to_a_boundary_that_is_not_a_power_of_two(self):
+        """The cursor rounds with a mask, which needs a power of two."""
+        for boundary in (0, 3):
+            with self.subTest(boundary=boundary):
+                with self.assertRaisesRegex(
+                        ValueError,
+                        "the MCAP decode plan aligns to a boundary that is "
+                        "not a power of two"):
+                    sc.core.McapDecodePlan(
+                        (("align", boundary), ("read", "uint8", 0)), 1)
+
+    def test_sequence_of_a_width_no_primitive_has(self):
+        """A width is a power of two up to eight; 3 fails one, 16 the other."""
+        for width in (3, 16):
+            with self.subTest(width=width):
+                with self.assertRaisesRegex(
+                        ValueError,
+                        "the MCAP decode plan skips a sequence of no CDR "
+                        "primitive width"):
+                    sc.core.McapDecodePlan(
+                        (("skip_sequence", width), ("read", "uint8", 0)), 1)
+
+    def test_read_inside_a_container(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                "the MCAP decode plan reads a field inside a container"):
+            sc.core.McapDecodePlan(
+                (("align", 4), ("skip_sequence_body", 2),
+                 ("align", 8), ("read", "float64", 0)), 1)
+
+    def test_field_read_more_than_once(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                "the MCAP decode plan does not read every column exactly "
+                "once"):
+            sc.core.McapDecodePlan(
+                (("read", "uint8", 0), ("read", "uint8", 0)), 1)
+
+    def test_field_never_read(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                "the MCAP decode plan does not read every column exactly "
+                "once"):
+            sc.core.McapDecodePlan((("read", "uint8", 0),), 2)
+
+    def test_read_into_a_column_the_plan_declares_no_field_for(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                "the MCAP decode plan does not read every column exactly "
+                "once"):
+            sc.core.McapDecodePlan((("read", "uint8", 1),), 1)
+
+    def test_container_body_longer_than_the_plan(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                "the MCAP decode plan states a container body that runs past "
+                "its container"):
+            sc.core.McapDecodePlan(
+                (("read", "uint8", 0), ("skip_array_body", 1, 4),
+                 ("skip", 1)), 1)
+
+    def test_container_body_longer_than_the_one_holding_it(self):
+        """The check bounds a body by its container, not by the plan.
+
+        An inner body that runs past its outer body shifts every later read.
+        """
+        with self.assertRaisesRegex(
+                ValueError,
+                "the MCAP decode plan states a container body that runs past "
+                "its container"):
+            sc.core.McapDecodePlan(
+                (("skip_array_body", 1, 1), ("skip_array_body", 1, 2),
+                 ("skip", 1), ("skip", 1), ("read", "uint8", 0)), 1)
+
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
`solvcon::mcap::DecodePlan` is the executable form of the walk program that `solvcon.mcap.DecodePlan` compiles. Construction checks the plan once, so the executor that runs it over the messages of a topic can walk without checking. It rejects a read inside a container, a column read twice or never, a read of a type no CDR primitive decodes into, an alignment that is not a power of two, a sequence of a width no primitive has, and a container body that runs past the range holding it.

`core.McapDecodePlan(instructions, column_count)` builds one from the instruction tuples the compiler emits. The tests state plans by hand, because the compiler emits only plans the check accepts, and confirm that a compiled plan passes.

This is the second of the four stacked PRs that split the executor step of issue #1286. #1410 shared the byte cursor. `worktree-issue-1286-pr3c-executor` (the walk and `McapReader.extract`) and `worktree-issue-1286-pr3d-python-extract` (`Reader.extract` and `ColumnSet`) follow, each opening once the one before it merges.

Related to #1286.
