### PR TITLE
Smoke-test the portable artifact through the `solvcon` package

### DIFF
--- a/.github/workflows/nightly_build_windows.yml
+++ b/.github/workflows/nightly_build_windows.yml
@@ -151,7 +151,6 @@ jobs:
           Copy-Item -Path ".\build\ci-win-rel\pilot.exe" -Destination $destination
           windeployqt --release "$destination\pilot.exe"
           Copy-Item -Path ".\solvcon" -Destination $destination -Recurse
-          Copy-Item -Path ".\_solvcon*.pyd" -Destination $destination
 
           # mkl_rt dispatches at run time to a threading layer, the CPU kernels
           # for the host ISA, and the vector-math kernels; that closure plus the
@@ -229,7 +228,7 @@ jobs:
             $system32 = Join-Path $env:SystemRoot 'System32'
             $env:PATH = "$portable_root;$system32"
             $smoke = @(
-              'import _solvcon as m'
+              'import solvcon as m'
               'a = m.SimpleArrayFloat64((17, 18)); a.fill(1.0)'
               'b = m.SimpleArrayFloat64((18, 19)); b.fill(1.0)'
               'c = a.matmul(b)'


### PR DESCRIPTION
PR #1412 broke `nightly_build_windows` Release job:

- 2026-08-29: https://github.com/solvcon/solvcon/actions/runs/33225454662/job/99028164283
- 2026-08-28: https://github.com/solvcon/solvcon/actions/runs/33133345204/job/98727686805
- 2026-08-26: https://github.com/solvcon/solvcon/actions/runs/33004978497/job/98296251530

The last green nightly is 2026-08-25, https://github.com/solvcon/solvcon/actions/runs/32880826676, which ran before the smoke test existed.

The failure happened in `generate portable` on every nightly since landed the shared Windows CI setup and the MKL runtime. The step assembles the portable tree, then runs a smoke test that imports the extension under a `PATH` holding only the artifact directory and `System32`. The import never resolves.

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import _solvcon as m; a = m.SimpleArrayFloat64((17, 18)); a.fill(1.0); b = m.SimpleArrayFloat64((18, 19)); b.fill(1.0); c = a.matmul(b); assert c.shape == (17, 19) and c[0, 0] == 18.0
    ^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named '_solvcon'
```

```
Exception: D:\a\_temp\8fda405a-db03-4e57-9d6b-5b90c8ec633b.ps1:146
Line |
 146 |      throw "portable MKL smoke test exited with code $LASTEXITCODE"
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | portable MKL smoke test exited with code 1
##[error]Process completed with exit code 1.
```

Fix by correcting the file copying for the portable package.