### PR TITLE
Enable mp4 output for movie recording

### DIFF
--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -75,6 +75,10 @@
 #       depending on SCDV_SHARED_DLDIR).
 #     SCDV_SHARED_DLDIR: Shared cache for downloaded tarballs across solvcon
 #       development environments (scdvs).
+#     SCDV_FFMPEG_DIR: Prefix of an FFmpeg holding include/ and lib/.  Qt
+#       Multimedia is built against it and is what encodes the pilot's MP4.
+#       Unset, the platform block looks for the packaged one --print-deps
+#       names, and leaves the module out where there is none.
 #
 # Platform block contract. Each per-OS `case` block below sets the variable
 # SCDV_OS_TAG (the token baked into the default prefix, e.g. ubuntu2404) and
@@ -91,6 +95,8 @@
 #   plat_numpy_run            Env-prep + `scdv_time build_numpy numpy`.
 #   plat_qt_env_strip         Strip a stray Qt from the loader/PATH env.
 #   plat_qt_extra_cfg         Set array PLAT_QT_CFG with extra Qt cmake args.
+#   plat_ffmpeg_cfg           Set array PLAT_FFMPEG_CFG; non-zero where
+#                             there is no FFmpeg to build against.
 #   plat_qt_libclang_setup    Set LLVM_INSTALL_DIR for shiboken.
 #   plat_pyside6_cmake_opt    Set array PLAT_PYSIDE_CMAKE_OPT for setup.py.
 
@@ -220,6 +226,22 @@ sudo apt install -y \
 EOF
 }
 
+scdv_apt_ffmpeg_cmd() {
+  # FFmpeg for Qt Multimedia, without which the QT section leaves the
+  # module out.  libasound2 and libpulse are its audio backends, which the
+  # MP4 encoder does not touch but the module is deaf without.
+  #
+  # Ubuntu configures FFmpeg --enable-gpl, so these are GPLv2+ and not the
+  # LGPL subset Qt's own prebuilt FFmpeg is; SCDV_FFMPEG_DIR can name a
+  # --disable-gpl build where that matters.
+  cat <<'EOF'
+sudo apt install -y \
+  libavcodec-dev libavformat-dev libavutil-dev \
+  libswresample-dev libswscale-dev \
+  libasound2-dev libpulse-dev
+EOF
+}
+
 scdv_apt_clang_lint_cmd() {
   # Print the apt command for the C++ lint tools: clang-format for
   # `make cformat` and clang-tidy for `make USE_CLANG_TIDY=ON` and
@@ -257,12 +279,15 @@ EOF
 }
 
 plat_print_deps() {
-  # Ubuntu prints the apt base/GCC/QT/LaTeX sets, then the lint toolchain.
+  # Ubuntu prints the apt base/GCC/QT/FFmpeg/LaTeX sets, then the lint
+  # toolchain.
   scdv_apt_base_cmd
   echo
   scdv_apt_gcc_cmd
   echo
   scdv_apt_qt_cmd
+  echo
+  scdv_apt_ffmpeg_cmd
   echo
   scdv_apt_latex_cmd
   echo
@@ -329,6 +354,22 @@ plat_qt_extra_cfg() {
   # dev package is missing, leaving only offscreen/minimal QPA.  Forcing turns
   # that into a configure-time failure.  The -dev list is in scdv_apt_qt_cmd.
   PLAT_QT_CFG=("-DFEATURE_xcb=ON" "-DFEATURE_xcb_xlib=ON")
+}
+
+plat_ffmpeg_cfg() {
+  # Saying nothing is how apt's FFmpeg is found: its headers are under the
+  # multiarch include directory, which FindFFmpeg reaches only through
+  # pkg-config, and pkg-config is consulted only while FFMPEG_DIR is unset.
+  # A prefix named by hand wins, and is deployed into the scdv for sitting
+  # outside the loader's paths.
+  PLAT_FFMPEG_CFG=()
+  if [ -n "${SCDV_FFMPEG_DIR:-}" ] ; then
+    PLAT_FFMPEG_CFG=("-DFFMPEG_DIR=${SCDV_FFMPEG_DIR}"
+                     "-DQT_DEPLOY_FFMPEG=ON")
+    return 0
+  fi
+  pkg-config --exists libavcodec libavformat libavutil \
+                      libswresample libswscale
 }
 
 plat_qt_libclang_setup() {
@@ -555,6 +596,20 @@ brew install \
 EOF
 }
 
+scdv_brew_ffmpeg_cmd() {
+  # FFmpeg for Qt Multimedia, without which the QT section leaves the
+  # module out.  ffmpeg@7 because Qt 6.11 is tested against FFmpeg 7.1 and
+  # the unversioned formula has moved to 9.x, which the backend has no
+  # guarded path for.
+  #
+  # brew configures FFmpeg --enable-gpl, so the keg is GPL and not the LGPL
+  # subset Qt's own prebuilt FFmpeg is; SCDV_FFMPEG_DIR can name a
+  # --disable-gpl build where that matters.
+  cat <<'EOF'
+brew install ffmpeg@7
+EOF
+}
+
 scdv_brew_clang_lint_cmd() {
   # Print the brew command for the C++ lint tools: clang-format for
   # `make cformat` and clang-tidy for `make USE_CLANG_TIDY=ON` and
@@ -596,9 +651,11 @@ EOF
 }
 
 plat_print_deps() {
-  # macOS prints the brew base set (the QT toolchain needs no extra brew
-  # packages), then the LaTeX and lint toolchains.
+  # macOS prints the brew base and FFmpeg sets, then the LaTeX and lint
+  # toolchains; the Qt toolchain itself needs no other brew package.
   scdv_brew_base_cmd
+  echo
+  scdv_brew_ffmpeg_cmd
   echo
   scdv_brew_latex_cmd
   echo
@@ -671,6 +728,23 @@ plat_qt_extra_cfg() {
   # (QT_SUPPORTED_MAX_MACOS_SDK_VERSION=26), so no SDK-max-version override is
   # needed any more either.
   PLAT_QT_CFG=("-DQT_NO_XCODE_MIN_VERSION_CHECK=ON")
+}
+
+plat_ffmpeg_cfg() {
+  # A versioned keg is not linked, so nothing points at ffmpeg@7 but its
+  # prefix, whose include/ and lib/ are the layout FindFFmpeg expects.  The
+  # libraries are deployed into the scdv, so a brew upgrade that moves the
+  # keg cannot strand the plugin.
+  PLAT_FFMPEG_CFG=()
+  local prefix=${SCDV_FFMPEG_DIR:-}
+  if [ -z "${prefix}" ] && [ -n "${BREW_PREFIX:-}" ] ; then
+    prefix=${BREW_PREFIX}/opt/ffmpeg@7
+  fi
+  if [ -z "${prefix}" ] || [ ! -f "${prefix}/include/libavcodec/avcodec.h" ]
+  then
+    return 1
+  fi
+  PLAT_FFMPEG_CFG=("-DFFMPEG_DIR=${prefix}" "-DQT_DEPLOY_FFMPEG=ON")
 }
 
 fetch_libclang() {
@@ -1526,9 +1600,18 @@ build_qt() {
              qtquick3dphysics qtremoteobjects qtscxml qtsensors \
              qtserialbus qtspeech qttranslations qtvirtualkeyboard \
              qtwayland qtwebchannel qtwebengine qtwebview \
-             qtquickeffectmaker qtgrpc qtmultimedia ; do
+             qtquickeffectmaker qtgrpc ; do
       cfgcmd+=("-DBUILD_${m}=OFF")
     done
+    # Only qtmultimedia's FFmpeg backend encodes the pilot's MP4, so it is
+    # built where there is an FFmpeg for it and left out where there is not.
+    if plat_ffmpeg_cfg ; then
+      cfgcmd+=("${PLAT_FFMPEG_CFG[@]}")
+    else
+      echo "no FFmpeg found: building Qt without qtmultimedia, so the pilot" \
+           "will write no MP4.  --print-deps names the package to install."
+      cfgcmd+=("-DBUILD_qtmultimedia=OFF")
+    fi
     # Extra platform Qt cmake args (xcb on Ubuntu, Xcode-check skip on macOS).
     plat_qt_extra_cfg
     cfgcmd+=("${PLAT_QT_CFG[@]}")

--- a/contrib/dependency/windows/build-scdv-windows.ps1
+++ b/contrib/dependency/windows/build-scdv-windows.ps1
@@ -80,6 +80,9 @@
 #     SCDV_SHARED_DLDIR: Shared cache for downloaded tarballs across solvcon
 #       development environments (scdvs).  Set to "none" (or pass
 #       -NoSharedDownload) to keep a per-scdv download directory.
+#     SCDV_FFMPEG_DIR: Prefix of an FFmpeg (holding include, lib, and bin).
+#       Set it to build Qt Multimedia against the FFmpeg backend, which is
+#       what encodes the pilot's MP4 movies; unset leaves the module out.
 #   MSVC selection (see the toolchain note above and Import-VcVars):
 #     SCDV_VS_VERSION: vswhere -version range choosing which Visual Studio
 #       provides cl/vcvars, e.g. "[17.0,18.0)" for VS 2022.  Default: newest.
@@ -273,6 +276,12 @@ winget install --id BrechtSanders.WinLibs.POSIX.UCRT -e --scope user
 # BLAS/LAPACK too; this script uses the scipy-openblas64 wheel and exports its
 # pkg-config, so no separate OpenBLAS install is required.  See Build-Numpy /
 # Build-Scipy for details.
+
+# Qt Multimedia encodes the pilot's MP4, and the QT section builds it only
+# where SCDV_FFMPEG_DIR names an FFmpeg.  Nothing to install: unpack a
+# prebuilt LGPL shared package, which ships the MSVC import libraries the Qt
+# build links against.  Qt 6.11 is tested against FFmpeg 7.1; 8.x compiles.
+$env:SCDV_FFMPEG_DIR = 'C:\path\to\ffmpeg-lgpl-shared'
 '@
 }
 
@@ -1218,8 +1227,22 @@ function Build-Qt {
         'qtpositioning', 'qtquick3dphysics', 'qtremoteobjects', 'qtscxml',
         'qtsensors', 'qtserialbus', 'qtspeech', 'qttranslations',
         'qtvirtualkeyboard', 'qtwayland', 'qtwebchannel', 'qtwebengine',
-        'qtwebview', 'qtquickeffectmaker', 'qtgrpc', 'qtmultimedia'
+        'qtwebview', 'qtquickeffectmaker', 'qtgrpc'
     )
+    # Only qtmultimedia's FFmpeg backend encodes the pilot's MP4, so it is
+    # built where SCDV_FFMPEG_DIR names an FFmpeg.  The native Windows
+    # backend is no use: deprecated since Qt 6.10, and it takes no frames
+    # from a QVideoFrameInput.  A prebuilt LGPL shared package serves, since
+    # those ship the MSVC import libraries the build links against.
+    $ffmpeg = $env:SCDV_FFMPEG_DIR
+    if ($ffmpeg -and
+        -not (Test-Path (Join-Path $ffmpeg 'include\libavcodec\avcodec.h'))) {
+        Write-Warning ("SCDV_FFMPEG_DIR='$ffmpeg' holds no " +
+                       'include\libavcodec\avcodec.h; building without ' +
+                       'qtmultimedia.')
+        $ffmpeg = $null
+    }
+    if (-not $ffmpeg) { $mods += 'qtmultimedia' }
     Push-Location $bld
     try {
         $cfg = @(
@@ -1228,6 +1251,9 @@ function Build-Qt {
             '-DCMAKE_BUILD_TYPE=Release'
         )
         foreach ($m in $mods) { $cfg += "-DBUILD_$m=OFF" }
+        if ($ffmpeg) {
+            $cfg += @("-DFFMPEG_DIR=$ffmpeg", '-DQT_DEPLOY_FFMPEG=ON')
+        }
         $cfg += @(
             '-DQT_ALLOW_SYMLINK_IN_PATHS=ON',
             "-DCMAKE_PREFIX_PATH=$ScdvUsrDir",
@@ -1290,7 +1316,16 @@ function Build-Pyside6 {
     # Bindings solvcon needs: Core/Gui/Widgets (pilot) plus Svg (matplotlib's Qt
     # backend).  Faster than the full build, and avoids QtDesigner/QtUiTools
     # (qttools is disabled).  Override with SCDV_PYSIDE_MODULES.
-    $modules = Get-EnvOrDefault 'SCDV_PYSIDE_MODULES' 'Core,Gui,Widgets,Svg'
+    $subset = 'Core,Gui,Widgets,Svg'
+    # shiboken binds the subset, so a built Qt Multimedia is not enough:
+    # without Multimedia named here there is no PySide6.QtMultimedia.
+    # Network comes with it, the bindings being generated against it.  The
+    # installed Qt decides, not SCDV_FFMPEG_DIR, which parts company with it
+    # when this section runs alone.
+    if (Test-Path (Join-Path $ScdvUsrDir 'include\QtMultimedia')) {
+        $subset += ',Network,Multimedia'
+    }
+    $modules = Get-EnvOrDefault 'SCDV_PYSIDE_MODULES' $subset
     Push-Location (Join-Path $ScdvSrcDir $full)
     try {
         # --make-spec=ninja: pyside-setup's _get_make returns a str for "make"

--- a/solvcon/pilot/apps/obsrefl/_control.py
+++ b/solvcon/pilot/apps/obsrefl/_control.py
@@ -130,6 +130,7 @@ class RunController(object):
         params = self._panel.params()
         self._cell_type = params['cell_type']
         self.session = ReflectionSession(**params)
+        self._apply_limits()
         self._painter = FieldPainter(self.session.shock.mesh)
         if record:
             self._start_movie()
@@ -208,14 +209,18 @@ class RunController(object):
         self._march_frame()
 
     def _march_frame(self):
-        """March one chunk and draw what it left behind.
-
-        The chunk length is read every frame, so changing it mid-run takes
-        effect on the next one.
-        """
-        self.session.steps_per_chunk = self._panel.steps_per_frame()
+        """March one chunk and draw what it left behind."""
+        self._apply_limits()
         self.session.advance()
         self._draw_frame()
+
+    def _apply_limits(self):
+        """Put the panel's step cap and chunk length onto the session.
+
+        Read every frame, so a change mid-run lands on the next chunk.
+        """
+        self.session.max_steps = self._panel.max_steps()
+        self.session.steps_per_chunk = self._panel.steps_per_frame()
 
     def _draw_frame(self):
         """Read the run out into the panel, and into the viewer if it is

--- a/solvcon/pilot/apps/obsrefl/_panel.py
+++ b/solvcon/pilot/apps/obsrefl/_panel.py
@@ -27,6 +27,7 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QFormLayout,
 
 from ....multidim.euler import EulerField
 from ...visual import _movie
+from ._session import ReflectionSession
 
 __all__ = [  # noqa: F822
     'SolutionPanel',
@@ -228,8 +229,9 @@ class NumericsBox(FoldBox):
 class RunBox(FoldBox):
     """The march controls and the live march readout, kept side by side.
 
-    The buttons stand in the order a run is used: started, held (paused,
-    stepped), and ended (stopped where it stands, or dropped).  The readout
+    The step cap leads, then the buttons in the order a run uses them:
+    started, held (paused, stepped), and ended (stopped where it stands,
+    or dropped).  The readout
     beneath them carries the step count, what ended the run, the mass the
     domain holds, and the CFL bounds of the last chunk.
     """
@@ -237,6 +239,8 @@ class RunBox(FoldBox):
     #: What ended a run reads as in the state cell; a live run reads as
     #: "running" or "paused" from the Pause button instead.
     STOP_STATES = {'cap': "step cap", 'stopped': "stopped"}
+    #: Highest step cap the box offers, past any run worth watching.
+    STEP_CAP_MAX = 1000000
 
     def __init__(self, parent=None):
         super().__init__("Run", parent)
@@ -250,6 +254,8 @@ class RunBox(FoldBox):
         self._paused = False
         self._live = False
 
+        self._max_steps = _count(ReflectionSession.MAX_STEPS, 1,
+                                 self.STEP_CAP_MAX)
         self._steps = _count(5, 1, 1000)
 
         # Opens and closes the one domain viewer the run buttons draw into.
@@ -284,6 +290,7 @@ class RunBox(FoldBox):
         self._cfl = _value_label()
 
         form = QFormLayout()
+        form.addRow("steps", self._max_steps)
         form.addRow("steps/frame", self._steps)
         form.addRow(self._viewer_btn)
         form.addRow(marching)
@@ -294,6 +301,9 @@ class RunBox(FoldBox):
         form.addRow("cfl min/max", self._cfl)
         self.set_content_layout(form)
         self.show_run(None)
+
+    def max_steps(self):
+        return self._max_steps.value()
 
     def steps_per_frame(self):
         return self._steps.value()
@@ -668,6 +678,9 @@ class SolutionPanel(QScrollArea):
 
     def bar_placement(self):
         return self._field.placement()
+
+    def max_steps(self):
+        return self._run.max_steps()
 
     def steps_per_frame(self):
         return self._run.steps_per_frame()

--- a/solvcon/pilot/apps/obsrefl/_panel.py
+++ b/solvcon/pilot/apps/obsrefl/_panel.py
@@ -26,6 +26,7 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QFormLayout,
                                QLineEdit)
 
 from ....multidim.euler import EulerField
+from ...visual import _movie
 
 __all__ = [  # noqa: F822
     'SolutionPanel',
@@ -381,11 +382,13 @@ class MovieBox(FoldBox):
 
     #: Where a recorded movie lands; the mesh flavor of the run is
     #: substituted for the placeholder and the suffix picks the format
-    #: (:attr:`~solvcon.pilot.visual.MovieRecorder.SUFFIXES`).  Shown
-    #: resolved against the working directory, which for a pilot started
-    #: from the desktop is not the checkout, so the control names the
-    #: movie's real destination.
-    MOVIE_PATH = 'tmp/obrefl_{cell_type}.webp'
+    #: (:attr:`~solvcon.pilot.visual.MovieRecorder.SUFFIXES`).  The suffix
+    #: comes from :func:`~solvcon.pilot.visual._movie._default_suffix`,
+    #: resolved when the box is built.  Shown resolved against the working
+    #: directory, which
+    #: for a pilot started from the desktop is not the checkout, so the
+    #: control names the movie's real destination.
+    MOVIE_PATH = 'tmp/obrefl_{cell_type}{suffix}'
 
     def __init__(self, parent=None):
         super().__init__("Movie", parent)
@@ -393,7 +396,8 @@ class MovieBox(FoldBox):
         self.record_toggled = None
         self._record = QCheckBox()
         self._record.toggled.connect(self._on_record_toggled)
-        self._path = QLineEdit(os.path.abspath(self.MOVIE_PATH))
+        self._path = QLineEdit(os.path.abspath(
+            self.MOVIE_PATH.replace('{suffix}', _movie._default_suffix())))
         # Names the movie's destination and, once written, what landed
         # there; selectable so the path can be copied out.
         self._status = QLabel("")

--- a/solvcon/pilot/visual/_movie.py
+++ b/solvcon/pilot/visual/_movie.py
@@ -88,6 +88,8 @@ class MovieRecorder(object):
     The movie takes the shape of its first frame, and a later frame of
     another shape is scaled to it, so resizing the window mid-run leaves an
     animation that still plays rather than one that changes size partway.
+    That shape is the widget's own, not the screen's; see
+    :meth:`_to_logical_size`.
 
     The output name picks the format.  An ``.mp4`` is the one a video
     player, a browser, and a slide deck all take, and the smallest of the
@@ -131,11 +133,28 @@ class MovieRecorder(object):
     def capture(self, widget):
         """Grab one frame of what ``widget`` shows and hold it."""
         path = os.path.join(self._folder.name, f"frame{self.nframe:05d}.png")
-        pixmap = widget.grab()
+        pixmap = self._to_logical_size(widget.grab())
         if pixmap.isNull() or not pixmap.save(path):
             raise RuntimeError("the viewer gave no frame")
         self._frames.append(path)
         return path
+
+    @staticmethod
+    def _to_logical_size(pixmap):
+        """``pixmap`` at the size its widget is drawn, not its backing store.
+
+        A high-DPI grab comes back at the display's pixel count, so one
+        window would record at two sizes on two screens.  A null pixmap
+        reports a ratio of one and passes through, leaving the caller its
+        own grab to reject.
+        """
+        if pixmap.devicePixelRatio() <= 1:
+            return pixmap
+        pixmap = pixmap.scaled(pixmap.deviceIndependentSize().toSize(),
+                               Qt.IgnoreAspectRatio, Qt.SmoothTransformation)
+        # Or the PNG claims a resolution the frame no longer has.
+        pixmap.setDevicePixelRatio(1)
+        return pixmap
 
     def write(self, path):
         """Assemble the held frames into the movie at ``path``; returns how

--- a/solvcon/pilot/visual/_movie.py
+++ b/solvcon/pilot/visual/_movie.py
@@ -13,10 +13,16 @@ the sides.
 
 The frames stay on disk as PNG files in a temporary directory until they
 are written out, so a long run does not pile up on the heap.
+
+Two encoders sit behind the formats: Qt Multimedia's FFmpeg backend for
+MP4, Pillow for GIF and WebP.  Either can be missing from a build, so
+:func:`_default_suffix` names one the build can write.
 """
 
 import os
 import tempfile
+
+import numpy as np
 
 try:
     from PIL import Image
@@ -26,9 +32,52 @@ except ImportError:
     Image = None
     HAS_IMAGE = False
 
+from PySide6.QtCore import (QCoreApplication, QEventLoop, QSize, Qt,
+                            QTimer, QUrl)
+from PySide6.QtGui import QImage
+
+try:
+    from PySide6.QtMultimedia import (QMediaCaptureSession, QMediaFormat,
+                                      QMediaRecorder, QVideoFrame,
+                                      QVideoFrameFormat, QVideoFrameInput)
+
+    HAS_VIDEO = True
+except ImportError:
+    HAS_VIDEO = False
+
+# Hold the encoder to software: a GPU is the backend's first choice, and
+# the drivers fail an opaque external-library error only once every frame
+# is spent.  An empty pair turns the list off, where unsetting it reads as
+# "no preference".  It has to be set before _can_write_mp4() makes the
+# backend read it once and keep the answer.
+os.environ.setdefault('QT_FFMPEG_ENCODING_HW_DEVICE_TYPES', ',')
+
 __all__ = [
     'MovieRecorder',
 ]
+
+
+def _can_write_mp4():
+    """Whether this build can write an MP4.
+
+    Only the FFmpeg backend encodes one; another plays an MP4 but cannot
+    make one.  The backend is a plugin the application loads, so there is
+    nothing to ask before one exists.
+    """
+    if not HAS_VIDEO or QCoreApplication.instance() is None:
+        return False
+    formats = QMediaFormat().supportedFileFormats(
+        QMediaFormat.ConversionMode.Encode)
+    return QMediaFormat.FileFormat.MPEG4 in formats
+
+
+def _default_suffix():
+    """The suffix a new movie is named with.
+
+    MP4 leads where there is an encoder for it, playing where neither
+    animation format does; without one, the WebP Pillow always writes.
+    """
+    return '.mp4' if _can_write_mp4() else '.webp'
 
 
 class MovieRecorder(object):
@@ -40,9 +89,12 @@ class MovieRecorder(object):
     another shape is scaled to it, so resizing the window mid-run leaves an
     animation that still plays rather than one that changes size partway.
 
-    The output name picks the format.  A ``.webp`` keeps the frames in
-    true color, which a field of smooth colors needs; a ``.gif`` goes
-    everywhere but is quantized to 255 colors.
+    The output name picks the format.  An ``.mp4`` is the one a video
+    player, a browser, and a slide deck all take, and the smallest of the
+    three, but it needs the Qt Multimedia encoder :func:`_can_write_mp4`
+    reports on; a ``.webp`` keeps the frames in true color, which a field
+    of smooth colors needs; a ``.gif`` goes everywhere but is quantized to
+    255 colors.
 
     :ivar frame_ms: Milliseconds each frame is shown.
     :ivar hold_ms: Milliseconds the last frame is held, so a loop ends on
@@ -51,13 +103,18 @@ class MovieRecorder(object):
     """
 
     #: Output suffixes that name a format :meth:`write` can write.
-    SUFFIXES = ('.gif', '.webp')
+    SUFFIXES = ('.mp4', '.gif', '.webp')
+    #: Of those, the ones Pillow assembles; the rest go through Qt.
+    IMAGE_SUFFIXES = ('.gif', '.webp')
     #: Frames sampled across the movie to build its one GIF palette, and
     #: the factor each sample is shrunk by.
     PALETTE_FRAMES = 16
     PALETTE_SHRINK = 2
     #: WebP encoding effort, 0 (fastest) to 6 (smallest).
     WEBP_METHOD = 4
+    #: Milliseconds the MP4 encoder is given before the write is called
+    #: off; a stalled backend would hang the window it was called from.
+    MP4_TIMEOUT_MS = 60000
 
     def __init__(self, frame_ms=80, hold_ms=1500, quality=80):
         self.frame_ms = frame_ms
@@ -86,18 +143,22 @@ class MovieRecorder(object):
 
         The suffix of ``path`` picks the format among :attr:`SUFFIXES`.
         """
-        if not HAS_IMAGE:
-            raise OSError("writing a movie needs PIL/Pillow installed")
         if not self._frames:
             raise ValueError("no frame is captured")
         suffix = os.path.splitext(path)[1].lower()
         if suffix not in self.SUFFIXES:
             raise ValueError(
                 f"cannot write a movie named '{os.path.basename(path)}'; "
-                f"name it {' or '.join(self.SUFFIXES)}")
+                f"name it {', '.join(self.SUFFIXES[:-1])} "
+                f"or {self.SUFFIXES[-1]}")
         folder = os.path.dirname(path)
         if folder:
             os.makedirs(folder, exist_ok=True)
+
+        if '.mp4' == suffix:
+            return self._write_mp4(path)
+        if not HAS_IMAGE:
+            raise OSError("writing a movie needs PIL/Pillow installed")
         durations = ([self.frame_ms] * (len(self._frames) - 1)
                      + [self.hold_ms])
         if '.webp' == suffix:
@@ -159,6 +220,207 @@ class MovieRecorder(object):
                                      Image.Resampling.NEAREST),
                         (0, it * height))
         return strip.quantize(colors=255)
+
+    def _write_mp4(self, path):
+        """Encode the held frames into the MP4 at ``path``.
+
+        Qt Multimedia records off a live source, not a list, so the frames
+        go through a ``QVideoFrameInput`` that :meth:`_pump` feeds.
+
+        One frame rate leaves a frame no duration of its own, so the hold
+        on the last is spelled by repeating it; H.264 codes a repeated
+        picture into almost nothing.
+        """
+        if not _can_write_mp4():
+            raise OSError("writing an MP4 needs Qt Multimedia built with "
+                          "the FFmpeg backend")
+        size = self._movie_size()
+        held = max(0, round(self.hold_ms / self.frame_ms) - 1)
+
+        session = QMediaCaptureSession()
+        recorder = QMediaRecorder()
+        # Left to take its format from the first frame: declaring one up
+        # front never arms the input, and the write stalls having written
+        # nothing.
+        source = QVideoFrameInput()
+
+        media = QMediaFormat(QMediaFormat.FileFormat.MPEG4)
+        media.setVideoCodec(QMediaFormat.VideoCodec.H264)
+        recorder.setMediaFormat(media)
+        recorder.setOutputLocation(QUrl.fromLocalFile(os.path.abspath(path)))
+        recorder.setVideoResolution(size)
+        recorder.setVideoFrameRate(1000.0 / self.frame_ms)
+        recorder.setQuality(QMediaRecorder.Quality.VeryHighQuality)
+        session.setVideoFrameInput(source)
+        session.setRecorder(recorder)
+
+        try:
+            self._pump(recorder, source, self.nframe + held,
+                       lambda it: self._video_frame(min(it, self.nframe - 1),
+                                                    size))
+        except OSError:
+            # What was muxed before it gave up plays, and would sit at
+            # the named path looking like the recording that failed.
+            if os.path.exists(path):
+                os.remove(path)
+            raise
+        return self.nframe
+
+    def _movie_size(self):
+        """The shape every frame goes to the encoder in.
+
+        The first frame sets it, rounded down to even sides: H.264 halves
+        the chroma and has no half pixel to take it from.
+        """
+        size = QImage(self._frames[0]).size()
+        return QSize(size.width() & ~1, size.height() & ~1)
+
+    def _yuv420p(self, image):
+        """The RGB888 ``image`` as the three planes of a YUV 4:2:0 frame.
+
+        RGB handed over instead lands the stream on H.264's 4:4:4 profile,
+        which browsers turn down: Qt picks the codec format nearest the
+        source in bits per pixel, and no 4:2:0 format is near 32-bit RGB.
+        Subsampling here is what leaves an MP4 that plays.
+
+        BT.601 studio range, which :meth:`_video_frame` tags the frame with
+        so no player has to guess.
+        """
+        width, height = image.width(), image.height()
+        pixels = np.frombuffer(image.constBits(), dtype='uint8')
+        pixels = pixels.reshape(height, image.bytesPerLine())
+        pixels = pixels[:, :width * 3].reshape(height, width, 3)
+        red, green, blue = (pixels[..., 0].astype('float32'),
+                            pixels[..., 1].astype('float32'),
+                            pixels[..., 2].astype('float32'))
+
+        luma = 16 + (65.481 * red + 128.553 * green + 24.966 * blue) / 255
+        blue_diff = 128 + (-37.797 * red - 74.203 * green
+                           + 112.0 * blue) / 255
+        red_diff = 128 + (112.0 * red - 93.786 * green
+                          - 18.214 * blue) / 255
+        return (self._to_byte_plane(luma),
+                self._to_byte_plane(self._shrink(blue_diff)),
+                self._to_byte_plane(self._shrink(red_diff)))
+
+    @staticmethod
+    def _shrink(plane):
+        """Subsample a chroma plane, which 4:2:0 carries at half size.
+
+        Both sides are even, which :meth:`_movie_size` guarantees.
+        """
+        height, width = plane.shape
+        return plane.reshape(height // 2, 2, width // 2, 2).mean(axis=(1, 3))
+
+    @staticmethod
+    def _to_byte_plane(plane):
+        return np.clip(np.rint(plane), 0, 255).astype('uint8')
+
+    def _video_frame(self, index, size):
+        """The held frame at ``index`` as a YUV 4:2:0 video frame of ``size``.
+
+        Built one at a time, as the encoder takes them, so a recording is
+        never held whole; the frames stay the PNG files :meth:`capture`
+        wrote, as they do for the animation formats.
+        """
+        image = QImage(self._frames[index])
+        if image.size() != size:
+            image = image.scaled(size, Qt.IgnoreAspectRatio,
+                                 Qt.SmoothTransformation)
+        planes = self._yuv420p(
+            image.convertToFormat(QImage.Format.Format_RGB888))
+
+        video = QVideoFrameFormat(
+            size, QVideoFrameFormat.PixelFormat.Format_YUV420P)
+        video.setColorSpace(QVideoFrameFormat.ColorSpace.ColorSpace_BT601)
+        video.setColorRange(QVideoFrameFormat.ColorRange.ColorRange_Video)
+        video.setStreamFrameRate(1000.0 / self.frame_ms)
+        frame = QVideoFrame(video)
+        if not frame.map(QVideoFrame.MapMode.WriteOnly):
+            raise OSError("a video frame would not open for writing")
+        try:
+            # Rows are padded to the stride the encoder chose.
+            for it, plane in enumerate(planes):
+                stride = frame.bytesPerLine(it)
+                rows, columns = plane.shape
+                padded = np.zeros((rows, stride), dtype='uint8')
+                padded[:, :columns] = plane
+                frame.bits(it)[:rows * stride] = padded.tobytes()
+        finally:
+            frame.unmap()
+        return frame
+
+    def _pump(self, recorder, source, total, build):
+        """Feed ``total`` frames to ``source`` until the recorder has them.
+
+        ``build`` makes the frame at an index, called as the encoder takes
+        them so only the one in flight is held.  The recorder runs on the
+        event loop, so the write borrows one until it stops.  A frame
+        turned down means the encoder is behind, not that the frame is
+        bad, so it is offered again on the next readiness signal.
+
+        The loop takes no user input: closing the window mid-write would
+        free the widgets the write returns into.
+        """
+        loop = QEventLoop()
+        sent, pending, stopped, failure, late = 0, None, False, None, False
+
+        def feed():
+            nonlocal sent, pending
+            while sent < total:
+                if pending is None:
+                    pending = build(sent)
+                if not source.sendVideoFrame(pending):
+                    return
+                pending, sent = None, sent + 1
+            if not stopped:
+                recorder.stop()
+
+        def on_state(state):
+            nonlocal stopped
+            if QMediaRecorder.RecorderState.StoppedState == state:
+                stopped = True
+                loop.quit()
+
+        def on_error(_, message):
+            nonlocal failure
+            failure = message
+            loop.quit()
+
+        def on_late():
+            nonlocal late
+            late = True
+            loop.quit()
+
+        # A timer to stop and a flag to read: a watchdog outliving the
+        # write would quit a later loop, and a shot spent before exec()
+        # would leave the write with no timeout at all.
+        watchdog = QTimer()
+        watchdog.setSingleShot(True)
+        watchdog.timeout.connect(on_late)
+
+        source.readyToSendVideoFrame.connect(feed)
+        recorder.recorderStateChanged.connect(on_state)
+        recorder.errorOccurred.connect(on_error)
+        try:
+            watchdog.start(self.MP4_TIMEOUT_MS)
+            recorder.record()
+            # Qt does not carry a quit into the exec() after it, and a
+            # backend can drain every frame while record() still runs.
+            if not (stopped or late or failure):
+                loop.exec(QEventLoop.ProcessEventsFlag.ExcludeUserInputEvents)
+        finally:
+            watchdog.stop()
+
+        # The recorder muxes what it was handed on its way to stopping, so
+        # only the stop says the file is whole.
+        if failure is not None:
+            recorder.stop()
+            raise OSError(f"the MP4 encoder failed: {failure}")
+        if not stopped:
+            recorder.stop()
+            raise OSError(f"the MP4 encoder stalled at {sent} of "
+                          f"{total} frames")
 
     def close(self):
         """Drop the held frames and the temporary directory."""

--- a/tests/apps/obsrefl/test_panel.py
+++ b/tests/apps/obsrefl/test_panel.py
@@ -88,6 +88,15 @@ class StatusReadoutTC(unittest.TestCase):
         self.assertEqual(_panel._number(sess.history.last.mass),
                          panel._run._mass.text())
 
+    def test_the_run_box_supplies_the_step_cap(self):
+        # The box opens on the session's own default, so a run started
+        # without touching it marches to the cap the session would have
+        # chosen anyway.
+        panel = SolutionPanel()
+        self.assertEqual(ReflectionSession.MAX_STEPS, panel.max_steps())
+        panel._run._max_steps.setValue(120)
+        self.assertEqual(120, panel.max_steps())
+
     def test_pausing_names_the_state(self):
         panel, _, _, _ = self._filled()
         panel.set_paused(True)

--- a/tests/apps/obsrefl/test_panel.py
+++ b/tests/apps/obsrefl/test_panel.py
@@ -19,6 +19,7 @@ try:
     from solvcon.pilot.apps.obsrefl import ReflectionSession
     from solvcon.pilot.apps.obsrefl import _panel
     from solvcon.pilot.apps.obsrefl._panel import SolutionPanel
+    from solvcon.pilot.visual import _movie
 except ImportError:
     pilot = None
 
@@ -207,11 +208,21 @@ class StatusReadoutTC(unittest.TestCase):
         # into it and names the movie's real destination.
         panel = SolutionPanel()
         self.assertTrue(os.path.isabs(panel._movie._path.text()))
-        self.assertEqual(os.path.abspath('tmp/obrefl_unstructured.webp'),
+        landing = f"tmp/obrefl_unstructured{_movie._default_suffix()}"
+        self.assertEqual(os.path.abspath(landing),
                          panel.movie_path('unstructured'))
         panel._movie._path.setText('movie.gif')
         self.assertEqual(os.path.abspath('movie.gif'),
                          panel.movie_path('quad'))
+
+    def test_the_movie_box_opens_on_a_format_the_build_can_write(self):
+        # A default naming a format this build has no encoder for would
+        # record a whole run and then drop it at the write.
+        panel = SolutionPanel()
+        suffix = os.path.splitext(panel._movie._path.text())[1]
+        self.assertIn(suffix, _movie.MovieRecorder.SUFFIXES)
+        self.assertEqual('.mp4' if _movie._can_write_mp4() else '.webp',
+                         suffix)
 
     def test_the_movie_box_reports_a_ticked_box_but_not_a_set_one(self):
         # The controller sets the box back when a recording drops under it,

--- a/tests/test_pilot_movie.py
+++ b/tests/test_pilot_movie.py
@@ -28,8 +28,8 @@ import solvcon
 try:
     from solvcon import pilot
     from solvcon.pilot.visual import _movie
-    from PySide6.QtCore import QEventLoop, QSize, QTimer, QUrl
-    from PySide6.QtGui import QImage
+    from PySide6.QtCore import QEventLoop, QSize, Qt, QTimer, QUrl
+    from PySide6.QtGui import QImage, QPixmap
     from PySide6.QtWidgets import QLabel
     from PIL import Image
 except ImportError:
@@ -49,6 +49,9 @@ class _StubPixmap(object):
 
     def isNull(self):
         return self.size is None
+
+    def devicePixelRatio(self):
+        return 1.0
 
     def save(self, path):
         if self.size is None:
@@ -97,6 +100,19 @@ class MovieRecorderTC(unittest.TestCase):
     def _capture(self, nframe):
         for _ in range(nframe):
             self.recorder.capture(self.viewer)
+
+    def test_a_high_dpi_grab_comes_down_to_the_widget_size(self):
+        # A grab off a high-DPI screen holds as many pixels as the display
+        # does, so the same window recorded on one screen and then another
+        # would give two movies of two sizes.
+        pixmap = QPixmap(320, 180)
+        pixmap.fill(Qt.GlobalColor.darkGreen)
+        pixmap.setDevicePixelRatio(2.0)
+        come_down = _movie.MovieRecorder._to_logical_size(pixmap)
+        self.assertEqual(QSize(160, 90), come_down.size())
+        # The ratio goes with the pixels, or the PNG still claims the
+        # resolution the grab had.
+        self.assertEqual(1.0, come_down.devicePixelRatio())
 
     def test_capture_grabs_the_widget_whole(self):
         path = self.recorder.capture(self.viewer)
@@ -346,7 +362,7 @@ class WidgetMovieTC(unittest.TestCase):
         recorder = _movie.MovieRecorder()
         self.addCleanup(recorder.close)
         recorder.capture(widget)
-        shape = widget.grab().size()
+        shape = widget.size()
 
         # The writer merges frames that come out identical, so the widget
         # has to show something else before the second capture.

--- a/tests/test_pilot_movie.py
+++ b/tests/test_pilot_movie.py
@@ -10,6 +10,9 @@ frame bookkeeping and the movie assembly with no graphics surface at all.
 One class hands it a real Qt widget, which is the only way to say that what
 a live grab returns is what lands in the movie.
 
+The MP4 tests need the Qt Multimedia encoder, which not every build has, so
+they stand apart and skip themselves where there is none.
+
 Every image read back here is closed before the folder holding it goes.
 PIL keeps the file open for as long as the image lives, and Windows refuses
 to remove a file that anything still holds open.
@@ -25,6 +28,8 @@ import solvcon
 try:
     from solvcon import pilot
     from solvcon.pilot.visual import _movie
+    from PySide6.QtCore import QEventLoop, QSize, QTimer, QUrl
+    from PySide6.QtGui import QImage
     from PySide6.QtWidgets import QLabel
     from PIL import Image
 except ImportError:
@@ -77,6 +82,13 @@ class _StubViewer(object):
 class MovieRecorderTC(unittest.TestCase):
     """Frame bookkeeping and movie assembly, over a stub viewer."""
 
+    @classmethod
+    def setUpClass(cls):
+        # _can_write_mp4() answers for the application's media backend, so
+        # without one here the build's own answer would depend on whether
+        # another test module happened to run first.
+        pilot.RManager.instance.setUp()
+
     def setUp(self):
         self.recorder = _movie.MovieRecorder(frame_ms=40, hold_ms=500)
         self.addCleanup(self.recorder.close)
@@ -102,12 +114,12 @@ class MovieRecorderTC(unittest.TestCase):
             self.recorder.capture(_StubViewer(ok=False))
         self.assertEqual(self.recorder.nframe, 0)
 
-    def test_either_suffix_writes_every_frame_into_a_loop(self):
+    def test_either_image_suffix_writes_every_frame_into_a_loop(self):
         # The suffix is the whole of the format choice, and either format
         # carries every frame captured, at the shape it was grabbed in.
         self._capture(3)
         with tempfile.TemporaryDirectory() as folder:
-            for suffix in _movie.MovieRecorder.SUFFIXES:
+            for suffix in _movie.MovieRecorder.IMAGE_SUFFIXES:
                 with self.subTest(suffix=suffix):
                     path = os.path.join(folder, f"movie{suffix}")
                     self.assertEqual(self.recorder.write(path), 3)
@@ -137,7 +149,31 @@ class MovieRecorderTC(unittest.TestCase):
     def test_write_rejects_a_name_of_no_known_format(self):
         self._capture(1)
         with self.assertRaises(ValueError):
-            self.recorder.write("movie.mp4")
+            self.recorder.write("movie.mkv")
+
+    def test_the_default_suffix_names_a_format_write_takes(self):
+        # Whichever encoder the build has, the name the panel opens on has
+        # to be one write() will not turn down.
+        self.assertIn(_movie._default_suffix(),
+                      _movie.MovieRecorder.SUFFIXES)
+
+    def test_a_flat_color_converts_to_its_standard_yuv(self):
+        # The stream says BT.601 studio range, so what goes into the planes
+        # has to be that.  Coefficients of any other kind would tag one
+        # color space and carry another, shifting every color in the movie.
+        self._capture(1)
+        image = QImage(self.recorder._frames[0]).convertToFormat(
+            QImage.Format.Format_RGB888)
+        luma, blue_diff, red_diff = self.recorder._yuv420p(image)
+        # The stub's first frame is pure red, which is (81, 90, 240) there,
+        # and every pixel of it, so a plane laid down crooked shows up here.
+        self.assertTrue((luma == 81).all())
+        self.assertTrue((blue_diff == 90).all())
+        self.assertTrue((red_diff == 240).all())
+        # Chroma is subsampled by two, luma is not.
+        self.assertEqual((32, 64), luma.shape)
+        self.assertEqual((16, 32), blue_diff.shape)
+        self.assertEqual((16, 32), red_diff.shape)
 
     def test_write_holds_the_last_frame_longer(self):
         self._capture(2)
@@ -169,6 +205,128 @@ class MovieRecorderTC(unittest.TestCase):
         self.assertFalse(os.path.exists(path))
         # A second close is a no-op, so a caller need not track it.
         self.recorder.close()
+
+    def test_mp4_is_a_known_name_wherever_it_is_asked_for(self):
+        # A missing encoder (OSError) and a name of no known format
+        # (ValueError) reach the control on different channels and read
+        # differently there, so naming MP4 on a build that cannot encode
+        # it must not come back as though the name were a typo.
+        self._capture(1)
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "movie.mp4")
+            if _movie._can_write_mp4():
+                self.assertEqual(self.recorder.write(path), 1)
+            else:
+                with self.assertRaises(OSError):
+                    self.recorder.write(path)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT and HAS_IMAGE,
+                     "Qt pilot is not built or PIL is missing")
+class Mp4MovieTC(unittest.TestCase):
+    """The MP4 itself, on a build whose Qt Multimedia can encode one."""
+
+    @classmethod
+    def setUpClass(cls):
+        # The backend that does the encoding is a plugin the application
+        # loads, so what it can encode cannot be asked before there is one.
+        pilot.RManager.instance.setUp()
+        if not _movie._can_write_mp4():
+            raise unittest.SkipTest("Qt Multimedia has no MP4 encoder")
+
+    def _recorder(self, **kw):
+        recorder = _movie.MovieRecorder(**kw)
+        self.addCleanup(recorder.close)
+        return recorder
+
+    @staticmethod
+    def _played_ms(path):
+        """How long a player makes the movie at ``path`` run.
+
+        QtMultimedia is imported here rather than at the top of the file:
+        a build without it must skip these tests, not lose the rest.
+        """
+        from PySide6.QtMultimedia import QMediaPlayer
+
+        player = QMediaPlayer()
+        loop = QEventLoop()
+        loaded = []
+        player.mediaStatusChanged.connect(
+            lambda status: (loaded.append(status), loop.quit())
+            if QMediaPlayer.MediaStatus.LoadedMedia == status else None)
+        QTimer.singleShot(10000, loop.quit)
+        player.setSource(QUrl.fromLocalFile(path))
+        loop.exec()
+        played = player.duration()
+        # Windows will not remove a file the player still holds open, and
+        # the movie sits in a temporary directory that is about to go.
+        player.setSource(QUrl())
+        # A duration read off a player that never opened the file is zero,
+        # which would read as a hold that never happened.
+        assert loaded, "the player never loaded the movie"
+        return played
+
+    def test_every_frame_lands_in_an_mp4_container(self):
+        # The frame is the size a viewer really is, not the stub's default.
+        # The size is a viewer's, not the stub default, so the encoder
+        # sees a picture of the shape a real recording gives it.
+        recorder = self._recorder(frame_ms=40, hold_ms=500)
+        viewer = _StubViewer(size=(800, 600))
+        for _ in range(3):
+            recorder.capture(viewer)
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "movie.mp4")
+            self.assertEqual(recorder.write(path), 3)
+            with open(path, 'rb') as stream:
+                head = stream.read(12)
+        # An MP4 opens on a file-type box, which is what tells a player it
+        # has an MP4 rather than whatever else was named one.
+        self.assertEqual(b'ftyp', head[4:8])
+
+    def test_the_last_frame_is_held_to_the_end(self):
+        # An MP4 runs at one frame rate, so a longer duration on the last
+        # frame is not a thing the stream can say; the hold has to come
+        # from handing that frame over again.  Without it the movie stops
+        # the instant the march does and never rests on the result.
+        recorder = self._recorder(frame_ms=80, hold_ms=1500)
+        viewer = _StubViewer(size=(320, 240))
+        for _ in range(4):
+            recorder.capture(viewer)
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "held.mp4")
+            self.assertEqual(4, recorder.write(path))
+            played = self._played_ms(path)
+        # Three frames at 80 ms and then 1500 ms on the last, give or take
+        # the frame rate the muxer rounds the stream to.
+        self.assertAlmostEqual(3 * 80 + 1500, played, delta=250)
+
+    def test_the_frames_reach_the_encoder_as_yuv_4_2_0(self):
+        # An encoder handed RGB keeps what it was given and puts the stream
+        # on H.264's 4:4:4 profile, which a browser turns down; subsampling
+        # to 4:2:0 here is what leaves an MP4 that plays where video plays.
+        from PySide6.QtMultimedia import QVideoFrame, QVideoFrameFormat
+
+        recorder = self._recorder()
+        recorder.capture(_StubViewer(size=(64, 32)))
+        frame = recorder._video_frame(0, recorder._movie_size())
+        self.assertEqual(QVideoFrameFormat.PixelFormat.Format_YUV420P,
+                         frame.surfaceFormat().pixelFormat())
+        # Read the planes back off the frame, so what the encoder would
+        # pull is checked rather than the format the frame was asked for.
+        self.assertTrue(frame.map(QVideoFrame.MapMode.ReadOnly))
+        try:
+            self.assertEqual(81, frame.bits(0)[0])
+            self.assertEqual(90, frame.bits(1)[0])
+            self.assertEqual(240, frame.bits(2)[0])
+        finally:
+            frame.unmap()
+
+    def test_an_odd_sized_grab_comes_down_to_even_sides(self):
+        # H.264 subsamples chroma by two and has no half pixel to take it
+        # from, so a grab of odd shape cannot go to the encoder as it is.
+        recorder = self._recorder()
+        recorder.capture(_StubViewer(size=(65, 33)))
+        self.assertEqual(QSize(64, 32), recorder._movie_size())
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT and HAS_IMAGE,


### PR DESCRIPTION
For issue #1272 

Use Qt Multimedia and ffmpeg to encode movie into mp4.  Update the build scripts for Unix and Windows to include ffmpeg.  Enhance the `MovieRecorder` class to default to use ffmpeg/mp4.  The mp4 movie recorder uses streaming without needing to save the snapshot on disk.  Add a spin box to set the stopping step number for the simulation.