### PR TITLE
Fix `TypeBroadcast` clang-tidy failures

### DIFF
--- a/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
+++ b/cpp/solvcon/buffer/pymod/TypeBroadcast.hpp
@@ -79,7 +79,7 @@ D TypeBroadcastImpl<T, D>::input_at(char const * data, pybind11::ssize_t const *
     {
         data += strides[axis] * sidx[axis];
     }
-    D value;
+    D value{};
     std::memcpy(&value, data, sizeof(value));
     return value;
 }
@@ -146,9 +146,9 @@ void TypeBroadcastImpl<T, D>::broadcast(
             size_t staged_index = 0;
             detail::for_each_index(output_shape, [&](shape_type const & sidx)
                                    {
-                                       // FIXME: NOLINTNEXTLINE(bugprone-signed-char-misuse,cert-str34-c)
                                        staged[staged_index++] = static_cast<T>(
-                                           input_at(data, strides, sidx)); });
+                                           input_at(data, strides, sidx)); // FIXME: NOLINT(bugprone-signed-char-misuse,cert-str34-c)
+                                   });
             staged_index = 0;
             detail::for_each_index(output_shape, [&](shape_type const & sidx)
                                    { output_at(arr_out, slices, sidx) = staged[staged_index++]; });
@@ -157,9 +157,9 @@ void TypeBroadcastImpl<T, D>::broadcast(
         {
             detail::for_each_index(output_shape, [&](shape_type const & sidx)
                                    {
-                                       // FIXME: NOLINTNEXTLINE(bugprone-signed-char-misuse,cert-str34-c)
                                        output_at(arr_out, slices, sidx) = static_cast<T>(
-                                           input_at(data, strides, sidx)); });
+                                           input_at(data, strides, sidx)); // FIXME: NOLINT(bugprone-signed-char-misuse,cert-str34-c)
+                                   });
         }
     }
     else


### PR DESCRIPTION
The merge of #1448 exposed clang-tidy 22 failures in `TypeBroadcast`. The signed-character suppressions covered only the first lines of multiline expressions, while the diagnostics were emitted on the following lines. After those diagnostics were removed, the full template build also reported that the object filled by `memcpy` was not value-initialized.

Move each suppression onto its diagnostic line and value-initialize the object before `memcpy`. The numerical conversion remains signed because casting NumPy `int8` through `unsigned char` would change negative values.

The int, uint, and complex wrapper translation units pass clang-tidy 22 with warnings as errors. `make lint` also passes.

Follow-up to #1448 and the failing master run: https://github.com/solvcon/solvcon/actions/runs/33389762749

Related to #1445.
