### PR TITLE
Initialize `RingInfo::role` by default

### DIFF
--- a/cpp/solvcon/universe/World.hpp
+++ b/cpp/solvcon/universe/World.hpp
@@ -519,7 +519,7 @@ public:
      */
     struct RingInfo
     {
-        RingRole role;
+        RingRole role = RingRole::OUTER;
         std::vector<std::vector<T>> vertices;
     }; /* end struct RingInfo */
 


### PR DESCRIPTION
`shape_rings()` default-constructs a `RingInfo` before filling it, so clang-tidy's cppcoreguidelines-pro-type-member-init rejects the implicit default constructor. The lint job builds with `-warnings-as-errors`, and it has failed on every master push since the ring storage landed.

The bug was introduced in PR #1348 .