### PR TITLE
Open an MCAP recording in the pilot

### DIFF
--- a/cpp/solvcon/pilot/app/RManager.cpp
+++ b/cpp/solvcon/pilot/app/RManager.cpp
@@ -537,6 +537,7 @@ void RManager::setUpMenu()
     m_menuModel->menu("Mesh", 40);
     m_menuModel->menu("Canvas", 50);
     m_menuModel->menu("Profiling", 60);
+    m_menuModel->menu("Track", 65);
     m_menuModel->menu("Window", 70);
 
     setUpEditMenuItems();

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ def main():
             'solvcon.pilot.onedim',
             'solvcon.pilot.painter',
             'solvcon.pilot.panel',
+            'solvcon.pilot.track',
             'solvcon.pilot.visual',
             'solvcon.plot',
             'solvcon.profiling',

--- a/solvcon/pilot/base/_gui.py
+++ b/solvcon/pilot/base/_gui.py
@@ -27,6 +27,7 @@ if _pcore.enable:
     # _gui" would shadow this module's own name at every use site.
     from .. import painter as _painter
     from ..panel import _profiling
+    from ..track import _mcap_viewer
     from ..agent import _agent_gui
     from . import _theme
     from . import _ui_state
@@ -74,6 +75,7 @@ class _Controller(metaclass=_Singleton):
         self.save_2d_canvas = None
         self.openprofiledata = None
         self.runprofiling = None
+        self.mcap_panel = None
         self.agent = None
         self.theme_menu = None
         self.window_manager = None
@@ -125,6 +127,7 @@ class _Controller(metaclass=_Singleton):
         self.save_2d_canvas = _canvas_gui.Save2DCanvasDialog(mgr=self._rmgr)
         self.openprofiledata = _profiling.Profiling(mgr=self._rmgr)
         self.runprofiling = _profiling.RunProfiling(mgr=self._rmgr)
+        self.mcap_panel = _mcap_viewer.McapPanel(mgr=self._rmgr)
         self.agent = _agent_gui.AgentPanel(mgr=self._rmgr)
         self.theme_menu = _theme.ThemeMenu(mgr=self._rmgr)
         self.window_manager = _window_manager.WindowManager(mgr=self._rmgr)
@@ -171,6 +174,7 @@ class _Controller(metaclass=_Singleton):
         self.canvas.populate_menu()
         self.openprofiledata.populate_menu()
         self.runprofiling.populate_menu()
+        self.mcap_panel.populate_menu()
         self.agent.populate_menu()
         self.theme_menu.populate_menu()
         self.window_manager.populate_menu()

--- a/solvcon/pilot/track/__init__.py
+++ b/solvcon/pilot/track/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""The MCAP viewer of the pilot: a dock that lists the open recording."""
+
+from .. import _pilot_core as _pcore
+
+if _pcore.enable:
+    from . import _mcap_viewer
+
+    McapDock = _mcap_viewer.McapDock
+    McapPanel = _mcap_viewer.McapPanel
+else:
+    # Bind only the public names: a None module attribute would shadow the
+    # real submodule import in no-GUI builds.
+    McapDock = None
+    McapPanel = None
+
+__all__ = [
+    'McapDock',
+    'McapPanel',
+]
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/track/_mcap_viewer.py
+++ b/solvcon/pilot/track/_mcap_viewer.py
@@ -1,0 +1,325 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Open an MCAP recording in the pilot: the Track menu opens a file, and the
+dock on the right shows what the reader gets without decoding a message.
+"""
+
+import os
+
+from PySide6.QtCore import Qt, Signal, QSize, QRect
+from PySide6.QtGui import QFontMetrics
+from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QGridLayout,
+                               QLabel, QPushButton, QListWidget,
+                               QListWidgetItem, QStyledItemDelegate, QStyle,
+                               QDockWidget, QFileDialog, QFrame)
+
+from ...track import mcap
+from .._style import PaletteStyled
+from ..base import _gui_common
+from ._style import (Rules, font, row_colors, BODY_TEXT_PIXEL_SIZE,
+                     CAPTION_TEXT_PIXEL_SIZE, TOPIC_NAME_PIXEL_SIZE,
+                     TOPIC_TYPE_PIXEL_SIZE)
+
+__all__ = [
+    "McapDock",
+    "McapPanel",
+]
+
+_TOPIC_ROLE = Qt.UserRole
+_COUNT_ROLE = Qt.UserRole + 1
+_TYPE_ROLE = Qt.UserRole + 2
+_ROW_PAD = 4
+_ROW_GAP = 8
+
+
+def format_size(nbytes):
+    """Return ``nbytes`` in the largest unit that keeps it under 1000."""
+    size = float(nbytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1000 or unit == "TB":
+            break
+        size /= 1000
+    return "{:.0f} {}".format(size, unit) if unit == "B" else \
+        "{:.2f} {}".format(size, unit)
+
+
+def format_duration(ns):
+    """Return ``ns`` as ``1h 02m 03s`` without the leading zero units."""
+    total = round(ns / 1e9)
+    hours, rest = divmod(total, 3600)
+    minutes, seconds = divmod(rest, 60)
+    if hours:
+        return "{}h {:02d}m {:02d}s".format(hours, minutes, seconds)
+    if minutes:
+        return "{}m {:02d}s".format(minutes, seconds)
+    return "{}s".format(seconds)
+
+
+def summarize(reader):
+    """Return the ``(size, duration, messages)`` rows of ``reader``."""
+    size = format_size(reader.size)
+    time_range = reader.time_range()
+    duration = "unknown" if time_range is None else \
+        format_duration(time_range[1] - time_range[0])
+    count = reader.message_count()
+    messages = "unknown" if count is None else "{:,}".format(count)
+    return size, duration, messages
+
+
+def topic_rows(reader):
+    """Return the ``(topic, count, type)`` rows in file order.
+
+    Channels that share a topic make one row, because the count already
+    covers the topic as a whole. The row takes the type of the first such
+    channel.
+    """
+    counts = reader.message_counts()
+    rows = {}
+    for channel in reader.channels():
+        if channel.topic not in rows:
+            schema = reader.schema_of(channel)
+            rows[channel.topic] = "" if schema is None else schema.name
+    return [(topic, None if counts is None else counts[topic], type_)
+            for topic, type_ in rows.items()]
+
+
+class _TopicDelegate(QStyledItemDelegate):
+    """Paint a topic row: the name and the count, then the type below."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._name_height = QFontMetrics(
+            font(TOPIC_NAME_PIXEL_SIZE, mono=True)).height()
+        self._type_height = QFontMetrics(font(TOPIC_TYPE_PIXEL_SIZE)).height()
+
+    def sizeHint(self, option, index):
+        height = self._name_height + self._type_height + 2 * _ROW_PAD
+        return QSize(option.rect.width(), height)
+
+    def paint(self, painter, option, index):
+        self.initStyleOption(option, index)
+        option.text = ""
+        option.widget.style().drawControl(QStyle.CE_ItemViewItem, option,
+                                          painter, option.widget)
+        text, sub = row_colors(self.parent(),
+                               option.state & QStyle.State_Selected)
+        rect = option.rect.adjusted(_ROW_GAP, _ROW_PAD, -_ROW_GAP, -_ROW_PAD)
+
+        painter.save()
+        painter.setPen(text)
+        top = QRect(rect.left(), rect.top(), rect.width(), self._name_height)
+        painter.setFont(font(CAPTION_TEXT_PIXEL_SIZE, mono=True))
+        count = index.data(_COUNT_ROLE)
+        width = painter.fontMetrics().horizontalAdvance(count) + _ROW_GAP
+        painter.drawText(top, Qt.AlignRight | Qt.AlignVCenter, count)
+        painter.setFont(font(TOPIC_NAME_PIXEL_SIZE, mono=True))
+        name = painter.fontMetrics().elidedText(
+            index.data(_TOPIC_ROLE), Qt.ElideRight, top.width() - width)
+        painter.drawText(top, Qt.AlignLeft | Qt.AlignVCenter, name)
+        painter.setFont(font(TOPIC_TYPE_PIXEL_SIZE))
+        painter.setPen(sub)
+        bottom = QRect(rect.left(), top.bottom() + 1, rect.width(),
+                       self._type_height)
+        type_ = painter.fontMetrics().elidedText(
+            index.data(_TYPE_ROLE), Qt.ElideRight, bottom.width())
+        painter.drawText(bottom, Qt.AlignLeft | Qt.AlignVCenter, type_)
+        painter.restore()
+
+
+class McapDock(PaletteStyled):
+    """The file summary and the topic list of the open recording."""
+
+    open_requested = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(10, 10, 10, 10)
+        layout.setSpacing(4)
+        self._build_summary(layout)
+        self._caption = QLabel("TOPICS")
+        self._caption.setFont(font(CAPTION_TEXT_PIXEL_SIZE))
+        layout.addWidget(self._caption)
+        self._build_topics(layout)
+        self._apply_style()
+
+    def _build_summary(self, layout):
+        grid = QGridLayout()
+        grid.setHorizontalSpacing(8)
+        grid.setVerticalSpacing(3)
+        grid.setColumnMinimumWidth(0, 64)
+        grid.setColumnStretch(1, 1)
+        self._keys = [QLabel(key) for key in
+                      ("File", "Size", "Duration", "Messages")]
+        self._values = [QLabel("-") for _ in self._keys]
+        self._file, self._size, self._duration, self._messages = self._values
+        for irow, (key, value) in enumerate(zip(self._keys, self._values)):
+            key.setFont(font(BODY_TEXT_PIXEL_SIZE))
+            value.setFont(font(BODY_TEXT_PIXEL_SIZE))
+            grid.addWidget(key, irow, 0)
+            grid.addWidget(value, irow, 1)
+        self._file.setFont(font(CAPTION_TEXT_PIXEL_SIZE, mono=True))
+        layout.addLayout(grid)
+        row = QHBoxLayout()
+        self._open = QPushButton("Open MCAP...")
+        self._open.setFont(font(BODY_TEXT_PIXEL_SIZE))
+        self._open.clicked.connect(self.open_requested)
+        row.addWidget(self._open)
+        row.addStretch(1)
+        layout.addLayout(row)
+        self._error = QLabel()
+        self._error.setFont(font(CAPTION_TEXT_PIXEL_SIZE))
+        self._error.setWordWrap(True)
+        self._error.hide()
+        layout.addWidget(self._error)
+        self._rule = QFrame()
+        self._rule.setFixedHeight(1)
+        layout.addWidget(self._rule)
+        layout.addSpacing(4)
+
+    def _build_topics(self, layout):
+        self._box = QFrame()
+        self._box.setObjectName("topics")
+        box = QVBoxLayout(self._box)
+        box.setContentsMargins(0, 0, 0, 0)
+        box.setSpacing(0)
+        head = QWidget()
+        head.setObjectName("header")
+        header = QHBoxLayout(head)
+        header.setContentsMargins(_ROW_GAP, 4, _ROW_GAP, 4)
+        self._columns = [QLabel("Topic"), QLabel("Count")]
+        for label in self._columns:
+            label.setFont(font(CAPTION_TEXT_PIXEL_SIZE, bold=True))
+        header.addWidget(self._columns[0], 1)
+        header.addWidget(self._columns[1])
+        box.addWidget(head)
+        self._topics = QListWidget()
+        self._topics.setUniformItemSizes(True)
+        self._topics.setItemDelegate(_TopicDelegate(self))
+        self._topics.setFrameShape(QFrame.NoFrame)
+        box.addWidget(self._topics, 1)
+        layout.addWidget(self._box, 1)
+
+    def set_reader(self, reader):
+        """Fill the dock from ``reader``; ``None`` clears it."""
+        self._topics.clear()
+        self._error.hide()
+        if reader is None:
+            for label in self._values:
+                label.setText("-")
+            self._file.setToolTip("")
+            self._caption.setText("TOPICS")
+            return
+        self._file.setText(os.path.basename(reader.path))
+        self._file.setToolTip(reader.path)
+        size, duration, messages = summarize(reader)
+        self._size.setText(size)
+        self._duration.setText(duration)
+        self._messages.setText(messages)
+        rows = topic_rows(reader)
+        self._caption.setText("TOPICS \u00b7 {}".format(len(rows)))
+        for topic, count, type_ in rows:
+            item = QListWidgetItem()
+            item.setData(_TOPIC_ROLE, topic)
+            item.setData(_COUNT_ROLE, "?" if count is None else
+                         "{:,}".format(count))
+            item.setData(_TYPE_ROLE, type_)
+            item.setToolTip(topic)
+            self._topics.addItem(item)
+
+    def set_error(self, path, message):
+        """Report that ``path`` would not open, and clear the summary."""
+        self.set_reader(None)
+        self._file.setText(os.path.basename(path))
+        self._file.setToolTip(path)
+        self._error.setText(message)
+        self._error.show()
+
+    def _apply_style(self):
+        sheet = Rules.sheet(self, "label")
+        for label in self._keys + self._columns:
+            label.setStyleSheet(sheet)
+        self._caption.setStyleSheet(Rules.sheet(self, "caption"))
+        self._rule.setStyleSheet(Rules.sheet(self, "rule"))
+        self._open.setStyleSheet(Rules.sheet(self, "button"))
+        self._box.setStyleSheet(Rules.sheet(self, "topics"))
+
+
+class McapPanel(_gui_common.PilotFeature):
+    """Open MCAP files from the Track menu into the dock."""
+
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self._action = None
+        self._dock = None
+        self._reader = None
+        self._diag = QFileDialog()
+        self._diag.setFileMode(QFileDialog.ExistingFile)
+        self._diag.setWindowTitle("Open MCAP file")
+        self._diag.setNameFilter("MCAP recording (*.mcap);;All files (*)")
+        self._diag.fileSelected.connect(self._on_selected)
+
+    @property
+    def reader(self):
+        return self._reader
+
+    @property
+    def panel(self):
+        return None if self._dock is None else self._dock.widget()
+
+    def populate_menu(self):
+        self.add_action(
+            "Track", "Open MCAP", "Open an MCAP recording",
+            self._diag.open, id="track.open_mcap", weight=10)
+        self._action = self.add_action(
+            "View/Panels", "MCAP", "Toggle the MCAP panel",
+            None, id="panel.mcap", weight=25, checkable=True)
+        self._action.toggled.connect(self._on_toggled)
+
+    def open_file(self, path):
+        """Read the summary of ``path`` into the dock."""
+        reader = mcap.Reader(path)
+        if self._reader is not None:
+            self._reader.close()
+        self._reader = reader
+        self._shown_panel().set_reader(reader)
+        return reader
+
+    def _on_selected(self, path):
+        """Open what the dialog chose, and report a file that will not open.
+
+        An exception raised in a slot leaves Qt with nothing to say to the
+        user, so the dock carries the failure instead.
+        """
+        try:
+            self.open_file(path)
+        except (OSError, mcap.McapError) as error:
+            self._shown_panel().set_error(path, str(error))
+
+    def _shown_panel(self):
+        """Return the dock, brought up if the user had it away."""
+        self._ensure_panel()
+        self._action.setChecked(True)
+        return self.panel
+
+    def _on_toggled(self, checked):
+        if checked:
+            self._ensure_panel()
+            self._dock.show()
+        elif self._dock is not None:
+            self._dock.hide()
+
+    def _ensure_panel(self):
+        if self._dock is not None:
+            return
+        panel = McapDock()
+        panel.open_requested.connect(self._diag.open)
+        self._dock = QDockWidget("MCAP")
+        self._dock.setWidget(panel)
+        self._mainWindow.addDockWidget(Qt.RightDockWidgetArea, self._dock)
+        self._dock.visibilityChanged.connect(self._action.setChecked)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/track/_style.py
+++ b/solvcon/pilot/track/_style.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+The style rules the pilot's track panels are drawn with.
+
+A rule here says only what the palette does not already give the widget.
+The delegate paints its rows itself and takes its colors from
+:func:`row_colors` rather than from a rule.
+"""
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor, QFontDatabase
+
+from .._style import RuleCatalog, Shades
+
+__all__ = [
+    'Rules',
+    'font',
+    'row_colors',
+    'BODY_TEXT_PIXEL_SIZE',
+    'CAPTION_TEXT_PIXEL_SIZE',
+    'TOPIC_NAME_PIXEL_SIZE',
+    'TOPIC_TYPE_PIXEL_SIZE',
+]
+
+BODY_TEXT_PIXEL_SIZE = 12
+CAPTION_TEXT_PIXEL_SIZE = 11
+TOPIC_NAME_PIXEL_SIZE = 12
+TOPIC_TYPE_PIXEL_SIZE = 10
+
+# How far the hairlines, the header, and the faint text sit from the
+# surface each is mixed against.
+_HAIRLINE_STEP_TOWARD_TEXT = 0.10
+_HEADER_UNDERLINE_STEP_TOWARD_TEXT = 0.06
+_BUTTON_BORDER_STEP_TOWARD_TEXT = 0.17
+_HEADER_SURFACE_STEP_TOWARD_TEXT = 0.05
+_HOVERED_ROW_STEP_TOWARD_ACCENT_ON_LIGHT = 0.06
+_HOVERED_ROW_STEP_TOWARD_ACCENT_ON_DARK = 0.2
+_CAPTION_STEP_TOWARD_PANEL = 0.5
+_TOPIC_NAME_COLOR_ON_LIGHT = QColor(Qt.black)
+_TOPIC_NAME_COLOR_ON_DARK = QColor(Qt.white)
+_TOPIC_TYPE_STEP_TOWARD_SURFACE_ON_LIGHT = 0.5
+_TOPIC_TYPE_STEP_TOWARD_SURFACE_ON_DARK = 0.5
+_SELECTED_TYPE_STEP_TOWARD_ACCENT = 0.2
+
+
+def _is_dark(shades):
+    """Whether ``shades`` come from a palette with light text on dark."""
+    return shades.base.lightness() < shades.on_base.lightness()
+
+
+def font(px, mono=False, bold=False):
+    """The system font at ``px``, fixed-width when ``mono``."""
+    got = QFontDatabase.systemFont(
+        QFontDatabase.FixedFont if mono else QFontDatabase.GeneralFont)
+    got.setPixelSize(px)
+    got.setBold(bold)
+    return got
+
+
+def row_colors(widget, selected):
+    """The ``(name, type)`` colors a topic row paints in.
+
+    A selected row sits on the accent and a plain one on the list surface,
+    so the type line is faded toward whichever of the two is behind it.
+    """
+    shades = Shades(widget)
+    if selected:
+        name = shades.on_accent
+        type_ = Shades.blend(name, shades.accent,
+                             _SELECTED_TYPE_STEP_TOWARD_ACCENT)
+        return name, type_
+    if _is_dark(shades):
+        name = _TOPIC_NAME_COLOR_ON_DARK
+        type_step = _TOPIC_TYPE_STEP_TOWARD_SURFACE_ON_DARK
+    else:
+        name = _TOPIC_NAME_COLOR_ON_LIGHT
+        type_step = _TOPIC_TYPE_STEP_TOWARD_SURFACE_ON_LIGHT
+    type_ = Shades.blend(shades.on_base, shades.base, type_step)
+    return name, type_
+
+
+class Rules(RuleCatalog):
+    """One method per role the pilot's track panels draw."""
+
+    @staticmethod
+    def label(shades):
+        """The key of a summary row and the header of a topic column."""
+        return f"QLabel {{ color: {shades.muted.name()}; }}"
+
+    @staticmethod
+    def caption(shades):
+        """The heading the topic list is filed under."""
+        color = shades.dimmed(_CAPTION_STEP_TOWARD_PANEL)
+        return (f"QLabel {{ color: {color.name()};"
+                f" letter-spacing: 1px; }}")
+
+    @staticmethod
+    def rule(shades):
+        """The hairline the summary is closed with."""
+        line = shades.raised(_HAIRLINE_STEP_TOWARD_TEXT)
+        return f"QFrame {{ background: {line.name()}; }}"
+
+    @staticmethod
+    def button(shades):
+        """The control the file dialog is opened from."""
+        border = shades.raised(_BUTTON_BORDER_STEP_TOWARD_TEXT)
+        return f"""
+            QPushButton {{
+                background: {shades.base.name()};
+                color: {shades.on_base.name()};
+                border: 1px solid {border.name()};
+                border-radius: 5px;
+                padding: 2px 12px;
+            }}
+            """
+
+    @staticmethod
+    def topics(shades):
+        """The box the topic list is read in.
+
+        The list is transparent so that the box paints the surface under
+        every row, which leaves the rounded corners to the box alone.
+        """
+        line = shades.raised(_HAIRLINE_STEP_TOWARD_TEXT)
+        underline = shades.raised(_HEADER_UNDERLINE_STEP_TOWARD_TEXT)
+        head = Shades.blend(shades.base, shades.on_base,
+                            _HEADER_SURFACE_STEP_TOWARD_TEXT)
+        if _is_dark(shades):
+            hover_step = _HOVERED_ROW_STEP_TOWARD_ACCENT_ON_DARK
+        else:
+            hover_step = _HOVERED_ROW_STEP_TOWARD_ACCENT_ON_LIGHT
+        hover = Shades.blend(shades.base, shades.accent, hover_step)
+        return f"""
+            QFrame#topics {{
+                background: {shades.base.name()};
+                border: 1px solid {line.name()};
+                border-radius: 4px;
+            }}
+            QWidget#header {{
+                background: {head.name()};
+                border-bottom: 1px solid {underline.name()};
+            }}
+            QListWidget {{
+                background: transparent;
+                border: none;
+            }}
+            QListWidget::item:hover {{
+                background-color: {hover.name()};
+            }}
+            QListWidget::item:selected {{
+                background-color: {shades.accent.name()};
+            }}
+            """
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/track/mcap/_reader.py
+++ b/solvcon/track/mcap/_reader.py
@@ -10,6 +10,7 @@ statistics, and the chunk indexes; the chunks themselves are read on demand
 by ``messages()`` and the ``extract*`` methods.
 """
 
+import os
 import struct
 import collections
 
@@ -93,16 +94,25 @@ class Reader:
     """
     Read one MCAP file.
 
-    The reader is a context manager; ``close()`` releases the file handle.
+    ``path`` is the file the reader opened and ``size`` its size in
+    bytes. The reader is a context manager; ``close()`` releases the
+    file handle.
     """
 
     def __init__(self, path):
+        self.path = path
+        self.size = os.path.getsize(path)
         self._file = open(path, "rb")
         self._schemas = {}
         self._channels = {}
         self._chunk_indexes = []
         self._statistics = None
-        self._read_summary()
+        self._message_count = None
+        self._message_counts = None
+        try:
+            self._read_summary()
+        except (struct.error, UnicodeDecodeError) as error:
+            raise McapError("malformed record: {}".format(error)) from error
 
     def __enter__(self):
         return self
@@ -154,13 +164,24 @@ class Reader:
                 fields, _ = unpack("<QQQQ", body, 0)
                 self._chunk_indexes.append(ChunkIndex(*fields))
             elif opcode == OP_STATISTICS:
-                (start_ns, end_ns), _ = unpack("<QQ", body, 8 + 2 + 4 * 4)
+                (self._message_count,), pos = unpack("<Q", body, 0)
+                (start_ns, end_ns), pos = unpack("<QQ", body, pos + 2 + 4 * 4)
                 self._statistics = (start_ns, end_ns)
+                counts, _ = unpack_prefixed("<I", body, pos)
+                self._message_counts = dict(struct.iter_unpack("<HQ", counts))
 
     def topics(self):
         """Return a map from topic to schema name."""
         return {ch.topic: self._schemas[ch.schema_id].name
                 for ch in self._channels.values()}
+
+    def channels(self):
+        """Return every channel in file order."""
+        return list(self._channels.values())
+
+    def schema_of(self, channel):
+        """Return the schema of ``channel``, or ``None`` when it has none."""
+        return self._schemas.get(channel.schema_id)
 
     def channel(self, topic):
         found = [ch for ch in self._channels.values() if ch.topic == topic]
@@ -175,6 +196,25 @@ class Reader:
     def time_range(self):
         """Return ``(start_ns, end_ns)``, or ``None`` without statistics."""
         return self._statistics
+
+    def message_count(self):
+        """Return the file's message count, or ``None`` without statistics."""
+        return self._message_count
+
+    def message_counts(self):
+        """Return a map from topic to its message count.
+
+        The counts come from the statistics record, which is optional; a
+        file without one gives ``None``. Channels that share a topic add
+        up.
+        """
+        if self._message_counts is None:
+            return None
+        counts = {}
+        for ch in self._channels.values():
+            counts[ch.topic] = counts.get(ch.topic, 0) + \
+                self._message_counts.get(ch.id, 0)
+        return counts
 
     def _iter_messages(self, channel_ids, start_ns, end_ns):
         """

--- a/tests/gui/test_bar.py
+++ b/tests/gui/test_bar.py
@@ -19,7 +19,7 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 BUILTINS = ["File", "Edit", "View", "One", "Mesh", "Canvas", "Profiling",
-            "Window"]
+            "Track", "Window"]
 
 
 @unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
@@ -50,8 +50,8 @@ class BarStructureTC(unittest.TestCase):
         panels = [a.text() for a in model.menu("View/Panels").actions()]
         self.assertEqual(
             list(dict.fromkeys(panels)),
-            ["Inspector", "Euler solver", "Painter", "Console", "Terminal",
-             "Agent Console"])
+            ["Inspector", "Euler solver", "Painter", "MCAP", "Console",
+             "Terminal", "Agent Console"])
 
         # The Console and Terminal toggles live with the other panel toggles;
         # the Window menu holds only the dynamic sub-window list.

--- a/tests/gui/test_mcap_viewer.py
+++ b/tests/gui/test_mcap_viewer.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""The MCAP panel feature on the pilot window: the menu and the dock."""
+
+import os
+import tempfile
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot.track import _mcap_viewer
+    from PySide6.QtCore import Qt
+    from PySide6.QtWidgets import QApplication
+except ImportError:
+    pilot = None
+
+try:
+    from mcap import writer as foxglove_mcap_writer
+except ImportError:
+    foxglove_mcap_writer = None
+
+# The offscreen platform cannot back a live window; neither can the headless
+# Windows CI runner, whose WARP software rasterizer faults on one.
+NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
+                  or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
+
+TOPIC = "/vehicle/brake"
+
+
+def write_fixture(path):
+    """One schemaless topic: the feature tests only list it."""
+    with open(path, "wb") as fp:
+        writer = foxglove_mcap_writer.Writer(fp)
+        writer.start(profile="ros2")
+        channel_id = writer.register_channel(TOPIC, "cdr", 0)
+        writer.add_message(channel_id, 10, b"\0\x01\0\0", 10)
+        writer.finish()
+
+
+@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+                 "pilot windows need a real window surface")
+@unittest.skipIf(foxglove_mcap_writer is None,
+                 "the Foxglove mcap package is not installed")
+class McapPanelTC(unittest.TestCase):
+
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.tmpdir.name, "drive.mcap")
+        write_fixture(self.path)
+        self.feature = _mcap_viewer.McapPanel(mgr=self.mgr)
+        self.feature.populate_menu()
+
+    def tearDown(self):
+        if self.feature.reader is not None:
+            self.feature.reader.close()
+        self.tmpdir.cleanup()
+
+    def test_track_menu_carries_the_open_action(self):
+        titles = [a.text() for a in self.mgr.mainWindow.menuBar().actions()]
+        self.assertLess(titles.index("Profiling"), titles.index("Track"))
+        self.assertLess(titles.index("Track"), titles.index("Window"))
+        texts = [a.text() for a in self.mgr.menu_model.menu("Track").actions()]
+        self.assertIn("Open MCAP", texts)
+
+    def test_open_file_fills_the_dock_and_the_toggle_hides_it(self):
+        reader = self.feature.open_file(self.path)
+        QApplication.processEvents()
+        self.assertIs(self.feature.reader, reader)
+        self.assertTrue(self.feature._action.isChecked())
+        self.assertFalse(self.feature._dock.isHidden())
+        topics = self.feature.panel._topics
+        self.assertEqual([topics.item(i).data(_mcap_viewer._TOPIC_ROLE)
+                          for i in range(topics.count())], [TOPIC])
+        self.assertEqual(
+            self.mgr.mainWindow.dockWidgetArea(self.feature._dock),
+            Qt.RightDockWidgetArea)
+        second = self.feature.open_file(self.path)
+        self.assertTrue(reader._file.closed)
+        self.assertIs(self.feature.reader, second)
+        self.feature._action.setChecked(False)
+        QApplication.processEvents()
+        self.assertTrue(self.feature._dock.isHidden())
+
+        # A file the reader refuses is reported without unseating the
+        # recording already open.
+        broken = os.path.join(self.tmpdir.name, "broken.mcap")
+        with open(broken, "wb") as fp:
+            fp.write(b"not an MCAP file")
+        self.feature._on_selected(broken)
+        QApplication.processEvents()
+        self.assertIs(self.feature.reader, second)
+        self.assertEqual(self.feature.panel._error.text(), "bad magic")
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_mcap_viewer.py
+++ b/tests/test_pilot_mcap_viewer.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""The MCAP dock filled from a generated recording."""
+
+import os
+import tempfile
+import unittest
+
+import solvcon
+from solvcon.track import mcap
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot.track import _mcap_viewer
+except ImportError:
+    pilot = None
+
+try:
+    from mcap import writer as foxglove_mcap_writer
+except ImportError:
+    foxglove_mcap_writer = None
+
+BRAKE_IDL = b"""
+module vehicle_msgs {
+  module msg {
+    struct Brake {
+      boolean active;
+    };
+  };
+};
+"""
+
+BRAKE_TOPIC = "/vehicle/brake"
+BRAKE_PAYLOAD = b"\0\x01\0\0\x01"
+DIAG_TOPIC = "/diagnostics"
+SECOND_NS = 1_000_000_000
+
+
+def write_fixture(path):
+    """One CDR topic with an IDL schema and one JSON topic."""
+    with open(path, "wb") as fp:
+        writer = foxglove_mcap_writer.Writer(fp)
+        writer.start(profile="ros2")
+        schema_id = writer.register_schema("vehicle_msgs/msg/Brake",
+                                           "ros2idl", BRAKE_IDL)
+        channel_id = writer.register_channel(BRAKE_TOPIC, "cdr", schema_id)
+        for log_time in (3 * SECOND_NS, 5 * SECOND_NS, 8 * SECOND_NS):
+            writer.add_message(channel_id, log_time, BRAKE_PAYLOAD, log_time)
+        schema_id = writer.register_schema("diagnostics", "jsonschema",
+                                           b"{}")
+        channel_id = writer.register_channel(DIAG_TOPIC, "json", schema_id)
+        writer.add_message(channel_id, 4 * SECOND_NS, b"{}", 4 * SECOND_NS)
+        writer.finish()
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+@unittest.skipIf(foxglove_mcap_writer is None,
+                 "the Foxglove mcap package is not installed")
+class McapDockTC(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.tmpdir.name, "drive.mcap")
+        write_fixture(self.path)
+        self.reader = mcap.Reader(self.path)
+
+    def tearDown(self):
+        self.reader.close()
+        self.tmpdir.cleanup()
+
+    def test_dock_lists_the_file_its_topics_and_the_one_selected(self):
+        dock = _mcap_viewer.McapDock()
+        dock.set_reader(self.reader)
+        self.assertEqual(dock._file.text(), "drive.mcap")
+        self.assertEqual(dock._file.toolTip(), self.path)
+        self.assertEqual(dock._size.text(),
+                         _mcap_viewer.format_size(self.reader.size))
+        self.assertEqual(dock._duration.text(), "5s")
+        self.assertEqual(dock._messages.text(), "4")
+        self.assertEqual(dock._caption.text(), "TOPICS \u00b7 2")
+
+        topics = dock._topics
+        self.assertEqual(
+            [[topics.item(i).data(role) for role in (
+                _mcap_viewer._TOPIC_ROLE, _mcap_viewer._COUNT_ROLE,
+                _mcap_viewer._TYPE_ROLE)]
+             for i in range(topics.count())],
+            [[BRAKE_TOPIC, "3", "vehicle_msgs/msg/Brake"],
+             [DIAG_TOPIC, "1", "diagnostics"]])
+
+        dock.set_reader(None)
+        self.assertEqual([label.text() for label in dock._values], ["-"] * 4)
+        self.assertEqual(dock._caption.text(), "TOPICS")
+        self.assertEqual(topics.count(), 0)
+
+    def test_a_file_without_statistics_reports_unknown(self):
+        path = os.path.join(self.tmpdir.name, "nostat.mcap")
+        with open(path, "wb") as fp:
+            writer = foxglove_mcap_writer.Writer(fp, use_statistics=False)
+            writer.start(profile="ros2")
+            schema_id = writer.register_schema("vehicle_msgs/msg/Brake",
+                                               "ros2idl", BRAKE_IDL)
+            channel_id = writer.register_channel(BRAKE_TOPIC, "cdr", schema_id)
+            writer.add_message(channel_id, SECOND_NS, BRAKE_PAYLOAD,
+                               SECOND_NS)
+            writer.finish()
+
+        with mcap.Reader(path) as reader:
+            size = _mcap_viewer.format_size(os.path.getsize(path))
+            self.assertEqual(_mcap_viewer.summarize(reader),
+                             (size, "unknown", "unknown"))
+            dock = _mcap_viewer.McapDock()
+            dock.set_reader(reader)
+            self.assertEqual(dock._topics.item(0).data(
+                _mcap_viewer._COUNT_ROLE), "?")
+
+    def test_a_file_that_will_not_open_is_reported_in_the_dock(self):
+        path = os.path.join(self.tmpdir.name, "broken.mcap")
+        with open(path, "wb") as fp:
+            fp.write(b"not an MCAP file")
+
+        dock = _mcap_viewer.McapDock()
+        dock.set_reader(self.reader)
+        with self.assertRaisesRegex(mcap.McapError, "bad magic"):
+            mcap.Reader(path)
+        dock.set_error(path, "bad magic")
+        self.assertEqual(dock._file.text(), "broken.mcap")
+        self.assertEqual(dock._error.text(), "bad magic")
+        self.assertFalse(dock._error.isHidden())
+        self.assertEqual(dock._topics.count(), 0)
+        dock.set_reader(self.reader)
+        self.assertTrue(dock._error.isHidden())
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_track_mcap.py
+++ b/tests/test_track_mcap.py
@@ -347,6 +347,10 @@ class McapInOutTC(unittest.TestCase):
             self.assertEqual(reader.topics(),
                              {TOPIC: "vehicle_msgs/msg/Status"})
             self.assertEqual(reader.time_range(), (10, 40))
+            self.assertEqual(reader.message_count(), 4)
+            self.assertEqual(reader.message_counts(), {TOPIC: 4})
+            self.assertEqual(reader.path, self.path)
+            self.assertEqual(reader.size, os.path.getsize(self.path))
 
             # Raw messages come in file order; the range is half open.
             self.assertEqual([t for t, _ in reader.messages(TOPIC)],
@@ -408,6 +412,8 @@ class McapInOutTC(unittest.TestCase):
             writer.finish()
 
         with mcap.Reader(path) as reader:
+            self.assertEqual(reader.message_counts(),
+                             {TOPIC: 4, BRAKE_TOPIC: 2})
             plan = mcap.DecodePlan(reader.schema(TOPIC),
                                    ["longitudinal_speed", "mode"])
             frames = reader.extract_frame_many({TOPIC: plan,
@@ -434,5 +440,12 @@ class McapInOutTC(unittest.TestCase):
                 theirs = sorted((msg.log_time, msg.data) for _, _, msg
                                 in foxglove.iter_messages(topics=[TOPIC]))
             self.assertEqual(ours, theirs, compression)
+
+    def test_a_truncated_file_raises_mcap_error(self):
+        path = os.path.join(self.tmpdir.name, "truncated.mcap")
+        with open(path, "wb") as fp:
+            fp.write(b"\x89MCAP0\r\n" * 2)
+        with self.assertRaisesRegex(mcap.McapError, "malformed record"):
+            mcap.Reader(path)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
The Track menu opens an MCAP file into a dock that lists the file, its size, its duration, its message count, and its topics with their message counts and schema types.

Related to #1454.
