### PR TITLE
Let any sub-window carry a resize grip

### DIFF
--- a/cpp/solvcon/pilot/app/RManager.cpp
+++ b/cpp/solvcon/pilot/app/RManager.cpp
@@ -193,6 +193,21 @@ RManager::~RManager()
     reset();
 }
 
+void RManager::addSubWindowGrip(QMdiSubWindow * subwin)
+{
+    if (subwin == nullptr)
+    {
+        return;
+    }
+    // A grip the hosted widget owns is not this one, so look no further than
+    // the sub-window's own children.
+    if (subwin->findChild<QSizeGrip *>(QString(), Qt::FindDirectChildrenOnly) != nullptr)
+    {
+        return;
+    }
+    new SubWindowGrip(subwin);
+}
+
 RDomainWidget * RManager::add3DWidget()
 {
     RDomainWidget * viewer = nullptr;
@@ -223,9 +238,7 @@ RDomainWidget * RManager::add3DWidget()
         }
         auto * subwin = this->addSubWindow(host);
         subwin->resize(400, 300);
-        // The sub-window frame is a few pixels wide, too little to aim a drag
-        // at.
-        new SubWindowGrip(subwin);
+        this->addSubWindowGrip(subwin);
     }
     return viewer;
 }

--- a/cpp/solvcon/pilot/app/RManager.hpp
+++ b/cpp/solvcon/pilot/app/RManager.hpp
@@ -86,6 +86,13 @@ public:
     template <typename... Args>
     QMdiSubWindow * addSubWindow(Args &&... args);
 
+    /**
+     * Put a resize grip over a sub-window's lower-right corner. The sub-window
+     * owns the grip. Nothing happens when @p subwin is null or already carries
+     * a grip of its own.
+     */
+    void addSubWindowGrip(QMdiSubWindow * subwin);
+
     /// The live model of the menu bar, addressable by path from Python.
     RMenuModel * menuModel() { return m_menuModel; }
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -1210,6 +1210,12 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                     return subwin;
                 },
                 py::arg("widget"))
+            .def(
+                "addSubWindowGrip",
+                &wrapped_type::addSubWindowGrip,
+                py::arg("subwin"),
+                "Put a resize grip over a sub-window's lower-right corner. A "
+                "sub-window that already carries one is left alone.")
             .def_property(
                 "windowTitle",
                 [](wrapped_type & self)

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -2009,6 +2009,59 @@ class RDomainWidgetManagerTC(unittest.TestCase):
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RManagerSubWindowGripTC(unittest.TestCase):
+    """The grip the manager hands to any sub-window, 3D viewer or not."""
+
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        # The reparent happens inside C++, where Shiboken does not see it,
+        # so Python still owns the host and frees a temporary out from under
+        # the sub-window.
+        self.host = QWidget()
+        self.subwin = self.mgr.addSubWindow(self.host)
+        self.subwin.resize(320, 240)
+
+    def tearDown(self):
+        # The manager is a singleton, so a plain sub-window left active is a
+        # stranger to every later test asking for the current viewer.
+        self.mgr.mdiArea.closeAllSubWindows()
+
+    def test_the_manager_adds_a_grip_to_a_plain_subwindow(self):
+        """A sub-window built from Python takes the same grip as the 3D one."""
+        self.assertEqual([], self.subwin.findChildren(QSizeGrip))
+        self.mgr.addSubWindowGrip(self.subwin)
+        grips = self.subwin.findChildren(QSizeGrip)
+        self.assertEqual(1, len(grips))
+        # findChildren reaches into the hosted widget, and the macOS style
+        # draws a grip only for the sub-window's own child.
+        self.assertIs(self.subwin, grips[0].parent())
+
+    def test_a_second_call_adds_no_second_grip(self):
+        # add3DWidget grips its own sub-window, so a caller reaching one
+        # through the manager can ask for a grip that is already there.
+        self.mgr.addSubWindowGrip(self.subwin)
+        self.mgr.addSubWindowGrip(self.subwin)
+        self.assertEqual(1, len(self.subwin.findChildren(QSizeGrip)))
+
+    def test_the_grip_takes_the_lower_right_corner(self):
+        self.mgr.addSubWindowGrip(self.subwin)
+        # The hosted widget spans the corner, so the grip answers a drag
+        # aimed there only by sitting over it.
+        corner = self.subwin.rect().bottomRight()
+        self.assertIs(self.subwin.findChild(QSizeGrip),
+                      self.subwin.childAt(corner))
+
+    def test_the_grip_leaves_the_layout_to_the_widget(self):
+        # QMdiSubWindow adopts a size grip into the layout that holds the
+        # widget, where it would claim a row of the height.
+        self.mgr.addSubWindowGrip(self.subwin)
+        layout = self.subwin.layout()
+        self.assertEqual(-1, layout.indexOf(self.subwin.findChild(QSizeGrip)))
+        self.assertEqual(1, layout.count())
+        self.assertIs(self.host, layout.itemAt(0).widget())
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class RDomainWidgetAxisTC(unittest.TestCase):
     """The orientation-guide overlay (step 6)."""
 


### PR DESCRIPTION
Allow to add a resize grip to all sub-window rather than just the 3D viewer (which was introduced with PR #1368).  `RManager::addSubWindowGrip` is now the one entry point that adds the grip but stays private to the translation unit. `add3DWidget` calls it.

For issue #1272.