### PR TITLE
Plot the profiled value in a separate widget (step 2 of line plot)

### DIFF
--- a/solvcon/pilot/apps/obsrefl/_app.py
+++ b/solvcon/pilot/apps/obsrefl/_app.py
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import QDockWidget
 from ...base import _gui_common
 from ._control import RunController
 from ._panel import SolutionPanel
-from ._viewer import DomainViewer
+from ._viewer import DomainViewer, LinePlotViewer
 
 __all__ = [  # noqa: F822
     'ObliqueShockApp',
@@ -29,7 +29,8 @@ __all__ = [  # noqa: F822
 class ObliqueShockApp(_gui_common.PilotFeature):
     """Euler solver panel, toggled from the View "Panels" submenu.
 
-    The panel owns one domain viewer sub-window and one solver run; the
+    The panel owns two sub-windows and one solver run: the domain viewer
+    the field is colored into, and the analysis plots that judge it.  The
     controller between them starts, pauses, steps, and ends the march.
     """
 
@@ -43,6 +44,7 @@ class ObliqueShockApp(_gui_common.PilotFeature):
         self._control = None
         self._viewer = DomainViewer(self._mgr)
         self._viewer.mesh_updated = self._notify_viewer_updated
+        self._lineplots = LinePlotViewer(self._mgr)
 
     def populate_menu(self):
         self._action = self.add_action(
@@ -61,7 +63,8 @@ class ObliqueShockApp(_gui_common.PilotFeature):
         if self._panel is not None:
             return
         self._panel = SolutionPanel()
-        self._control = RunController(self._panel, self._viewer)
+        self._control = RunController(self._panel, self._viewer,
+                                      self._lineplots)
         self._control.reported = self._report
         self._dock = QDockWidget("euler solver")
         self._dock.setWidget(self._panel)

--- a/solvcon/pilot/apps/obsrefl/_control.py
+++ b/solvcon/pilot/apps/obsrefl/_control.py
@@ -11,11 +11,11 @@ the controller plants on the panel, a viewer close arrives through the
 viewer's ``closed``, and everything the widgets show is pushed back into
 them from this side.  No widget ever reaches into a sibling.
 
-The gauge that marks the profile cut on the domain and the movie a run
-records are both driven from here as well.  The movie rides on the frames
-the viewer draws and the gauge on its own controls, and both belong beside
-the march rather than in the run session, which stays free of the GUI it
-is watched from.
+The analysis plot window, the gauge that marks the profile cut on the
+domain, and the movie a run records are all driven from here as well.  The
+plots and the movie ride on the frames the viewer draws and the gauge on
+its own controls, and all three belong beside the march rather than in the
+run session, which stays free of the GUI it is watched from.
 """
 
 from PySide6.QtCore import QTimer
@@ -38,6 +38,9 @@ class RunController(object):
     after each, so however fast the solver is, the widgets update at the
     frame rate and no march outlives its viewer.
 
+    The plot window is optional, so a run can be driven with only a viewer;
+    every call into it is guarded.
+
     :ivar session: The running :class:`~._session.ReflectionSession`, or
         None until the first :meth:`preview` or :meth:`start` builds one.
     :ivar movie: The open :class:`~solvcon.pilot.visual.MovieRecorder`, or
@@ -49,9 +52,10 @@ class RunController(object):
     #: Qt timer interval in milliseconds.
     INTERVAL_MS = 50
 
-    def __init__(self, panel, viewer):
+    def __init__(self, panel, viewer, lineplots=None):
         self._panel = panel
         self._viewer = viewer
+        self._lineplots = lineplots
         self.session = None
         self.movie = None
         self.reported = None
@@ -72,7 +76,10 @@ class RunController(object):
         panel.placement_changed = self._on_bar_placement
         panel.gauge_changed = self._on_gauge_changed
         panel.record_toggled = self._on_record
+        panel.lineplots_toggled = self._on_lineplots
         viewer.closed = self._on_viewer_closed
+        if lineplots is not None:
+            lineplots.closed = self._on_lineplots_closed
 
     def preview(self):
         """Open the viewer on the initial state of the configured run.
@@ -164,9 +171,32 @@ class RunController(object):
         else:
             self._viewer.close()
 
+    def _on_lineplots(self, open_):
+        if self._lineplots is None:
+            return
+        if open_:
+            self._lineplots.open()
+            self._panel.set_lineplots_open(True)
+            self._draw_lineplots()
+        else:
+            self._lineplots.close()
+
+    def _on_lineplots_closed(self):
+        self._panel.set_lineplots_open(False)
+
     def _on_gauge_changed(self):
         self._set_gauge()
         self._draw_frame()
+
+    def _draw_lineplots(self):
+        """Read the cut out into the plot window, if it is open.
+
+        The plot follows the cut, not the gauge marks over it.
+        """
+        if self._lineplots is None:
+            return
+        height = None if self.session is None else self._cut_height()
+        self._lineplots.show_run(self.session, self._panel.field(), height)
 
     def _on_viewer_closed(self):
         # Reached from the sub-window's close event; stop the run before Qt
@@ -241,6 +271,7 @@ class RunController(object):
         session = self.session
         if None is session:
             self._panel.set_status(None, None, None)
+            self._draw_lineplots()
             return
         name = self._panel.field()
         field = session.field.field(name)
@@ -256,6 +287,7 @@ class RunController(object):
             if self.movie is not None:
                 self._capture_frame()
         self._panel.set_status(session, vmin, vmax)
+        self._draw_lineplots()
 
     def _set_gauge(self):
         """Put the marks of the profile cut into the painter, or take them

--- a/solvcon/pilot/apps/obsrefl/_panel.py
+++ b/solvcon/pilot/apps/obsrefl/_panel.py
@@ -251,6 +251,7 @@ class RunBox(FoldBox):
         self.step_requested = None
         self.stop_requested = None
         self.reset_requested = None
+        self.lineplots_toggled = None
         self._paused = False
         self._live = False
 
@@ -258,12 +259,18 @@ class RunBox(FoldBox):
                                  self.STEP_CAP_MAX)
         self._steps = _count(5, 1, 1000)
 
-        # Opens and closes the one domain viewer the run buttons draw
-        # into.
+        # The two windows a run draws into.
         self._viewer_btn = QPushButton("Open viewer")
         self._viewer_btn.setCheckable(True)
         self._viewer_btn.toggled.connect(self._on_viewer_toggled)
         _reserve_width(self._viewer_btn, ("Open viewer", "Close viewer"))
+        self._lineplots_btn = QPushButton("Open plots")
+        self._lineplots_btn.setCheckable(True)
+        self._lineplots_btn.toggled.connect(self._on_lineplots_toggled)
+        _reserve_width(self._lineplots_btn, ("Open plots", "Close plots"))
+        windows = QHBoxLayout()
+        windows.addWidget(self._viewer_btn)
+        windows.addWidget(self._lineplots_btn)
 
         self._start = QPushButton("Start")
         self._start.clicked.connect(self._on_start_clicked)
@@ -293,7 +300,7 @@ class RunBox(FoldBox):
         form = QFormLayout()
         form.addRow("steps", self._max_steps)
         form.addRow("steps/frame", self._steps)
-        form.addRow(self._viewer_btn)
+        form.addRow(windows)
         form.addRow(marching)
         form.addRow(ending)
         form.addRow("step", self._progress)
@@ -332,6 +339,13 @@ class RunBox(FoldBox):
         self._viewer_btn.setText("Close viewer" if open_ else "Open viewer")
         self._viewer_btn.blockSignals(False)
 
+    def set_lineplots_open(self, open_):
+        """Reflect the plot window state without re-firing its button."""
+        self._lineplots_btn.blockSignals(True)
+        self._lineplots_btn.setChecked(open_)
+        self._lineplots_btn.setText("Close plots" if open_ else "Open plots")
+        self._lineplots_btn.blockSignals(False)
+
     def show_run(self, session):
         """Read the march progress of one run, or the lack of a run."""
         self._live = session is not None and session.stop_reason is None
@@ -361,6 +375,11 @@ class RunBox(FoldBox):
         self._viewer_btn.setText("Close viewer" if open_ else "Open viewer")
         if self.viewer_toggled is not None:
             self.viewer_toggled(open_)
+
+    def _on_lineplots_toggled(self, open_):
+        self._lineplots_btn.setText("Close plots" if open_ else "Open plots")
+        if self.lineplots_toggled is not None:
+            self.lineplots_toggled(open_)
 
     def _on_start_clicked(self):
         if self.start_requested is not None:
@@ -651,6 +670,14 @@ class SolutionPanel(QScrollArea):
         self._run.viewer_toggled = callback
 
     @property
+    def lineplots_toggled(self):
+        return self._run.lineplots_toggled
+
+    @lineplots_toggled.setter
+    def lineplots_toggled(self, callback):
+        self._run.lineplots_toggled = callback
+
+    @property
     def start_requested(self):
         return self._run.start_requested
 
@@ -772,6 +799,9 @@ class SolutionPanel(QScrollArea):
 
     def set_viewer_open(self, open_):
         self._run.set_viewer_open(open_)
+
+    def set_lineplots_open(self, open_):
+        self._run.set_lineplots_open(open_)
 
     def set_status(self, session, vmin, vmax):
         """Read one run out into the readout boxes.

--- a/solvcon/pilot/apps/obsrefl/_plots.py
+++ b/solvcon/pilot/apps/obsrefl/_plots.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""The plot that judges a reflection run against the analytic answer.
+
+:class:`AnalysisLinePlots` draws a horizontal cut of the field over the
+analytic three-zone step it is heading for, so the gap between the curves
+is the error at that station, which a color map cannot show.
+
+The widget holds no run.  Its owner pushes a session in whenever a frame
+is drawn, and the plot follows it.
+"""
+
+from PySide6.QtWidgets import QWidget, QVBoxLayout
+
+from ...visual import _plot
+
+__all__ = [  # noqa: F822
+    'AnalysisLinePlots',
+]
+
+
+class AnalysisLinePlots(QWidget):
+    """The line profile of one run against the analytic step."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._profile = _plot.LinePlotWidget(
+            title="line profile", xlabel="x", ylabel="density")
+        self._computed = self._profile.add_series("computed")
+        self._analytic = self._profile.add_series("analytic")
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.addWidget(self._profile)
+
+    def show_run(self, session, name, height):
+        """Draw ``session`` into the plot, or blank it without one.
+
+        Both curves come off one :meth:`~._analytic.Reflection.profile`, so
+        they are sampled at the same abscissae and the gap between them is
+        the error at that station rather than an artifact of the sampling.
+        """
+        if None is session:
+            self._computed.clear_data()
+            self._analytic.clear_data()
+        else:
+            cut = session.profile(height, name)
+            self._computed.set_data(_plot._array(cut.x),
+                                    _plot._array(cut.computed))
+            self._analytic.set_data(_plot._array(cut.x),
+                                    _plot._array(cut.analytic))
+            self._profile.set_ylabel(name)
+        self._profile.refresh()
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/apps/obsrefl/_viewer.py
+++ b/solvcon/pilot/apps/obsrefl/_viewer.py
@@ -2,13 +2,16 @@
 # BSD 3-Clause License, see COPYING
 
 
-"""The domain sub-window a reflection run draws into.
+"""The sub-windows a reflection run draws into.
 
 :class:`DomainViewer` wraps the one 3D sub-window of a run: it opens and
 closes the window, watches for a close from any source, and forwards what
 the run wants drawn (the mesh, the analytic shock overlay, the colored
-field, and the color-bar legend laid over them).  Every drawing call is a
-no-op while the window is closed, so the owner never draws into a freed
+field).  :class:`LinePlotViewer` wraps the plain sub-window that holds the
+analysis plots the same way.
+
+Both share the one rule this module exists to keep: every drawing call is
+a no-op while the window is closed, so the owner never draws into a freed
 widget.  What to draw and when stays with the owner, which hears about a
 close through the :attr:`closed` callback.
 """
@@ -16,9 +19,11 @@ close through the :attr:`closed` callback.
 from PySide6.QtCore import Qt, QObject, QEvent
 
 from ._colorbar import ColorBar
+from ._plots import AnalysisLinePlots
 
 __all__ = [  # noqa: F822
     'DomainViewer',
+    'LinePlotViewer',
 ]
 
 
@@ -229,5 +234,68 @@ class DomainViewer(object):
         if host is None:
             return
         movie.capture(host)
+
+
+class LinePlotViewer(object):
+    """Own the sub-window holding the analysis plots.
+
+    The plots are built once and outlive the window: a reopened window is
+    handed the same :class:`~._plots.AnalysisLinePlots` back rather than a
+    fresh one that dropped what it was showing.
+
+    :ivar lineplots: The :class:`~._plots.AnalysisLinePlots` widget,
+        always live.
+    """
+
+    SIZE = (520, 620)
+
+    def __init__(self, mgr):
+        self._mgr = mgr
+        # Owner-supplied callback fired when the sub-window closes from any
+        # source.
+        self.closed = None
+        self.lineplots = AnalysisLinePlots()
+        self._subwin = None
+        self._close_filter = None
+
+    @property
+    def is_open(self):
+        return self._subwin is not None
+
+    def open(self):
+        if self._subwin is not None:
+            return
+        # A parented widget is deleted with its window, so the plots are
+        # unparented on a close and handed to the new sub-window here.  The
+        # manager shows the window and marks it delete-on-close.
+        self.lineplots.setParent(None)
+        self._subwin = self._mgr.addSubWindow(self.lineplots)
+        self._subwin.setWindowTitle("reflection analysis")
+        self._subwin.resize(*self.SIZE)
+        self._mgr.addSubWindowGrip(self._subwin)
+        self._close_filter = _SubWindowCloseFilter(
+            self._on_subwin_closed, self._subwin)
+        self._subwin.installEventFilter(self._close_filter)
+
+    def close(self):
+        """Close the sub-window; its close event fires :attr:`closed`."""
+        if self._subwin is not None:
+            self._subwin.close()
+        else:
+            self._on_subwin_closed()
+
+    def _on_subwin_closed(self):
+        # Take the plots back out before Qt deletes the window around them,
+        # then drop the window and tell the owner.
+        self.lineplots.setParent(None)
+        self._subwin = None
+        self._close_filter = None
+        if self.closed is not None:
+            self.closed()
+
+    def show_run(self, session, name, height):
+        if self._subwin is None:
+            return
+        self.lineplots.show_run(session, name, height)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/visual/__init__.py
+++ b/solvcon/pilot/visual/__init__.py
@@ -4,7 +4,8 @@
 
 """
 The visual pieces of the pilot: sample meshes, the Gmsh file dialog, the
-mesh style status helpers, and the viewer movie recorder.
+mesh style status helpers, the viewer movie recorder, and the line plot
+widget.
 """
 
 from .. import _pilot_core as _pcore
@@ -12,12 +13,14 @@ from .. import _pilot_core as _pcore
 if _pcore.enable:
     from . import _mesh
     from . import _movie
+    from . import _plot
 
     SampleMesh = _mesh.SampleMesh
     SampleMeshFeature = _mesh.SampleMeshFeature
     MeshStyleStatus = _mesh.MeshStyleStatus
     GmshFileDialog = _mesh.GmshFileDialog
     MovieRecorder = _movie.MovieRecorder
+    LinePlotWidget = _plot.LinePlotWidget
 else:
     # Bind only the public names: a None module attribute would shadow the
     # real submodule import in no-GUI builds.
@@ -26,9 +29,11 @@ else:
     MeshStyleStatus = None
     GmshFileDialog = None
     MovieRecorder = None
+    LinePlotWidget = None
 
 __all__ = [
     'GmshFileDialog',
+    'LinePlotWidget',
     'MeshStyleStatus',
     'MovieRecorder',
     'SampleMesh',

--- a/solvcon/pilot/visual/_plot.py
+++ b/solvcon/pilot/visual/_plot.py
@@ -1,0 +1,327 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""Draw a :class:`~solvcon.pilot.RPlotModel` into a Qt widget.
+
+The plot model is Qt-free by design and paints nothing, and its
+``view()`` carries one zoom, which suits a spatial plot and flattens an xy
+one whose axes share no scale.  :class:`LinePlotWidget` is the front end it
+lacks: it stretches each axis onto the frame and draws the axes, the
+ticks, and the legend around the curves.  It is a widget and not a canvas,
+that name being the 2D drawing surface of :mod:`solvcon.pilot.canvas`.
+
+The ordinate can go on a log scale, for a quantity spanning decades.  The
+series keep their true values; only the mapping to the screen is
+logarithmic.
+"""
+
+import math
+
+import numpy as np
+
+from PySide6.QtCore import Qt, QRect, QPointF
+from PySide6.QtGui import QPainter, QPen, QColor, QPolygonF
+from PySide6.QtWidgets import QWidget, QSizePolicy
+
+from ... import core
+from .. import _pilot_core as _pcore
+
+__all__ = [  # noqa: F822
+    'LinePlotWidget',
+]
+
+
+def _nice_ticks(lo, hi, want=5):
+    """Round tick positions covering ``lo`` to ``hi``, about ``want`` of
+    them.
+
+    The step is the 1, 2, or 5 times a power of ten nearest below the even
+    spacing, which is what keeps tick labels short enough to read.
+    """
+    span = hi - lo
+    if not span > 0 or not math.isfinite(span):
+        return []
+    raw = span / max(1, want)
+    power = 10.0 ** math.floor(math.log10(raw))
+    for mult in (1.0, 2.0, 5.0, 10.0):
+        step = mult * power
+        if raw <= step:
+            break
+    # Count the steps rather than accumulate them: where the span is small
+    # beside the offset, `first + step` rounds back to `first` and never
+    # ends, inside the paint that called it.  The slack keeps a tick that
+    # sits on the end and the clamp keeps rounding from carrying one past
+    # it; zero is snapped off the residue that would print as an exponent.
+    first = math.ceil(lo / step)
+    last = math.floor((hi + 1e-9 * step) / step)
+    return [0.0 if 0 == it else min(max(it * step, lo), hi)
+            for it in range(first, last + 1)]
+
+
+def _decade_ticks(lo, hi):
+    """Powers of ten covering the decades from ``lo`` to ``hi``.
+
+    Both bounds are already logarithms, so the ticks are the integers in
+    between; a range inside one decade still gets its two ends marked.
+    """
+    low, high = math.ceil(lo), math.floor(hi)
+    if high < low:
+        return [lo, hi]
+    return [float(it) for it in range(int(low), int(high) + 1)]
+
+
+def _decade_label(value):
+    """Format a log-axis tick, which is drawn at its exponent.
+
+    A range inside one decade is ticked at its own ends, which are not
+    whole exponents and do not read as powers of ten.
+    """
+    if float(value).is_integer():
+        return f"1e{value:.0f}"
+    return _tick_label(10.0 ** value)
+
+
+def _tick_label(value):
+    """Format a tick to something short enough to sit under an axis."""
+    if 0.0 == value:
+        return "0"
+    if 1e-3 <= abs(value) < 1e5:
+        return f"{value:.4g}"
+    return f"{value:.0e}"
+
+
+class LinePlotWidget(QWidget):
+    """Paint one plot model, with axes, ticks, and a legend.
+
+    The model is the widget's own; a caller fills its series and calls
+    :meth:`refresh`.  Limits are taken from the data every refresh, so a
+    plot that is appended to while a run marches keeps following it.
+
+    :ivar model: The :class:`~solvcon.pilot.RPlotModel` being drawn.
+    :ivar log_y: Whether the ordinate is mapped logarithmically.
+    """
+
+    #: Room for the axis labels, as (left, top, right, bottom) pixels.  The
+    #: left holds a tick label, the bottom a label and the axis title, and
+    #: the top the plot title.
+    MARGINS = (58, 22, 12, 34)
+    #: Smallest ordinate a log plot draws; zero and below have no
+    #: logarithm to place.
+    LOG_FLOOR = 1e-16
+
+    def __init__(self, title="", xlabel="", ylabel="", log_y=False,
+                 parent=None):
+        super().__init__(parent)
+        self.model = _pcore.RPlotModel()
+        self.log_y = log_y
+        self._title = title
+        self._xlabel = xlabel
+        self._ylabel = ylabel
+        self._limits = None
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.setMinimumSize(240, 160)
+
+    def add_series(self, label, color=None):
+        """Add one named curve; returns the new series."""
+        series = self.model.add_series()
+        series.label = label
+        if color is not None:
+            series.color = color
+        return series
+
+    def set_ylabel(self, text):
+        """Rename the ordinate, for a plot whose quantity is selectable."""
+        self._ylabel = text
+        self.update()
+
+    def refresh(self):
+        """Recompute the limits from the series and repaint."""
+        self._limits = self._calc_limits()
+        self.update()
+
+    def limits(self):
+        """The drawn limits as ``(xmin, xmax, ymin, ymax)``, or None while
+        there is nothing to draw.
+
+        The ordinate is in the mapped space, so a log plot reports the
+        exponents it drew between.
+        """
+        return self._limits
+
+    def _points(self, series):
+        """The series data as ``(x, y)`` pairs, mapped for the axis.
+
+        A log plot drops what it cannot place, a non-positive ordinate
+        having no logarithm, rather than breaking the curve around it.
+        """
+        out = []
+        for it in range(series.size):
+            x, y = series.x(it), series.y(it)
+            if not math.isfinite(x) or not math.isfinite(y):
+                continue
+            if self.log_y:
+                if y <= self.LOG_FLOOR:
+                    continue
+                y = math.log10(y)
+            out.append((x, y))
+        return out
+
+    def _calc_limits(self):
+        """The box the curves are drawn in, or None with nothing to draw.
+
+        The model does the scaling, margin and zero-span guard included.
+        Only the mapping onto the screen is the widget's.
+        """
+        if self.log_y:
+            return self._log_limits()
+        if None is self.model.data_limits():
+            return None
+        self.model.autoscale()
+        return self.model.view_limits()
+
+    def _log_limits(self):
+        """Scale the mapped points through a model of their own.
+
+        The exponents a log plot draws are not in the series, so they are
+        scaled by the same rule rather than by a second one written here.
+        """
+        xs, ys = [], []
+        for it in range(self.model.size):
+            for x, y in self._points(self.model.series(it)):
+                xs.append(x)
+                ys.append(y)
+        if not xs:
+            return None
+        mapped = _pcore.RPlotModel()
+        mapped.margin = self.model.margin
+        mapped.add_series().set_data(_array(xs), _array(ys))
+        mapped.autoscale()
+        return mapped.view_limits()
+
+    def _lineplot_rect(self):
+        left, top, right, bottom = self.MARGINS
+        return QRect(left, top, max(1, self.width() - left - right),
+                     max(1, self.height() - top - bottom))
+
+    def _mapper(self, rect):
+        xmin, xmax, ymin, ymax = self._limits
+        xspan = xmax - xmin
+        yspan = ymax - ymin
+
+        def to_screen(x, y):
+            return QPointF(
+                rect.left() + (x - xmin) / xspan * rect.width(),
+                rect.bottom() - (y - ymin) / yspan * rect.height())
+
+        return to_screen
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing, True)
+        ink = self.palette().windowText().color()
+        rect = self._lineplot_rect()
+        self._draw_titles(painter, ink, rect)
+        if None is self._limits:
+            painter.setPen(QPen(ink))
+            painter.drawRect(rect)
+            return
+        to_screen = self._mapper(rect)
+        self._draw_grid(painter, ink, rect, to_screen)
+        painter.setPen(QPen(ink))
+        painter.drawRect(rect)
+        self._draw_series(painter, rect, to_screen)
+        self._draw_legend(painter, rect)
+
+    def _draw_titles(self, painter, ink, rect):
+        painter.setPen(QPen(ink))
+        height = self.fontMetrics().height()
+        painter.drawText(QRect(0, 0, self.width(), self.MARGINS[1]),
+                         Qt.AlignCenter, self._title)
+        painter.drawText(
+            QRect(rect.left(), self.height() - height, rect.width(), height),
+            Qt.AlignCenter, self._xlabel)
+        painter.drawText(QRect(0, 0, self.width(), height),
+                         Qt.AlignLeft | Qt.AlignVCenter, self._ylabel)
+
+    def _draw_grid(self, painter, ink, rect, to_screen):
+        xmin, xmax, ymin, ymax = self._limits
+        faint = QColor(ink)
+        faint.setAlpha(48)
+        metrics = self.fontMetrics()
+        for value in _nice_ticks(xmin, xmax):
+            at = to_screen(value, ymin).x()
+            painter.setPen(QPen(faint))
+            painter.drawLine(at, rect.top(), at, rect.bottom())
+            painter.setPen(QPen(ink))
+            painter.drawText(
+                QRect(round(at) - 40, rect.bottom() + 2, 80,
+                      metrics.height()),
+                Qt.AlignCenter, _tick_label(value))
+        ticks = (_decade_ticks(ymin, ymax) if self.log_y
+                 else _nice_ticks(ymin, ymax, want=4))
+        for value in ticks:
+            at = to_screen(xmin, value).y()
+            painter.setPen(QPen(faint))
+            painter.drawLine(rect.left(), at, rect.right(), at)
+            painter.setPen(QPen(ink))
+            text = (_decade_label(value) if self.log_y
+                    else _tick_label(value))
+            painter.drawText(
+                QRect(0, round(at) - metrics.height() // 2,
+                      self.MARGINS[0] - 4, metrics.height()),
+                Qt.AlignRight | Qt.AlignVCenter, text)
+
+    def _draw_series(self, painter, rect, to_screen):
+        painter.save()
+        painter.setClipRect(rect)
+        for it in range(self.model.size):
+            series = self.model.series(it)
+            points = self._points(series)
+            if len(points) < 2:
+                continue
+            pen = QPen(_qcolor(series.color))
+            pen.setWidthF(series.line_width)
+            painter.setPen(pen)
+            painter.drawPolyline(
+                QPolygonF([to_screen(x, y) for x, y in points]))
+        painter.restore()
+
+    def _draw_legend(self, painter, rect):
+        """Name each curve in its own color, inside the top right.
+
+        The names are backed by the window color, since a curve running
+        through the top right would otherwise be read as part of the text.
+        """
+        metrics = self.fontMetrics()
+        labels = [self.model.series(it).label
+                  for it in range(self.model.size)]
+        labels = [label for label in labels if label]
+        if not labels:
+            return
+        width = max(metrics.horizontalAdvance(text) for text in labels) + 8
+        box = QRect(rect.right() - width - 4, rect.top() + 4, width,
+                    metrics.height() * len(labels))
+        backing = QColor(self.palette().window().color())
+        backing.setAlpha(216)
+        painter.fillRect(box, backing)
+        top = box.top()
+        for it in range(self.model.size):
+            series = self.model.series(it)
+            if not series.label:
+                continue
+            painter.setPen(QPen(_qcolor(series.color)))
+            painter.drawText(QRect(box.left(), top, width,
+                                   metrics.height()),
+                             Qt.AlignRight | Qt.AlignVCenter, series.label)
+            top += metrics.height()
+
+
+def _array(values):
+    return core.SimpleArrayFloat64(array=np.asarray(values, dtype='float64'))
+
+
+def _qcolor(color):
+    return QColor(color.r, color.g, color.b, color.a)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/gui/test_obsrefl.py
+++ b/tests/gui/test_obsrefl.py
@@ -15,7 +15,7 @@ try:
     from solvcon.pilot.base import _gui
     from solvcon.pilot.apps.obsrefl import ReflectionSession, _app
     from solvcon.pilot.apps.obsrefl import _field_render
-    from PySide6.QtWidgets import QApplication
+    from PySide6.QtWidgets import QApplication, QSizeGrip
     from PIL import Image
 except ImportError:
     pilot = None
@@ -524,6 +524,175 @@ class SolutionGaugeTC(_AppFixture, unittest.TestCase):
         remeshed = feature._control._painter.verts.ndarray
         self.assertEqual(list(box[0]), list(remeshed.min(axis=0)))
         self.assertEqual(list(box[1]), list(remeshed.max(axis=0)))
+        QApplication.processEvents()
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+class SolutionLinePlotsTC(_AppFixture, unittest.TestCase):
+    """The analysis plot sub-window and the lines it draws."""
+
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+
+    def _feature(self, nx=10, ny=4):
+        feature = super()._feature()
+        self._coarsen(feature, nx, ny)
+        return feature
+
+    @staticmethod
+    def _series_xy(series):
+        return ([series.x(it) for it in range(series.size)],
+                [series.y(it) for it in range(series.size)])
+
+    def test_the_button_opens_and_closes_the_lineplot_window(self):
+        feature = self._feature()
+        self.assertFalse(feature._lineplots.is_open)
+        feature._panel._run._lineplots_btn.click()
+        self.assertTrue(feature._lineplots.is_open)
+        # The window has to actually hold the plots: a sub-window that
+        # opened empty would look the same from every other check here.
+        self.assertIs(feature._lineplots.lineplots,
+                      feature._lineplots._subwin.widget())
+        # A close from any source has to reach the button, or the panel
+        # would offer to close a window that is already gone.
+        feature._lineplots.close()
+        self.assertFalse(feature._lineplots.is_open)
+        self.assertFalse(feature._panel._run._lineplots_btn.isChecked())
+        QApplication.processEvents()
+
+    def test_the_lineplot_window_carries_a_size_grip(self):
+        # What the grip then does is the manager's, and RManagerSubWindow
+        # GripTC pins it; the window only has to ask for one.
+        feature = self._feature()
+        feature._panel._run._lineplots_btn.click()
+        subwin = feature._lineplots._subwin
+        self.assertEqual(1, len(subwin.findChildren(QSizeGrip)))
+        QApplication.processEvents()
+
+    def test_the_reopened_window_holds_the_same_lineplots(self):
+        feature = self._feature()
+        feature._panel._run._lineplots_btn.click()
+        lineplots = feature._lineplots.lineplots
+        feature._lineplots.close()
+        QApplication.processEvents()
+        feature._panel._run._lineplots_btn.click()
+        # The plots outlive the window they were shown in, so reopening
+        # installs the same widget rather than building another.
+        self.assertIs(lineplots, feature._lineplots.lineplots)
+        QApplication.processEvents()
+
+    def test_the_profile_tracks_the_marching_session(self):
+        feature = self._feature()
+        feature._panel._run._lineplots_btn.click()
+        feature._control.start()
+        feature._control._timer.stop()
+        before = self._series_xy(feature._lineplots.lineplots._computed)[1]
+        feature._control._on_step()
+        feature._control._on_step()
+        # The line is read off the session every frame, so a march that
+        # moves the field has to move the curve with it.
+        after = self._series_xy(feature._lineplots.lineplots._computed)[1]
+        self.assertNotEqual(before, after)
+        QApplication.processEvents()
+
+    def test_the_profile_draws_the_field_against_the_analytic_step(self):
+        feature = self._feature()
+        feature._panel._run._lineplots_btn.click()
+        feature._control.start()
+        feature._control._timer.stop()
+        lineplots = feature._lineplots.lineplots
+        session = feature._control.session
+        cut = session.profile(
+            session.analysis.cut_height(feature._panel.cut_fraction()),
+            'density')
+        computed_x, computed_y = self._series_xy(lineplots._computed)
+        analytic_x, analytic_y = self._series_xy(lineplots._analytic)
+        self.assertEqual(list(cut.x), computed_x)
+        self.assertEqual(list(cut.computed), computed_y)
+        self.assertEqual(list(cut.analytic), analytic_y)
+        # Both curves are sampled at the same abscissae, so the gap between
+        # them at a station is the error there and not a sampling artifact.
+        self.assertEqual(computed_x, analytic_x)
+        QApplication.processEvents()
+
+    def test_moving_the_cut_redraws_the_profile(self):
+        feature = self._feature()
+        feature._panel._run._lineplots_btn.click()
+        feature._control.start()
+        feature._control._timer.stop()
+        lineplots = feature._lineplots.lineplots
+        before = self._series_xy(lineplots._analytic)[1]
+        # The shocks lean, so a cut at another height crosses them at other
+        # abscissae and the step has to move with it.
+        feature._panel._gauge._height.setValue(0.8)
+        self.assertNotEqual(before, self._series_xy(lineplots._analytic)[1])
+        QApplication.processEvents()
+
+    def test_the_lineplot_draws_a_cut_nothing_marks(self):
+        feature = self._feature()
+        feature._panel._run._lineplots_btn.click()
+        feature._control.start()
+        feature._control._timer.stop()
+        lineplots = feature._lineplots.lineplots
+        gauge = feature._panel._gauge
+        # The marks start off.  The window is opened deliberately, so it
+        # draws the cut it was opened for rather than waiting on a box in
+        # another fold of the panel.
+        self.assertFalse(gauge.marking_cells())
+        self.assertFalse(gauge.marking_line())
+        self.assertGreater(lineplots._computed.size, 0)
+        self.assertIsNotNone(lineplots._profile.limits())
+        drawn = self._series_xy(lineplots._computed)
+        # Marking the cut on the domain says where the curve was read; it
+        # does not change what was read.
+        gauge._cells.setChecked(True)
+        gauge._line.setChecked(True)
+        self.assertEqual(drawn, self._series_xy(lineplots._computed))
+        QApplication.processEvents()
+
+    def test_a_closed_lineplot_window_is_not_drawn_into(self):
+        feature = self._feature()
+        feature._panel._run._lineplots_btn.click()
+        feature._control.start()
+        feature._control._timer.stop()
+        held = self._series_xy(feature._lineplots.lineplots._computed)
+        feature._lineplots.close()
+        feature._control._on_step()
+        # The plots outlive their window, so what they hold is left alone
+        # rather than followed into a widget Qt has freed.
+        self.assertEqual(
+            held, self._series_xy(feature._lineplots.lineplots._computed))
+        QApplication.processEvents()
+
+    def test_reopening_the_window_draws_the_standing_run_back(self):
+        feature = self._feature()
+        feature._control.start()
+        feature._control._timer.stop()
+        feature._control._on_step()
+        # The window opens on a run already under way, so it has to be
+        # filled from the session rather than wait for the next frame.
+        feature._panel._run._lineplots_btn.click()
+        lineplots = feature._lineplots.lineplots
+        session = feature._control.session
+        cut = session.profile(
+            session.analysis.cut_height(feature._panel.cut_fraction()),
+            'density')
+        self.assertEqual(list(cut.computed),
+                         self._series_xy(lineplots._computed)[1])
+        QApplication.processEvents()
+
+    def test_resetting_the_run_blanks_the_lineplots(self):
+        feature = self._feature()
+        feature._panel._run._lineplots_btn.click()
+        feature._control.start()
+        feature._control._timer.stop()
+        feature._control._on_step()
+        feature._control.reset()
+        # A dropped run leaves no run to plot; a stale curve would read as
+        # if one were still standing.
+        self.assertEqual(0, feature._lineplots.lineplots._computed.size)
+        self.assertEqual(0, feature._lineplots.lineplots._analytic.size)
         QApplication.processEvents()
 
 

--- a/tests/test_pilot_plot_widget.py
+++ b/tests/test_pilot_plot_widget.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Tests for the widget that paints a plot model.
+
+The plot is a widget, not a window, so it is checked here rather than in
+the window lane: a manager for the QApplication and a filled model are all
+it takes to map the axes and render the curves.
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot.visual import _plot
+except ImportError:
+    pilot = None
+    _plot = None
+
+
+def _array(values):
+    return solvcon.SimpleArrayFloat64(array=np.array(values, dtype='float64'))
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class LinePlotTickTC(unittest.TestCase):
+    """The tick placement the axes are labelled from."""
+
+    def test_linear_ticks_are_round_and_cover_the_span(self):
+        ticks = _plot._nice_ticks(0.0, 10.0, want=5)
+        self.assertEqual([0.0, 2.0, 4.0, 6.0, 8.0, 10.0], ticks)
+        # Every tick has to land inside the span it was asked for, or the
+        # axis is labelled outside its own frame.
+        for lo, hi in ((0.3, 0.7), (-5.0, 5.0), (1e4, 1.2e4)):
+            for tick in _plot._nice_ticks(lo, hi):
+                self.assertGreaterEqual(tick, lo)
+                self.assertLessEqual(tick, hi)
+
+    def test_a_span_of_nothing_has_no_ticks(self):
+        # A flat curve leaves a zero span; ticking it would divide by it.
+        self.assertEqual([], _plot._nice_ticks(1.0, 1.0))
+        self.assertEqual([], _plot._nice_ticks(1.0, float('nan')))
+
+    def test_ticks_are_counted_and_not_accumulated(self):
+        # Where the span is small beside the offset, adding the step rounds
+        # back to where it started and a walk along the axis never ends.
+        # This runs inside paintEvent, so it takes the GUI thread with it.
+        ticks = _plot._nice_ticks(1e16, 1e16 + 4.0)
+        self.assertGreater(len(ticks), 0)
+        self.assertLessEqual(len(ticks), 12)
+
+    def test_a_log_tick_off_a_whole_decade_reads_its_own_value(self):
+        # A range inside one decade is ticked at its own ends, which are
+        # not powers of ten.  Labelling those as powers of ten puts the
+        # axis off by a factor the reader has no way to see.
+        self.assertEqual(["1e-4", "1e-3"],
+                         [_plot._decade_label(it) for it in (-4.0, -3.0)])
+        self.assertEqual(["1.91", "5.235"],
+                         [_plot._decade_label(it)
+                          for it in _plot._decade_ticks(0.2811, 0.7189)])
+
+    def test_log_ticks_are_whole_decades(self):
+        self.assertEqual([-4.0, -3.0, -2.0], _plot._decade_ticks(-4.2, -1.8))
+        # A range inside one decade still gets its ends marked, so the axis
+        # is never left blank.
+        self.assertEqual([-2.4, -2.1], _plot._decade_ticks(-2.4, -2.1))
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class LinePlotWidgetTC(unittest.TestCase):
+    """What the widget maps and what it draws."""
+
+    @classmethod
+    def setUpClass(cls):
+        # The manager owns the QApplication the widget needs to exist.
+        pilot.RManager.instance.setUp()
+
+    def _filled(self, xs, ys, **kw):
+        widget = _plot.LinePlotWidget(**kw)
+        series = widget.add_series("curve")
+        series.set_data(_array(xs), _array(ys))
+        widget.refresh()
+        return widget
+
+    def test_a_lineplot_with_no_data_draws_nothing_and_survives(self):
+        widget = _plot.LinePlotWidget(title="empty")
+        widget.refresh()
+        self.assertIsNone(widget.limits())
+        widget.resize(300, 200)
+        self.assertFalse(widget.grab().isNull())
+
+    def test_the_axes_are_scaled_apart(self):
+        # A step count against a small quantity share no scale, so the
+        # model's own view, which carries one zoom, would flatten one of
+        # them to nothing.  Each axis is stretched onto the frame here.
+        widget = self._filled([0.0, 1000.0], [0.0, 1e-3])
+        widget.resize(320, 240)
+        rect = widget._lineplot_rect()
+        to_screen = widget._mapper(rect)
+        xmin, xmax, ymin, ymax = widget.limits()
+        low = to_screen(xmin, ymin)
+        high = to_screen(xmax, ymax)
+        self.assertAlmostEqual(rect.left(), low.x())
+        self.assertAlmostEqual(rect.bottom(), low.y())
+        self.assertAlmostEqual(rect.left() + rect.width(), high.x())
+        self.assertAlmostEqual(rect.bottom() - rect.height(), high.y())
+
+    def test_the_model_scales_the_lineplot(self):
+        # The box drawn in is the model's autoscale rather than a second
+        # rule here, so the margin the model carries is what opens it.
+        widget = self._filled([0.0, 1.0, 2.0], [5.0, 5.0, 5.0])
+        self.assertEqual(widget.model.view_limits(), widget.limits())
+        tight = widget.limits()
+        widget.model.margin = 0.5
+        widget.refresh()
+        loose = widget.limits()
+        self.assertLess(loose[2], tight[2])
+        self.assertGreater(loose[3], tight[3])
+
+    def test_a_log_lineplot_maps_the_exponents(self):
+        widget = self._filled([1.0, 2.0, 3.0], [1e-1, 1e-3, 1e-5],
+                              log_y=True)
+        _, _, ymin, ymax = widget.limits()
+        # The limits are reported in the space that was drawn, so a decade
+        # of data is a unit of ordinate.
+        self.assertLess(ymin, -5.0)
+        self.assertGreater(ymax, -1.0)
+
+    def test_a_log_lineplot_drops_what_it_cannot_place(self):
+        # Zero and negative values have no logarithm; keeping them would
+        # break the whole curve rather than leave a gap in it.
+        widget = self._filled([1.0, 2.0, 3.0, 4.0],
+                              [1e-2, 0.0, -1.0, 1e-4], log_y=True)
+        drawn = widget._points(widget.model.series(0))
+        self.assertEqual([1.0, 4.0], [x for x, _ in drawn])
+        self.assertTrue(all(math.isfinite(y) for _, y in drawn))
+
+    def test_the_curve_is_painted_between_the_axes(self):
+        # The widget draws rather than lays out, so only rendering says
+        # whether it works.  A rising line has to leave ink off the
+        # frame's own edges.
+        widget = self._filled([0.0, 1.0, 2.0], [0.0, 1.0, 2.0])
+        widget.resize(320, 240)
+        pixmap = widget.grab()
+        image = pixmap.toImage()
+        self.assertFalse(image.isNull())
+        scale = pixmap.devicePixelRatio()
+        rect = widget._lineplot_rect()
+        background = image.pixelColor(round(rect.left() * scale) + 4,
+                                      round(rect.top() * scale) + 4)
+        inked = 0
+        for step in range(1, 20):
+            at = step / 20.0
+            point = widget._mapper(rect)(2.0 * at, 2.0 * at)
+            color = image.pixelColor(round(point.x() * scale),
+                                     round(point.y() * scale))
+            inked += int(color != background)
+        self.assertGreater(inked, 10)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Step 2 of line plot in issue #1272.

Create `LinePlotWidget` to paint one line plot model: the frame, the ticks, the curves, and a legend.  The line plot data outlive their window.  Closing and reopening the plot sub window show the same data.

<img width="1840" height="1195" alt="image" src="https://github.com/user-attachments/assets/710eb615-f8b1-47c8-80a4-59cf28bc4bf4" />
