### PR TITLE
Add a new page to document the problem of oblique shock reflection

### DIFF
--- a/doc/source/application/index.md
+++ b/doc/source/application/index.md
@@ -4,6 +4,7 @@
 :maxdepth: 2
 
 euler
+obsrefl
 ```
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/application/obsrefl.md
+++ b/doc/source/application/obsrefl.md
@@ -1,0 +1,265 @@
+# Oblique-Shock Reflection
+
+The oblique-shock reflection describes a supersonic stream that crosses an
+oblique shock. The shock bounces off a slip wall, and the flow reaches
+a steady state with three zones. The case has a closed-form solution for the
+states of the three zones, the angles of the two shocks, and the reflection
+point[^ywh1985]. A computed solution can be measured against it.
+
+The configuration is shown in {numref}`f:obsrefl:domain`. A uniform supersonic
+stream enters from the left. The top boundary has the second inflow behind the
+first oblique shock. The shock stands and runs down to the bottom slip-wall
+boundary. The first shock reflects off the wall. The flow turns back to
+horizontal behind the reflected shock and leaves the domain on the right
+boundary.
+
+```{eval-rst}
+.. pstake:: schematic/obsrefl_domain.tex
+   :align: center
+   :name: f:obsrefl:domain
+
+   Three zones stand in the converged field. Zone 1 is the free stream, zone 2
+   sits between the two shocks, and zone 3 sits behind the reflected shock. The
+   incident shock runs from the upper-left corner to the reflection point on
+   the wall, and the reflected shock leaves through the outflow.
+```
+
+(s:obsrefl:relations)=
+
+## Oblique Shock Relations
+
+An oblique shock separates the flow into two states: ahead and behind.
+Subscript ${}_{\mathrm{U}}$ denotes flow states in the upstream (ahead of
+the shock) and ${}_{\mathrm{D}}$ in the downstream (behind the shock). The
+oblique-shock-reflection problem has two oblique shocks and three zones. The
+oblique-shock relations are applied twice: $\mathrm{U}, \mathrm{D} = 1, 2$
+across the incident shock, and $\mathrm{U}, \mathrm{D} = 2, 3$ across the
+reflected one.
+
+The flow states across an oblique shock are shown in
+{numref}`f:obsrefl:oblique`. The straight shock stands at the angle $\beta$.
+The flow is turned toward the shock front by angle $\theta$.
+
+```{eval-rst}
+.. pstake:: schematic/obsrefl_oblique.tex
+   :align: center
+   :name: f:obsrefl:oblique
+   :width: 61%
+
+   One oblique shock: the front stands at the angle :math:`\beta` from the
+   incoming flow, which crosses it and leaves deflected by :math:`\theta`.
+```
+
+Split each velocity into a tangential component along the front and a normal
+component across it. See {numref}`f:obsrefl:components`.
+
+```{eval-rst}
+.. pstake:: schematic/obsrefl_components.tex
+   :align: center
+   :name: f:obsrefl:components
+   :width: 62%
+
+   The same shock, with the velocity on each side split into its tangential and
+   normal components. The tangential components are the same, so the jump is
+   carried by the normal components.
+```
+
+The tangential component across the shock remains unchanged. The deflection
+falls to the normal component. That component crosses what is, in its own
+frame, a normal shock, at the normal upstream Mach number
+(${M_{\mathrm{U}}}_n$)
+
+```{math}
+:label: e:obsrefl:mn1
+
+{M_{\mathrm{U}}}_n = M_{\mathrm{U}}\sin\beta
+```
+
+so the jumps are the normal-shock relations[^naca1135] in ${M_{\mathrm{U}}}_n$,
+
+```{math}
+:label: e:obsrefl:jump
+
+\frac{\rho_{\mathrm{D}}}{\rho_{\mathrm{U}}}
+= \frac{(\gamma+1){M_{\mathrm{U}}}_n^2}{(\gamma-1){M_{\mathrm{U}}}_n^2 + 2},
+\;
+\frac{p_{\mathrm{D}}}{p_{\mathrm{U}}}
+= 1 + \frac{2\gamma}{\gamma+1}\left({M_{\mathrm{U}}}_n^2 - 1\right),
+\;
+\frac{T_{\mathrm{D}}}{T_{\mathrm{U}}}
+= \frac{p_{\mathrm{D}}}{p_{\mathrm{U}}}
+  \frac{\rho_{\mathrm{U}}}{\rho_{\mathrm{D}}}
+```
+
+and the downstream Mach number follows from its own normal component,
+
+```{math}
+:label: e:obsrefl:mn2
+
+{M_{\mathrm{D}}}_n^2
+= \frac{(\gamma-1){M_{\mathrm{U}}}_n^2 + 2}
+        {2\gamma {M_{\mathrm{U}}}_n^2 - (\gamma-1)},
+\;
+M_{\mathrm{D}} = \frac{{M_{\mathrm{D}}}_n}{\sin(\beta - \theta)}
+```
+
+The downstream velocity has magnitude
+$M_{\mathrm{D}}\sqrt{\gamma p_{\mathrm{D}}/\rho_{\mathrm{D}}}$ and
+points $\theta$ away from the upstream direction, toward the shock.
+
+## Shock and Deflection Angles
+
+The deflection angle $\theta$ and shock angle $\beta$ are related with the Mach
+number $M$ (theta-beta-M relation),
+
+```{math}
+:label: e:obsrefl:tbm
+
+\tan\theta = 2\cot\beta\,
+\frac{M_{\mathrm{U}}^2\sin^2\beta - 1}
+     {M_{\mathrm{U}}^2\left(\gamma + \cos 2\beta\right) + 2}
+```
+
+The problem provides the deflection angle $\theta$ and wants the shock angle
+$\beta$. Rearrange {eq}`e:obsrefl:tbm` into a cubic in $\tan\beta$,
+
+```{math}
+\begin{aligned}
+&\left(1 + \frac{\gamma-1}{2}M_{\mathrm{U}}^2\right)\tan\theta\,\tan^3\beta
+ - \left(M_{\mathrm{U}}^2 - 1\right)\tan^2\beta \\
+&\qquad + \left(1 + \frac{\gamma+1}{2}M_{\mathrm{U}}^2\right)
+   \tan\theta\,\tan\beta + 1 = 0
+\end{aligned}
+```
+
+Its three roots have the closed form[^rudd1998], indexed by $\delta = 0, 1,
+2$,
+
+```{math}
+:label: e:obsrefl:beta
+
+\tan\beta(M_{\mathrm{U}}, \theta) = \frac
+{M_{\mathrm{U}}^2 - 1
+ + 2\lambda\cos\left(\dfrac{4\pi\delta + \arccos\chi}{3}\right)}
+{3\left(1 + \dfrac{\gamma-1}{2}M_{\mathrm{U}}^2\right)\tan\theta}
+```
+
+where $\lambda$ and $\chi$ depend only on $M_{\mathrm{U}}$ and $\theta$,
+
+```{math}
+:label: e:obsrefl:lambda
+
+\begin{aligned}
+\lambda &= \left[\left(M_{\mathrm{U}}^2-1\right)^2
+  - 3\left(1 + \frac{\gamma-1}{2}M_{\mathrm{U}}^2\right)
+     \left(1 + \frac{\gamma+1}{2}M_{\mathrm{U}}^2\right)
+     \tan^2\theta\right]^{1/2} \\
+\chi &= \frac{1}{\lambda^3}\left[\left(M_{\mathrm{U}}^2-1\right)^3
+  - 9\left(1 + \frac{\gamma-1}{2}M_{\mathrm{U}}^2\right)
+     \left(1 + \frac{\gamma-1}{2}M_{\mathrm{U}}^2
+             + \frac{\gamma+1}{4}M_{\mathrm{U}}^4\right)
+     \tan^2\theta\right]
+\end{aligned}
+```
+
+$\delta = 0$ selects the strong shock standing at the larger angle. $\delta =
+1$ selects the weak shock standing at the smaller angle. The reflection is the
+weak branch, the one that occurs unless a raised back pressure downstream
+forces the strong shock. See {numref}`f:obsrefl:tbm` for the weak and strong
+shock in the relation chart between the shock angle $\beta$ and deflection
+angle $\theta$ at $M_{\mathrm{U}} = 3$. $\delta = 2$ is a negative root without
+physical meaning.
+
+```{eval-rst}
+.. pstake:: schematic/obsrefl_tbm.tex
+   :align: center
+   :name: f:obsrefl:tbm
+   :width: 75%
+
+   The deflection angle :math:`\theta` against the shock angle
+   :math:`\beta`, Eq.
+   :eq:`e:obsrefl:tbm`, for :math:`M_{\mathrm{U}} = 3`.  A deflection line
+   crosses the curve twice, the weak root on the rising branch and the strong
+   root on the falling one; the line drawn is the reference case's
+   :math:`\theta = 10` degrees, whose weak root is the incident shock angle
+   :math:`\beta_1`.  The curve rises from zero deflection at the Mach angle
+   :math:`\mu = \arcsin(1/M_{\mathrm{U}})` and peaks at the largest deflection
+   an attached shock can turn.
+```
+
+At the peak $\chi$ reaches $-1$ and the weak and the strong roots merge. It is
+the largest deflection angle that the flow has a straight, attached shock. At
+Mach 3 it is 34.07 degrees. For a deflection angle larger than the peak, there
+is no attached shock.
+
+## Shock Reflection
+
+The flow states of the incident and reflected shocks shown in
+{numref}`f:obsrefl:domain` can be determined by applying the {ref}`oblique
+shock relations <s:obsrefl:relations>` twice. The incident shock uses
+$\mathrm{U}, \mathrm{D} = 1, 2$. It deflects the free stream by angle $\theta$
+toward the wall and stands at $\beta_1 = \beta (M_1, \theta)$. The reflected
+shock uses $\mathrm{U}, \mathrm{D} = 2, 3$. It turns the flow back by the same
+angle $\theta$, and the flow direction in zone 3 is along the $x$-coordinate
+because no flow passes the wall. The shock angle is $\beta_2 = \beta (M_2,
+\theta)$.
+
+The point of shock reflection can be calculated from the angles. Over a domain
+running from $(x_0, y_0)$ to $(x_1, y_1)$, the incident shock enters at the
+upper-left corner and descends at $\beta_1$, so it reaches the wall at
+
+```{math}
+:label: e:obsrefl:xr
+
+x_r = x_0 + \frac{y_1 - y_0}{\tan\beta_1}
+```
+
+The reflected shock leaves the wall at $x_r$, rises at $\beta_2 - \theta$, and
+meets the right-hand-side outflow boundary at
+
+```{math}
+:label: e:obsrefl:ye
+
+y_e = y_0 + (x_1 - x_r)\tan(\beta_2 - \theta)
+```
+
+If $x_r > x_1$, the domain is too short to hold the reflection: the incident
+shock leaves through the outflow and there is no zone 3.
+
+## Example Case
+
+The example case uses a domain 4 units long and 1 unit tall, running from
+$(x_0, y_0) = (0, 0)$ to $(x_1, y_1) = (4, 1)$. The inflow is a Mach 3 stream
+of unit density and unit pressure, deflected 10 degrees: $M_1 = 3$,
+$\rho_1 = p_1 = 1$, $\theta = 10^{\circ}$, and $\gamma = 1.4$. The flow
+states in the three zones are:
+
+|                 | zone 1 |  zone 2 | zone 3 |
+|-----------------|-------:|--------:|-------:|
+| density $\rho$  | 1.0000 |  1.6546 | 2.5651 |
+| pressure $p$    | 1.0000 |  2.0545 | 3.8329 |
+| Mach number $M$ | 3.0000 |  2.5050 | 2.0902 |
+| $x$ velocity    | 3.5496 |  3.2526 | 3.0233 |
+| $y$ velocity    | 0.0000 | -0.5735 | 0.0000 |
+
+The two shocks stand at $\beta_1 = 27.383$ and $\beta_2 = 31.795$ degrees. The
+second shock is 21.795 degrees above the wall ($\beta_2 - \theta =
+21.795^{\circ}$). The reflection point is $x_r = 1.9306$, and the reflected
+shock reaches the outflow at $y_e = 0.8275$.
+
+[^ywh1985]: H. C. Yee, R. F. Warming, and A. Harten, "Implicit total variation
+    diminishing (TVD) schemes for steady-state calculations," Journal of
+    Computational Physics 57(3):327-360, 1985.
+    <https://doi.org/10.1016/0021-9991(85)90183-4>
+
+[^naca1135]: Ames Research Staff, "Equations, tables, and charts for
+    compressible flow," NACA Report 1135, 1953, the canonical compilation of
+    the normal- and oblique-shock relations.
+    <https://ntrs.nasa.gov/citations/19930091059>
+
+[^rudd1998]: L. von Eggers Rudd and M. J. Lewis, "Comparison of shock
+    calculation methods," Journal of Aircraft 35(4):647-649, 1998, which
+    weighs the closed-form root against iterative solutions of the
+    theta-beta-M relation. <https://doi.org/10.2514/2.2349>
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/application/schematic/obsrefl_components.tex
+++ b/doc/source/application/schematic/obsrefl_components.tex
@@ -1,0 +1,34 @@
+\begin{pspicture}(1.0,-0.4)(8.2,2.9)
+\psset{arrowsize=4pt 2}
+
+% The same front as the previous figure.
+\psline[linewidth=1.2pt](2.19,2.40)(6.81,0.00)
+\rput{-27.4}(3.05,2.32){\small shock}
+
+% The upstream velocity and its components.  The legs are drawn tangential
+% first, so neither of them lies along the front.
+\psline[linewidth=1pt]{->}(1.9,1.2)(4.5,1.2)
+\rput[c](2.35,1.44){$V_{\mathrm{U}}$}
+\psline[linewidth=0.4pt,linestyle=dashed](1.9,1.2)(3.95,0.137)
+\psline[linewidth=0.4pt,linestyle=dashed](3.95,0.137)(4.5,1.2)
+\rput[r](2.92,0.53){${V_{\mathrm{U}}}_t$}
+\rput[l](4.42,0.74){${V_{\mathrm{U}}}_n$}
+
+% The downstream velocity and its components, drawn normal first for the
+% same reason.
+\psline[linewidth=1pt]{->}(4.5,1.2)(6.88,0.78)
+\rput[l](7.02,0.66){$V_{\mathrm{D}}$}
+\psline[linewidth=0.4pt,linestyle=dashed](4.5,1.2)(4.833,1.842)
+\psline[linewidth=0.4pt,linestyle=dashed](4.833,1.842)(6.883,0.779)
+\rput[r](4.52,1.82){${V_{\mathrm{D}}}_n$}
+\rput[l](6.02,1.54){${V_{\mathrm{D}}}_t$}
+
+% One tick across each tangential leg: the two are the same length.
+\psline[linewidth=0.5pt](2.879,0.580)(2.971,0.758)
+\psline[linewidth=0.5pt](5.812,1.222)(5.904,1.400)
+
+% The two states.
+\rput[l](1.05,-0.05){$\rho_{\mathrm{U}},\; p_{\mathrm{U}},\; T_{\mathrm{U}},\; M_{\mathrm{U}}$}
+\rput[l](5.30,2.30){$\rho_{\mathrm{D}},\; p_{\mathrm{D}},\; T_{\mathrm{D}},\; M_{\mathrm{D}}$}
+
+\end{pspicture}

--- a/doc/source/application/schematic/obsrefl_domain.tex
+++ b/doc/source/application/schematic/obsrefl_domain.tex
@@ -1,0 +1,66 @@
+\begin{pspicture}(-2.4,-1.7)(11.8,3.5)
+\psset{arrowsize=4pt 2}
+
+% The rectangular computing domain, four units long and one tall.
+\psframe[linewidth=1pt](0,0)(8.8,2.2)
+
+% The slip wall along the bottom.
+\psline[linewidth=2pt](0,0)(8.8,0)
+\multips(0,0)(0.55,0){5}{\psline[linewidth=0.4pt](0,0)(-0.25,-0.25)}
+
+% The incident shock, from the upper-left corner to the wall.
+\psline[linewidth=1.2pt](0,2.2)(4.247,0)
+\rput{-27.4}(2.05,1.5){\small incident shock}
+
+% The reflected shock, from the wall to the outflow.
+\psline[linewidth=1.2pt](4.247,0)(8.8,1.821)
+\rput{21.8}(7.45,1.63){\small reflected shock}
+
+% The incident shock angle, measured from the oncoming free stream.
+\psarc[linewidth=0.5pt](4.247,0){1.1}{152.6}{180}
+\rput[r](2.85,0.36){$\beta_1$}
+
+% The reflected shock angle, measured from the zone-2 flow that runs into
+% it: the solid arrow is that flow, the dashed line carries its direction
+% on through the front, and the arc between the two is beta_2.  The shock
+% therefore meets the wall at beta_2 - theta.
+\psline[linewidth=0.7pt]{->}(5.3,0.95)(6.1,0.81)
+\psline[linewidth=0.4pt,linestyle=dashed](6.1,0.81)(7.5,0.56)
+\psarc[linewidth=0.5pt](6.218,0.788){0.75}{-10}{21.8}
+\rput[c](7.24,0.90){$\beta_2$}
+\psarc[linewidth=0.5pt](4.247,0){1.1}{0}{21.8}
+\rput[l](5.42,0.22){$\beta_2-\theta$}
+
+% The reflection point.
+\psdot[dotsize=4pt](4.247,0)
+\psline[linewidth=0.5pt]{->}(4.247,-0.8)(4.247,-0.08)
+\rput[t](4.247,-0.95){\small reflection point}
+
+% Zone 1: the free stream.
+\psline[linewidth=0.7pt]{->}(0.5,0.45)(1.6,0.45)
+\psline[linewidth=0.7pt]{->}(0.5,0.95)(1.6,0.95)
+\pscircle[linewidth=0.5pt](2.05,0.52){0.25}
+\rput[c](2.05,0.52){1}
+
+% Zone 2: behind the incident shock, deflected by theta.
+\psline[linewidth=0.4pt,linestyle=dashed](3.6,1.85)(5.3,1.85)
+\psline[linewidth=0.7pt]{->}(3.6,1.85)(4.95,1.61)
+\psarc[linewidth=0.5pt](3.6,1.85){1.2}{-10}{0}
+\rput[l](5.4,1.72){$\theta$}
+\pscircle[linewidth=0.5pt](5.1,1.25){0.25}
+\rput[c](5.1,1.25){2}
+
+% Zone 3: behind the reflected shock, horizontal again.
+\psline[linewidth=0.7pt]{->}(6.6,0.28)(7.6,0.28)
+\pscircle[linewidth=0.5pt](8.15,0.62){0.25}
+\rput[c](8.15,0.62){3}
+
+% The four boundary conditions.
+\rput[r](-0.3,1.1){\small\begin{tabular}[c]{r}
+  inlet:\\zone-1\end{tabular}}
+\rput[b](4.4,2.45){\small inlet: zone-2}
+\rput[t](1.5,-0.5){\small slip wall}
+\rput[l](9.1,1.1){\small\begin{tabular}[c]{l}
+  non-reflective\\outflow\end{tabular}}
+
+\end{pspicture}

--- a/doc/source/application/schematic/obsrefl_oblique.tex
+++ b/doc/source/application/schematic/obsrefl_oblique.tex
@@ -1,0 +1,29 @@
+\begin{pspicture}(1.0,-0.4)(8.2,2.9)
+\psset{arrowsize=4pt 2}
+
+% The shock front, at beta from the oncoming flow.
+\psline[linewidth=1.2pt](2.19,2.40)(6.81,0.00)
+\rput{-27.4}(3.05,2.32){\small shock}
+
+% The upstream velocity, arriving at the front.
+\psline[linewidth=1pt]{->}(1.9,1.2)(4.5,1.2)
+\rput[c](2.35,1.44){$V_{\mathrm{U}}$}
+
+% The shock angle, between the front and the oncoming flow.
+\psarc[linewidth=0.5pt](4.5,1.2){1.5}{152.6}{180}
+\rput[c](2.78,1.66){$\beta$}
+
+% The downstream velocity, deflected by theta toward the front.
+\psline[linewidth=1pt]{->}(4.5,1.2)(6.88,0.78)
+\rput[l](7.02,0.66){$V_{\mathrm{D}}$}
+
+% The deflection, against the upstream direction carried through.
+\psline[linewidth=0.4pt,linestyle=dashed](4.5,1.2)(6.9,1.2)
+\psarc[linewidth=0.5pt](4.5,1.2){2.1}{-10}{0}
+\rput[l](6.96,1.02){$\theta$}
+
+% The two states.
+\rput[l](1.05,0.35){$\rho_{\mathrm{U}},\; p_{\mathrm{U}},\; T_{\mathrm{U}},\; M_{\mathrm{U}}$}
+\rput[l](5.30,2.30){$\rho_{\mathrm{D}},\; p_{\mathrm{D}},\; T_{\mathrm{D}},\; M_{\mathrm{D}}$}
+
+\end{pspicture}

--- a/doc/source/application/schematic/obsrefl_tbm.tex
+++ b/doc/source/application/schematic/obsrefl_tbm.tex
@@ -1,0 +1,32 @@
+\psset{xunit=0.09cm,yunit=0.12cm}
+\begin{pspicture}(-16,-9)(102,46)
+\psset{arrowsize=4pt 2}
+
+% The theta-beta curve of Mach 3, gamma 1.4: theta = atan(num/den) with
+% num = 2 cot(beta) (9 sin^2(beta) - 1) and den = 9 (1.4 + cos(2 beta)) + 2.
+\psplot[linewidth=1pt,plotpoints=400]{19.6}{89.8}{%
+  x sin dup mul 9 mul 1 sub x cos mul 2 mul x sin div
+  14.6 x 2 mul cos 9 mul add atan}
+
+\psaxes[linewidth=0.5pt,Dx=30,Dy=10,ticksize=0 3pt]{->}(0,0)(0,0)(97,43)
+\rput[t](50,-5.5){$\beta$ (deg)}
+\rput{90}(-11,22){$\theta$ (deg)}
+
+% The default deflection cuts the curve at the weak and the strong root.
+\psline[linewidth=0.4pt,linestyle=dashed](0,10)(90,10)
+\rput[t](8,8.2){$\theta = 10$}
+\psdot[dotsize=3.5pt](27.383,10)
+\psline[linewidth=0.4pt,linestyle=dotted](27.383,0)(27.383,10)
+\rput[r](25.0,14.5){weak, $\beta_1$}
+\psdot[dotsize=3.5pt](86.408,10)
+\rput[r](84.0,15.0){strong}
+
+% The peak: the largest deflection an attached shock can turn.
+\psdot[dotsize=3.5pt](65.241,34.073)
+\psline[linewidth=0.4pt,linestyle=dotted](0,34.073)(65.241,34.073)
+\rput[b](65.241,37.0){$\theta_{\mathrm{max}} = 34.07$}
+
+% The curve leaves zero deflection at the Mach angle.
+\rput[t](19.5,-1.5){$\mu$}
+
+\end{pspicture}

--- a/solvcon/pstake.py
+++ b/solvcon/pstake.py
@@ -638,6 +638,9 @@ if HAS_SPHINX:
             if isinstance(children[0], nodes.system_message):
                 return children[:1]
             figure_node = nodes.figure('', *children)
+            # Register the :name: option on the figure, so it can be
+            # cross-referenced; docutils leaves this to the directive.
+            self.add_name(figure_node)
             # Pop options.
             figwidth = self.options.pop('figwidth', None)
             figclasses = self.options.pop('figclass', None)


### PR DESCRIPTION
For issue #1274 

Add notes for the equations needed to understand the problem of oblique shock reflection.

Also update pstake for the necessary documenting support.

It is difficult to review the schematics and document without building it.  To build the document, run `make -C doc html`.