### PR TITLE
Add allocation-wide buffer synchronization

### DIFF
--- a/contrib/standalone_buffer/Makefile
+++ b/contrib/standalone_buffer/Makefile
@@ -60,6 +60,9 @@ $(SETUPROOT)/wrap_SimpleArrayPlex.o: $(SETUPROOT)/solvcon/buffer/pymod/wrap_Simp
 $(SETUPROOT)/buffer_pymod.o: $(SETUPROOT)/solvcon/buffer/pymod/buffer_pymod.cpp Makefile
 	c++ $(CFLAGS) -c $< -o $@
 
+$(SETUPROOT)/BufferAccess.o: $(SETUPROOT)/solvcon/buffer/BufferAccess.cpp Makefile
+	c++ $(CFLAGS) -c $< -o $@
+
 $(SETUPROOT)/BufferExpander.o: $(SETUPROOT)/solvcon/buffer/BufferExpander.cpp Makefile
 	c++ $(CFLAGS) -c $< -o $@
 
@@ -88,6 +91,7 @@ $(SETUPROOT)/radix_tree.o: $(SETUPROOT)/solvcon/profiling/RadixTree.cpp Makefile
 	c++ $(CFLAGS) -c $< -o $@
 
 OBJS = \
+	$(SETUPROOT)/BufferAccess.o \
 	$(SETUPROOT)/BufferExpander.o \
 	$(SETUPROOT)/ConcreteBuffer.o \
 	$(SETUPROOT)/SimpleArray.o \

--- a/cpp/solvcon/buffer/BufferAccess.cpp
+++ b/cpp/solvcon/buffer/BufferAccess.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/buffer/BufferAccess.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace solvcon
+{
+
+namespace detail
+{
+
+void BufferAccessState::begin_host_access()
+{
+    std::shared_ptr<DeviceCompletionToken> completion;
+    {
+        std::unique_lock lock(m_mutex);
+        m_submission_changed.wait(lock, [this]()
+                                  { return m_phase != AccessPhase::SubmissionReserved; });
+        ++m_host_access_count;
+        completion = m_last_completion;
+    }
+    try
+    {
+        wait_for_completion(completion);
+    }
+    catch (...)
+    {
+        // Construction failed, so no HostLease destructor will decrement the lease count.
+        end_host_access();
+        throw;
+    }
+}
+
+void BufferAccessState::wait_for_completion(std::shared_ptr<DeviceCompletionToken> const & completion)
+{
+    if (!completion)
+    {
+        return;
+    }
+    completion->wait();
+    std::scoped_lock const lock(m_mutex);
+    // A wait-only caller must not clear work published after its snapshot.
+    if (m_last_completion == completion)
+    {
+        m_last_completion.reset();
+    }
+}
+
+BufferAccessState::Submission::Submission(std::span<state_type * const> states)
+    : m_reserved_states(states.begin(), states.end())
+{
+    std::ranges::sort(m_reserved_states);
+    m_reserved_states.erase(std::unique(m_reserved_states.begin(), m_reserved_states.end()), m_reserved_states.end());
+    if (m_reserved_states.empty() || std::ranges::find(m_reserved_states, nullptr) != m_reserved_states.end())
+    {
+        throw std::invalid_argument("BufferAccessState::Submission: access states must be non-empty and non-null");
+    }
+
+    auto locks = lock_states();
+    for (state_type const * state : m_reserved_states)
+    {
+        if (state->m_phase != AccessPhase::Unreserved || state->m_host_access_count != 0)
+        {
+            throw std::runtime_error("BufferAccessState::Submission: buffer is unavailable for device submission");
+        }
+        if (state->m_last_completion && std::ranges::find(m_dependencies, state->m_last_completion) == m_dependencies.end())
+        {
+            m_dependencies.push_back(state->m_last_completion);
+        }
+    }
+    // No state is reserved until validation and dependency allocation have both succeeded.
+    for (state_type * state : m_reserved_states)
+    {
+        state->m_phase = AccessPhase::SubmissionReserved;
+    }
+}
+
+std::vector<std::unique_lock<std::mutex>> BufferAccessState::Submission::lock_states() const
+{
+    std::vector<std::unique_lock<std::mutex>> locks;
+    locks.reserve(m_reserved_states.size());
+    for (state_type * state : m_reserved_states)
+    {
+        locks.emplace_back(state->m_mutex);
+    }
+    return locks;
+}
+
+void BufferAccessState::Submission::publish(std::shared_ptr<completion_type> const & completion)
+{
+    {
+        auto locks = lock_states();
+        if (!completion || m_reserved_states.empty())
+        {
+            throw std::invalid_argument("BufferAccessState::Submission::publish: active guard and non-null token required");
+        }
+        if (!completion->try_claim())
+        {
+            throw std::invalid_argument("BufferAccessState::Submission::publish: token already claimed");
+        }
+        // Dependencies retain old tokens, preventing backend deletion under these locks.
+        for (state_type * state : m_reserved_states)
+        {
+            state->m_last_completion = completion;
+            state->m_phase = AccessPhase::Unreserved;
+        }
+    }
+    for (state_type * state : m_reserved_states)
+    {
+        state->m_submission_changed.notify_all();
+    }
+    // A later submission may already hold new reservations; this guard must leave them intact.
+    m_reserved_states.clear();
+}
+
+BufferAccessState::Submission::~Submission()
+{
+    for (state_type * state : m_reserved_states)
+    {
+        {
+            std::scoped_lock const lock(state->m_mutex);
+            state->m_phase = AccessPhase::Unreserved;
+        }
+        state->m_submission_changed.notify_all();
+    }
+}
+
+void BufferAccessState::wait()
+{
+    std::shared_ptr<DeviceCompletionToken> completion;
+    {
+        std::unique_lock lock(m_mutex);
+        m_submission_changed.wait(lock, [this]()
+                                  { return m_phase != AccessPhase::SubmissionReserved; });
+        completion = m_last_completion;
+    }
+    wait_for_completion(completion);
+}
+
+bool BufferAccessState::ready() const
+{
+    std::shared_ptr<DeviceCompletionToken> completion;
+    AccessPhase phase;
+    {
+        std::scoped_lock const lock(m_mutex);
+        phase = m_phase;
+        completion = m_last_completion;
+    }
+    return phase != AccessPhase::SubmissionReserved && (!completion || completion->ready());
+}
+
+void BufferAccessState::export_host_access()
+{
+    if (host_exported())
+    {
+        return;
+    }
+    HostLease const access(this);
+    std::scoped_lock const lock(m_mutex);
+    m_phase = AccessPhase::HostExported;
+}
+
+} /* end namespace detail */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/buffer/BufferAccess.hpp
+++ b/cpp/solvcon/buffer/BufferAccess.hpp
@@ -1,0 +1,301 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Array aliases share memory: CPU access must wait for prior device work and exclude new submissions.
+ * HostLease and Submission run on CPU threads; DeviceCompletionToken tracks device completion.
+ * @code
+ * array + slices --> ConcreteBuffer --owns--> BufferAccessState
+ *                                              ^           ^
+ * HostLease --------------------borrows--------+           |
+ * Submission -------------------borrows--------------------+
+ *
+ * DeviceCompletionToken ownership (shared_ptr):
+ *   state -------------> latest operation
+ *   host acquisition --> prior operation (temporary, while waiting)
+ *   submission --------> prior operations (dependencies)
+ * @endcode
+ * Token arrows may share an instance. Tokens do not own buffer allocations.
+ * @ingroup group_core
+ */
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <span>
+#include <vector>
+
+namespace solvcon
+{
+
+namespace detail
+{
+
+/**
+ * Track one device operation, shared by all allocations participating in that operation.
+ * Backend ready()/wait() must support concurrent callers.
+ * Observing completion makes device writes visible.
+ * Completion is permanent. Keeping the token alive does not keep the allocations alive.
+ * @ingroup group_core
+ */
+class DeviceCompletionToken // NOLINT(cppcoreguidelines-special-member-functions)
+{
+public:
+    /// Destroy through the base interface; destruction alone does not wait for device work.
+    virtual ~DeviceCompletionToken() = default;
+    /**
+     * Query without blocking.
+     * @return ``true`` once device work has completed.
+     */
+    virtual bool ready() const = 0;
+    /**
+     * Wait for completion, or throw on backend failure.
+     * Called without state mutexes held.
+     */
+    virtual void wait() const = 0;
+    /**
+     * Claim once, even across submissions with disjoint state mutexes.
+     * This atomic protects token identity; backend ready()/wait() synchronize device writes.
+     * @return ``true`` for the first claim only.
+     */
+    bool try_claim() noexcept { return !m_claimed.exchange(true, std::memory_order_relaxed); }
+
+private:
+    std::atomic<bool> m_claimed{false};
+}; /* end class DeviceCompletionToken */
+
+/**
+ * Coordinate all aliases of one allocation.
+ * @code
+ * Caller       Existing access                        Action
+ * HostLease    submission reservation                 wait for reservation release
+ * HostLease    unfinished device work                 wait on token
+ * Submission   CPU lease / reservation / host export  throw
+ * @endcode
+ * CPU leases may coexist; callers synchronize conflicting CPU reads/writes.
+ * One mutex protects three records:
+ * @code
+ * m_phase             reservation / permanent host export
+ * m_host_access_count CPU leases, including those waiting for device work
+ * m_last_completion   latest device operation, possibly still running
+ * @endcode
+ * The phase only controls reservation and export:
+ * @code
+ * Unreserved -- reserve, no CPU leases ----------> SubmissionReserved
+ * Unreserved <-- publish / abandon reservation --- SubmissionReserved
+ * Unreserved -- export after host wait ----------> HostExported (permanent)
+ * @endcode
+ * Unreserved does not mean idle: CPU leases or device work may still be active.
+ * State mutexes protect bookkeeping, never computation or backend waits.
+ * The buffer owner must outlive all guards and concurrent state calls.
+ * @ingroup group_core
+ */
+class BufferAccessState
+{
+public:
+    /// Scoped CPU access that blocks new device submissions.
+    class HostLease;
+    /// Reservation of several allocations for one device operation.
+    class Submission;
+
+    /**
+     * Wait for observed device work without reserving CPU access.
+     * A new submission may start before this returns. Use HostLease for CPU memory access.
+     */
+    void wait();
+    /**
+     * Query a snapshot without reserving access.
+     * @return ``true`` if neither submission nor device completion is pending.
+     */
+    bool ready() const;
+    /**
+     * Wait for safe CPU access, then permanently reject device submissions.
+     * Call before an untracked pointer escapes. Raw accessors do not call this for you.
+     */
+    void export_host_access();
+    /**
+     * Query permanent device exclusion.
+     * @return ``true`` after export_host_access() succeeds.
+     */
+    bool host_exported() const noexcept
+    {
+        std::scoped_lock const lock(m_mutex);
+        return m_phase == AccessPhase::HostExported;
+    }
+
+private:
+    enum class AccessPhase : std::uint8_t
+    {
+        Unreserved,
+        SubmissionReserved,
+        HostExported,
+    }; /* end enum class AccessPhase */
+
+    /**
+     * Count the lease before the device wait, so new submissions cannot enter the gap.
+     * @code
+     * Wait for reservation to end      (CV releases mutex)
+     *               |
+     *               v
+     * Count lease + retain prior token (mutex held)
+     *               |
+     *               v
+     * Wait for device completion       (no mutex held)
+     *               |
+     *               v
+     * CPU access may begin
+     * @endcode
+     */
+    void begin_host_access();
+    /// Release one counted lease; permanent export exclusion remains.
+    void end_host_access() noexcept
+    {
+        std::scoped_lock const lock(m_mutex);
+        --m_host_access_count;
+    }
+    /**
+     * Wait unlocked, then relock the state.
+     * Clear its token only if it still matches the retained snapshot.
+     */
+    void wait_for_completion(std::shared_ptr<DeviceCompletionToken> const & completion);
+
+    /// Protect all state fields, including the shared_ptr member itself.
+    mutable std::mutex m_mutex;
+    /// Wake when a reservation is released; recheck m_phase under m_mutex.
+    std::condition_variable m_submission_changed;
+    /**
+     * Latest operation, or null. Waiter snapshots and dependencies retain replaced tokens,
+     * so unlocked waits stay valid and backend destructors run outside state mutexes.
+     */
+    std::shared_ptr<DeviceCompletionToken> m_last_completion;
+    AccessPhase m_phase = AccessPhase::Unreserved;
+    /// Include leases waiting for prior work; nonzero rejects device submissions.
+    size_t m_host_access_count = 0;
+}; /* end class BufferAccessState */
+
+/**
+ * Exclude device submissions throughout CPU access.
+ * @code
+ * acquire HostLease --> CPU / BLAS work --> release HostLease
+ * (wait for prior work) (all workers done)  (CPU access finished)
+ * @endcode
+ * Computation holds no state mutex. The caller joins workers; HostLease does not.
+ * @ingroup group_core
+ */
+class BufferAccessState::HostLease // NOLINT(cppcoreguidelines-special-member-functions)
+{
+public:
+    /**
+     * Acquire CPU access, waiting for prior device work; failed waits leave no lease behind.
+     * @param state Borrowed state that outlives the lease; ``nullptr`` skips all work.
+     */
+    explicit HostLease(BufferAccessState * state)
+        : m_state(state)
+    {
+        if (m_state != nullptr)
+        {
+            m_state->begin_host_access();
+        }
+    }
+    HostLease(HostLease const &) = delete;
+    HostLease & operator=(HostLease const &) = delete;
+    /// Release this lease without waiting for device work.
+    ~HostLease()
+    {
+        if (m_state != nullptr)
+        {
+            m_state->end_host_access();
+        }
+    }
+
+private:
+    /// Borrowed for the whole lease; null skips acquisition and release.
+    BufferAccessState * m_state;
+}; /* end class BufferAccessState::HostLease */
+
+/**
+ * Reserve buffers until publication; the token tracks work after publication.
+ * @code
+ * reserve --> order dependencies --> enqueue --> publish token --> guard may end
+ *                                                |
+ *                                                +--> device work may still run
+ * @endcode
+ * The executor orders dependencies and retains buffers until device completion.
+ * Wait on dependencies(), never on these reserved states: that would self-wait.
+ * Each guard has one caller; separate guards may run concurrently.
+ * @ingroup group_core
+ */
+class BufferAccessState::Submission // NOLINT(cppcoreguidelines-special-member-functions)
+{
+public:
+    /// Allocation-wide state borrowed by this submission.
+    using state_type = BufferAccessState;
+    /// Backend completion shared by the participating states.
+    using completion_type = DeviceCompletionToken;
+    /**
+     * Reserve all states, or throw if any is exported, CPU-leased, or already reserved.
+     * Validate and allocate dependencies first; failure leaves no reservation.
+     * @param states Non-empty span of non-null borrowed pointers; aliases are deduplicated.
+     */
+    explicit Submission(std::span<state_type * const> states);
+    Submission(Submission const &) = delete;
+    Submission & operator=(Submission const &) = delete;
+    /**
+     * Release an unpublished reservation; this cannot cancel device work.
+     * If publish() throws after enqueue, finish or safely cancel work before destruction.
+     */
+    ~Submission();
+    /**
+     * Expose prior tokens for the executor to wait on or encode as backend dependencies.
+     * @return Borrowed span valid while this submission exists; obtaining it does not wait.
+     */
+    std::span<std::shared_ptr<completion_type> const> dependencies() const { return m_dependencies; }
+    /**
+     * Install the token in all states, then unlock and notify CPU waiters.
+     * Example with one prior operation shared by source and destination:
+     * @code
+     *                         before publish          after publish
+     * states' completion      prior token             new token
+     * m_dependencies          [prior token]           [prior token]
+     * m_reserved_states       [source, destination]   []
+     * @endcode
+     * Dependencies retain the prior token until guard destruction.
+     * Empty m_reserved_states prevents this guard from releasing a later reservation.
+     * The new token may still be pending. A guard publishes once.
+     * Failure preserves any existing reservation for caller cleanup.
+     * @param completion Non-null, previously unclaimed token for this operation.
+     */
+    void publish(std::shared_ptr<completion_type> const & completion);
+
+private:
+    /**
+     * Lock distinct states in pointer order to prevent state-lock cycles.
+     * @code
+     * [source, destination] --+
+     *                        +--> sort + deduplicate --> same lock order
+     * [destination, source] --+
+     * @endcode
+     * The constructor sorts once; every lock_states() call follows that order.
+     * @return Guards that unlock on scope exit, including exceptions.
+     */
+    std::vector<std::unique_lock<std::mutex>> lock_states() const;
+    // TODO: Use move-aware small containers after executor arity is defined (see issue #1397).
+    /// Sorted unique borrowed states reserved by this guard; empty after publish.
+    std::vector<state_type *> m_reserved_states;
+    /// Unique prior tokens retained until destruction.
+    std::vector<std::shared_ptr<completion_type>> m_dependencies;
+}; /* end class BufferAccessState::Submission */
+
+} /* end namespace detail */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/buffer/BufferExpander.cpp
+++ b/cpp/solvcon/buffer/BufferExpander.cpp
@@ -54,6 +54,7 @@ std::shared_ptr<ConcreteBuffer> const & BufferExpander::as_concrete(size_type ca
         m_concrete_buffer = copy_concrete(cap);
         m_data_holder.reset();
     }
+    m_concrete_buffer->export_host_access();
     m_begin = m_concrete_buffer->data();
     m_end = m_begin + old_size;
     m_end_cap = m_begin + m_concrete_buffer->size();

--- a/cpp/solvcon/buffer/BufferExpander.hpp
+++ b/cpp/solvcon/buffer/BufferExpander.hpp
@@ -53,6 +53,7 @@ public:
         , m_concrete_buffer(clone ? buf->clone() : buf)
         , m_alignment(validate_alignment(alignment, "BufferExpander::BufferExpander"))
     {
+        m_concrete_buffer->export_host_access();
         m_begin = m_concrete_buffer->data();
         m_end = m_begin + m_concrete_buffer->size();
         m_end_cap = m_begin + m_concrete_buffer->size(); // NOLINT(cppcoreguidelines-prefer-member-initializer)

--- a/cpp/solvcon/buffer/CMakeLists.txt
+++ b/cpp/solvcon/buffer/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 4.0.1)
 
 set(SOLVCON_BUFFER_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/buffer.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/BufferAccess.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BufferBase.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BufferDevice.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BufferStorage.hpp
@@ -21,6 +22,7 @@ set(SOLVCON_BUFFER_HEADERS
     CACHE FILEPATH "" FORCE)
 
 set(SOLVCON_BUFFER_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/BufferAccess.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BufferExpander.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ConcreteBuffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SimpleArray.cpp

--- a/cpp/solvcon/buffer/ConcreteBuffer.cpp
+++ b/cpp/solvcon/buffer/ConcreteBuffer.cpp
@@ -25,7 +25,9 @@ std::shared_ptr<ConcreteBuffer> ConcreteBuffer::construct(size_t nbytes, size_t 
 #ifdef SOLVCON_METAL
     {
         detail::DeviceBufferStorage device_storage = device::MetalManager::instance().allocate_buffer(nbytes, alignment);
-        return construct(nbytes, device_storage.m_data, std::move(device_storage.m_remover), alignment);
+        auto buffer = construct(nbytes, device_storage.m_data, std::move(device_storage.m_remover), alignment);
+        buffer->m_access_state = std::make_unique<access_state_type>();
+        return buffer;
     }
 #else
         throw std::runtime_error("ConcreteBuffer::construct: Metal storage is unavailable");

--- a/cpp/solvcon/buffer/ConcreteBuffer.hpp
+++ b/cpp/solvcon/buffer/ConcreteBuffer.hpp
@@ -13,6 +13,7 @@
  */
 
 #include <solvcon/base.hpp>
+#include <solvcon/buffer/BufferAccess.hpp>
 #include <solvcon/buffer/BufferBase.hpp>
 #include <solvcon/buffer/BufferDevice.hpp>
 #include <solvcon/buffer/BufferStorage.hpp>
@@ -99,6 +100,8 @@ private:
 public:
 
     using remover_type = detail::ConcreteBufferRemover;
+    using access_state_type = detail::BufferAccessState;
+    using host_access_type = access_state_type::HostLease;
     using size_type = std::size_t;
 
     static std::shared_ptr<ConcreteBuffer> construct(size_t nbytes, size_t alignment = 0)
@@ -140,7 +143,7 @@ public:
     std::shared_ptr<ConcreteBuffer> clone() const
     {
         std::shared_ptr<ConcreteBuffer> ret = construct(nbytes(), m_alignment);
-        std::copy_n(data(), size(), (*ret).data());
+        ret->copy_from(*this);
         return ret;
     }
 
@@ -207,7 +210,7 @@ public:
         {
             throw std::out_of_range("Buffer size mismatch");
         }
-        std::copy_n(other.data(), size(), data());
+        copy_from(other);
     }
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
@@ -220,7 +223,7 @@ public:
             {
                 throw std::out_of_range("Buffer size mismatch");
             }
-            std::copy_n(other.data(), size(), data());
+            copy_from(other);
         }
         return *this;
     }
@@ -231,12 +234,58 @@ public:
 
     size_type alignment() const noexcept { return m_alignment; }
 
+    /// Wait for currently observed work without reserving host access.
+    void wait() const
+    {
+        if (m_access_state != nullptr)
+        {
+            m_access_state->wait();
+        }
+    }
+
+    /**
+     * Query completion without reserving host access.
+     * @return ``true`` when nothing observed is pending.
+     */
+    bool ready() const { return m_access_state == nullptr || m_access_state->ready(); }
+    /**
+     * Access synchronization state, including for const-buffer reads.
+     * @return Borrowed state, or ``nullptr`` for CPU storage.
+     */
+    access_state_type * access_state() const noexcept { return m_access_state.get(); }
+
+    /**
+     * Acquire recoverable host access for one internal operation.
+     * @return Lease that blocks device submission until destruction; empty for CPU storage.
+     * @note This buffer must outlive the returned lease.
+     */
+    host_access_type acquire_host_access() const { return host_access_type(m_access_state.get()); }
+
+    /**
+     * Wait and permanently exclude device submissions before exposing an untracked pointer.
+     * data() does not call this. BufferExpander calls it before retaining raw pointers.
+     */
+    void export_host_access() const
+    {
+        if (m_access_state != nullptr)
+        {
+            m_access_state->export_host_access();
+        }
+    }
+
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     using unique_ptr_type = std::unique_ptr<int8_t, data_deleter_type>;
 
     static constexpr const char * name() { return "ConcreteBuffer"; }
 
 private:
+    void copy_from(ConcreteBuffer const & other)
+    {
+        auto const src_access = other.acquire_host_access();
+        auto const dst_access = acquire_host_access();
+        std::copy_n(other.data<int8_t>(), size(), data<int8_t>());
+    }
+
     static unique_ptr_type allocate(size_t nbytes, size_t alignment)
     {
         unique_ptr_type ret(nullptr, data_deleter_type());
@@ -268,6 +317,8 @@ private:
     size_t m_nbytes;
     size_t m_alignment = 0; // Alignment of the data buffer in bytes. 0 means no alignment.
     unique_ptr_type m_data;
+    /// Coordinates host/device access; nullptr for CPU storage.
+    std::unique_ptr<access_state_type> m_access_state;
 }; /* end class ConcreteBuffer */
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/buffer/SimpleArray.cpp
+++ b/cpp/solvcon/buffer/SimpleArray.cpp
@@ -165,7 +165,9 @@ SimpleArrayCopier::SimpleArrayCopier(
     shape_type const & dst_stride,
     shape_type const & shape,
     size_t const itemsize)
-    : m_src(src_buffer.data<int8_t>() + src_body_offset)
+    : m_src_access(src_buffer.acquire_host_access())
+    , m_dst_access(dst_buffer.acquire_host_access())
+    , m_src(src_buffer.data<int8_t>() + src_body_offset)
     , m_dst(dst_buffer.data<int8_t>() + dst_body_offset)
     , m_shape(shape)
     , m_src_stride(src_stride)

--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -2970,6 +2970,12 @@ public:
 
 private:
 
+    using host_access_type = buffer_type::host_access_type;
+
+    /// Acquired before m_src and held while it may be read.
+    host_access_type m_src_access;
+    /// Acquired before m_dst and held while it may be written.
+    host_access_type m_dst_access;
     int8_t const * m_src;
     int8_t * m_dst;
     shape_type const & m_shape;

--- a/cpp/solvcon/buffer/matmul_executor.hpp
+++ b/cpp/solvcon/buffer/matmul_executor.hpp
@@ -296,6 +296,14 @@ private:
     size_t m_lhs_scratch_elements = 0;
     value_type const * m_cached_lhs_source = nullptr;
     value_type const * m_cached_rhs_source = nullptr;
+    /**
+     * Exclude device submissions for this CPU executor's lifetime.
+     * Acquire before data pointers; cover packing, BLAS, and fallback kernels.
+     * A future dispatcher must choose its backend before constructing this CPU executor.
+     */
+    typename Array::buffer_type::host_access_type m_output_access;
+    typename Array::buffer_type::host_access_type m_lhs_access;
+    typename Array::buffer_type::host_access_type m_rhs_access;
     value_type * m_output_data;
     value_type const * m_lhs_data;
     value_type const * m_rhs_data;
@@ -306,6 +314,9 @@ MatmulExecutor<Array>::MatmulExecutor(MatmulPlan plan, Array & output, Array con
     : m_plan(std::move(plan))
     , m_lhs(lhs)
     , m_rhs(rhs)
+    , m_output_access(output.buffer().acquire_host_access())
+    , m_lhs_access(lhs.buffer().acquire_host_access())
+    , m_rhs_access(rhs.buffer().acquire_host_access())
     , m_output_data(output.logical_data())
     , m_lhs_data(lhs.logical_data())
     , m_rhs_data(rhs.logical_data())

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -3,12 +3,18 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <barrier>
 #include <bit>
 #include <cfenv>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <future>
+#include <latch>
 #include <limits>
+#include <memory>
 #include <random>
+#include <semaphore>
 #include <type_traits>
 #ifdef Py_PYTHON_H
 #error "Python.h should not be included."
@@ -19,6 +25,10 @@
 
 namespace
 {
+
+using buffer_access_state_type = solvcon::detail::BufferAccessState;
+using buffer_host_lease_type = buffer_access_state_type::HostLease;
+using buffer_submission_type = buffer_access_state_type::Submission;
 
 template <typename Evaluate, typename Expected>
 void expect_rounding_result(int mode, Evaluate evaluate, Expected const & expected)
@@ -33,6 +43,50 @@ void expect_rounding_result(int mode, Evaluate evaluate, Expected const & expect
     EXPECT_EQ(0, mode_status);
     EXPECT_EQ(0, restore_status);
     EXPECT_EQ(expected, actual);
+}
+
+class BlockingDeviceCompletionToken final : public solvcon::detail::DeviceCompletionToken
+{
+public:
+    explicit BlockingDeviceCompletionToken(buffer_access_state_type const & reentrant_state)
+        : m_reentrant_state(reentrant_state)
+    {
+    }
+
+    bool ready() const override { return m_done.wait_for(std::chrono::seconds(0)) == std::future_status::ready; }
+    void wait() const override
+    {
+        m_wait_started.release();
+        static_cast<void>(m_reentrant_state.ready());
+        m_done.wait();
+    }
+    bool wait_until_started() const { return m_wait_started.try_acquire_for(std::chrono::seconds(5)); }
+    void complete() { m_done_promise.set_value(); }
+
+private:
+    /// Borrowed state re-entered to catch waits under its mutex.
+    buffer_access_state_type const & m_reentrant_state;
+    mutable std::counting_semaphore<> m_wait_started{0};
+    /// Declared before m_done, which obtains its future.
+    std::promise<void> m_done_promise;
+    std::shared_future<void> m_done = m_done_promise.get_future().share();
+}; /* end class BlockingDeviceCompletionToken */
+
+class FailingDeviceCompletionToken final : public solvcon::detail::DeviceCompletionToken
+{
+public:
+    bool ready() const override { return false; }
+    void wait() const override { throw std::runtime_error("work failed"); }
+}; /* end class FailingDeviceCompletionToken */
+
+bool wait_started_or_complete(BlockingDeviceCompletionToken & completion)
+{
+    bool const started = completion.wait_until_started();
+    if (!started)
+    {
+        completion.complete();
+    }
+    return started;
 }
 
 } /* end namespace */
@@ -96,6 +150,312 @@ TEST(ConcreteBuffer, iterator)
     {
         EXPECT_EQ(it, i++);
     }
+}
+
+TEST(BufferAccess, dependencies_and_wait_preserve_eligibility)
+{
+    buffer_access_state_type first, second;
+    auto previous = std::make_shared<BlockingDeviceCompletionToken>(first);
+    std::array<buffer_access_state_type *, 2> first_access{&first, &second};
+    buffer_submission_type(std::span{first_access}).publish(previous);
+    std::array<buffer_access_state_type *, 3> accesses{&second, &first, &first};
+    auto first_wait = std::async(std::launch::async, &buffer_access_state_type::wait, &first);
+    ASSERT_TRUE(wait_started_or_complete(*previous));
+    buffer_submission_type submission(std::span{accesses});
+    ASSERT_EQ(size_t{1}, submission.dependencies().size());
+    EXPECT_EQ(previous, submission.dependencies().front());
+    auto next = std::make_shared<BlockingDeviceCompletionToken>(first);
+    submission.publish(next);
+    previous->complete();
+    first_wait.get();
+    EXPECT_FALSE(first.ready());
+
+    auto next_wait = std::async(std::launch::async, &buffer_access_state_type::wait, &first);
+    ASSERT_TRUE(wait_started_or_complete(*next));
+    next->complete();
+    next_wait.get();
+    second.wait();
+    buffer_submission_type reused(std::span{accesses});
+    EXPECT_THROW(reused.publish(nullptr), std::invalid_argument);
+    EXPECT_THROW(reused.publish(previous), std::invalid_argument);
+    auto final = std::make_shared<BlockingDeviceCompletionToken>(first);
+    reused.publish(final);
+    final->complete();
+}
+
+TEST(BufferAccess, scoped_host_access_blocks_submission)
+{
+    buffer_access_state_type access;
+    std::array<buffer_access_state_type *, 1> accesses{&access};
+    auto work = std::make_shared<BlockingDeviceCompletionToken>(access);
+    buffer_submission_type(std::span{accesses}).publish(work);
+
+    std::binary_semaphore release{0}, acquired{0};
+    auto host = std::async(std::launch::async, [&]()
+                           {
+                               buffer_host_lease_type lease(&access);
+                               acquired.release();
+                               release.acquire(); });
+    bool const started = wait_started_or_complete(*work);
+    if (!started)
+    {
+        release.release();
+    }
+    ASSERT_TRUE(started);
+    bool const acquired_early = acquired.try_acquire();
+    EXPECT_FALSE(acquired_early);
+    EXPECT_THROW(buffer_submission_type(std::span{accesses}), std::runtime_error);
+    work->complete();
+    EXPECT_TRUE(acquired_early || acquired.try_acquire_for(std::chrono::seconds(5)));
+
+    EXPECT_THROW(buffer_submission_type(std::span{accesses}), std::runtime_error);
+    release.release();
+    host.get();
+    EXPECT_NO_THROW({ buffer_submission_type canceled(std::span{accesses}); });
+    EXPECT_NO_THROW({ buffer_submission_type after_cancel(std::span{accesses}); });
+}
+
+TEST(BufferAccess, raw_export_orders_with_submission)
+{
+    buffer_access_state_type access;
+    std::array<buffer_access_state_type *, 1> accesses{&access};
+    buffer_submission_type submission(std::span{accesses});
+    auto exported = std::async(std::launch::async, &buffer_access_state_type::export_host_access, &access);
+    auto work = std::make_shared<BlockingDeviceCompletionToken>(access);
+    submission.publish(work);
+    ASSERT_TRUE(wait_started_or_complete(*work));
+    EXPECT_FALSE(access.host_exported());
+    work->complete();
+    exported.get();
+    EXPECT_TRUE(access.host_exported());
+    EXPECT_THROW(buffer_submission_type(std::span{accesses}), std::runtime_error);
+}
+
+TEST(BufferAccess, failed_wait_releases_host_access)
+{
+    buffer_access_state_type access;
+    std::array<buffer_access_state_type *, 1> accesses{&access};
+    buffer_submission_type(std::span{accesses}).publish(std::make_shared<FailingDeviceCompletionToken>());
+
+    EXPECT_THROW(access.export_host_access(), std::runtime_error);
+    EXPECT_FALSE(access.host_exported());
+    EXPECT_NO_THROW({ buffer_submission_type next(std::span{accesses}); });
+}
+
+TEST(BufferAccess, concurrent_exports_remain_permanent_after_leases)
+{
+    buffer_access_state_type access;
+    std::array<buffer_access_state_type *, 1> accesses{&access};
+    {
+        buffer_host_lease_type host(&access);
+        std::barrier start(2);
+        auto export_access = [&]()
+        {
+            start.arrive_and_wait();
+            access.export_host_access();
+        };
+        auto first = std::async(std::launch::async, export_access);
+        auto second = std::async(std::launch::async, export_access);
+        first.get();
+        second.get();
+    }
+    access.export_host_access();
+    {
+        buffer_host_lease_type after_export(&access);
+    }
+    access.wait();
+    EXPECT_TRUE(access.ready());
+    EXPECT_TRUE(access.host_exported());
+    EXPECT_THROW(buffer_submission_type(std::span{accesses}), std::runtime_error);
+}
+
+TEST(BufferAccess, waiter_owns_replaced_completion)
+{
+    buffer_access_state_type access;
+    std::array<buffer_access_state_type *, 1> accesses{&access};
+    auto previous = std::make_shared<BlockingDeviceCompletionToken>(access);
+    std::weak_ptr<BlockingDeviceCompletionToken> previous_lifetime = previous;
+    buffer_submission_type(std::span{accesses}).publish(previous);
+    auto waiter = std::async(std::launch::async, &buffer_access_state_type::wait, &access);
+    ASSERT_TRUE(wait_started_or_complete(*previous));
+
+    auto next = std::make_shared<BlockingDeviceCompletionToken>(access);
+    buffer_submission_type(std::span{accesses}).publish(next);
+    previous.reset();
+    // State and submission released the old token; only the waiter retains it.
+    auto retained = previous_lifetime.lock();
+    ASSERT_NE(nullptr, retained);
+    retained->complete();
+    retained.reset();
+    waiter.get();
+    EXPECT_TRUE(previous_lifetime.expired());
+    EXPECT_FALSE(access.ready());
+    next->complete();
+    access.wait();
+}
+
+TEST(BufferAccess, concurrent_overlapping_submissions)
+{
+    buffer_access_state_type source, destination;
+    std::array<buffer_access_state_type *, 2> forward{&source, &destination};
+    std::array<buffer_access_state_type *, 2> reverse{&destination, &source};
+    std::barrier start(2);
+    std::latch attempted(2);
+    auto reserve = [&](auto const & states)
+    {
+        start.arrive_and_wait();
+        try
+        {
+            buffer_submission_type submission(std::span{states});
+            attempted.count_down();
+            // Keep the winner's reservation until the other thread has tried to acquire it.
+            attempted.wait();
+            return true;
+        }
+        catch (std::runtime_error const &)
+        {
+            attempted.count_down();
+            return false;
+        }
+    };
+    auto first = std::async(std::launch::async, [&]()
+                            { return reserve(forward); });
+    auto second = std::async(std::launch::async, [&]()
+                             { return reserve(reverse); });
+    EXPECT_NE(first.get(), second.get());
+    EXPECT_NO_THROW({ buffer_submission_type after_cancel(std::span{forward}); });
+}
+
+TEST(BufferAccess, rejected_submission_leaves_no_partial_reservation)
+{
+    std::array<buffer_access_state_type, 2> states;
+    std::array<buffer_access_state_type *, 2> accesses{&states[0], &states[1]};
+    buffer_host_lease_type host(&states[1]);
+    EXPECT_THROW(buffer_submission_type(std::span{accesses}), std::runtime_error);
+    std::array<buffer_access_state_type *, 1> available{&states[0]};
+    EXPECT_NO_THROW({ buffer_submission_type independent(std::span{available}); });
+}
+
+TEST(BufferAccess, cancellation_releases_each_state_to_host_waiters)
+{
+    std::array<buffer_access_state_type, 2> states;
+    std::array<buffer_access_state_type *, 2> accesses{&states[0], &states[1]};
+    for (size_t iteration = 0; iteration < 16; ++iteration)
+    {
+        std::barrier start(3);
+        std::array<std::future<void>, 2> hosts;
+        {
+            buffer_submission_type canceled(std::span{accesses});
+            for (size_t index = 0; index < states.size(); ++index)
+            {
+                EXPECT_FALSE(states[index].ready());
+                hosts[index] = std::async(std::launch::async, [&, index]()
+                                          {
+                                              start.arrive_and_wait();
+                                              buffer_host_lease_type host(&states[index]); });
+            }
+            start.arrive_and_wait();
+        }
+        for (auto & host : hosts)
+        {
+            host.get();
+        }
+    }
+    EXPECT_NO_THROW({ buffer_submission_type after_hosts(std::span{accesses}); });
+}
+
+TEST(BufferAccess, concurrent_disjoint_submissions_cannot_reuse_token)
+{
+    buffer_access_state_type first, second;
+    auto completion = std::make_shared<BlockingDeviceCompletionToken>(first);
+    completion->complete();
+    std::barrier reserved(2);
+    auto publish = [&](buffer_access_state_type & state)
+    {
+        std::array<buffer_access_state_type *, 1> accesses{&state};
+        buffer_submission_type submission(std::span{accesses});
+        // Reserve both states independently before racing to claim the same token.
+        reserved.arrive_and_wait();
+        try
+        {
+            submission.publish(completion);
+            return true;
+        }
+        catch (std::invalid_argument const &)
+        {
+            return false;
+        }
+    };
+    auto first_publish = std::async(std::launch::async, [&]()
+                                    { return publish(first); });
+    auto second_publish = std::async(std::launch::async, [&]()
+                                     { return publish(second); });
+    EXPECT_NE(first_publish.get(), second_publish.get());
+    std::array<buffer_access_state_type *, 2> accesses{&first, &second};
+    buffer_submission_type after_race(std::span{accesses});
+    ASSERT_EQ(size_t{1}, after_race.dependencies().size());
+    EXPECT_EQ(completion, after_race.dependencies().front());
+}
+
+TEST(BufferAccess, published_guard_cannot_change_next_submission)
+{
+    buffer_access_state_type access;
+    std::array<buffer_access_state_type *, 1> accesses{&access};
+    auto completion = std::make_shared<BlockingDeviceCompletionToken>(access);
+    completion->complete();
+    auto published = std::make_unique<buffer_submission_type>(std::span{accesses});
+    published->publish(completion);
+    buffer_submission_type next(std::span{accesses});
+    auto next_completion = std::make_shared<BlockingDeviceCompletionToken>(access);
+    EXPECT_THROW(published->publish(next_completion), std::invalid_argument);
+    published.reset();
+    EXPECT_FALSE(access.ready());
+    EXPECT_THROW(buffer_submission_type(std::span{accesses}), std::runtime_error);
+    next.publish(next_completion);
+    next_completion->complete();
+}
+
+TEST(BufferAccess, concurrent_waiters_share_completion_across_states)
+{
+    buffer_access_state_type first, second;
+    std::array<buffer_access_state_type *, 2> accesses{&first, &second};
+    auto completion = std::make_shared<BlockingDeviceCompletionToken>(first);
+    buffer_submission_type(std::span{accesses}).publish(completion);
+    auto first_wait = std::async(std::launch::async, &buffer_access_state_type::wait, &first);
+    auto second_wait = std::async(std::launch::async, &buffer_access_state_type::wait, &second);
+    bool const first_started = completion->wait_until_started();
+    bool const second_started = completion->wait_until_started();
+    completion->complete();
+    first_wait.get();
+    second_wait.get();
+    EXPECT_TRUE(first_started && second_started);
+    EXPECT_TRUE(first.ready());
+    EXPECT_TRUE(second.ready());
+}
+
+TEST(BufferAccess, concurrent_host_leases_all_precede_device_submission)
+{
+    buffer_access_state_type access;
+    std::array<buffer_access_state_type *, 1> accesses{&access};
+    std::latch acquired(2);
+    std::binary_semaphore release_first(0), release_second(0);
+    auto hold_host = [&](std::binary_semaphore & release)
+    {
+        buffer_host_lease_type host(&access);
+        acquired.count_down();
+        release.acquire();
+    };
+    auto first = std::async(std::launch::async, [&]()
+                            { hold_host(release_first); });
+    auto second = std::async(std::launch::async, [&]()
+                             { hold_host(release_second); });
+    acquired.wait();
+    release_first.release();
+    first.get();
+    EXPECT_THROW(buffer_submission_type(std::span{accesses}), std::runtime_error);
+    release_second.release();
+    second.get();
+    EXPECT_NO_THROW({ buffer_submission_type after_hosts(std::span{accesses}); });
 }
 
 TEST(Float16, type_properties)

--- a/gtests/test_nopython_metal.cpp
+++ b/gtests/test_nopython_metal.cpp
@@ -1,12 +1,20 @@
+#include <solvcon/buffer/BufferExpander.hpp>
 #include <solvcon/buffer/ConcreteBuffer.hpp>
+#include <solvcon/buffer/SimpleArray.hpp>
 #include <solvcon/device/metal/metal.hpp>
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstdint>
+#include <future>
 #include <limits>
+#include <memory>
+#include <semaphore>
 #include <stdexcept>
+#include <utility>
 
 #ifdef Py_PYTHON_H
 #error "Python.h should not be included."
@@ -17,6 +25,104 @@ namespace solvcon
 
 namespace device
 {
+
+namespace
+{
+
+class PendingMatmulToken final : public detail::DeviceCompletionToken
+{
+public:
+    bool ready() const override { return m_done.wait_for(std::chrono::seconds(0)) == std::future_status::ready; }
+    void wait() const override
+    {
+        m_started.release();
+        m_done.wait();
+    }
+    bool wait_until_started() const { return m_started.try_acquire_for(std::chrono::seconds(5)); }
+    void complete() { m_completion.set_value(); }
+
+private:
+    mutable std::counting_semaphore<> m_started{0};
+    std::promise<void> m_completion;
+    std::shared_future<void> m_done = m_completion.get_future().share();
+}; /* end class PendingMatmulToken */
+
+} /* end namespace */
+
+TEST(MetalManager, cpu_matmul_waits_before_blas_and_naive)
+{
+    if (!MetalManager::instance().started())
+    {
+        GTEST_SKIP() << "No unified-memory Metal device is available";
+    }
+    for (auto kernel : {detail::MatmulKernel::Naive, detail::MatmulKernel::BlasGemm})
+    {
+        using array_type = SimpleArray<double>;
+        using state_type = detail::BufferAccessState;
+        auto lhs_buffer = ConcreteBuffer::construct(4 * sizeof(double), 0, BufferDevice::Metal);
+        auto rhs_buffer = ConcreteBuffer::construct(4 * sizeof(double), 0, BufferDevice::Metal);
+        auto output_buffer = ConcreteBuffer::construct(4 * sizeof(double), 0, BufferDevice::Metal);
+        array_type lhs(array_type::shape_type{2, 2}, lhs_buffer);
+        array_type rhs(array_type::shape_type{2, 2}, rhs_buffer);
+        array_type output(array_type::shape_type{2, 2}, output_buffer);
+        std::array<state_type *, 3> states{lhs_buffer->access_state(), rhs_buffer->access_state(), output_buffer->access_state()};
+        // A distinct pending operand in each case catches a missing input or output lease.
+        for (state_type * pending_state : states)
+        {
+            std::fill_n(lhs.logical_data(), 4, 0.0);
+            std::fill_n(rhs.logical_data(), 4, 0.0);
+            std::array<state_type *, 1> pending{pending_state};
+            auto completion = std::make_shared<PendingMatmulToken>();
+            state_type::Submission(std::span{pending}).publish(completion);
+            auto compute = std::async(std::launch::async, [&]()
+                                      {
+                auto plan = detail::MatmulPlan::make(lhs, rhs);
+                detail::MatmulExecutor<array_type> executor(std::move(plan), output, lhs, rhs);
+                executor.execute(kernel); });
+            if (!completion->wait_until_started())
+            {
+                completion->complete();
+                compute.get();
+                FAIL() << "CPU executor did not wait for pending device work";
+            }
+            EXPECT_THROW(state_type::Submission(std::span{pending}), std::runtime_error);
+            // Simulate prior device writes while the CPU executor waits for their completion.
+            std::fill_n(lhs.logical_data(), 4, 2.0);
+            std::fill_n(rhs.logical_data(), 4, 3.0);
+            completion->complete();
+            compute.get();
+            for (size_t index = 0; index < 4; ++index)
+            {
+                EXPECT_DOUBLE_EQ(12.0, output.logical_data()[index]);
+            }
+            EXPECT_NO_THROW({ state_type::Submission after_cpu(std::span{states}); });
+        }
+    }
+}
+
+TEST(MetalManager, unavailable_cpu_kernel_releases_host_access)
+{
+    if (!MetalManager::instance().started())
+    {
+        GTEST_SKIP() << "No unified-memory Metal device is available";
+    }
+    using array_type = SimpleArray<int32_t>;
+    using state_type = detail::BufferAccessState;
+    auto lhs_buffer = ConcreteBuffer::construct(4 * sizeof(int32_t), 0, BufferDevice::Metal);
+    auto rhs_buffer = ConcreteBuffer::construct(4 * sizeof(int32_t), 0, BufferDevice::Metal);
+    array_type lhs(array_type::shape_type{2, 2}, lhs_buffer);
+    array_type rhs(array_type::shape_type{2, 2}, rhs_buffer);
+    std::fill_n(lhs.logical_data(), 4, 2);
+    std::fill_n(rhs.logical_data(), 4, 3);
+    EXPECT_THROW(lhs.matmul(rhs, detail::MatmulKernel::BlasGemm), MatmulKernelUnavailable);
+    auto output = lhs.matmul(rhs);
+    for (size_t index = 0; index < 4; ++index)
+    {
+        EXPECT_EQ(12, output.logical_data()[index]);
+    }
+    std::array<state_type *, 2> states{lhs_buffer->access_state(), rhs_buffer->access_state()};
+    EXPECT_NO_THROW({ state_type::Submission after_cpu(std::span{states}); });
+}
 
 TEST(MetalManager, repeated_lifecycle_calls_preserve_state)
 {
@@ -47,7 +153,13 @@ TEST(MetalManager, allocate_shared_buffer)
     for (size_t const alignment : std::array<size_t, 4>{0, 16, 32, 64})
     {
         auto buffer = ConcreteBuffer::construct(64, alignment, BufferDevice::Metal);
+        SimpleArray<int8_t> const array({8, 8}, {1, 8}, buffer);
+        EXPECT_TRUE(array.to_row_major().is_c_contiguous());
+        EXPECT_FALSE(buffer->access_state()->host_exported());
         ASSERT_NE(nullptr, buffer->data());
+        EXPECT_FALSE(buffer->access_state()->host_exported());
+        buffer->export_host_access();
+        EXPECT_TRUE(buffer->access_state()->host_exported());
         EXPECT_EQ(size_t{64}, buffer->size());
         EXPECT_EQ(alignment, buffer->alignment());
         EXPECT_TRUE(buffer->has_remover());
@@ -62,6 +174,12 @@ TEST(MetalManager, allocate_shared_buffer)
         EXPECT_EQ(12, (*buffer)[0]);
         EXPECT_EQ(34, (*buffer)[63]);
     }
+
+    auto buffer = ConcreteBuffer::construct(64, 0, BufferDevice::Metal);
+    EXPECT_FALSE(buffer->access_state()->host_exported());
+    auto expander = BufferExpander::construct(buffer, false);
+    EXPECT_TRUE(buffer->access_state()->host_exported());
+    EXPECT_EQ(buffer->data(), expander->data());
 }
 
 TEST(MetalManager, allocate_empty_shared_buffer)


### PR DESCRIPTION
## Motivation

Device work can outlive its submitting call. CPU access through any array alias must wait for that work and exclude new device submissions until CPU computation ends.

## Method

Both guards run on CPU threads; the published token tracks device completion.

```text
CPU access:  HostLease  -> compute -> release lease
Device work: Submission -> order dependencies -> enqueue -> publish token
```

Each Metal allocation owns one state; CPU-only buffers allocate none. Guards borrow the state; `shared_ptr` retains completion tokens.

```mermaid
flowchart TB
    subgraph Access["Buffer ownership and borrowed access"]
        Array["Array / slices"] --> Buffer["ConcreteBuffer"]
        Buffer -->|owns| State["BufferAccessState<br/>Phase / lease count / completion"]
        Host["HostLease"] -.->|borrows| State
        Submit["Submission"] -.->|borrows| State
    end
    subgraph Tokens["DeviceCompletionToken ownership (shared_ptr)"]
        direction LR
        Waiter["Host acquisition"] -->|temporary| Prior["Prior token<br/>Wait before CPU use"]
        StateOwner["State"] -->|latest| Latest["Published token<br/>Track completion"]
        SubmitOwner["Submission"] -->|dependencies| Dependencies["Prior tokens<br/>Order device work"]
    end
    Access ~~~ Tokens
```

Separate token boxes may refer to the same instance. Tokens do not own buffer allocations.

| Caller | Existing access | Action |
| --- | --- | --- |
| `HostLease` | Submission reservation | Wait for reservation release |
| `HostLease` | Unfinished device work | Wait on token |
| `Submission` | CPU lease / reservation / host export | Throw |

CPU leases may coexist; callers synchronize conflicting CPU reads/writes. Publishing or abandoning a reservation releases it; abandonment alone cannot cancel device work.

The state mutex protects three separate records:

| Record | Meaning |
| --- | --- |
| Phase | Submission reservation or permanent host export |
| CPU lease count | New submissions require zero leases |
| Latest completion token | Prior operation for CPU waits and device ordering |

`Unreserved` does not mean idle: CPU leases or device work may still be active.

Host acquisition waits for reservation release, then prior device completion. This example follows the publication path through a future device executor:

```mermaid
sequenceDiagram
    participant Host as CPU host caller
    participant Submit as CPU submitter
    participant Device as Device/backend
    Submit->>Submit: Reserve buffers (mutex)
    Host->>Host: Acquire HostLease
    Note over Host: Wait for publication<br/>CV releases state mutex
    Submit->>Submit: Order dependencies (unlocked)
    Submit->>Device: Enqueue work
    activate Device
    Submit->>Submit: Publish token (mutex)
    Submit-->>Host: Unlock and notify
    Note over Submit: Submission may end
    Host->>Host: Recheck phase + count lease<br/>Copy token (mutex)
    Host->>Device: Wait on token (unlocked)
    Device-->>Host: Complete (writes visible)
    deactivate Device
    Note over Host: CPU / BLAS work (unlocked)<br/>All workers finish
    Host->>Host: Release lease (mutex)
```

Publication replaces the states' token and releases the guard's reservations. Example with one shared prior operation:

```text
                         before publish          after publish
states' completion       prior token             new token
guard dependencies       [prior token]           [prior token]
guard reserved states    [source, destination]   []
```

Multi-buffer submissions lock states in pointer order. Backend waits run unlocked; the token atomic rejects reuse. After enqueue, finish or safely cancel work before releasing an unpublished reservation.

- Copies and CPU matmul hold leases; callers join workers before releasing them.
- Raw pointer export permanently excludes device submissions; unchecked `data()` does not trigger export.
- The executor must retain buffers and order dependencies; its implementation is outside this PR.

## Validation

283 Metal-enabled C++ tests pass. The 13 state tests pass 100 shuffled runs under ThreadSanitizer with simulated device completions. `make lint` and `make pilot_clang_tidy_diff` pass.

Related to #1397, task 3.
