### PR TITLE
Drop prototype from the MCAP test names and spell out OMG

### DIFF
--- a/solvcon/track/mcap/__init__.py
+++ b/solvcon/track/mcap/__init__.py
@@ -5,10 +5,10 @@
 mcap: read an MCAP recording into time-series columns.
 
 ``_reader`` handles the file format and ``_decodeplan`` the ``ros2idl``
-schema, where IDL stands for the OMG Interface Definition Language.
-Every ``extract*`` call takes ``fields`` in three forms: ``None`` selects
-every scalar leaf, a list of dotted paths selects those leaves, and a
-``DecodePlan`` runs as given.
+schema, where IDL stands for the Interface Definition Language of the
+Object Management Group (OMG).  Every ``extract*`` call takes ``fields``
+in three forms: ``None`` selects every scalar leaf, a list of dotted
+paths selects those leaves, and a ``DecodePlan`` runs as given.
 """
 
 

--- a/solvcon/track/mcap/_decodeplan.py
+++ b/solvcon/track/mcap/_decodeplan.py
@@ -76,7 +76,7 @@ def parse_schema(schema):
     annotations, which the parser drops.  ``structs`` maps a scoped name to
     ``(field, type, scope)`` triples in declaration order, where ``scope``
     is the enclosing module path that resolves an unqualified ``type``; a
-    field the prototype cannot decode keeps its whole declaration as
+    field the parser cannot decode keeps its whole declaration as
     ``field`` with a ``None`` type.  ``enums`` maps a scoped name to its
     member names.
     """

--- a/tests/test_track_mcap.py
+++ b/tests/test_track_mcap.py
@@ -99,7 +99,7 @@ def write_fixture(path, compression):
 
 @unittest.skipIf(foxglove_mcap_writer is None,
                  "the Foxglove mcap package is not installed")
-class McapPrototypeTC(unittest.TestCase):
+class McapInOutTC(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.TemporaryDirectory()


### PR DESCRIPTION
Rename the MCAP test module and test class so that neither says "prototype", and spell out the Object Management Group in the package docstring.

The review of #1463 asked for these names.  `tests/test_track_mcap_prototype.py` becomes `tests/test_track_mcap.py`, and the class `McapPrototypeTC` becomes `McapInOutTC`.  The docstring of `solvcon/track/mcap/__init__.py` now expands "OMG" to "the Interface Definition Language of the Object Management Group (OMG)".  The docstring of `parse_schema` in `solvcon/track/mcap/_decodeplan.py` now says "a field the parser cannot decode", which is the last place that named the code a prototype.

Related to #1438.
