### PR TITLE
Parse ros2idl with a tokenizer instead of line regexes

### DIFF
--- a/solvcon/track/mcap/_decodeplan.py
+++ b/solvcon/track/mcap/_decodeplan.py
@@ -4,18 +4,16 @@
 """
 Schema layer: from ``ros2idl`` text to a ``DecodePlan``.
 
-IDL is the OMG Interface Definition Language.  ROS 2 embeds IDL text
-in a recording under the ``ros2idl`` schema encoding, and this module
-parses that text.
+IDL is the OMG Interface Definition Language.  ROS 2 embeds IDL text in a
+recording under the ``ros2idl`` schema encoding, and ``parse_schema``
+turns that text into one ``Registry`` of structs, enums, unions,
+typedefs, and integer constants.
 
-``parse_schema`` turns the schema text into a registry of structs and
-enums.  ``DecodePlan`` flattens the root struct into scalar leaves and
-compiles the selected ones into one ``struct`` format per byte order, so a
-message decodes with a single ``unpack_from``.
-
-The plan flattens structs whose fields are scalars, enums, or other
-structs.  A string, sequence, array, or union field raises ``McapError``
-when a plan reaches it.
+``DecodePlan`` flattens the root struct into scalar leaves and compiles
+the selected ones into one ``struct`` format per byte order, so a message
+decodes with a single ``unpack_from``.  The plan flattens structs whose
+fields are scalars, enums, or other structs.  A string, sequence, array,
+or union field raises ``McapError`` when a plan reaches it.
 """
 
 import re
@@ -28,20 +26,28 @@ from . import McapError
 
 __all__ = ["parse_schema", "DecodePlan", "COLUMN_TYPES"]
 
-Registry = collections.namedtuple("Registry", "structs enums")
+Registry = collections.namedtuple("Registry",
+                                  "structs enums unions typedefs consts")
 
 # IDL scalar type -> column dtype.
 SCALAR_TYPES = {
     "boolean": "bool",
     "octet": "uint8",
+    "char": "uint8",
     "uint8": "uint8",
     "int8": "int8",
     "uint16": "uint16",
     "int16": "int16",
+    "unsigned short": "uint16",
+    "short": "int16",
     "uint32": "uint32",
     "int32": "int32",
+    "unsigned long": "uint32",
+    "long": "int32",
     "uint64": "uint64",
     "int64": "int64",
+    "unsigned long long": "uint64",
+    "long long": "int64",
     "float": "float32",
     "double": "float64",
 }
@@ -62,83 +68,308 @@ COLUMN_TYPES = {
     "float64": ("d", sc.SimpleArrayFloat64),
 }
 
-_FIELD = re.compile(r"^([\w:]+)\s+(\w+);$")
-_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+_COMMENT = re.compile(r'("(?:[^"\\]|\\.)*")|/\*.*?\*/|//[^\n]*', re.S)
 _ANNOTATION = re.compile(r'@\w+(\s*\((?:[^()"]|"(?:[^"\\]|\\.)*")*\))?')
+_ENUM_VALUE = re.compile(r"@value\s*\(\s*(\w+)\s*\)\s*(\w+)")
+_TOKEN = re.compile(r'[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*|"(?:[^"\\]|\\.)*"'
+                    r'|\d[\w.]*|\S')
+_SEPARATOR = re.compile(r"^=+\s*$", re.M)
 
 
 def parse_schema(schema):
     """
     Parse a ``ros2idl`` ``Schema`` into a ``Registry``.
 
-    The text may be the concatenated form of a ROS 2 recording: several
-    ``IDL:`` blocks with ``#include`` lines, block comments, and
-    annotations, which the parser drops.  ``structs`` maps a scoped name to
-    ``(field, type, scope)`` triples in declaration order, where ``scope``
-    is the enclosing module path that resolves an unqualified ``type``; a
-    field the parser cannot decode keeps its whole declaration as
-    ``field`` with a ``None`` type.  ``enums`` maps a scoped name to its
-    member names.
+    Every name in the registry is scoped with ``::``.  ``structs`` maps a
+    name to ``(field, type)`` pairs in declaration order, and ``enums``
+    maps a name to the member names.  ``unions`` maps a name to
+    ``(discriminator, cases)``.  Each case is ``(values, type)``, where
+    ``values`` holds the discriminator values it matches and ``None``
+    marks the default case.  ``typedefs`` maps a name to the aliased
+    type.  ``consts`` maps a name to an integer value; the parser drops
+    a constant that is not an integer.
+
+    A type is a tuple headed by ``scalar``, ``string``, ``sequence``,
+    ``array``, ``unsupported``, or ``named``.  A ``named`` type carries
+    the raw name and the enclosing module path that resolves it.
     """
+    registry = Registry({}, {}, {}, {}, {})
+    try:
+        text = schema.data.decode()
+    except UnicodeDecodeError:
+        raise McapError("schema {} is not UTF-8".format(
+            schema.name)) from None
     if schema.encoding != "ros2idl":
-        raise McapError("schema encoding {!r}".format(schema.encoding))
-    text = _ANNOTATION.sub("", _COMMENT.sub("", schema.data.decode()))
+        raise McapError("schema encoding {!r} of {}".format(
+            schema.encoding, schema.name))
+    _IdlParser(_strip_idl(text), registry).definitions((), None)
+    return registry
 
-    scope = []
-    structs = {}
-    enums = {}
-    for line in text.splitlines():
-        line = line.split("//")[0].strip()
-        if not line or line.startswith(("=", "IDL:", "#")):
-            continue
-        if line.endswith("{"):
-            kind, name = line.split()[:2]
-            scope.append((kind, name))
-            scoped = "::".join(name for _, name in scope)
-            if kind == "struct":
-                structs[scoped] = []
-            elif kind == "enum":
-                enums[scoped] = []
-            continue
-        if line == "};":
-            scope.pop()
-            continue
 
-        kind, name = scope[-1]
-        scoped = "::".join(name for _, name in scope)
-        if kind == "enum":
-            enums[scoped].append(line.rstrip(","))
-        elif kind == "struct":
-            field = _FIELD.match(line)
-            modules = tuple(name for _, name in scope[:-1])
-            if field:
-                type_name, field_name = field.groups()
-                structs[scoped].append((field_name, type_name, modules))
+def _strip_idl(text):
+    """Drop annotations, comments, includes, and the bundle separators."""
+    text = _COMMENT.sub(lambda match: match.group(1) or "", text)
+    text = _ENUM_VALUE.sub(r"\2 = \1", text)
+    lines = [line for line in _ANNOTATION.sub("", text).splitlines()
+             if not line.lstrip().startswith(("#", "IDL:"))
+             and not _SEPARATOR.match(line.strip())]
+    return "\n".join(lines)
+
+
+class _IdlParser:
+
+    def __init__(self, text, registry):
+        self.tokens = _TOKEN.findall(text)
+        self.pos = 0
+        self.registry = registry
+
+    def peek(self):
+        return self.tokens[self.pos] if self.pos < len(self.tokens) else None
+
+    def next(self):
+        token = self.peek()
+        self.pos += 1
+        return token
+
+    def expect(self, token):
+        found = self.next()
+        if found != token:
+            raise McapError("expected {!r} but found {!r} in the IDL".format(
+                token, found))
+
+    def skip_optional(self, token):
+        if self.peek() == token:
+            self.pos += 1
+
+    def skip_statement(self):
+        while self.next() not in (";", None):
+            pass
+
+    def definitions(self, modules, end):
+        while True:
+            token = self.next()
+            if token == end:
+                return
+            if token is None:
+                raise McapError("the IDL ends inside a block")
+            if token == "module":
+                name = self.next()
+                self.expect("{")
+                self.definitions(modules + (name,), "}")
+                self.skip_optional(";")
+            elif token == "struct":
+                self.struct(modules)
+            elif token == "enum":
+                self.enum(modules)
+            elif token == "union":
+                self.union(modules)
+            elif token == "typedef":
+                type_ = self.type(modules)
+                name = self.next()
+                type_ = _arrayed(type_, self.dims(modules))
+                self.registry.typedefs[_scoped(modules, name)] = type_
+                self.expect(";")
+            elif token == "const":
+                self.const(modules)
+            elif token != ";":
+                self.skip_statement()
+
+    def struct(self, modules):
+        name = self.next()
+        if self.peek() == ";":
+            self.next()
+            return
+        if self.peek() == ":":
+            raise McapError("struct {} inherits, which is unsupported".format(
+                _scoped(modules, name)))
+        self.expect("{")
+        fields = []
+        while self.peek() not in ("}", None):
+            type_ = self.type(modules)
+            while True:
+                field = self.next()
+                fields.append((field, _arrayed(type_, self.dims(modules))))
+                if self.peek() != ",":
+                    break
+                self.next()
+            self.expect(";")
+        self.expect("}")
+        self.skip_optional(";")
+        self.registry.structs[_scoped(modules, name)] = fields
+
+    def enum(self, modules):
+        name = self.next()
+        self.expect("{")
+        members = []
+        while self.peek() not in ("}", None):
+            token = self.next()
+            if token == "=":
+                if self.integer(self.next(), modules) != len(members) - 1:
+                    raise McapError("enum {} assigns values out of "
+                                    "declaration order".format(name))
+            elif token != ",":
+                members.append(token)
+        self.expect("}")
+        self.skip_optional(";")
+        self.registry.enums[_scoped(modules, name)] = tuple(members)
+
+    def union(self, modules):
+        name = self.next()
+        self.expect("switch")
+        self.expect("(")
+        discriminator = self.type(modules)
+        self.expect(")")
+        self.expect("{")
+        members = None
+        if discriminator[0] == "named":
+            scoped = _lookup(self.registry.enums, discriminator[1], modules)
+            members = self.registry.enums.get(scoped)
+        cases = []
+        values = []
+        while self.peek() not in ("}", None):
+            token = self.next()
+            if token == "case":
+                label = ""
+                while self.peek() not in (":", None):
+                    label += self.next()
+                self.expect(":")
+                values.append(self.label_value(label, members, modules))
+            elif token == "default":
+                values.append(None)
+                self.expect(":")
             else:
-                structs[scoped].append((line, None, modules))
-    return Registry(structs, enums)
+                self.pos -= 1
+                type_ = self.type(modules)
+                self.next()
+                cases.append((tuple(values),
+                              _arrayed(type_, self.dims(modules))))
+                values = []
+                self.expect(";")
+        self.expect("}")
+        self.skip_optional(";")
+        self.registry.unions[_scoped(modules, name)] = (discriminator, cases)
+
+    def label_value(self, label, members, modules):
+        """Return the discriminator value a union case label names."""
+        if members is not None and label.split("::")[-1] in members:
+            return members.index(label.split("::")[-1])
+        if label in ("TRUE", "FALSE"):
+            return label == "TRUE"
+        if len(label) == 3 and label[0] == label[2] == "'":
+            return ord(label[1])
+        value = self.integer(label, modules)
+        if value is None:
+            raise McapError("bad union case label {!r}".format(label))
+        return value
+
+    def integer(self, token, modules):
+        """Return the integer a token holds or names, or ``None``."""
+        if token is None:
+            raise McapError("the IDL ends inside a block")
+        try:
+            return int(token, 0)
+        except ValueError:
+            return self.registry.consts.get(
+                _lookup(self.registry.consts, token, modules))
+
+    def const(self, modules):
+        self.type(modules)
+        name = self.next()
+        self.expect("=")
+        tokens = []
+        while self.peek() not in (";", None):
+            tokens.append(self.next())
+        self.expect(";")
+        try:
+            value = int("".join(tokens), 0)
+        except ValueError:
+            return
+        self.registry.consts[_scoped(modules, name)] = value
+
+    def type(self, modules):
+        token = self.next()
+        if token == "unsigned":
+            token += " " + self.next()
+        if token in ("long", "unsigned long") and \
+                self.peek() in ("long", "double"):
+            token += " " + self.next()
+        if token in SCALAR_TYPES:
+            return ("scalar", SCALAR_TYPES[token])
+        if token == "string":
+            if self.peek() == "<":
+                self.next()
+                self.next()
+                self.expect(">")
+            return ("string",)
+        if token == "sequence":
+            self.expect("<")
+            element = self.type(modules)
+            if self.peek() == ",":
+                self.next()
+                self.next()
+            self.expect(">")
+            return ("sequence", element)
+        if token in ("long double", "wchar", "wstring", "map", "bitmask",
+                     "bitset"):
+            return ("unsupported", token)
+        if token is None or not token[0].isalpha() and token[0] != "_":
+            raise McapError("expected a type but found {!r}".format(token))
+        return ("named", token, modules)
+
+    def dims(self, modules):
+        """Return the flattened array size after a name, or ``None``."""
+        size = None
+        while self.peek() == "[":
+            self.next()
+            token = self.next()
+            self.expect("]")
+            dim = self.integer(token, modules)
+            if dim is None:
+                raise McapError("bad array size {!r}".format(token))
+            size = dim if size is None else size * dim
+        return size
+
+
+def _scoped(modules, name):
+    return "::".join(modules + (name,))
+
+
+def _arrayed(type_, size):
+    return type_ if size is None else ("array", type_, size)
+
+
+def _lookup(table, name, modules):
+    """Find ``name`` in ``table`` from the innermost module outward."""
+    for depth in range(len(modules), -1, -1):
+        scoped = _scoped(modules[:depth], name)
+        if scoped in table:
+            return scoped
+    return None
 
 
 class DecodePlan:
     """
     The selected scalar leaves of one schema.
 
-    ``fields`` are the selected dotted paths, ``types`` their column dtypes,
-    and ``enums`` the member names of each enum-typed field.  Without
-    ``fields`` the plan selects every scalar leaf in declaration order.  An
-    enum reads as its ``uint32`` ordinal.
+    ``fields`` are the selected dotted paths, ``types`` their column
+    dtypes, and ``enums`` the member names of each enum-typed field.
+    Without ``fields`` the plan selects every scalar leaf in declaration
+    order.  An enum reads as its ``uint32`` ordinal.
     """
 
     def __init__(self, schema, fields=None):
         self.schema = schema
         registry = parse_schema(schema)
-        leaves = _leaves(registry, schema.name.replace("/", "::"), "", ())
+        leaves = _leaves(registry, ("named", schema.name.replace("/", "::"),
+                                    ()), (), ())
         types = {path: dtype for path, dtype, _ in leaves}
 
         self.fields = tuple(types if fields is None else fields)
         unknown = [path for path in self.fields if path not in types]
         if unknown:
             raise McapError("unknown or non-scalar fields {}".format(unknown))
+        if len(set(self.fields)) != len(self.fields):
+            raise McapError("duplicate fields in {}".format(self.fields))
         self.types = tuple(types[path] for path in self.fields)
         self.enums = {path: members for path, _, members in leaves
                       if members and path in self.fields}
@@ -161,40 +392,53 @@ class DecodePlan:
 
     def decode(self, payload):
         """Return the selected values of one CDR payload as a tuple."""
-        if len(payload) < 4 or payload[1] not in self._structs:
+        if len(payload) < 4 or payload[0] != 0 or \
+                payload[1] not in self._structs:
             raise McapError("unsupported CDR encapsulation")
-        values = self._structs[payload[1]].unpack_from(payload, 4)
+        try:
+            values = self._structs[payload[1]].unpack_from(payload, 4)
+        except struct.error:
+            raise McapError("the payload ends before the fields do") from None
         return tuple(values[i] for i in self._select)
 
 
-def _leaves(registry, struct_name, prefix, visiting):
-    """Return ``(path, dtype, enum_members)`` per scalar leaf, in order."""
-    if struct_name in visiting or struct_name not in registry.structs:
-        raise McapError("bad struct {}".format(struct_name))
+def _leaves(registry, type_, path, visiting):
+    """Return ``(path, dtype, enum members)`` per scalar leaf, in order."""
+    kind, type_ = _resolve(registry, type_)
+    if kind == "scalar":
+        return [(".".join(path), type_, None)]
+    if kind == "enum":
+        return [(".".join(path), ENUM_TYPE, registry.enums[type_])]
+    if kind != "struct":
+        raise McapError("unsupported field {!r} of kind {}".format(
+            ".".join(path), kind))
+    if type_ in visiting:
+        raise McapError("struct {} contains itself".format(type_))
     leaves = []
-    for field_name, type_name, modules in registry.structs[struct_name]:
-        path = prefix + field_name
-        if type_name in SCALAR_TYPES:
-            leaves.append((path, SCALAR_TYPES[type_name], None))
-            continue
-        type_name = _resolve(registry, type_name, modules)
-        if type_name in registry.enums:
-            leaves.append((path, ENUM_TYPE, tuple(registry.enums[type_name])))
-        elif type_name in registry.structs:
-            leaves.extend(_leaves(registry, type_name, path + ".",
-                                  visiting + (struct_name,)))
-        else:
-            raise McapError("unsupported field {!r} in {}".format(
-                path, struct_name))
+    for field, field_type in registry.structs[type_]:
+        leaves.extend(_leaves(registry, field_type, path + (field,),
+                              visiting + (type_,)))
     return leaves
 
 
-def _resolve(registry, type_name, modules):
-    """Look ``type_name`` up from the innermost enclosing module outward."""
-    for depth in range(len(modules), -1, -1) if type_name else ():
-        scoped = "::".join(modules[:depth] + (type_name,))
-        if scoped in registry.structs or scoped in registry.enums:
-            return scoped
-    return None
+def _resolve(registry, type_):
+    """Follow names and typedefs to ``(kind, name or dtype)``."""
+    seen = set()
+    while type_[0] == "named":
+        _, name, modules = type_
+        for table, kind in ((registry.typedefs, None),
+                            (registry.structs, "struct"),
+                            (registry.enums, "enum"),
+                            (registry.unions, "union")):
+            scoped = _lookup(table, name, modules)
+            if scoped is not None:
+                type_ = (kind, scoped) if kind else table[scoped]
+                break
+        else:
+            raise McapError("unknown type {!r}".format(name))
+        if scoped in seen:
+            raise McapError("typedef {} is cyclic".format(scoped))
+        seen.add(scoped)
+    return type_[0], type_[1] if len(type_) > 1 else None
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_track_mcap.py
+++ b/tests/test_track_mcap.py
@@ -67,9 +67,240 @@ module vehicle_msgs {
 };
 """
 
+SIGNALS_IDL = b"""
+module demo_msgs { module msg {
+  const uint32 kMax = 4;
+  const string kUrl = "http://x/y"; // a string constant
+  const long kNeg = -1;
+  typedef double Cov[2][2];
+  enum Kind { A, B, C };
+  union Extra switch(Kind) {
+    case A: long number;
+    case B: string<16> text;
+    default: double value;
+  };
+  union Tail switch(long) {
+    case kNeg: case 'x': octet small;
+    case 7: double big;
+  };
+  struct Tag { string<8> name; uint8 level; };
+  struct Signals{
+    string<256> frame_id;
+    sequence<Tag, kMax> tags;
+    Cov cov;
+    unsigned long count;
+    Kind kind;
+    Extra extra;
+    sequence<float> samples;
+    Tag corners[2];
+    boolean ok;
+    Tail tail;
+    double speed;
+  };
+}; };
+"""
+
+SUMMARY_IDL = b"""
+========================================
+IDL: monitor_msgs/msg/Summary
+#include "monitor_msgs/msg/Header.idl"
+
+module monitor_msgs {
+  module msg {
+    const uint32 kReasonCapacity = 32;
+    const unsigned long MAX_LANE_ID_LENGTH = 255;
+
+    struct Summary{
+      monitor_msgs::msg::Header header;
+
+      Version version;
+
+      sequence<Reason, kReasonCapacity> reasons;
+
+      //! [Fields]
+      @verbatim (language="comment", text=
+        " target speed" "\\n"
+        " in m/s")
+      double v_target;
+      //! [Fields]
+    };
+  };
+};
+
+========================================
+IDL: monitor_msgs/msg/Header
+module monitor_msgs {
+  module msg {
+    struct Header {
+      @verbatim (language="comment", text=
+        " Publishing module name")
+      string<256> module_name;
+
+      uint32 sequence_number;
+    };
+  };
+};
+
+========================================
+IDL: monitor_msgs/msg/Version
+module monitor_msgs {
+    module msg {
+        struct Version {
+            uint16 major;
+            uint16 minor;
+        };
+    };
+};
+
+========================================
+IDL: monitor_msgs/msg/Reason
+module monitor_msgs {
+  module msg {
+    struct Reason {
+      uint64 timestamp;
+      string<64> text;
+    };
+  };
+};
+"""
+
 TOPIC = "/vehicle/status"
 BRAKE_TOPIC = "/vehicle/brake"
 LOG_TIMES = [30, 10, 20, 40]
+
+
+class SchemaParseTC(unittest.TestCase):
+
+    def test_signals(self):
+        """One IDL exercises every construct the parser must recognize."""
+        schema = mcap.Schema(1, "demo_msgs/msg/Signals", "ros2idl",
+                             SIGNALS_IDL)
+        registry = mcap.parse_schema(schema)
+        self.assertEqual(registry.enums["demo_msgs::msg::Kind"],
+                         ("A", "B", "C"))
+        self.assertEqual(registry.consts["demo_msgs::msg::kMax"], 4)
+        self.assertEqual(registry.consts["demo_msgs::msg::kNeg"], -1)
+        self.assertEqual(registry.typedefs["demo_msgs::msg::Cov"],
+                         ("array", ("scalar", "float64"), 4))
+        self.assertEqual([name for name, _ in
+                          registry.structs["demo_msgs::msg::Signals"]],
+                         ["frame_id", "tags", "cov", "count", "kind",
+                          "extra", "samples", "corners", "ok", "tail",
+                          "speed"])
+        self.assertEqual(registry.unions["demo_msgs::msg::Extra"][1],
+                         [((0,), ("scalar", "int32")), ((1,), ("string",)),
+                          ((None,), ("scalar", "float64"))])
+        self.assertEqual(registry.unions["demo_msgs::msg::Tail"][1],
+                         [((-1, 120), ("scalar", "uint8")),
+                          ((7,), ("scalar", "float64"))])
+
+    def test_bundle(self):
+        """A recording bundles several IDL blocks under one schema."""
+        schema = mcap.Schema(1, "monitor_msgs/msg/Summary", "ros2idl",
+                             SUMMARY_IDL)
+        registry = mcap.parse_schema(schema)
+        self.assertEqual(registry.consts["monitor_msgs::msg::"
+                                         "MAX_LANE_ID_LENGTH"], 255)
+        self.assertEqual(registry.structs["monitor_msgs::msg::Version"],
+                         [("major", ("scalar", "uint16")),
+                          ("minor", ("scalar", "uint16"))])
+        self.assertEqual(registry.structs["monitor_msgs::msg::Summary"][2],
+                         ("reasons",
+                          ("sequence", ("named", "Reason",
+                                        ("monitor_msgs", "msg")))))
+
+    def test_plan_rejects_what_it_cannot_flatten(self):
+        """A string, sequence, array, or union field has no column yet."""
+        schema = mcap.Schema(1, "monitor_msgs/msg/Summary", "ros2idl",
+                             SUMMARY_IDL)
+        with self.assertRaisesRegex(mcap.McapError, "unsupported field"):
+            mcap.DecodePlan(schema)
+        schema = mcap.Schema(1, "x/msg/Y", "ros2idl",
+                             b"module x { module msg { struct Y {"
+                             b" uint32 a; double b[3]; }; }; };")
+        with self.assertRaisesRegex(mcap.McapError, "unsupported field 'b'"):
+            mcap.DecodePlan(schema)
+
+    def test_nested_structs_flatten(self):
+        """A struct of structs, enums, and scalars still gives columns."""
+        schema = mcap.Schema(1, "vehicle_msgs/msg/Status", "ros2idl",
+                             STATUS_IDL)
+        plan = mcap.DecodePlan(schema)
+        self.assertEqual(plan.fields, ("header.seq", "longitudinal_speed",
+                                       "brake_active", "mode"))
+        self.assertEqual(plan.types, ("uint32", "float64", "bool", "uint32"))
+        self.assertEqual(plan.enums, {"mode": ("OFF", "ON")})
+        with self.assertRaisesRegex(mcap.McapError, "duplicate fields"):
+            mcap.DecodePlan(schema, ["mode", "mode"])
+
+    def test_unsupported(self):
+        """An IDL construct the plan cannot decode raises ``McapError``."""
+        for field in (b"wchar c;", b"wstring s;"):
+            schema = mcap.Schema(1, "x/msg/Y", "ros2idl",
+                                 b"module x { module msg { struct Y { " +
+                                 field + b" }; }; };")
+            with self.assertRaisesRegex(mcap.McapError, "unsupported"):
+                mcap.DecodePlan(schema)
+        schema = mcap.Schema(1, "x/msg/Y", "ros2idl",
+                             b"module x { module msg { typedef B A; "
+                             b"typedef A B; struct Y { A a; }; }; };")
+        with self.assertRaisesRegex(mcap.McapError, "cyclic"):
+            mcap.DecodePlan(schema)
+        schema = mcap.Schema(1, "x/msg/Y", "ros2idl",
+                             b"module x { module msg { enum E { A, "
+                             b"@value(5) B }; struct Y { E e; }; }; };")
+        with self.assertRaisesRegex(mcap.McapError, "declaration order"):
+            mcap.DecodePlan(schema)
+        schema = mcap.Schema(1, "x/msg/Y", "ros2idl",
+                             b"module x { module msg { enum E { "
+                             b"@value(0) A, @value(1) B }; "
+                             b"struct Y { E e; }; }; };")
+        self.assertEqual(mcap.DecodePlan(schema).enums, {"e": ("A", "B")})
+        schema = mcap.Schema(1, "x/msg/Y", "ros2idl",
+                             b"module x { module msg { struct Y { "
+                             b"Z z; }; }; };")
+        with self.assertRaisesRegex(mcap.McapError, "unknown type 'Z'"):
+            mcap.DecodePlan(schema)
+        schema = mcap.Schema(1, "x/msg/Y", "protobuf", b"")
+        with self.assertRaisesRegex(mcap.McapError, "protobuf"):
+            mcap.DecodePlan(schema)
+        schema = mcap.Schema(1, "x/msg/Y", "ros2idl", b"\xff\xfe")
+        with self.assertRaisesRegex(mcap.McapError, "not UTF-8"):
+            mcap.DecodePlan(schema)
+
+    def test_malformed(self):
+        """Every parse failure raises ``McapError``, never a raw builtin."""
+        schema = mcap.Schema(1, "x/msg/Y", "ros2idl",
+                             b"module x { module msg { enum E { A =")
+        with self.assertRaisesRegex(mcap.McapError, "ends inside a block"):
+            mcap.DecodePlan(schema)
+        schema = mcap.Schema(1, "x/msg/Y", "ros2idl",
+                             b"module x { module msg { const long V = 1; "
+                             b"enum E { A, B = V }; struct Y { E e; }; "
+                             b"}; };")
+        self.assertEqual(mcap.DecodePlan(schema).enums, {"e": ("A", "B")})
+
+    def test_const_spans_lines(self):
+        """A ``const`` broken before its ``=`` keeps its value."""
+        schema = mcap.Schema(1, "x/msg/Y", "ros2idl",
+                             b"module x { module msg {\nconst long N\n"
+                             b"= 3;\nstruct Y { double v[N]; uint8 t; };\n"
+                             b"}; };")
+        registry = mcap.parse_schema(schema)
+        self.assertEqual(registry.consts["x::msg::N"], 3)
+        self.assertEqual(registry.structs["x::msg::Y"][0][1],
+                         ("array", ("scalar", "float64"), 3))
+
+    def test_string_const_does_not_shadow(self):
+        """A string ``const`` does not hide an integer one further out."""
+        schema = mcap.Schema(1, "x/msg/Y", "ros2idl",
+                             b"module x { const long N = 3; module msg {"
+                             b" const string N = \"s\";"
+                             b" struct Y { double v[N]; uint8 t; }; }; };")
+        registry = mcap.parse_schema(schema)
+        self.assertNotIn("x::msg::N", registry.consts)
+        self.assertEqual(registry.structs["x::msg::Y"][0][1],
+                         ("array", ("scalar", "float64"), 3))
 
 
 def pack_status(seq, speed, brake_active, mode):


### PR DESCRIPTION
This PR replaces the line-based `ros2idl` parser in `solvcon.track.mcap` with a recursive-descent parser over a token stream. The registry now records typedefs, unions, and integer constants next to structs and enums. Every field carries a parsed type instead of its source text.

The old parser matched a field declaration with one regular expression. It read only a declaration that fits on one line, and it kept anything else as raw text. A real recording defeats that shape. The schema arrives as a bundle of IDL blocks, and those blocks carry typedefs, constants, unions, multi-dimensional arrays, and annotations that wrap across lines. Across 20 recordings holding 48 distinct `ros2idl` schemas, one raised `IndexError` and one lost its root struct. All 48 parse now.

A type is a tuple headed by `scalar`, `string`, `sequence`, `array`, `unsupported`, or `named`. That vocabulary is what the decoder compiles against in the next PR of this stack.

The decode model does not change here. The plan still flattens the root struct into scalar leaves and reads them with one `unpack_from`. A string, sequence, array, or union field still raises `McapError`, so this PR adds no new column to any topic.

This is the first of four stacked PRs that take the reader from the prototype parser to one that decodes real recordings. The next PR compiles the schema into a walk-and-skip program, which is the change that makes a message containing a string decodable.

Related to #1438.
