### PR TITLE
Mail the list when a master push breaks CI

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -301,3 +301,25 @@ jobs:
         export SOLVCON_TEST_SHOW_WINDOWS=ON
         make run_pilot_pytest VERBOSE=1
         echo "::endgroup::"
+
+  send_email_on_failure:
+    needs: [check_skip, standalone_buffer, build]
+    # Mail a master push failure only. A nightly call reads the caller's
+    # event name, and nightly_devbuild mails that one itself. A
+    # `timeout-minutes` kill reports `cancelled`, not `failure`.
+    if: |
+      always() &&
+      (contains(needs.*.result, 'failure') ||
+       contains(needs.*.result, 'cancelled')) &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      github.event.repository.fork == false
+    uses: ./.github/workflows/send_email_on_fail.yml
+    with:
+      job_results: |
+        - check_skip: ${{ needs.check_skip.result }}
+        - standalone_buffer: ${{ needs.standalone_buffer.result }}
+        - build: ${{ needs.build.result }}
+    secrets:
+      EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/.github/workflows/devbuild_windows.yml
+++ b/.github/workflows/devbuild_windows.yml
@@ -106,3 +106,23 @@ jobs:
           $env:SOLVCON_TEST_SHOW_WINDOWS = "ON"
           cmake --workflow --preset ci-win-rel
           echo "::endgroup::"
+
+  send_email_on_failure:
+    needs: [check_skip, build_windows]
+    # Mail a master push failure only. A `timeout-minutes` kill reports
+    # `cancelled`, not `failure`.
+    if: |
+      always() &&
+      (contains(needs.*.result, 'failure') ||
+       contains(needs.*.result, 'cancelled')) &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      github.event.repository.fork == false
+    uses: ./.github/workflows/send_email_on_fail.yml
+    with:
+      job_results: |
+        - check_skip: ${{ needs.check_skip.result }}
+        - build_windows: ${{ needs.build_windows.result }}
+    secrets:
+      EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -203,3 +203,24 @@ jobs:
           CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON" \
           SOLVCON_DIFF_BASE=${{ github.event.pull_request.base.sha }}
+
+  send_email_on_failure:
+    needs: [check_skip, lint]
+    # Mail a master push failure only. A nightly call reads the caller's
+    # event name, and nightly_devbuild mails that one itself. A
+    # `timeout-minutes` kill reports `cancelled`, not `failure`.
+    if: |
+      always() &&
+      (contains(needs.*.result, 'failure') ||
+       contains(needs.*.result, 'cancelled')) &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      github.event.repository.fork == false
+    uses: ./.github/workflows/send_email_on_fail.yml
+    with:
+      job_results: |
+        - check_skip: ${{ needs.check_skip.result }}
+        - lint: ${{ needs.lint.result }}
+    secrets:
+      EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}


### PR DESCRIPTION
Each nightly workflow calls send_email_on_fail.yml when a job fails, but a failure on a master push sent no mail. This change adds the same job to devbuild, lint, and devbuild_windows. The job runs on a push to master in the upstream repository and mails solvcon@googlegroups.com when a needed job fails or is cancelled.

The job tests the event name for push. nightly_devbuild calls devbuild and lint on the cron, and a called workflow reads the caller's event name, so the nightly path still sends one mail from nightly_devbuild. The job also needs check_skip: when that reusable job fails, the build and lint jobs are skipped, and the mail job would otherwise see only skipped results.

actionlint passes on the three workflows. The job itself runs only on the upstream master branch, so it has not been exercised in this pull request.

Related to the comment in #1425
