### PR TITLE
Apply the skip-ci label to the runs a pull request already has

### DIFF
--- a/.github/workflows/check_skip_ci.yml
+++ b/.github/workflows/check_skip_ci.yml
@@ -14,9 +14,11 @@ name: check_skip_ci
 #      comments written by a repository owner, member, or collaborator are
 #      honored, so an external contributor cannot bypass CI by commenting.
 #
-# Adding or removing the label (or pushing a new commit) re-evaluates the
-# decision, because the callers listen to the "labeled"/"unlabeled" pull
-# request activity types in addition to the defaults.
+# Pushing a new commit re-evaluates the decision.  A label that arrives after
+# that reaches skip_ci_label.yml, which cancels the runs in flight when
+# "skip-ci" is added and re-runs them when it is removed.  The callers keep
+# their own activity types, so no label event writes a check result of its
+# own.
 #
 # The "skip" output is "true" only for pull_request events; it is empty for
 # push events, which keeps their existing gating untouched.
@@ -73,7 +75,15 @@ jobs:
             const hasControlLine = text =>
               (text || '').split(/\r?\n/)
                 .some(line => control.test(line.trim()));
-            const pr = context.payload.pull_request;
+            // Read the pull request from the API rather than from the event
+            // payload. skip_ci_label.yml re-runs this workflow when the
+            // skip-ci label is removed, and a re-run replays the payload of
+            // the original event, where the label is still attached.
+            const {data: pr} = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
 
             // 1. The skip-ci label, set by a repository member.
             if (pr.labels.some(label => label.name === 'skip-ci')) {

--- a/.github/workflows/skip_ci_label.yml
+++ b/.github/workflows/skip_ci_label.yml
@@ -1,0 +1,60 @@
+name: skip_ci_label
+
+# Carries the "skip-ci" label to the runs a pull request already has: adding
+# the label cancels what is still running, and removing it re-runs what the
+# label stopped.  See issue solvcon/modmesh#814.
+#
+# devbuild, devbuild_windows, and lint keep their own activity types, so no
+# label event writes a check of its own.  Letting them listen to "labeled"
+# instead hides a failed check: GitHub carries every label on that activity
+# type, and a run whose jobs the label gates off writes a skipped check under
+# the name of the real one.
+#
+# pull_request_target runs the copy of this file on the default branch, with a
+# token that may cancel and re-run.  Its checkout takes the base branch, never
+# the head, so no code from the pull request runs here.
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled]
+
+permissions: {}
+
+concurrency:
+  # Two labels toggled in a row must not act on the same runs at once.
+  group: skip_ci_label-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+
+  apply:
+
+    name: skip_ci_label
+
+    runs-on: ubuntu-24.04
+
+    timeout-minutes: 5
+
+    permissions:
+      # contents for the checkout below, which a public repository would also
+      # grant an anonymous clone, and actions to cancel and re-run.
+      contents: read
+      actions: write
+
+    steps:
+
+      # A full tree costs more than the work itself, so take the one script
+      # and nothing else. Cone mode matches directories, not files, hence off.
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: contrib/ci/apply-skip-ci-label.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Cancel or re-run the gated workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          LABEL_ACTION: ${{ github.event.action }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: contrib/ci/apply-skip-ci-label.sh

--- a/contrib/ci/apply-skip-ci-label.sh
+++ b/contrib/ci/apply-skip-ci-label.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+#
+# Carry the "skip-ci" label to the runs a pull request already has: cancel
+# what is still running when the label arrives, and re-run what the label
+# stopped when it goes away. Driven by .github/workflows/skip_ci_label.yml,
+# and runnable by hand against any repository the local `gh` can reach:
+#
+#   GITHUB_REPOSITORY=solvcon/solvcon LABEL_NAME=skip-ci \
+#     LABEL_ACTION=labeled HEAD_SHA=<sha> contrib/ci/apply-skip-ci-label.sh
+
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${LABEL_NAME:?LABEL_NAME is required}"
+: "${LABEL_ACTION:?LABEL_ACTION is required}"
+: "${HEAD_SHA:?HEAD_SHA is required}"
+: "${HEAD_REF:?HEAD_REF is required}"
+
+# The workflows whose heavy jobs check_skip_ci gates.
+WORKFLOWS="devbuild.yml devbuild_windows.yml lint.yml"
+
+if [ "$LABEL_NAME" != "skip-ci" ]; then
+  echo "::notice::The \"$LABEL_NAME\" label does not gate CI."
+  exit 0
+fi
+
+# Pull request runs only. check_skip_ci reports a skip for a pull request and
+# nothing for a push, so the label governs no push run. The branch narrows the
+# commit further, because one commit can head more than one pull request. A
+# run raised by a fork carries no pull request number to key on, so the branch
+# is as close as the listing gets.
+runs() {
+  gh api --paginate \
+    "repos/$GITHUB_REPOSITORY/actions/workflows/$1/runs?event=pull_request&head_sha=$HEAD_SHA&branch=$HEAD_REF&per_page=100" \
+    --jq "$2"
+}
+
+for workflow in $WORKFLOWS; do
+  if [ "$LABEL_ACTION" = "labeled" ]; then
+    for id in $(runs "$workflow" \
+        '.workflow_runs[] | select(.status != "completed") | .id'); do
+      if error="$(gh api -X POST \
+          "repos/$GITHUB_REPOSITORY/actions/runs/$id/cancel" 2>&1 >/dev/null)"
+      then
+        echo "::notice::Cancelled $workflow run $id."
+        continue
+      fi
+      # A run that ended between the listing and the request answers 409,
+      # which is the label arriving a moment too late, not a failure. Any
+      # other answer leaves the run going and must not read as success.
+      case "$error" in
+        *"HTTP 409"*)
+          echo "::notice::$workflow run $id was no longer running."
+          ;;
+        *)
+          echo "::error::Could not cancel $workflow run $id: $error"
+          exit 1
+          ;;
+      esac
+    done
+    continue
+  fi
+
+  # A cancelled run is one this script stopped, and it reported nothing.
+  for id in $(runs "$workflow" \
+      '.workflow_runs[] | select(.conclusion == "cancelled") | .id'); do
+    gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$id/rerun" >/dev/null
+    echo "::notice::Re-ran $workflow run $id."
+  done
+
+  for id in $(runs "$workflow" \
+      '.workflow_runs[] | select(.status == "completed" and
+                                 .conclusion != "cancelled") | .id'); do
+    # A run that finished with the label on skipped every gated job. One that
+    # built, failed, or timed out keeps the result it reported, so a broken
+    # build does not spend the matrix again over a label. The gate itself
+    # always succeeds and says nothing about whether the run did any work.
+    reported="$(gh api --paginate \
+      "repos/$GITHUB_REPOSITORY/actions/runs/$id/jobs?per_page=100" \
+      --jq '[.jobs[]
+             | select(.name | endswith("check_skip_ci") | not)
+             | select(.conclusion != "skipped")] | length')"
+    if [ "$reported" -eq 0 ]; then
+      gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$id/rerun" \
+        >/dev/null
+      echo "::notice::Re-ran $workflow run $id."
+    fi
+  done
+done
+
+# vim: set ff=unix fenc=utf8 et sw=2 ts=2 sts=2:


### PR DESCRIPTION
The skip-ci label reached nothing once a pull request was open. devbuild, devbuild_windows, and lint listen to the opened, reopened, and synchronize activity types, so the label worked only when it was set before the pull request opened, or when a later commit arrived.

skip_ci_label listens to the label events and acts on the runs that already exist: adding the label cancels what is still running, and removing it re-runs what the label stopped. A re-run reports into the original run, so the pull request keeps one set of checks. The three workflows keep their own activity types, because a label event that writes its own checks replaces a failed job with a skipped one of the same name and turns the pull request green.

skip_ci_label uses pull_request_target, so a pull request from a fork gets a token that can cancel and re-run. It checks out one shell script from the base branch and runs no code from the pull request. GitHub starts such a workflow only from the copy on the default branch, so it does nothing until it lands on master and this pull request cannot exercise it.

Tested on a fork over a job that sleeps instead of building: an unrelated label touches nothing, adding skip-ci cancels the run in flight, removing it re-runs that same run, and a run that had really built is left alone.
