### PR TITLE
Store and execute matmul benchmarks

### DIFF
--- a/solvcon/benchmark/__init__.py
+++ b/solvcon/benchmark/__init__.py
@@ -1,14 +1,16 @@
 # Copyright (c) 2026, solvcon team <contact@solvcon.net>
 # BSD 3-Clause License, see COPYING
 
-"""Expose benchmark specification and collection modules."""
+"""Expose benchmark modules."""
 
+from . import artifact
 from . import collector
 from . import matmul
 from . import spec
 
 
 __all__ = [
+    'artifact',
     'collector',
     'matmul',
     'spec',

--- a/solvcon/benchmark/artifact.py
+++ b/solvcon/benchmark/artifact.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""Validate and atomically store benchmark artifacts."""
+
+import json
+import math
+import os
+import pathlib
+import tempfile
+
+from . import matmul
+from . import spec as benchmark_spec
+
+
+class ArtifactError(ValueError):
+    """Report an invalid benchmark artifact."""
+
+
+def _require_exact_fields(value, label, expected_fields):
+    if not isinstance(value, dict):
+        raise ArtifactError(f'{label} must be an object')
+    if any(not isinstance(field, str) for field in value):
+        raise ArtifactError(f'{label} field names must be strings')
+    actual = set(value)
+    expected = set(expected_fields)
+    missing = sorted(expected - actual)
+    if missing:
+        raise ArtifactError(f'{label} is missing fields: {missing}')
+    unknown = sorted(actual - expected)
+    if unknown:
+        raise ArtifactError(f'{label} has unknown fields: {unknown}')
+
+
+def _require_list(value, label):
+    if not isinstance(value, list):
+        raise ArtifactError(f'{label} must be an array')
+
+
+def _require_nonnegative_int(value, label):
+    is_integer = isinstance(value, int) and not isinstance(value, bool)
+    if not is_integer or value < 0:
+        raise ArtifactError(f'{label} must be a non-negative integer')
+
+
+def _require_diff(value, label, allow_none=False):
+    if value is None and allow_none:
+        return
+    if not isinstance(value, float):
+        raise ArtifactError(f'{label} must be a floating-point number')
+    if not math.isfinite(value) or value < 0:
+        raise ArtifactError(f'{label} must be finite and non-negative')
+
+
+def _validate_result(result, label, rounds, output_empty):
+    expected_fields = (
+        'name', 'status', 'reason', 'max_abs_diff', 'relative_diff',
+        'round_elapsed_ns')
+    _require_exact_fields(result, label, expected_fields)
+    if not isinstance(result['name'], str) or not result['name']:
+        raise ArtifactError(f'{label}.name must be a non-empty string')
+    status = result['status']
+    if status not in ('measured', 'invalid', 'ineligible'):
+        raise ArtifactError(f'{label}.status is unsupported')
+
+    elapsed = result['round_elapsed_ns']
+    elapsed_label = f'{label}.round_elapsed_ns'
+    _require_list(elapsed, elapsed_label)
+    for index, value in enumerate(elapsed):
+        value_label = f'{elapsed_label}[{index}]'
+        _require_nonnegative_int(value, value_label)
+
+    max_abs_diff = result['max_abs_diff']
+    relative_diff = result['relative_diff']
+    has_differences = max_abs_diff is not None or relative_diff is not None
+    if status == 'measured':
+        if result['reason'] is not None:
+            raise ArtifactError(f'{label}.reason must be null when measured')
+        _require_diff(max_abs_diff, f'{label}.max_abs_diff', output_empty)
+        relative_label = f'{label}.relative_diff'
+        _require_diff(relative_diff, relative_label, allow_none=True)
+        if output_empty and has_differences:
+            raise ArtifactError(f'{label} differences must be null when empty')
+        if len(elapsed) != rounds:
+            raise ArtifactError(f'{label} must contain one time per round')
+    else:
+        if not isinstance(result['reason'], str) or not result['reason']:
+            raise ArtifactError(f'{label}.reason must explain its status')
+        if has_differences or elapsed:
+            raise ArtifactError(f'{label} must not contain measurements')
+
+
+def validate_artifact(artifact):
+    """Validate one benchmark artifact."""
+    expected_fields = ('spec', 'round_orders', 'results')
+    _require_exact_fields(artifact, 'artifact', expected_fields)
+    try:
+        parsed_spec = matmul.MatmulSpec.from_dict(artifact['spec'])
+    except benchmark_spec.SpecError as exc:
+        raise ArtifactError(f'invalid artifact spec: {exc}') from exc
+    if artifact['spec'] != parsed_spec.to_dict():
+        raise ArtifactError('artifact spec must use canonical JSON data')
+
+    expected_names = parsed_spec.kernels + ('numpy',)
+    results = artifact['results']
+    _require_list(results, 'artifact.results')
+    rounds = parsed_spec.sampling.rounds
+    output_empty = 0 in parsed_spec.output_shape
+    for index, result in enumerate(results):
+        result_label = f'artifact.results[{index}]'
+        _validate_result(result, result_label, rounds, output_empty)
+    names = tuple(result['name'] for result in results)
+    if names != expected_names:
+        raise ArtifactError('artifact results do not match spec kernels')
+    numpy_status = results[-1]['status']
+    if numpy_status == 'ineligible':
+        raise ArtifactError('the NumPy result cannot be ineligible')
+    if numpy_status == 'invalid':
+        statuses = {result['status'] for result in results}
+        if statuses != {'invalid'}:
+            raise ArtifactError(
+                'all results must be invalid when NumPy is invalid')
+
+    measured_names = {result['name'] for result in results
+                      if result['status'] == 'measured'}
+
+    round_orders = artifact['round_orders']
+    _require_list(round_orders, 'artifact.round_orders')
+    if len(round_orders) != rounds:
+        raise ArtifactError('artifact must contain every timing round')
+    for index, order in enumerate(round_orders):
+        order_label = f'artifact.round_orders[{index}]'
+        _require_list(order, order_label)
+        names_are_valid = all(isinstance(name, str) and name for name in order)
+        if not names_are_valid:
+            raise ArtifactError(f'{order_label} has an invalid name')
+        same_size = len(order) == len(measured_names)
+        same_names = set(order) == measured_names
+        if not same_size or not same_names:
+            raise ArtifactError(f'{order_label} must order measured results')
+    return artifact
+
+
+def write_artifact(artifact, path):
+    """Atomically replace a path with one validated artifact."""
+    validate_artifact(artifact)
+    path = pathlib.Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+                mode='w', encoding='utf8', dir=path.parent,
+                delete=False) as stream:
+            temporary_path = pathlib.Path(stream.name)
+            json.dump(artifact, stream, indent=2, sort_keys=True,
+                      allow_nan=False)
+            stream.write('\n')
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+    return path
+
+
+def load_artifact(path):
+    """Load and validate one artifact."""
+    with pathlib.Path(path).open(encoding='utf8') as stream:
+        artifact = json.load(stream)
+    return validate_artifact(artifact)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/benchmark/worker.py
+++ b/solvcon/benchmark/worker.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""Execute one matmul benchmark through a JSON-lines protocol."""
+
+import json
+import sys
+
+from . import artifact
+from . import collector
+from . import matmul
+from . import spec as benchmark_spec
+
+
+def _emit(event, stream):
+    stream.write(json.dumps(event, sort_keys=True, allow_nan=False) + '\n')
+    stream.flush()
+
+
+def _read_request(stream):
+    line = stream.readline()
+    if not line:
+        raise benchmark_spec.SpecError('worker request is missing')
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise benchmark_spec.SpecError(
+            'worker request must be valid JSON') from exc
+    benchmark_spec._require_fields(
+        data, 'worker request', ('spec', 'output_path'))
+    output_path = data['output_path']
+    if not isinstance(output_path, str) or not output_path:
+        raise benchmark_spec.SpecError(
+            'worker request output_path must be a non-empty string')
+    return matmul.MatmulSpec.from_dict(data['spec']), output_path
+
+
+def run(stdin, stdout):
+    """Run one request and emit one terminal result or error event."""
+    try:
+        specification, output_path = _read_request(stdin)
+        comparison = collector.collect(specification)
+        artifact_path = artifact.write_artifact(comparison, output_path)
+        _emit({
+            'type': 'result',
+            'artifact_path': str(artifact_path),
+        }, stdout)
+        return 0
+    except Exception as exc:
+        _emit({
+            'type': 'error',
+            'error_type': type(exc).__name__,
+            'message': str(exc),
+        }, stdout)
+        return 1
+
+
+def main():
+    """Run the worker on the process streams."""
+    return run(sys.stdin, sys.stdout)
+
+
+if __name__ == '__main__':
+    sys.exit(main())
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,11 +1,22 @@
 # Copyright (c) 2026, solvcon team <contact@solvcon.net>
 # BSD 3-Clause License, see COPYING
 
+import copy
+import io
+import json
 import math
+import os
+import pathlib
+import shutil
+import subprocess
 import sys
+import tempfile
 import unittest
+import unittest.mock
 
 from solvcon import benchmark
+from solvcon.benchmark import artifact
+from solvcon.benchmark import worker
 
 
 def make_matmul_spec(**updates):
@@ -194,4 +205,179 @@ class MatmulSpecTC(unittest.TestCase):
                         benchmark.spec.SpecError, message):
                     benchmark.matmul.MatmulSpec.from_dict(spec)
 
-# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:
+
+def make_comparison():
+    return {
+        'spec': {
+            'operation': 'matmul',
+            'lhs': {'shape': [2, 3], 'strides': [3, 1]},
+            'rhs': {'shape': [3, 2], 'strides': [2, 1]},
+            'dtype': 'float64',
+            'sampling': {'warmups': 0, 'repetitions': 1, 'rounds': 2},
+            'kernels': ['naive', 'winograd'],
+        },
+        'round_orders': [['naive', 'numpy'], ['numpy', 'naive']],
+        'results': [
+            {
+                'name': 'naive', 'status': 'measured', 'reason': None,
+                'max_abs_diff': 0.0, 'relative_diff': 0.0,
+                'round_elapsed_ns': [10, 11],
+            },
+            {
+                'name': 'winograd', 'status': 'ineligible',
+                'reason': 'unsupported shape', 'max_abs_diff': None,
+                'relative_diff': None, 'round_elapsed_ns': [],
+            },
+            {
+                'name': 'numpy', 'status': 'measured', 'reason': None,
+                'max_abs_diff': 0.0, 'relative_diff': 0.0,
+                'round_elapsed_ns': [12, 13],
+            },
+        ],
+    }
+
+
+class ArtifactTC(unittest.TestCase):
+    def test_round_trip(self):
+        document = make_comparison()
+        with tempfile.TemporaryDirectory() as dirname:
+            path = pathlib.Path(dirname) / 'nested' / 'result.json'
+            written = artifact.write_artifact(document, path)
+            loaded = artifact.load_artifact(path)
+
+        self.assertEqual(written, path)
+        self.assertEqual(loaded, document)
+
+    def test_rejects_inconsistent_artifact_data(self):
+        mutations = (
+            lambda item: item.__setitem__('extra', None),
+            lambda item: item['results'].reverse(),
+            lambda item: item['results'][0]['round_elapsed_ns'].pop(),
+            lambda item: item['round_orders'][0].remove('numpy'),
+            lambda item: item['results'][1].__setitem__(
+                'max_abs_diff', 0.0),
+            lambda item: item['results'][1].__setitem__('reason', ''),
+            lambda item: item['results'][0].__setitem__(
+                'relative_diff', float('nan')),
+            lambda item: item['results'][0].__setitem__(
+                'max_abs_diff', 0),
+            lambda item: item['round_orders'][0].__setitem__(0, []),
+        )
+        for mutate in mutations:
+            with self.subTest(mutate=mutate):
+                document = make_comparison()
+                mutate(document)
+                with self.assertRaises(artifact.ArtifactError):
+                    artifact.validate_artifact(document)
+
+    def test_rejects_measured_kernel_when_numpy_is_invalid(self):
+        document = make_comparison()
+        for result in document['results'][1:]:
+            result.update(
+                status='invalid', reason='non-finite NumPy reference',
+                max_abs_diff=None, relative_diff=None,
+                round_elapsed_ns=[])
+        for order in document['round_orders']:
+            order.remove('numpy')
+
+        with self.assertRaisesRegex(artifact.ArtifactError, 'NumPy'):
+            artifact.validate_artifact(document)
+
+    def test_failed_replace_preserves_existing_artifact(self):
+        original = make_comparison()
+        replacement = copy.deepcopy(original)
+        replacement['results'][0]['round_elapsed_ns'][0] = 99
+        with tempfile.TemporaryDirectory() as dirname:
+            path = pathlib.Path(dirname) / 'result.json'
+            artifact.write_artifact(original, path)
+            with unittest.mock.patch.object(
+                    artifact.os, 'replace', side_effect=OSError('failed')):
+                with self.assertRaisesRegex(OSError, 'failed'):
+                    artifact.write_artifact(replacement, path)
+
+            self.assertEqual(artifact.load_artifact(path), original)
+            self.assertEqual(list(path.parent.iterdir()), [path])
+
+    def test_load_validates(self):
+        document = make_comparison()
+        document['results'][0]['relative_diff'] = float('nan')
+        with tempfile.TemporaryDirectory() as dirname:
+            path = pathlib.Path(dirname) / 'result.json'
+            path.write_text(json.dumps(document), encoding='ascii')
+
+            with self.assertRaisesRegex(artifact.ArtifactError, 'finite'):
+                artifact.load_artifact(path)
+
+
+def make_request(output_path):
+    return {
+        'spec': {
+            'operation': 'matmul',
+            'lhs': {'shape': [2, 2], 'strides': [2, 1]},
+            'rhs': {'shape': [2, 2], 'strides': [2, 1]},
+            'dtype': 'float64',
+            'sampling': {'warmups': 0, 'repetitions': 1, 'rounds': 1},
+            'kernels': ['naive'],
+        },
+        'output_path': os.fspath(output_path),
+    }
+
+
+class BenchmarkWorkerTC(unittest.TestCase):
+    def test_reports_invalid_requests(self):
+        valid = make_request('artifact.json')
+        cases = (
+            ('', 'missing'),
+            ('{', 'valid JSON'),
+            (json.dumps({**valid, 'extra': None}), 'unknown fields'),
+            (json.dumps({**valid, 'output_path': ''}), 'non-empty'),
+        )
+        for payload, message in cases:
+            with self.subTest(message=message):
+                stdout = io.StringIO()
+                with unittest.mock.patch.object(
+                        worker.collector, 'collect') as collect:
+                    return_code = worker.run(
+                        io.StringIO(payload), stdout)
+
+                self.assertEqual(return_code, 1)
+                event = json.loads(stdout.getvalue())
+                self.assertEqual(event['type'], 'error')
+                self.assertIn(message, event['message'])
+                collect.assert_not_called()
+
+    def test_reports_collection_failure(self):
+        stdout = io.StringIO()
+        with unittest.mock.patch.object(
+                worker.collector, 'collect',
+                side_effect=RuntimeError('native failure')):
+            return_code = worker.run(io.StringIO(
+                json.dumps(make_request('unused.json'))), stdout)
+
+        event = json.loads(stdout.getvalue())
+        self.assertEqual(return_code, 1)
+        self.assertEqual(event['error_type'], 'RuntimeError')
+        self.assertEqual(event['message'], 'native failure')
+
+    def test_process_writes_artifact(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / 'artifact.json'
+            request = make_request(path)
+            python = shutil.which('python3')
+            self.assertIsNotNone(python)
+            process = subprocess.run(
+                [python, '-m', 'solvcon.benchmark.worker'],
+                input=json.dumps(request) + '\n',
+                capture_output=True, text=True, check=False)
+
+            self.assertEqual(
+                process.returncode, 0, process.stderr or process.stdout)
+            self.assertEqual(json.loads(process.stdout), {
+                'type': 'result',
+                'artifact_path': str(path),
+            })
+            document = artifact.load_artifact(path)
+            self.assertEqual(document['spec'], request['spec'])
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:


### PR DESCRIPTION
## Motivation

This PR stores one comparison in a strict artifact and runs one request in an isolated worker. The collector from #1433 runs in process, but the Route Inspector needs saved JSON before Qt controls the worker.

## Approach

The artifact validates its complete structure before a same-directory atomic replacement:

```text
comparison -> validate -> sibling temp -> fsync -> replace
```

The worker reads one strict request and emits one terminal JSON line:

```text
{spec, output_path} -> collect -> validate -> write -> result
           `------------ any failure ------------> error
```

Qt process control and progress events remain in Task 6. The benchmark tests and `make lint` pass.

Related to #1369.