### PR TITLE
Disable `google-objc-global-variable-declaration`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -38,6 +38,7 @@ Checks: >
     -cppcoreguidelines-pro-type-union-access,
     -cppcoreguidelines-use-default-member-init,-modernize-use-default-member-init,
     -cppcoreguidelines-use-enum-class,
+    -google-objc-global-variable-declaration,
     -google-readability-casting,
     -google-readability-todo,
     -google-runtime-references,


### PR DESCRIPTION
Fix the CI failure introduced from PR #1408.

`make pilot` fails on macos-26 in the lint workflow: https://github.com/solvcon/solvcon/actions/runs/33309961997/job/99253117541

```
[ 30%] Building OBJCXX object cpp/solvcon/CMakeFiles/solvcon_primary.dir/device/metal/metal.mm.o
/Users/runner/work/solvcon/solvcon/cpp/solvcon/base.hpp:62:23: error: const global variable 'is_specialization_of_v' must have a name which starts with an appropriate prefix [google-objc-global-variable-declaration,-warnings-as-errors]
   62 | inline constexpr bool is_specialization_of_v = is_specialization_of<Template, T>::value;
      |                       ^
5260 warnings generated.
Suppressed 5267 warnings (5259 in non-user code, 8 NOLINT).
1 warning treated as error
make[4]: *** [cpp/solvcon/CMakeFiles/solvcon_primary.dir/device/metal/metal.mm.o] Error 1
make[3]: *** [cpp/solvcon/CMakeFiles/solvcon_primary.dir/all] Error 2
make[2]: *** [cpp/binary/pilot/CMakeFiles/pilot.dir/rule] Error 2
make[1]: *** [pilot] Error 2
make: *** [pilot] Error 2
```

The `google-objc-global-variable-declaration` check enforces Google's Objective-C naming convention, which wants a global constant named with a `k` or `g` prefix. It fires on any C++ global that an Objective-C++ translation unit reaches. `metal.mm` now includes `BufferBase.hpp`, which pulls in `base.hpp`, so `is_specialization_of_v` fails `make pilot` under `LINT_AS_ERRORS=ON`.

solvcon writes C++ and keeps the `.mm` files as thin Objective-C++ shims. The check cannot tell the two apart, and renaming a C++ variable template away from the `_v` suffix to satisfy an Objective-C rule is not a trade worth making.