### PR TITLE
Drop stale style items when `MeshInfoTree` clears

### DIFF
--- a/solvcon/pilot/panel/_tree_panel.py
+++ b/solvcon/pilot/panel/_tree_panel.py
@@ -186,6 +186,7 @@ class MeshInfoTree(TreePanelBase):
     def set_mesh(self, mh):
         """Rebuild the tree from ``mh``, or show "No mesh loaded" when None."""
         self._building = True
+        self._style_items = {}
         try:
             if mh is None:
                 self._show_placeholder("No mesh loaded")
@@ -208,7 +209,6 @@ class MeshInfoTree(TreePanelBase):
         Each mirrors the active viewer's style through the shared status, so a
         fresh viewer shows the wireframe checked and the other two clear.
         """
-        self._style_items = {}
         if self.style_status is None:
             return
         for name, label in _mesh.MeshStyleStatus.STYLES:

--- a/tests/gui/test_tree_panel.py
+++ b/tests/gui/test_tree_panel.py
@@ -130,6 +130,15 @@ class MeshInfoTreeTC(unittest.TestCase):
         self.assertEqual(tree._style_items["wireframe"].checkState(0),
                          Qt.Checked)
 
+    def test_clearing_the_mesh_drops_the_style_items(self):
+        # Clearing the tree deletes the items in C++; keeping the wrappers
+        # would make the next status refresh touch dangling objects.
+        tree = _tree_panel.MeshInfoTree(style_status=self.status,
+                                        mh=_make_sample_mesh())
+        tree.set_mesh(None)
+        tree.refresh_style_checks()
+        self.assertEqual(tree._style_items, {})
+
 
 @unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")


### PR DESCRIPTION
Empty the style check-box cache when the mesh inspector clears its tree, so a later refresh cannot touch items that Qt already deleted in C++. The stale cache raises `RuntimeError: libshiboken: Internal C++ object (PySide6.QtWidgets.QTreeWidgetItem) already deleted`, which the Linux CI job logs 696 times per run.

This bug is found while finding the bug of#1438, but this PR doesn't fix the root cause of it.

Related to #1478
