### PR TITLE
Complete `Float16` SimpleArray operations

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -293,6 +293,22 @@ template <typename U>
 inline constexpr bool is_bool_v = std::is_same_v<bool, std::remove_const_t<U>>;
 
 template <typename U>
+inline constexpr bool is_array_real_v =
+    is_real_v<std::remove_cv_t<U>> || std::is_same_v<std::remove_cv_t<U>, Float16>;
+
+template <typename U>
+constexpr U min_identity() { return std::numeric_limits<U>::max(); }
+
+template <>
+constexpr Float16 min_identity<Float16>() { return Float16::from_bits(0x7c00U); }
+
+template <typename U>
+constexpr U max_identity() { return std::numeric_limits<U>::lowest(); }
+
+template <>
+constexpr Float16 max_identity<Float16>() { return Float16::from_bits(0xfc00U); }
+
+template <typename U>
 struct select_real_t
 {
     using type = U;
@@ -712,7 +728,7 @@ public:
 
     real_type std_op(small_vector<value_type> & sv, size_t ddof) const
     {
-        return static_cast<real_type>(std::sqrt(var_op(sv, ddof)));
+        return static_cast<real_type>(solvcon::sqrt(var_op(sv, ddof)));
     }
 
     auto std(const shape_type & axis, size_t ddof) const
@@ -723,12 +739,12 @@ public:
     real_type std(size_t ddof) const
     {
         auto athis = static_cast<A const *>(this);
-        return static_cast<real_type>(std::sqrt(athis->var(ddof)));
+        return static_cast<real_type>(solvcon::sqrt(athis->var(ddof)));
     }
 
     value_type min() const
     {
-        value_type initial = std::numeric_limits<value_type>::max();
+        value_type initial = min_identity<value_type>();
         auto athis = static_cast<A const *>(this);
         for (size_t i = 0; i < athis->size(); ++i)
         {
@@ -742,7 +758,7 @@ public:
 
     value_type max() const
     {
-        value_type initial = std::numeric_limits<value_type>::lowest();
+        value_type initial = max_identity<value_type>();
         auto athis = static_cast<A const *>(this);
         for (size_t i = 0; i < athis->size(); ++i)
         {
@@ -758,11 +774,12 @@ public:
     {
         auto athis = static_cast<A const *>(this);
         A ret(*athis);
-        if constexpr (!std::is_same_v<bool, std::remove_const_t<value_type>> && std::is_signed_v<value_type>)
+        if constexpr (std::is_signed_v<std::remove_cv_t<value_type>> ||
+                      std::is_same_v<std::remove_cv_t<value_type>, Float16>)
         {
             for (size_t i = 0; i < athis->size(); ++i)
             {
-                ret.data(i) = static_cast<value_type>(std::abs(athis->data(i)));
+                ret.data(i) = static_cast<value_type>(solvcon::abs(athis->data(i)));
             }
         }
         return ret;
@@ -1494,13 +1511,13 @@ bool nan_aware_less(V const & lhs, V const & rhs)
         }
         return nan_aware_less(lhs.imag(), rhs.imag());
     }
-    else if constexpr (std::is_floating_point_v<V>)
+    else if constexpr (is_array_real_v<V>)
     {
-        if (std::isnan(rhs))
+        if (solvcon::isnan(rhs))
         {
-            return !std::isnan(lhs);
+            return !solvcon::isnan(lhs);
         }
-        if (std::isnan(lhs))
+        if (solvcon::isnan(lhs))
         {
             return false;
         }
@@ -1616,11 +1633,11 @@ void SimpleArrayMixinSort<A, T>::sort()
         // Complex numbers are sorted lexicographically by real and then imaginary parts.
         std::sort(athis->begin(), athis->end(), NanAwareLess{});
     }
-    else if constexpr (std::is_floating_point_v<value_type>)
+    else if constexpr (is_array_real_v<value_type>)
     {
         // Partition the array into two parts: non-NaN values and NaN values.
         auto * const mid = std::partition(athis->begin(), athis->end(), [](value_type const & v)
-                                          { return !std::isnan(v); });
+                                          { return !solvcon::isnan(v); });
         std::sort(athis->begin(), mid);
     }
     else
@@ -3388,9 +3405,9 @@ size_t detail::SimpleArrayMixinSearch<A, T>::argmin() const
         {
             value_type const current_value = ptr[i];
 
-            if constexpr (std::is_floating_point_v<value_type>)
+            if constexpr (is_array_real_v<value_type>)
             {
-                if (std::isnan(current_value))
+                if (solvcon::isnan(current_value))
                 {
                     return i;
                 }
@@ -3416,9 +3433,9 @@ size_t detail::SimpleArrayMixinSearch<A, T>::argmin() const
     {
         value_type const current_value = *(ptr + unchecked_logical_offset(*athis, idx));
 
-        if constexpr (std::is_floating_point_v<value_type>)
+        if constexpr (is_array_real_v<value_type>)
         {
-            if (std::isnan(current_value))
+            if (solvcon::isnan(current_value))
             {
                 return flat_index;
             }
@@ -3456,9 +3473,9 @@ size_t detail::SimpleArrayMixinSearch<A, T>::argmax() const
         {
             value_type const current_value = ptr[i];
 
-            if constexpr (std::is_floating_point_v<value_type>)
+            if constexpr (is_array_real_v<value_type>)
             {
-                if (std::isnan(current_value))
+                if (solvcon::isnan(current_value))
                 {
                     return i;
                 }
@@ -3484,9 +3501,9 @@ size_t detail::SimpleArrayMixinSearch<A, T>::argmax() const
     {
         value_type const current_value = *(ptr + unchecked_logical_offset(*athis, idx));
 
-        if constexpr (std::is_floating_point_v<value_type>)
+        if constexpr (is_array_real_v<value_type>)
         {
-            if (std::isnan(current_value))
+            if (solvcon::isnan(current_value))
             {
                 return flat_index;
             }
@@ -3548,9 +3565,9 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmin(ssize_t axis)
         {
             ssize_t const current_index = input_index + i * axis_stride;
             value_type const current_value = (*athis)[static_cast<size_t>(current_index)];
-            if constexpr (std::is_floating_point_v<value_type>)
+            if constexpr (is_array_real_v<value_type>)
             {
-                if (std::isnan(current_value))
+                if (solvcon::isnan(current_value))
                 {
                     min_index = static_cast<uint64_t>(i);
                     break;
@@ -3616,9 +3633,9 @@ SimpleArray<uint64_t> detail::SimpleArrayMixinSearch<A, T>::argmax(ssize_t axis)
         {
             ssize_t const current_index = input_index + i * axis_stride;
             value_type const current_value = (*athis)[static_cast<size_t>(current_index)];
-            if constexpr (std::is_floating_point_v<value_type>)
+            if constexpr (is_array_real_v<value_type>)
             {
-                if (std::isnan(current_value))
+                if (solvcon::isnan(current_value))
                 {
                     max_index = static_cast<uint64_t>(i);
                     break;

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -192,24 +192,11 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             .def_property_readonly("nbody", &wrapped_type::nbody)
             .def_property_readonly("plex", [](wrapped_type const & arr)
                                    { return pybind11::cast(SimpleArrayPlex(arr)); })
-            .wrap_modifiers();
-
-        if constexpr (std::is_same_v<T, Float16>)
-        {
-            auto const reject_calculation = [](wrapped_type const &, py::object const &)
-            { throw std::runtime_error("Float16 array calculations are not supported"); };
-            (*this)
-                .def("__eq__", reject_calculation, py::is_operator())
-                .def("__ne__", reject_calculation, py::is_operator());
-        }
-        else
-        {
-            (*this)
-                .wrap_calculators()
-                .wrap_matrix()
-                .wrap_sort()
-                .wrap_search();
-        }
+            .wrap_modifiers()
+            .wrap_calculators()
+            .wrap_matrix()
+            .wrap_sort()
+            .wrap_search();
     }
 
     wrapper_type & wrap_modifiers()
@@ -751,6 +738,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
             SC_DECL_WHERE_TYPED(Uint16)
             SC_DECL_WHERE_TYPED(Uint32)
             SC_DECL_WHERE_TYPED(Uint64)
+            SC_DECL_WHERE_TYPED(Float16)
             SC_DECL_WHERE_TYPED(Float32)
             SC_DECL_WHERE_TYPED(Float64)
         default:

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArrayPlex.cpp
@@ -267,15 +267,6 @@ static pybind11::type get_typed_array_class(std::string const & dtype)
 #undef SC_DECL_GET_TYPED_ARRAY_CLASS
 }
 
-// NOLINTNEXTLINE(misc-use-anonymous-namespace)
-static void verify_calculator_supported(SimpleArrayPlex const & array)
-{
-    if (array.data_type() == DataType::Float16)
-    {
-        throw std::runtime_error("Float16 array calculations are not supported");
-    }
-}
-
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<WrapSimpleArrayPlex, SimpleArrayPlex>
 {
     using root_base_type = WrapBase<WrapSimpleArrayPlex, SimpleArrayPlex>;
@@ -441,10 +432,8 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArrayPlex : public WrapBase<Wr
     wrapper_type & wrap_calculators()
     {
 #define SC_DECL_EXECUTE_TYPED_ARRAY_METHOD_RETUN_TYPED_VALUE(typed_array_method) \
-    [](wrapped_type & self) {                                                      \
-        verify_calculator_supported(self);                                         \
-        return execute_callback_with_typed_array(                                  \
-            self, [](auto & array) { return pybind11::cast(array.typed_array_method()); }); }
+    [](wrapped_type & self) { return execute_callback_with_typed_array(          \
+                                  self, [](auto & array) { return pybind11::cast(array.typed_array_method()); }); }
 
         (*this)
             .def("min", SC_DECL_EXECUTE_TYPED_ARRAY_METHOD_RETUN_TYPED_VALUE(min))

--- a/cpp/solvcon/math/math.hpp
+++ b/cpp/solvcon/math/math.hpp
@@ -74,6 +74,8 @@ inline auto real(T const & val)
     }
 }
 
+inline Float16 abs(Float16 val) { return Float16::from_bits(val.bits() & 0x7fffU); }
+
 template <typename T>
 inline auto abs(T const & val)
 {
@@ -85,6 +87,24 @@ inline auto abs(T const & val)
     {
         return std::abs(val);
     }
+}
+
+inline Float16 sqrt(Float16 val) { return Float16(std::sqrt(static_cast<float>(val))); }
+
+template <typename T>
+requires std::is_arithmetic_v<T>
+inline auto sqrt(T val)
+{
+    return std::sqrt(val);
+}
+
+inline bool isnan(Float16 val) { return (val.bits() & 0x7c00U) == 0x7c00U && (val.bits() & 0x03ffU) != 0; }
+
+template <typename T>
+requires std::is_floating_point_v<T>
+inline bool isnan(T val)
+{
+    return std::isnan(val);
 }
 
 } /* end namespace solvcon */

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1560,23 +1560,27 @@ class SimpleArrayBasicTC(unittest.TestCase):
         # The built-in `<` answers false in both directions for a NaN, which
         # is not a strict ordering and leaves std::sort undefined.
         nan = float('nan')
-        data = np.array([3.0, nan, 1.0, nan, 2.0], dtype='float64')
+        for dtype in ('float16', 'float32', 'float64'):
+            with self.subTest(dtype=dtype):
+                cls = getattr(solvcon, 'SimpleArray' + dtype.capitalize())
+                data = np.array([3.0, nan, 1.0, nan, 2.0], dtype=dtype)
 
-        sarr = solvcon.SimpleArrayFloat64(array=data.copy())
-        sarr.sort()
-        np.testing.assert_array_equal(sarr.ndarray, np.sort(data))
+                sarr = cls(array=data.copy())
+                sarr.sort()
+                np.testing.assert_array_equal(sarr.ndarray, np.sort(data))
 
-        sarr = solvcon.SimpleArrayFloat64(array=data.copy())
-        np.testing.assert_array_equal(sarr.argsort().ndarray,
-                                      np.argsort(data, kind='stable'))
+                sarr = cls(array=data.copy())
+                np.testing.assert_array_equal(
+                    sarr.argsort().ndarray,
+                    np.argsort(data, kind='stable'))
 
-        sarr = solvcon.SimpleArrayFloat64(array=data.copy())
-        sarr.sort()
-        varr = solvcon.SimpleArrayFloat64(array=data)
-        for side in ('left', 'right'):
-            np.testing.assert_array_equal(
-                sarr.searchsorted(varr, side=side).ndarray,
-                np.searchsorted(np.sort(data), data, side=side))
+                sarr = cls(array=data.copy())
+                sarr.sort()
+                varr = cls(array=data)
+                for side in ('left', 'right'):
+                    np.testing.assert_array_equal(
+                        sarr.searchsorted(varr, side=side).ndarray,
+                        np.searchsorted(np.sort(data), data, side=side))
 
     def test_sort_complex_nan_goes_last(self):
         nan = float('nan')
@@ -1687,23 +1691,30 @@ class SimpleArrayBasicTC(unittest.TestCase):
 
     def test_searchsorted_nan(self):
         nan = float('nan')
-        nvalues = np.array([2.0, nan, 1.0, nan, 3.0], dtype='float64')
-        varr = solvcon.SimpleArrayFloat64(array=nvalues)
+        for dtype in ('float16', 'float32', 'float64'):
+            with self.subTest(dtype=dtype):
+                cls = getattr(solvcon, 'SimpleArray' + dtype.capitalize())
+                nvalues = np.array([2.0, nan, 1.0, nan, 3.0], dtype=dtype)
+                varr = cls(array=nvalues)
+                scalar_nan = nvalues[1]
 
-        # A NaN answers with the trailing run of NaN, not the end of the
-        # array, so it must not bound the search of the value after it.
-        for data in ([1.0, 2.0, 3.0], [1.0, 2.0, nan],
-                     [1.0, nan, nan], [nan]):
-            ndata = np.array(data, dtype='float64')
-            sarr = solvcon.SimpleArrayFloat64(array=ndata)
+                # A NaN answers with the trailing run of NaN, not the end of
+                # the array, so it must not bound the search of the value
+                # after it.
+                for data in ([1.0, 2.0, 3.0], [1.0, 2.0, nan],
+                             [1.0, nan, nan], [nan]):
+                    ndata = np.array(data, dtype=dtype)
+                    sarr = cls(array=ndata)
 
-            for side in ('left', 'right'):
-                self.assertEqual(
-                    sarr.searchsorted(nan, side=side),
-                    np.searchsorted(ndata, nan, side=side))
-                np.testing.assert_array_equal(
-                    sarr.searchsorted(varr, side=side).ndarray,
-                    np.searchsorted(ndata, nvalues, side=side))
+                    for side in ('left', 'right'):
+                        self.assertEqual(
+                            sarr.searchsorted(scalar_nan, side=side),
+                            np.searchsorted(
+                                ndata, scalar_nan, side=side))
+                        np.testing.assert_array_equal(
+                            sarr.searchsorted(varr, side=side).ndarray,
+                            np.searchsorted(
+                                ndata, nvalues, side=side))
 
     def test_searchsorted_complex_nan(self):
         nan = float('nan')
@@ -1739,7 +1750,7 @@ class SimpleArrayBasicTC(unittest.TestCase):
     SEARCHSORTED_DTYPES = (
         'bool', 'int8', 'int16', 'int32', 'int64',
         'uint8', 'uint16', 'uint32', 'uint64',
-        'float32', 'float64', 'complex64', 'complex128',
+        'float16', 'float32', 'float64', 'complex64', 'complex128',
     )
 
     @staticmethod
@@ -2250,6 +2261,46 @@ class SimpleArrayAlignmentTC(unittest.TestCase):
 
 class SimpleArrayCalculatorsTC(unittest.TestCase):
 
+    FLOAT_DTYPES = ('float16', 'float32', 'float64')
+
+    def test_float_dtypes(self):
+        for dtype in self.FLOAT_DTYPES:
+            with self.subTest(dtype=dtype):
+                cls = getattr(solvcon, 'SimpleArray' + dtype.capitalize())
+                # Small values isolate API parity from dtype-specific overflow.
+                data = np.array([[1, 2, 3, 4]], dtype=dtype)
+                array = cls(array=data)
+
+                np.testing.assert_array_equal(
+                    array.add(array).ndarray, data + data)
+                np.testing.assert_array_equal(
+                    (array == array).ndarray, data == data)
+                np.testing.assert_array_equal((array != 3).ndarray, data != 3)
+                negative = cls(array=-data)
+                np.testing.assert_array_equal(negative.abs().ndarray, data)
+                self.assertEqual(array.min(), np.min(data))
+                self.assertEqual(negative.max(), np.max(-data))
+                self.assertEqual(array.sum(), np.sum(data))
+
+                for name in ('mean', 'var', 'std', 'median'):
+                    method = getattr(array, name)
+                    self.assertEqual(method(), getattr(np, name)(data))
+                    np.testing.assert_array_equal(
+                        method(axis=1).ndarray,
+                        getattr(np, name)(data, axis=1))
+
+                strided = np.arange(1, 9, dtype=dtype)[::2]
+                self.assertEqual(cls(array=strided).sum(), np.sum(strided))
+
+                weight_data = np.array([[4, 3, 2, 1]], dtype=dtype)
+                weight = cls(array=weight_data)
+                self.assertEqual(
+                    array.average(weight),
+                    np.average(data, weights=weight_data))
+                np.testing.assert_array_equal(
+                    array.average(1, weight).ndarray,
+                    np.average(data, axis=1, weights=weight_data[0]))
+
     def test_minmaxsum(self):
         sarr = solvcon.SimpleArrayFloat64(shape=(2, 4), value=10.0)
 
@@ -2330,7 +2381,7 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
     SCAN_DTYPES = (
         'int8', 'int16', 'int32', 'int64',
         'uint8', 'uint16', 'uint32', 'uint64',
-        'float32', 'float64', 'complex64', 'complex128',
+        'float16', 'float32', 'float64', 'complex64', 'complex128',
     )
 
     def test_diff_every_dtype(self):
@@ -4891,6 +4942,13 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         self.assertEqual(symmetric.shape, ndsymmetric.shape)
         np.testing.assert_equal(symmetric.ndarray, ndsymmetric)
 
+        ndarr_float16 = np.array([[1.0, 2.0], [4.0, 5.0]],
+                                 dtype='float16')
+        sarr_float16 = solvcon.SimpleArrayFloat16(array=ndarr_float16)
+        np.testing.assert_array_equal(
+            sarr_float16.symmetrize().ndarray,
+            (ndarr_float16 + ndarr_float16.T) / np.float16(2))
+
         vector = solvcon.SimpleArrayFloat64(5)
         with self.assertRaisesRegex(
             RuntimeError,
@@ -4927,6 +4985,11 @@ class SimpleArrayCalculatorsTC(unittest.TestCase):
         sarr_cplx = solvcon.SimpleArrayComplex128(array=ndarr_cplx)
         self.assertEqual(complex(sarr_cplx.trace()), 8.0 + 10.0j)
 
+        ndarr_float16 = np.array([[1.0, 2.0], [4.0, 5.0]],
+                                 dtype='float16')
+        sarr_float16 = solvcon.SimpleArrayFloat16(array=ndarr_float16)
+        self.assertEqual(sarr_float16.trace(), np.trace(ndarr_float16))
+
         vector = solvcon.SimpleArrayFloat64(5)
         with self.assertRaisesRegex(
             RuntimeError,
@@ -4959,12 +5022,13 @@ class SimpleArraySearchTC(unittest.TestCase):
 
         # test N-D data
         data = [[1, 3, 5, 7, 9], [2, 4, 6, 8, 10], [1, 10, 1, 10, 1]]
-        narr = np.array(data, dtype='float64')
-        sarr = solvcon.SimpleArrayFloat64(array=narr)
-        self.assertEqual(sarr.argmin(), 0)
-        self.assertEqual(sarr.argmax(), 9)
-        self.assertEqual(narr.argmin(), sarr.argmin())
-        self.assertEqual(narr.argmax(), sarr.argmax())
+        for dtype in ('float16', 'float64'):
+            with self.subTest(dtype=dtype):
+                cls = getattr(solvcon, 'SimpleArray' + dtype.capitalize())
+                narr = np.array(data, dtype=dtype)
+                sarr = cls(array=narr)
+                self.assertEqual(narr.argmin(), sarr.argmin())
+                self.assertEqual(narr.argmax(), sarr.argmax())
 
         with self.subTest(name='empty_array'):
             narr = np.array([], dtype='float64')
@@ -5155,6 +5219,8 @@ class SimpleArraySearchTC(unittest.TestCase):
         cases = [
             ("1d_contiguous", solvcon.SimpleArrayUint64,
              np.arange(10, dtype='uint64'), 5),
+            ('2d_float16', solvcon.SimpleArrayFloat16,
+             np.arange(6, dtype='float16').reshape(2, 3), 3),
             ('2d_contiguous', solvcon.SimpleArrayFloat64,
              np.arange(12, dtype='float64').reshape(3, 4), 6),
             ('3d_contiguous', solvcon.SimpleArrayInt32,

--- a/tests/test_float16.py
+++ b/tests/test_float16.py
@@ -59,12 +59,6 @@ class Float16PythonIntegrationTC(unittest.TestCase):
         with self.assertRaises(TypeError):
             collector.push_back(view)
 
-        calculation_error = r'Float16.*not supported'
-        with self.assertRaisesRegex(RuntimeError, calculation_error):
-            _ = scalar == scalar
-        with self.assertRaisesRegex(RuntimeError, calculation_error):
-            _ = scalar != 1
-
     def test_typed_numpy_conversion_rules(self):
         target = sc.SimpleArrayFloat16((2, 3))
         source = np.arange(6, dtype='float64').reshape(2, 3) / 3
@@ -129,7 +123,6 @@ class Float16PythonIntegrationTC(unittest.TestCase):
         shared = sc.SimpleArray(array=source)
         self.assertTrue(np.shares_memory(source, np.asarray(shared)))
 
-        with self.assertRaisesRegex(RuntimeError, r'Float16.*not supported'):
-            shared.min()
+        self.assertEqual(-0.75, shared.sum())
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -45,6 +45,12 @@ class MatrixTestBase(sc.testing.TestBase):
                                          f"should be 0.0")
 
 
+class MatrixFloat16TC(MatrixTestBase, unittest.TestCase):
+    def setUp(self):
+        self.dtype = 'float16'
+        self.SimpleArray = sc.SimpleArrayFloat16
+
+
 class MatrixFloat32TC(MatrixTestBase, unittest.TestCase):
     def setUp(self):
         self.dtype = np.float32
@@ -836,6 +842,19 @@ class MatrixPowerFloat64TC(MatrixPowerTestBase, unittest.TestCase):
     def setUp(self):
         self.dtype = np.float64
         self.SimpleArray = sc.SimpleArrayFloat64
+
+
+class MatmulFloat16TC(unittest.TestCase):
+    def test_naive_column_blocks(self):
+        lhs_data = np.array([[1, 2, 3]], dtype='float16')
+        rhs_data = np.arange(3 * 13, dtype='float16').reshape(3, 13)
+        lhs = sc.SimpleArrayFloat16(array=lhs_data)
+        rhs = sc.SimpleArrayFloat16(array=rhs_data)
+
+        # Thirteen columns reach the 8- and 4-column blocks and scalar tail.
+        result = lhs.matmul(rhs, kernel='naive')
+
+        np.testing.assert_array_equal(lhs_data @ rhs_data, result.ndarray)
 
 
 class MatmulFloat32TC(MatmulTestBase, unittest.TestCase):


### PR DESCRIPTION
Enable the existing `SimpleArray` calculation, sorting, searching, matrix, and matrix multiplication interfaces for `Float16`.

Reuse the existing algorithms and result types:

```text
Float16 storage -> existing SimpleArray algorithm -> existing result type
```

Add the required `abs`, `sqrt`, and NaN handling. Tests cover calculations, NaN ordering, matrix helpers, and naive matrix multiplication.

Existing generic zero-dimensional and non-contiguous limitations remain unchanged.

Related to #1393.
