### PR TITLE
Infer `SimpleArray` reduction identities

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -744,7 +744,7 @@ public:
 
     value_type min() const
     {
-        value_type initial = min_identity<value_type>();
+        auto initial = min_identity<value_type>();
         auto athis = static_cast<A const *>(this);
         for (size_t i = 0; i < athis->size(); ++i)
         {
@@ -758,7 +758,7 @@ public:
 
     value_type max() const
     {
-        value_type initial = max_identity<value_type>();
+        auto initial = max_identity<value_type>();
         auto athis = static_cast<A const *>(this);
         for (size_t i = 0; i < athis->size(); ++i)
         {


### PR DESCRIPTION
`SimpleArray::min()` and `SimpleArray::max()` now infer their identity value types from the typed helpers. This removes the Clang-Tidy 22 `modernize-use-auto` errors without changing the reduction types.

`make lint` passes. `make gtest` passes all 264 tests with Clang-Tidy 22 and `warnings-as-errors`.

Related to #1460.