### PR TITLE
Canonicalize packed `matmul` operands

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -2395,9 +2395,13 @@ public:
     bool is_f_contiguous() const { return is_f_contiguous(m_shape, m_stride); }
 
 private:
+    template <typename Array>
+    friend class detail::MatmulExecutor;
+
     size_t logical_data_offset() const;
     void update_data_pointers(size_t data_offset = 0);
     void copy_logical_into(SimpleArray & out) const;
+    SimpleArray to_compact_row_major() const;
 
     template <size_t N, size_t... I>
     detail::SignedStrideLayout::mapping<std::dextents<ssize_t, N>> make_mdspan_mapping_impl(
@@ -3059,6 +3063,28 @@ SimpleArray<T> SimpleArray<T>::to_row_major() const
     }
     SimpleArray out(m_shape);
     copy_logical_into(out);
+    return out;
+}
+
+/**
+ * @brief Copy every logical element into exact C-order storage for matmul.
+ *
+ * @details
+ *      The internal view clears ghost metadata so the copy starts at
+ *      logical_data() and covers the full shape, including stored ghosts.
+ *      The returned packing temporary has canonical strides and no ghosts.
+ */
+template <typename T>
+SimpleArray<T> SimpleArray<T>::to_compact_row_major() const
+{
+    if (m_shape.empty())
+    {
+        return m_buffer ? SimpleArray(*this) : SimpleArray(m_shape);
+    }
+    SimpleArray const logical_view(
+        m_shape, m_stride, m_buffer, logical_data_offset());
+    SimpleArray out(m_shape);
+    logical_view.copy_logical_into(out);
     return out;
 }
 

--- a/cpp/solvcon/buffer/matmul_executor.hpp
+++ b/cpp/solvcon/buffer/matmul_executor.hpp
@@ -662,11 +662,11 @@ void MatmulExecutor<Array>::pack(PackingState const & packing)
 {
     if (packing.lhs)
     {
-        m_packed_lhs.emplace(m_lhs.to_row_major());
+        m_packed_lhs.emplace(m_lhs.to_compact_row_major());
     }
     if (packing.rhs)
     {
-        m_packed_rhs.emplace(m_rhs.to_row_major());
+        m_packed_rhs.emplace(m_rhs.to_compact_row_major());
     }
 
     Array const & lhs = m_packed_lhs ? *m_packed_lhs : m_lhs;

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -639,6 +639,33 @@ class MatmulTestBase(sc.testing.TestBase):
                     lhs, rhs, expected,
                     forced_kernels=('blas_dot',))
 
+    def test_matmul_packs_singleton_strides(self):
+        """Forced BLAS canonicalizes singleton strides before execution."""
+        dtype = np.dtype(self.dtype).name
+        data = np.ones(1, dtype=dtype)
+        lhs_data = self.make_strided_view(data, 0, -2)
+        rhs_data = self.make_strided_view(data, 0, -3)
+        lhs = self.SimpleArray(array=lhs_data)
+        rhs = self.SimpleArray(array=rhs_data)
+
+        self.assert_matmul(
+            lhs, rhs, np.atleast_1d(np.matmul(lhs_data, rhs_data)),
+            forced_kernels=('blas_dot',))
+
+    def test_matmul_packs_stored_ghosts(self):
+        """Packing preserves every row stored by a ghosted operand."""
+        dtype = np.dtype(self.dtype).name
+        lhs_data = self.make_strided_view(
+            np.arange(2, dtype=dtype).reshape((2, 1)) + 1, 1, -2)
+        rhs_data = np.ones(1, dtype=dtype)
+        lhs = self.SimpleArray(array=lhs_data)
+        lhs.nghost = 1
+        rhs = self.SimpleArray(array=rhs_data)
+
+        self.assert_matmul(
+            lhs, rhs, np.matmul(lhs_data, rhs_data),
+            forced_kernels=('blas_gemv',))
+
     def test_wrong_shape_error(self):
         """Every operand role reports mismatched contraction dimensions."""
         dtype = np.dtype(self.dtype).name


### PR DESCRIPTION
## Motivation

Packed BLAS operands may still carry non-canonical singleton strides. Ghosted operands also need the full stored shape preserved during packing.

## Approach

Copy every packed operand into exact row-major storage through a private `SimpleArray` helper. Clear ghost metadata only on the temporary while copying the full stored shape. Add forced-BLAS regressions for singleton strides and stored ghost rows.

Related to #1449.