### PR TITLE
Prepare one `matmul` comparison

### DIFF
--- a/cpp/solvcon/buffer/matmul_executor.hpp
+++ b/cpp/solvcon/buffer/matmul_executor.hpp
@@ -32,6 +32,17 @@
 namespace solvcon
 {
 
+/**
+ * Report that a forced matmul kernel is unavailable for this call.
+ *
+ * @ingroup group_core
+ */
+class MatmulKernelUnavailable : public std::invalid_argument
+{
+public:
+    using std::invalid_argument::invalid_argument;
+}; /* end class MatmulKernelUnavailable */
+
 namespace detail
 {
 
@@ -316,8 +327,7 @@ void MatmulExecutor<Array>::execute(MatmulKernel kernel)
         std::string_view const reason = use_matmul_blas_v<value_type>
                                             ? "is not eligible for these operands"
                                             : "requires a BLAS backend";
-        throw std::invalid_argument(
-            std::format("matmul(): kernel '{}' {}", matmul_kernel_name(kernel), reason));
+        throw MatmulKernelUnavailable(std::format("matmul(): kernel '{}' {}", matmul_kernel_name(kernel), reason));
     }
     run(selection.value());
 }

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.cpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.cpp
@@ -13,6 +13,8 @@ namespace python
 
 void wrap_SimpleArray(pybind11::module & mod)
 {
+    pybind11::register_exception<MatmulKernelUnavailable>(mod, "MatmulKernelUnavailable", PyExc_ValueError);
+
     wrap_SimpleArray_bool(mod);
     wrap_SimpleArray_int(mod);
     wrap_SimpleArray_uint(mod);

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -240,6 +240,34 @@ static SimpleArrayPlex make_arrayplex_from_numpy(pybind11::array & arr_in)
 }
 
 // NOLINTNEXTLINE(misc-use-anonymous-namespace)
+static pybind11::type get_typed_array_class(std::string const & dtype)
+{
+#define SC_DECL_GET_TYPED_ARRAY_CLASS(DataTypeValue, ArrayType) \
+    case DataTypeValue: return pybind11::type::of<ArrayType>();
+
+    switch (DataType(dtype))
+    {
+        SC_DECL_GET_TYPED_ARRAY_CLASS(DataType::Bool, SimpleArrayBool)
+        SC_DECL_GET_TYPED_ARRAY_CLASS(DataType::Int8, SimpleArrayInt8)
+        SC_DECL_GET_TYPED_ARRAY_CLASS(DataType::Int16, SimpleArrayInt16)
+        SC_DECL_GET_TYPED_ARRAY_CLASS(DataType::Int32, SimpleArrayInt32)
+        SC_DECL_GET_TYPED_ARRAY_CLASS(DataType::Int64, SimpleArrayInt64)
+        SC_DECL_GET_TYPED_ARRAY_CLASS(DataType::Uint8, SimpleArrayUint8)
+        SC_DECL_GET_TYPED_ARRAY_CLASS(DataType::Uint16, SimpleArrayUint16)
+        SC_DECL_GET_TYPED_ARRAY_CLASS(DataType::Uint32, SimpleArrayUint32)
+        SC_DECL_GET_TYPED_ARRAY_CLASS(DataType::Uint64, SimpleArrayUint64)
+        SC_DECL_GET_TYPED_ARRAY_CLASS(DataType::Float16, SimpleArrayFloat16)
+        SC_DECL_GET_TYPED_ARRAY_CLASS(DataType::Float32, SimpleArrayFloat32)
+        SC_DECL_GET_TYPED_ARRAY_CLASS(DataType::Float64, SimpleArrayFloat64)
+        SC_DECL_GET_TYPED_ARRAY_CLASS(DataType::Complex64, SimpleArrayComplex64)
+        SC_DECL_GET_TYPED_ARRAY_CLASS(DataType::Complex128, SimpleArrayComplex128)
+    default: throw std::invalid_argument("Unsupported datatype");
+    }
+
+#undef SC_DECL_GET_TYPED_ARRAY_CLASS
+}
+
+// NOLINTNEXTLINE(misc-use-anonymous-namespace)
 static void verify_calculator_supported(SimpleArrayPlex const & array)
 {
     if (array.data_type() == DataType::Float16)
@@ -295,6 +323,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
             ;
 
         (*this)
+            .def_static("typed_class", &get_typed_array_class, pybind11::arg("dtype"))
             .def("clone",
                  [](wrapped_type const & self)
                  { return wrapped_type(self); }) // cloning the object using the copy constructor. never add the clone method to the C++ class.

--- a/solvcon/benchmark/collector.py
+++ b/solvcon/benchmark/collector.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""Prepare exact operands and compare matmul kernel results."""
+
+import numpy as np
+
+import solvcon as sc
+
+
+_CHUNK_SIZE = 1 << 20
+
+
+def _storage_bounds(operand):
+    """Return inclusive element offsets, using (0, 0) for empty layouts."""
+    if any(extent == 0 for extent in operand.shape):
+        return 0, 0
+    minimum = 0
+    maximum = 0
+    for extent, stride in zip(operand.shape, operand.strides):
+        displacement = (extent - 1) * stride
+        minimum += min(0, displacement)
+        maximum += max(0, displacement)
+    return minimum, maximum
+
+
+def _fill_random_components(storage, seed):
+    components = storage.view(storage.real.dtype.name)
+    generator = np.random.default_rng(seed)
+    values = np.empty(
+        min(components.size, _CHUNK_SIZE), dtype='float64')
+    for start in range(0, components.size, _CHUNK_SIZE):
+        stop = min(start + _CHUNK_SIZE, components.size)
+        chunk = values[:stop - start]
+        generator.random(chunk.shape, dtype='float64', out=chunk)
+        chunk *= 2
+        chunk -= 1
+        components[start:stop] = chunk
+
+
+def _make_operand(operand, dtype, seed):
+    dtype = np.dtype(dtype)
+    minimum, maximum = _storage_bounds(operand)
+    storage = np.empty(maximum - minimum + 1, dtype=dtype.name)
+    _fill_random_components(storage, seed)
+
+    return np.ndarray(
+        shape=operand.shape,
+        dtype=dtype.name,
+        buffer=storage,
+        offset=-minimum * dtype.itemsize,
+        strides=tuple(stride * dtype.itemsize for stride in operand.strides),
+    )
+
+
+class _MatmulExecutor:
+    def __init__(self, spec, lhs, rhs):
+        array_type = sc.SimpleArray.typed_class(spec.dtype)
+        self._lhs_array = lhs
+        self._rhs_array = rhs
+        self._native_lhs = array_type(array=lhs)
+        self._native_rhs = array_type(array=rhs)
+
+    def __call__(self, name):
+        if name == 'numpy':
+            return np.matmul(self._lhs_array, self._rhs_array)
+        return self._native_lhs.matmul(self._native_rhs, kernel=name)
+
+
+def _make_executor(spec):
+    lhs = _make_operand(spec.lhs, spec.dtype, 0)
+    rhs = _make_operand(spec.rhs, spec.dtype, 1)
+    return _MatmulExecutor(spec, lhs, rhs)
+
+
+def _difference_metrics(result, reference):
+    if result.size == 0:
+        return None, None
+    max_abs_diff = 0.0
+    reference_scale = 0.0
+    chunks = np.nditer(
+        (result, reference),
+        flags=('external_loop', 'buffered'),
+        op_flags=(('readonly',), ('readonly',)),
+        order='C', buffersize=_CHUNK_SIZE,
+    )
+    for result_chunk, reference_chunk in chunks:
+        max_abs_diff = max(
+            max_abs_diff,
+            float(np.max(np.abs(result_chunk - reference_chunk))))
+        reference_scale = max(
+            reference_scale, float(np.max(np.abs(reference_chunk))))
+    if reference_scale:
+        return max_abs_diff, max_abs_diff / reference_scale
+    return max_abs_diff, 0.0 if max_abs_diff == 0 else None
+
+
+def _compare_result(execute, name, reference):
+    try:
+        result = np.atleast_1d(execute(name))
+    except sc.MatmulKernelUnavailable as exc:
+        return {
+            'status': 'ineligible',
+            'reason': str(exc),
+            'max_abs_diff': None,
+            'relative_diff': None,
+        }
+    if result.shape != reference.shape:
+        reason = 'shape mismatch'
+    elif result.dtype != reference.dtype:
+        reason = 'dtype mismatch'
+    elif not np.all(np.isfinite(result)):
+        reason = 'non-finite values'
+    else:
+        max_abs_diff, relative_diff = _difference_metrics(result, reference)
+        return {
+            'status': 'measured',
+            'reason': None,
+            'max_abs_diff': max_abs_diff,
+            'relative_diff': relative_diff,
+        }
+    return {
+        'status': 'invalid',
+        'reason': reason,
+        'max_abs_diff': None,
+        'relative_diff': None,
+    }
+
+
+def _compare(spec, execute):
+    """Compare every requested kernel with the NumPy reference."""
+    reference = np.atleast_1d(execute('numpy'))
+    if reference.shape != spec.output_shape:
+        raise RuntimeError('NumPy reference shape does not match spec')
+    if reference.dtype.name != spec.dtype:
+        raise RuntimeError('NumPy reference dtype does not match spec')
+    if not np.all(np.isfinite(reference)):
+        return {
+            name: {
+                'status': 'invalid',
+                'reason': 'non-finite NumPy reference',
+                'max_abs_diff': None,
+                'relative_diff': None,
+            }
+            for name in spec.kernels + ('numpy',)
+        }
+    comparison = {
+        name: _compare_result(execute, name, reference)
+        for name in spec.kernels
+    }
+    comparison['numpy'] = {
+        'status': 'measured',
+        'reason': None,
+        'max_abs_diff': 0.0 if reference.size else None,
+        'relative_diff': 0.0 if reference.size else None,
+    }
+    return comparison
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/core.py
+++ b/solvcon/core.py
@@ -18,6 +18,7 @@ from . import pylibmgr
 list_of_buffer = [
     'ConcreteBuffer',
     'BufferExpander',
+    'MatmulKernelUnavailable',
     'SimpleArray',
     'SimpleArrayBool',
     'SimpleArrayInt8',

--- a/tests/test_benchmark_collector.py
+++ b/tests/test_benchmark_collector.py
@@ -1,0 +1,292 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+import unittest
+import unittest.mock
+
+import numpy as np
+
+import solvcon as sc
+from solvcon.benchmark import collector
+from solvcon.benchmark import matmul
+from solvcon.benchmark import spec as benchmark_spec
+
+
+def make_spec(**updates):
+    data = {
+        'operation': 'matmul',
+        'lhs': {'shape': [2, 3], 'strides': [3, 1]},
+        'rhs': {'shape': [3, 2], 'strides': [2, 1]},
+        'dtype': 'float64',
+        'sampling': {'warmups': 1, 'repetitions': 2, 'rounds': 6},
+        'kernels': ['naive', 'blas_gemm'],
+    }
+    data.update(updates)
+    return matmul.MatmulSpec.from_dict(data)
+
+
+class FakeExecutor:
+    def __init__(self, outputs):
+        self.outputs = outputs
+        self.calls = []
+
+    def __call__(self, name):
+        self.calls.append(name)
+        output = self.outputs[name]
+        if isinstance(output, Exception):
+            raise output
+        if isinstance(output, np.ndarray):
+            return output.copy()
+        return np.array(output, dtype='float64')
+
+
+class OperandConstructionTC(unittest.TestCase):
+    def test_quantizes_shared_component_stream(self):
+        operand = benchmark_spec.OperandSpec.from_dict({
+            'shape': [2, 3], 'strides': [3, 1],
+        })
+        expected = 2 * np.random.default_rng(7).random(
+            12, dtype='float64') - 1
+        with unittest.mock.patch.object(
+                collector, '_CHUNK_SIZE', 4):
+            arrays = {
+                dtype: collector._make_operand(operand, dtype, 7)
+                for dtype in ('float32', 'float64',
+                              'complex64', 'complex128')
+            }
+        for array in arrays.values():
+            components = array.view(array.real.dtype.name).ravel()
+            np.testing.assert_array_equal(
+                components,
+                expected[:components.size].astype(components.dtype.name))
+
+    def test_preserves_negative_zero_and_empty_strides(self):
+        cases = (
+            ({'shape': [2, 3], 'strides': [-4, 0]}, (-4, 0)),
+            ({'shape': [0, 3], 'strides': [99, -2]}, (99, -2)),
+        )
+        for data, strides in cases:
+            with self.subTest(shape=data['shape']):
+                operand = benchmark_spec.OperandSpec.from_dict(data)
+                array = collector._make_operand(operand, 'complex64', 0)
+
+                self.assertEqual(array.shape, tuple(data['shape']))
+                self.assertEqual(
+                    tuple(value // array.itemsize
+                          for value in array.strides),
+                    strides,
+                )
+                self.assertEqual(array.dtype.name, 'complex64')
+                self.assertTrue(np.all(np.isfinite(array)))
+
+        operand = benchmark_spec.OperandSpec.from_dict(cases[0][0])
+        array = collector._make_operand(operand, 'complex64', 0)
+        np.testing.assert_array_equal(array[:, 0], array[:, 1])
+        np.testing.assert_array_equal(array[:, 1], array[:, 2])
+        self.assertNotEqual(array[0, 0], array[1, 0])
+
+
+class MatmulComparisonTC(unittest.TestCase):
+    def test_measures_each_result(self):
+        expected = np.array([[1.0, 2.0], [3.0, 4.0]], dtype='float64')
+        execute = FakeExecutor({
+            'naive': expected,
+            'blas_gemm': expected + 1,
+            'winograd': sc.MatmulKernelUnavailable('not eligible'),
+            'numpy': expected,
+        })
+        spec = make_spec(kernels=['naive', 'blas_gemm', 'winograd'])
+
+        comparison = collector._compare(spec, execute)
+
+        self.assertEqual(comparison, {
+            'naive': {
+                'status': 'measured',
+                'reason': None,
+                'max_abs_diff': 0.0,
+                'relative_diff': 0.0,
+            },
+            'blas_gemm': {
+                'status': 'measured',
+                'reason': None,
+                'max_abs_diff': 1.0,
+                'relative_diff': 0.25,
+            },
+            'winograd': {
+                'status': 'ineligible',
+                'reason': 'not eligible',
+                'max_abs_diff': None,
+                'relative_diff': None,
+            },
+            'numpy': {
+                'status': 'measured',
+                'reason': None,
+                'max_abs_diff': 0.0,
+                'relative_diff': 0.0,
+            },
+        })
+        self.assertEqual(
+            execute.calls,
+            ['numpy', 'naive', 'blas_gemm', 'winograd'],
+        )
+
+    def test_rejects_invalid_outputs(self):
+        expected = np.ones((2, 2), dtype='float64')
+        nonfinite = expected.copy()
+        nonfinite[0, 0] = np.nan
+        cases = (
+            (np.ones((1, 4), dtype='float64'), 'shape mismatch'),
+            (expected.astype('float32'), 'dtype mismatch'),
+            (nonfinite, 'non-finite values'),
+        )
+        for output, reason in cases:
+            with self.subTest(reason=reason):
+                result = collector._compare_result(
+                    FakeExecutor({'naive': output}),
+                    'naive', expected)
+                self.assertEqual(result['status'], 'invalid')
+                self.assertEqual(result['reason'], reason)
+                self.assertIsNone(result['max_abs_diff'])
+                self.assertIsNone(result['relative_diff'])
+
+    def test_rejects_invalid_numpy_reference(self):
+        cases = (
+            (np.ones((1, 4), dtype='float64'), 'shape does not match'),
+            (np.ones((2, 2), dtype='float32'), 'dtype does not match'),
+        )
+        for reference, reason in cases:
+            with self.subTest(reason=reason):
+                execute = FakeExecutor({'numpy': reference})
+                with self.assertRaisesRegex(RuntimeError, reason):
+                    collector._compare(make_spec(), execute)
+                self.assertEqual(execute.calls, ['numpy'])
+
+    def test_marks_nonfinite_numpy_reference_invalid(self):
+        reference = np.ones((2, 2), dtype='float64')
+        reference[0, 0] = np.nan
+        execute = FakeExecutor({'numpy': reference})
+
+        comparison = collector._compare(make_spec(kernels=['naive']), execute)
+
+        expected = {
+            'status': 'invalid',
+            'reason': 'non-finite NumPy reference',
+            'max_abs_diff': None,
+            'relative_diff': None,
+        }
+        self.assertEqual(comparison, {
+            'naive': expected,
+            'numpy': expected,
+        })
+        self.assertEqual(execute.calls, ['numpy'])
+
+    def test_internal_failures_propagate(self):
+        expected = np.ones((2, 2), dtype='float64')
+        for failure in (ValueError('native bug'), RuntimeError('native bug'),
+                        MemoryError('out of memory')):
+            with self.subTest(failure=type(failure).__name__):
+                execute = FakeExecutor({
+                    'naive': failure,
+                    'blas_gemm': expected,
+                    'numpy': expected,
+                })
+                with self.assertRaises(type(failure)):
+                    collector._compare(make_spec(), execute)
+
+    @unittest.mock.patch.object(collector, '_CHUNK_SIZE', 1)
+    def test_reports_zero_complex_and_empty_differences(self):
+        cases = (
+            (np.zeros(1, dtype='float64'),
+             np.zeros(1, dtype='float64'), (0.0, 0.0)),
+            (np.ones(1, dtype='float64'),
+             np.zeros(1, dtype='float64'), (1.0, None)),
+            (np.array([3 + 8j, 1 + 2j], dtype='complex64'),
+             np.array([3 + 4j, 1 + 1j], dtype='complex64'), (4.0, 0.8)),
+            (np.empty(0, dtype='float64'),
+             np.empty(0, dtype='float64'), (None, None)),
+        )
+        for result, reference, expected in cases:
+            with self.subTest(result=result, reference=reference):
+                self.assertEqual(
+                    collector._difference_metrics(result, reference),
+                    expected,
+                )
+
+    def test_dispatches_real_executor_for_every_dtype(self):
+        for dtype in ('float32', 'float64', 'complex64', 'complex128'):
+            with self.subTest(dtype=dtype):
+                spec = make_spec(dtype=dtype, kernels=['naive'])
+                execute = collector._make_executor(spec)
+                self.assertEqual(execute._native_lhs.ndarray.dtype.name, dtype)
+                self.assertEqual(execute._native_rhs.ndarray.dtype.name, dtype)
+                self.assertTrue(execute._native_lhs.is_from_python)
+                self.assertTrue(execute._native_rhs.is_from_python)
+                self.assertTrue(np.shares_memory(
+                    execute._lhs_array, execute._native_lhs.ndarray))
+                self.assertTrue(np.shares_memory(
+                    execute._rhs_array, execute._native_rhs.ndarray))
+                comparison = collector._compare(spec, execute)
+                self.assertEqual(
+                    [item['status'] for item in comparison.values()],
+                    ['measured', 'measured'],
+                )
+                for item in comparison.values():
+                    self.assertIsInstance(item['max_abs_diff'], float)
+                    self.assertIsInstance(item['relative_diff'], float)
+
+    def test_checks_operand_roles_and_broadcast_batches(self):
+        cases = (
+            ({'shape': [3], 'strides': [1]},
+             {'shape': [3], 'strides': [1]}),
+            ({'shape': [3], 'strides': [1]},
+             {'shape': [3, 2], 'strides': [2, 1]}),
+            ({'shape': [2, 3], 'strides': [3, 1]},
+             {'shape': [3], 'strides': [1]}),
+            ({'shape': [2, 1, 2, 3], 'strides': [6, 6, 3, 1]},
+             {'shape': [1, 4, 3, 2], 'strides': [24, 6, 2, 1]}),
+        )
+        for lhs, rhs in cases:
+            with self.subTest(lhs=lhs['shape'], rhs=rhs['shape']):
+                spec = make_spec(lhs=lhs, rhs=rhs, kernels=['naive'])
+                comparison = collector._compare(
+                    spec, collector._make_executor(spec))
+                self.assertEqual(
+                    [item['status'] for item in comparison.values()],
+                    ['measured', 'measured'],
+                )
+
+    def test_checks_exact_strided_and_empty_operands(self):
+        operands = (
+            {'shape': [2, 3], 'strides': [-3, 1]},
+            {'shape': [2, 3], 'strides': [0, 1]},
+            {'shape': [2, 3], 'strides': [1, 1]},
+            {'shape': [0, 3], 'strides': [99, -2]},
+        )
+        for lhs in operands:
+            with self.subTest(lhs=lhs):
+                spec = make_spec(lhs=lhs, kernels=['naive'])
+                execute = collector._make_executor(spec)
+                self.assertEqual(execute._native_lhs.stride,
+                                 tuple(lhs['strides']))
+                comparison = collector._compare(spec, execute)
+                self.assertEqual(
+                    [item['status'] for item in comparison.values()],
+                    ['measured', 'measured'],
+                )
+                if lhs['shape'][0] == 0:
+                    for item in comparison.values():
+                        self.assertIsNone(item['max_abs_diff'])
+                        self.assertIsNone(item['relative_diff'])
+
+    def test_marks_real_ineligible_kernel(self):
+        spec = make_spec(kernels=['naive', 'winograd'])
+
+        comparison = collector._compare(spec, collector._make_executor(spec))
+
+        self.assertEqual(
+            [item['status'] for item in comparison.values()],
+            ['measured', 'ineligible', 'measured'],
+        )
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -5453,10 +5453,14 @@ class SimpleArrayPlexTC(unittest.TestCase):
                                  "<class '_solvcon.SimpleArray'>")
 
     def test_SimpleArrayPlex_cast_to_typed(self):
+        with self.assertRaisesRegex(ValueError, 'Unsupported datatype'):
+            solvcon.SimpleArray.typed_class('invalid')
         for dtype, (_, typed_name, np_dtype) in self._DTINFO.items():
             with self.subTest(dtype=dtype):
                 plex = solvcon.SimpleArray((2, 3, 4), dtype=dtype)
                 typed = plex.typed
+                self.assertIs(solvcon.SimpleArray.typed_class(dtype),
+                              type(typed))
                 self.assertEqual(str(type(typed)),
                                  "<class '{}'>".format(typed_name))
                 self.assertEqual(typed.ndarray.dtype, np_dtype)

--- a/tests/test_float16.py
+++ b/tests/test_float16.py
@@ -106,6 +106,8 @@ class Float16PythonIntegrationTC(unittest.TestCase):
     def test_plex_float16_dispatch(self):
         array = sc.SimpleArray(
             shape=(2,), value=np.float16(1.25), dtype='float16')
+        self.assertIs(sc.SimpleArray.typed_class('float16'),
+                      sc.SimpleArrayFloat16)
         self.assertIsInstance(array.typed, sc.SimpleArrayFloat16)
         assert_array(np.full(2, 1.25, dtype='float16'), np.asarray(array))
 

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -134,10 +134,14 @@ class MatmulTestBase(sc.testing.TestBase):
         rhs = self.SimpleArray(
             array=np.ones((3, 3), dtype=dtype))
 
-        with self.assertRaisesRegex(ValueError, "unknown kernel 'unknown'"):
-            lhs.matmul(rhs, kernel='unknown')
+        self.assertTrue(issubclass(sc.MatmulKernelUnavailable, ValueError))
         with self.assertRaisesRegex(
-                ValueError,
+                ValueError, "unknown kernel 'unknown'") as context:
+            lhs.matmul(rhs, kernel='unknown')
+        self.assertNotIsInstance(
+            context.exception, sc.MatmulKernelUnavailable)
+        with self.assertRaisesRegex(
+                sc.MatmulKernelUnavailable,
                 "kernel 'winograd'.*(not eligible|requires a BLAS backend)"):
             lhs.matmul(rhs, kernel='winograd')
         with self.assertRaises(TypeError):


### PR DESCRIPTION
## Motivation

The Route Inspector needs reproducible operands and numerical differences from NumPy before it compares kernel runtime.

## Approach

Generate deterministic components in bounded FP64 chunks, then cast them into the target real or complex storage:

```text
bounded FP64 chunks
        |
        v
target real-component dtype
        |
        v
float or interleaved complex storage
        |
        v
SimpleArray.typed_class(dtype)
```

This gives every dtype the same component stream without a dtype-specific RNG table. Construct NumPy views with the requested shape, dtype, and element strides. The registered typed arrays share operand storage, so the collector keeps no duplicate dtype-to-class table and performs no input copy.

Let C++ report an unavailable forced kernel through a typed Python exception.

```text
execution result
|-- unavailable                       -> ineligible
|-- wrong shape, dtype, or non-finite -> invalid
`-- otherwise                         -> measured
```

Each non-empty `measured` result reports its maximum absolute difference from NumPy. It also reports that difference relative to NumPy's maximum magnitude. The collector applies no tolerance or numerical pass/fail rule.

Unexpected allocation and execution failures propagate. This PR adds no warmup, timing, storage, runtime limit, or memory limit.

Related to #1369.