### PR TITLE
Allow normal vector scaling

### DIFF
--- a/cpp/solvcon/pilot/visual/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/visual/RDomainWidget.cpp
@@ -261,6 +261,7 @@ void RDomainWidget::updateMesh(std::shared_ptr<StaticMesh> const & mesh)
     {
         m_scene.fitCameraToScene(viewportAspect());
     }
+    rebuildNormals();
     update();
 }
 
@@ -930,20 +931,41 @@ void RDomainWidget::showFeatureEdges(bool show)
 
 void RDomainWidget::showNormals(bool show)
 {
+    m_show_normals = show;
+    rebuildNormals();
+    update();
+}
+
+void RDomainWidget::showNormals(bool show, float scale)
+{
+    m_normal_scale = std::max(scale, 0.0f);
+    showNormals(show);
+}
+
+void RDomainWidget::setNormalScale(float scale)
+{
+    m_normal_scale = std::max(scale, 0.0f);
+    if (m_show_normals)
+    {
+        rebuildNormals();
+        update();
+    }
+}
+
+void RDomainWidget::rebuildNormals()
+{
     m_scene.removeDrawableIf(
         [](RDrawable const * d)
         { return nullptr != dynamic_cast<RNormals const *>(d); });
 
-    if (show && nullptr != m_mesh)
+    if (m_show_normals && nullptr != m_mesh)
     {
-        auto normals = std::make_unique<RNormals>(m_mesh);
+        auto normals = std::make_unique<RNormals>(m_mesh, m_normal_scale);
         if (normals->hasGeometry())
         {
             m_scene.addDrawable(std::move(normals));
         }
     }
-
-    update();
 }
 
 namespace

--- a/cpp/solvcon/pilot/visual/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/visual/RDomainWidget.hpp
@@ -144,6 +144,12 @@ public:
 
     /// Show or hide a short arrow at every face center along its normal.
     void showNormals(bool show);
+    /// Show or hide face-normal arrows after setting their scale.
+    void showNormals(bool show, float scale);
+    /// Set the face-normal arrow scale, rebuilding the overlay when shown.
+    void setNormalScale(float scale);
+    float normalScale() const { return m_normal_scale; }
+    bool normalsShown() const { return m_show_normals; }
 
     /// The result of a pick: the entity kind ("cell", "node", "face", or
     /// "none" for a miss), its id, its element type (for a cell), a measure
@@ -352,6 +358,9 @@ private:
         std::vector<float> & scals,
         std::vector<uint32_t> & tris) const;
 
+    /// Rebuild the face-normal overlay from the current mesh and scale.
+    void rebuildNormals();
+
     /// Back-project the widget pixel (x, y) to a world-space ray. Returns
     /// false when the viewport or the view-projection is degenerate.
     bool computePickRay(int x, int y, QVector3D & origin, QVector3D & dir) const;
@@ -415,6 +424,8 @@ private:
     bool m_has_field_bbox = false;
 
     std::shared_ptr<StaticMesh> m_mesh;
+    bool m_show_normals = false; ///< Whether the normals overlay is requested.
+    float m_normal_scale = 1.0f; ///< Multiplier for the base normal length.
 
     bool m_transparent_capture = false; ///< Clear alpha 0 for a capture.
 

--- a/cpp/solvcon/pilot/visual/RNormals.cpp
+++ b/cpp/solvcon/pilot/visual/RNormals.cpp
@@ -41,13 +41,13 @@ QVector3D head_perpendicular(QVector3D const & n, uint32_t ndim)
 
 } /* end namespace */
 
-RNormals::RNormals(std::shared_ptr<StaticMesh> const & mesh)
+RNormals::RNormals(std::shared_ptr<StaticMesh> const & mesh, float scale)
 {
-    build(*mesh);
+    build(*mesh, scale);
     setColor(QVector4D(NORMAL_COLOR[0], NORMAL_COLOR[1], NORMAL_COLOR[2], 1.0f));
 }
 
-void RNormals::build(StaticMesh const & mh)
+void RNormals::build(StaticMesh const & mh, float scale)
 {
     uint32_t const ndim = mh.ndim();
     uint32_t const nface = mh.nface();
@@ -73,7 +73,7 @@ void RNormals::build(StaticMesh const & mh)
         hi = QVector3D(std::max(hi.x(), p.x()), std::max(hi.y(), p.y()), std::max(hi.z(), p.z()));
     }
     float const diag = (hi - lo).length();
-    float const shaft = (diag > 0.0f ? diag : 1.0f) * SHAFT_FRACTION;
+    float const shaft = (diag > 0.0f ? diag : 1.0f) * SHAFT_FRACTION * std::max(scale, 0.0f);
 
     auto push = [this](QVector3D const & a, QVector3D const & b)
     {

--- a/cpp/solvcon/pilot/visual/RNormals.hpp
+++ b/cpp/solvcon/pilot/visual/RNormals.hpp
@@ -7,7 +7,7 @@
 
 /**
  * @file
- * Draw a short arrow at every face center along the face normal.
+ * Draw a scaled arrow at every face center along the face normal.
  *
  * @ingroup group_domain
  */
@@ -27,10 +27,10 @@ namespace solvcon
  * @brief The face normals drawn as short line arrows, one per face.
  *
  * Each arrow starts at the face center (StaticMesh::fccnd) and points along
- * the unit face normal (StaticMesh::fcnml); its length is a small fraction of
- * the mesh extent, so the field reads as short quills. A two-segment head
- * marks the direction. Both are precomputed by StaticMesh, so no geometry is
- * derived here beyond scaling.
+ * the unit face normal (StaticMesh::fcnml); its base length is a small
+ * fraction of the mesh extent and the scale parameter stretches that length for
+ * inspection. A two-segment head marks the direction. Both inputs are
+ * precomputed by StaticMesh, so no geometry is derived here beyond scaling.
  *
  * @ingroup group_domain
  */
@@ -40,7 +40,7 @@ class RNormals
 
 public:
 
-    explicit RNormals(std::shared_ptr<StaticMesh> const & mesh);
+    explicit RNormals(std::shared_ptr<StaticMesh> const & mesh, float scale = 1.0f);
 
     bool hasGeometry() const { return m_positions.size() > 0; }
 
@@ -56,7 +56,7 @@ protected:
 
 private:
 
-    void build(StaticMesh const & mh);
+    void build(StaticMesh const & mh, float scale);
 
     SimpleCollector<float> m_positions; ///< Line-segment endpoints (x, y, z).
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -319,7 +319,20 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                 py::arg("title"))
             .def("showBoundary", &wrapped_type::showBoundary, py::arg("ibc"), py::arg("show"))
             .def("showFeatureEdges", &wrapped_type::showFeatureEdges, py::arg("show"))
-            .def("showNormals", &wrapped_type::showNormals, py::arg("show"))
+            .def(
+                "showNormals",
+                py::overload_cast<bool>(&wrapped_type::showNormals),
+                py::arg("show"))
+            .def(
+                "showNormals",
+                py::overload_cast<bool, float>(&wrapped_type::showNormals),
+                py::arg("show"),
+                py::arg("scale"))
+            .def_property(
+                "normalScale",
+                &wrapped_type::normalScale,
+                &wrapped_type::setNormalScale)
+            .def_property_readonly("normalsShown", &wrapped_type::normalsShown)
             .def(
                 "pickCell",
                 [](wrapped_type & self, int x, int y)

--- a/solvcon/pilot/panel/_tree_panel.py
+++ b/solvcon/pilot/panel/_tree_panel.py
@@ -14,8 +14,8 @@ from PySide6.QtGui import QColor, QPainter
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QTreeWidget,
                                QTreeWidgetItem, QFrame, QDockWidget,
                                QStackedWidget, QHBoxLayout, QButtonGroup,
-                               QRadioButton, QPushButton,
-                               QSizePolicy, QAbstractButton)
+                               QRadioButton, QPushButton, QSizePolicy,
+                               QAbstractButton, QSlider)
 
 from ... import core
 from .._style import PaletteStyled
@@ -99,6 +99,13 @@ class MeshInfoTree(TreePanelBase):
     _ROLE_IBC = Qt.UserRole + 1
     _ROLE_STYLE = Qt.UserRole + 2
 
+    _NORMAL_SCALE_MIN = 10
+    _NORMAL_SCALE_MAX = 300
+    _NORMAL_SCALE_DEFAULT = 100
+    _NORMAL_SCALE_SLIDER_WIDTH = 150
+    _NORMAL_SCALE_BASE_FRACTION = 0.04
+    _NORMAL_SCALE_SPACING_FRACTION = 0.30
+
     # Map cell type numbers to human-readable names.
     CELL_TYPE_NAME = {
         core.StaticMesh.POINT: "point",
@@ -117,6 +124,11 @@ class MeshInfoTree(TreePanelBase):
         if self.style_status is not None:
             self.style_status.changed.connect(self.refresh_style_checks)
         self._style_items = {}
+        self._normal_item = None
+        self._normal_scale_item = None
+        self._normal_scale_slider = None
+        self._normal_scale_user_set = False
+        self._mesh = None
         self.boundary_toggled = None
         self.edges_toggled = None
         self.normals_toggled = None
@@ -183,11 +195,46 @@ class MeshInfoTree(TreePanelBase):
         return [[ibc, mh.bc(ibc).name, int(counts[ibc])]
                 for ibc in range(mh.nbcs)]
 
+    @classmethod
+    def recommended_normal_scale_value(cls, mh):
+        """
+        Return a recommended scale value by the face density.
+
+        Use the bounding-box measure and face count to estimate a
+        characteristic length. When the measure is too small, fall back to the
+        diagonal. By default, the normal vector is around 30% of that length.
+        """
+        crd = mh.ndcrd.ndarray[mh.ndcrd.nghost:]
+        nface = int(mh.nface)
+        if not nface or not crd.size:
+            return cls._NORMAL_SCALE_DEFAULT
+
+        ndim = int(mh.ndim)
+        extent = crd.max(axis=0)[:ndim] - crd.min(axis=0)[:ndim]
+        diag = float(np.linalg.norm(extent))
+        if diag <= np.finfo('float64').eps:
+            return cls._NORMAL_SCALE_DEFAULT
+
+        measure = float(np.prod(extent))
+        if measure > np.finfo('float64').eps:
+            spacing = measure ** (1.0 / ndim) / nface ** (1.0 / ndim)
+        else:
+            spacing = diag / nface ** (1.0 / ndim)
+        scale = (cls._NORMAL_SCALE_SPACING_FRACTION * spacing
+                 / (cls._NORMAL_SCALE_BASE_FRACTION * diag))
+        value = int(round(100.0 * scale))
+        return max(cls._NORMAL_SCALE_MIN, min(value, cls._NORMAL_SCALE_MAX))
+
     def set_mesh(self, mh):
         """Rebuild the tree from ``mh``, or show "No mesh loaded" when None."""
         self._building = True
         self._style_items = {}
         try:
+            self._mesh = mh
+            self._normal_scale_user_set = False
+            self._normal_item = None
+            self._normal_scale_item = None
+            self._normal_scale_slider = None
             if mh is None:
                 self._show_placeholder("No mesh loaded")
                 return
@@ -237,12 +284,71 @@ class MeshInfoTree(TreePanelBase):
 
         Both default off; each drives its own viewer overlay.
         """
-        for label, kind in (("feature edges", 'edges'),
-                            ("normals", 'normals')):
-            item = QTreeWidgetItem(root, [label])
-            item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
-            item.setData(0, self._ROLE_KIND, kind)
-            item.setCheckState(0, Qt.Unchecked)
+        item = QTreeWidgetItem(root, ["feature edges"])
+        item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+        item.setData(0, self._ROLE_KIND, 'edges')
+        item.setCheckState(0, Qt.Unchecked)
+
+        item = QTreeWidgetItem(root, ["normals"])
+        item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+        item.setData(0, self._ROLE_KIND, 'normals')
+        item.setCheckState(0, Qt.Unchecked)
+        self._normal_item = item
+        self._add_normal_scale_control(item)
+        item.setExpanded(True)
+        self._sync_normal_scale_enabled(False)
+
+    def normal_scale(self):
+        return self._normal_scale_slider.value() / 100.0
+
+    def _set_normal_scale_value(self, value):
+        blocked = self._normal_scale_slider.blockSignals(True)
+        self._normal_scale_slider.setValue(value)
+        self._normal_scale_slider.blockSignals(blocked)
+        self._sync_normal_scale_text()
+
+    def _add_normal_scale_control(self, parent):
+        self._normal_scale_item = QTreeWidgetItem(parent, ["scale: 1.00x"])
+        self._normal_scale_item.setFlags(
+            self._normal_scale_item.flags() & ~Qt.ItemIsSelectable)
+        self._normal_scale_item.setSizeHint(0, QSize(1, 18))
+
+        row = QWidget()
+        layout = QHBoxLayout(row)
+        layout.setContentsMargins(4, 2, 10, 2)
+        layout.setSpacing(0)
+
+        slider = QSlider(Qt.Horizontal)
+        slider.setFixedWidth(self._NORMAL_SCALE_SLIDER_WIDTH)
+        slider.setRange(self._NORMAL_SCALE_MIN, self._NORMAL_SCALE_MAX)
+        slider.setSingleStep(5)
+        slider.setPageStep(25)
+        slider.setValue(self._NORMAL_SCALE_DEFAULT)
+
+        layout.addWidget(slider)
+        layout.addStretch(1)
+        slider_item = QTreeWidgetItem(parent, ["scale slider: control"])
+        slider_item.setFlags(slider_item.flags() & ~Qt.ItemIsSelectable)
+        slider_item.setSizeHint(0, QSize(1, 24))
+        self._tree.setItemWidget(slider_item, 0, row)
+
+        self._normal_scale_slider = slider
+        slider.valueChanged.connect(self._on_normal_scale_changed)
+
+    def _sync_normal_scale_enabled(self, shown):
+        self._normal_scale_item.setDisabled(not shown)
+        self._normal_scale_slider.setEnabled(shown)
+
+    def _sync_normal_scale_text(self):
+        scale = self.normal_scale()
+        self._normal_scale_item.setText(0, f"scale: {scale:.2f}x")
+
+    def _on_normal_scale_changed(self, _value):
+        self._normal_scale_user_set = True
+        self._sync_normal_scale_text()
+        if (self._normal_item.checkState(0) == Qt.Checked
+                and self.normals_toggled is not None):
+            self.normals_toggled(True)
 
     def _add_boundary_group(self, root, mh):
         """Add the boundary sets as a group of check boxes (default off)."""
@@ -272,8 +378,13 @@ class MeshInfoTree(TreePanelBase):
                 item.data(0, self._ROLE_STYLE), checked)
         elif kind == 'edges' and self.edges_toggled is not None:
             self.edges_toggled(checked)
-        elif kind == 'normals' and self.normals_toggled is not None:
-            self.normals_toggled(checked)
+        elif kind == 'normals':
+            if checked and not self._normal_scale_user_set:
+                value = self.recommended_normal_scale_value(self._mesh)
+                self._set_normal_scale_value(value)
+            self._sync_normal_scale_enabled(checked)
+            if self.normals_toggled is not None:
+                self.normals_toggled(checked)
 
 
 class _CollapsibleSection(PaletteStyled):
@@ -816,7 +927,7 @@ class TreePanel(_gui_common.PilotFeature):
     def _on_normals_toggled(self, checked):
         widget = self._mgr.currentR3DWidget()
         if widget is not None:
-            widget.showNormals(checked)
+            widget.showNormals(checked, self._mesh_tree.normal_scale())
 
     def _mdi_area(self):
         return self._mainWindow.centralWidget()

--- a/tests/gui/test_tree_panel.py
+++ b/tests/gui/test_tree_panel.py
@@ -58,6 +58,36 @@ def _make_single_triangle():
     return mh
 
 
+def _make_dense_rect_mesh():
+    """A denser 4-by-1 rectangle whose normals need a shorter scale."""
+    core = solvcon.core
+    T = core.StaticMesh.TRIANGLE
+    nx = 16
+    ny = 4
+    mh = core.StaticMesh(ndim=2, nnode=(nx + 1) * (ny + 1), nface=0,
+                         ncell=2 * nx * ny)
+    nodes = []
+    for iy in range(ny + 1):
+        for ix in range(nx + 1):
+            nodes.append((4.0 * ix / nx, 1.0 * iy / ny))
+    mh.ndcrd.ndarray[:, :] = nodes
+    cells = []
+    for iy in range(ny):
+        for ix in range(nx):
+            n0 = iy * (nx + 1) + ix
+            n1 = n0 + 1
+            n2 = n0 + nx + 1
+            n3 = n2 + 1
+            cells.append((3, n0, n1, n3, -1))
+            cells.append((3, n0, n3, n2, -1))
+    mh.cltpn.ndarray[:] = T
+    mh.clnds.ndarray[:, :5] = cells
+    mh.build_interior()
+    mh.build_boundary()
+    mh.build_ghost()
+    return mh
+
+
 def _crossing_world():
     """Two lines crossing at (1, 1): shape 0 and shape 1."""
     world = solvcon.WorldFp64()
@@ -138,6 +168,13 @@ class MeshInfoTreeTC(unittest.TestCase):
         tree.set_mesh(None)
         tree.refresh_style_checks()
         self.assertEqual(tree._style_items, {})
+
+    def test_recommended_normal_scale_follows_mesh_density(self):
+        sparse = _tree_panel.MeshInfoTree.recommended_normal_scale_value(
+            _make_sample_mesh())
+        dense = _tree_panel.MeshInfoTree.recommended_normal_scale_value(
+            _make_dense_rect_mesh())
+        self.assertLess(dense, sparse)
 
 
 @unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
@@ -331,6 +368,41 @@ class TreePanelTC(unittest.TestCase):
             item.setCheckState(0, Qt.Checked)
             item.setCheckState(0, Qt.Unchecked)
             self.assertEqual(calls, [True, False])
+
+    def test_normal_scale_slider_drives_viewer(self):
+        mesh = _make_sample_mesh()
+        widget = self.mgr.add3DWidget()
+        widget.updateMesh(mesh)
+        panel = self._panel_on()._mesh_tree
+        root = panel._tree.topLevelItem(0)
+        item = next(root.child(i) for i in range(root.childCount())
+                    if root.child(i).text(0) == "normals")
+        slider = panel._normal_scale_slider
+        expected = panel.recommended_normal_scale_value(mesh)
+
+        # Check the width of slider is _NORMAL_SCALE_SLIDER_WIDTH.
+        self.assertIsNotNone(slider)
+        self.assertFalse(slider.isEnabled())
+        self.assertEqual(slider.width(), panel._NORMAL_SCALE_SLIDER_WIDTH)
+
+        # Checked the normal vector option
+        item.setCheckState(0, Qt.Checked)
+        self.assertTrue(widget.normalsShown)
+        self.assertTrue(slider.isEnabled())
+        self.assertEqual(slider.value(), expected)
+        self.assertAlmostEqual(widget.normalScale, expected / 100.0, 6)
+
+        # Check normalScale will modify by slider.
+        slider.setValue(175)
+        self.assertAlmostEqual(widget.normalScale, 1.75, 6)
+
+        # Check the slider can be disable by unchecked.
+        item.setCheckState(0, Qt.Unchecked)
+        self.assertFalse(widget.normalsShown)
+        self.assertFalse(slider.isEnabled())
+        item.setCheckState(0, Qt.Checked)
+        self.assertEqual(slider.value(), 175)
+        self.assertAlmostEqual(widget.normalScale, 1.75, 6)
 
     def test_mesh_viewer_without_mesh_shows_placeholder(self):
         self.mgr.add3DWidget()  # fresh viewer becomes current, no mesh

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -898,6 +898,27 @@ class RDomainWidgetOverlayTC(unittest.TestCase):
         hidden = _count_green(_grab_or_skip(hidden_widget))
         self.assertLess(hidden, shown)
 
+    def test_normals_scale_changes_arrow_length(self):
+        """A larger normal scale draws longer arrows from the same vectors."""
+        # Create a small normal vector
+        small_widget = pilot.RDomainWidget()
+        small_widget.resize(320, 240)
+        small_widget.updateMesh(_make_2d_mesh())
+        small_widget.showNormals(True, scale=0.25)
+        small = _count_green(_grab_or_skip(small_widget))
+
+        # Create a large normal vector
+        large_widget = pilot.RDomainWidget()
+        large_widget.resize(320, 240)
+        large_widget.updateMesh(_make_2d_mesh())
+        large_widget.showNormals(True, scale=2.0)
+        large = _count_green(_grab_or_skip(large_widget))
+
+        # Check small normal vector bigger than large normal vector
+        self.assertTrue(large_widget.normalsShown)
+        self.assertAlmostEqual(large_widget.normalScale, 2.0)
+        self.assertGreater(large, small)
+
     def test_normals_without_mesh_is_noop(self):
         """showNormals on a widget with no mesh does nothing, not crash."""
         widget = pilot.RDomainWidget()


### PR DESCRIPTION
In this PR, according to the #994, we found that the current version of API still not have scale feature on normal vector. Therefore, I implement these:

 - `showNormals` supports the scale parameter to scale the normal vector.
 - GUI supports with a slider to scale the normal vector. The minimal ratio can be x0.01 and maximal ratio can be x3.0.

<img width="2032" height="1215" alt="image" src="https://github.com/user-attachments/assets/bd9f0266-37ec-496b-be7e-85022ef78169" />

<img width="2032" height="1215" alt="image" src="https://github.com/user-attachments/assets/3a9df9a5-868d-4afe-8574-2f1ace223834" />

Moreover, the normal vector will scale automatically according to the dense of faces. We measure the spatial of 2D/3D mesh from the bounding box, and divide the spatial by the number of faces to get the average spatial for each faces. After get the average spatial of faces, we can take (d)-dimension root to get the approxmately length of faces as candidiate length. For the length of normal vector, we take 30% length of candidiate length in default.

We added 3 tests to test the GUI and the mechanism of recommended scale:
 - `test_recommended_normal_scale_follows_mesh_density` in `test_tree_panel.py`: Test the lenght of normal vector will be scaled by the dense of faces. We prepare two different dense of mesh to compare the length of normal vector. The mesh with more dense faces will have smaller faces.
 - `test_normal_scale_slider_drives_viewer` in `test_tree_panel.py`: Test the slider in GUI will changes the length of normal vector.
 - `test_normals_scale_changes_arrow_length` in `test_pilot_domain_widget.py`: Test the scale values will change the length of normal vector. The test compared the length of normal vector in small and larger scale value.

Thanks codex for the GUI implementation.