### PR TITLE
Bind Pilot Exit to Cmd/Ctrl+W

### DIFF
--- a/cpp/solvcon/pilot/app/keymap.cpp
+++ b/cpp/solvcon/pilot/app/keymap.cpp
@@ -18,7 +18,7 @@ namespace
 
 /**
  * Bindings shared by every platform. The per-platform tables append only
- * their Exit accent on top of this seed.
+ * their Exit row (Primary+W, with Quit role on macOS) on top of this seed.
  */
 std::vector<ShortcutBinding> sharedSeed()
 {
@@ -62,8 +62,12 @@ std::vector<ShortcutBinding> tableWith(std::vector<ShortcutBinding> extra)
 
 std::vector<ShortcutBinding> const & linuxTable()
 {
+    // Primary+W is Ctrl+W on Linux and Windows; Quit's standard chord is
+    // unbound on Windows, so a curated Exit keeps the same quit key everywhere.
     static std::vector<ShortcutBinding> const table = tableWith({
-        {ShortcutCommand::Exit, StandardAction::Quit, ShortcutContext::Application},
+        {ShortcutCommand::Exit,
+         KeyChord{KeyMod::Primary, Key::W},
+         ShortcutContext::Application},
     });
     return table;
 }
@@ -76,10 +80,11 @@ std::vector<ShortcutBinding> const & windowsTable()
 
 std::vector<ShortcutBinding> const & macTable()
 {
-    // macOS routes Quit through the application menu with its Quit role.
+    // Primary+W is Cmd+W on macOS. Quit role still moves Exit into the
+    // application menu; the curated chord replaces Qt's standard Quit.
     static std::vector<ShortcutBinding> const table = tableWith({
         {ShortcutCommand::Exit,
-         StandardAction::Quit,
+         KeyChord{KeyMod::Primary, Key::W},
          ShortcutContext::Application,
          MenuRole::Quit},
     });

--- a/gtests/test_nopython_pilot_keymap.cpp
+++ b/gtests/test_nopython_pilot_keymap.cpp
@@ -63,7 +63,8 @@ TEST(PilotKeymapTable, SeedsSharedBindingsOnEveryPlatform)
 
         auto const * exit = solvcon::bindingFor(platform, solvcon::ShortcutCommand::Exit);
         ASSERT_NE(exit, nullptr);
-        EXPECT_EQ(std::get<solvcon::StandardAction>(exit->key), solvcon::StandardAction::Quit);
+        EXPECT_EQ(std::get<solvcon::KeyChord>(exit->key),
+                  (solvcon::KeyChord{solvcon::KeyMod::Primary, solvcon::Key::W}));
         EXPECT_EQ(exit->context, solvcon::ShortcutContext::Application);
     }
 }
@@ -108,7 +109,8 @@ TEST(PilotKeymapMac, AddsQuitRoleOverTheSharedExitBinding)
 
     auto const * exit = solvcon::bindingFor(solvcon::PlatformId::Mac, solvcon::ShortcutCommand::Exit);
     ASSERT_NE(exit, nullptr);
-    EXPECT_EQ(std::get<solvcon::StandardAction>(exit->key), solvcon::StandardAction::Quit);
+    EXPECT_EQ(std::get<solvcon::KeyChord>(exit->key),
+              (solvcon::KeyChord{solvcon::KeyMod::Primary, solvcon::Key::W}));
     EXPECT_EQ(exit->role, solvcon::MenuRole::Quit);
 
     EXPECT_EQ(solvcon::bindingFor(solvcon::PlatformId::Linux, solvcon::ShortcutCommand::Exit)->role,

--- a/tests/test_pilot_shortcut.py
+++ b/tests/test_pilot_shortcut.py
@@ -37,7 +37,6 @@ if QtGui is not None:
     _STANDARD_IDS = {
         "edit.undo": QtGui.QKeySequence.StandardKey.Undo,
         "edit.redo": QtGui.QKeySequence.StandardKey.Redo,
-        "file.exit": QtGui.QKeySequence.StandardKey.Quit,
         "canvas.blank_2d": QtGui.QKeySequence.StandardKey.New,
     }
 
@@ -118,15 +117,14 @@ class ShortcutResolutionTC(unittest.TestCase):
         self.assertEqual(r["sequences"], _portable_standard_sequences(
             QtGui.QKeySequence.StandardKey.New))
 
-    def test_exit_carries_quit_and_platform_role(self):
+    def test_exit_resolves_to_primary_w(self):
+        # Cmd+W on macOS, Ctrl+W on Linux and Windows.
         r = self.mgr.resolve_shortcut("file.exit")
         self.assertTrue(r["known"])
         self.assertTrue(r["bound"])
-        self.assertTrue(r["standard"])
-        self.assertEqual(r["standard_key"], "Quit")
+        self.assertFalse(r["standard"])
         self.assertEqual(r["context"], "application")
-        self.assertEqual(r["sequences"], _portable_standard_sequences(
-            QtGui.QKeySequence.StandardKey.Quit))
+        self.assertEqual(r["sequences"], ["Ctrl+W"])
         if self.mgr.shortcut_platform == "mac":
             self.assertEqual(r["role"], "quit")
         else:
@@ -142,8 +140,8 @@ class ShortcutResolutionTC(unittest.TestCase):
         self.assertEqual(self.mgr.shortcut_conflicts(), [])
 
     def test_every_vocabulary_command_resolves(self):
-        # Standard keys may be unbound on a platform (Quit has no chord on
-        # Windows); curated phrasebook rows must still carry a sequence.
+        # Curated phrasebook rows must carry a sequence; standard keys may be
+        # unbound on a platform, so their expected list comes from Qt.
         all_bindings = self.mgr.resolve_all_shortcuts()
         for oid, entry in all_bindings.items():
             with self.subTest(oid=oid):


### PR DESCRIPTION
Bind Pilot Exit to `Primary+W` so Cmd+W on macOS and Ctrl+W on Linux and Windows quit the app.

Qt `StandardKey.Quit` does not spell that chord. On macOS it resolves to an `Exit` token, and on Windows it is often unbound.

`make gtest` and `tests/test_pilot_shortcut.py` passed.
