### PR TITLE
Prepare Linux CUDA builds

### DIFF
--- a/.claude/hooks/check-source.sh
+++ b/.claude/hooks/check-source.sh
@@ -55,7 +55,7 @@ check_file() {
 
     [ ! -f "$file" ] && return
     case "$file" in
-        *.py|*.cpp|*.hpp|*.c|*.h|*.cxx|*.hxx|*.mm) ;;
+        *.py|*.cpp|*.hpp|*.c|*.h|*.cxx|*.hxx|*.mm|*.cu) ;;
         *) return ;;
     esac
 

--- a/.github/actions/setup_linux/action.yml
+++ b/.github/actions/setup_linux/action.yml
@@ -25,7 +25,7 @@ runs:
         echo "::endgroup::"
 
     - name: Free disk space
-      if: "${{ inputs.workflow == 'lint' || inputs.workflow == 'build' }}"
+      if: "${{ inputs.workflow == 'lint' || inputs.workflow == 'build' || inputs.workflow == 'build_cuda' }}"
       shell: bash
       run: |
         echo "::group::Free disk space"
@@ -115,6 +115,19 @@ runs:
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-16 100
         sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-16 100
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-16 100
+        echo "::endgroup::"
+
+    - name: install CUDA toolkit
+      if: ${{ inputs.workflow == 'build_cuda' }}
+      shell: bash
+      run: |
+        echo "::group::install CUDA toolkit"
+        wget -qO cuda-keyring_1.1-1_all.deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+        echo "d2a6b11c096396d868758b86dab1823b25e14d70333f1dfa74da5ddaf6a06dba  cuda-keyring_1.1-1_all.deb" | sha256sum --check -
+        sudo dpkg -i cuda-keyring_1.1-1_all.deb
+        sudo contrib/ci/apt-update.sh -qq
+        sudo apt-get -qy install cuda-nvcc-13-0 cuda-cudart-dev-13-0 g++-14
+        echo "/usr/local/cuda-13.0/bin" >> "${GITHUB_PATH}"
         echo "::endgroup::"
 
     - name: install qt

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -283,8 +283,66 @@ jobs:
         make run_pilot_pytest VERBOSE=1
         echo "::endgroup::"
 
+  build_cuda:
+
+    needs: [check_skip, standalone_buffer]
+
+    if: |
+      needs.check_skip.outputs.skip != 'true' && (
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' &&
+       ((vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH) == '*' ||
+        contains(vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))))
+
+    name: build_cuda_ubuntu-24.04
+
+    runs-on: ubuntu-24.04
+
+    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_BUILD || vars.MMGH_TIMEOUT_BUILD || '45') }}
+
+    env:
+      MAKE_PARALLEL: -j4
+      CMAKE_BUILD_TYPE: Release
+      PIP_BREAK_SYSTEM_PACKAGES: 1
+
+    steps:
+
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+
+    - name: event name
+      run: |
+        echo "github.event_name: ${{ github.event_name }}"
+
+    - name: setup dependencies for Linux
+      uses: ./.github/actions/setup_linux
+      with:
+        workflow: 'build_cuda'
+
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2.23
+      with:
+        key: ${{ runner.os }}-cuda-Release
+        restore-keys: ${{ runner.os }}-cuda-Release
+        save: ${{ github.event_name != 'pull_request' }}
+        max-size: 1500M
+
+    - name: make buildext BUILD_CUDA=ON
+      run: |
+        echo "::group::make buildext BUILD_CUDA=ON"
+        nvcc --version
+        make buildext \
+          VERBOSE=1 USE_CLANG_TIDY=OFF \
+          BUILD_QT=OFF BUILD_CUDA=ON \
+          CMAKE_CUDA_ARCHITECTURES=all-major \
+          CMAKE_CUDA_HOST_COMPILER=g++-14
+        echo "::endgroup::"
+
   send_email_on_failure:
-    needs: [check_skip, standalone_buffer, build]
+    needs: [check_skip, standalone_buffer, build, build_cuda]
     # Mail a master push failure only. A nightly call reads the caller's
     # event name, and nightly_devbuild mails that one itself. A
     # `timeout-minutes` kill reports `cancelled`, not `failure`.
@@ -301,6 +359,7 @@ jobs:
         - check_skip: ${{ needs.check_skip.result }}
         - standalone_buffer: ${{ needs.standalone_buffer.result }}
         - build: ${{ needs.build.result }}
+        - build_cuda: ${{ needs.build_cuda.result }}
     secrets:
       EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
       EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,24 @@ if(BUILD_METAL)
     add_compile_options($<$<COMPILE_LANGUAGE:OBJCXX>:-fobjc-arc>)
 endif()
 
+option(BUILD_CUDA "build with CUDA" OFF)
+message(STATUS "BUILD_CUDA: ${BUILD_CUDA}")
+if(BUILD_CUDA)
+    if(APPLE)
+        message(FATAL_ERROR "BUILD_CUDA is not supported on macOS")
+    endif()
+    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+        set(CMAKE_CUDA_ARCHITECTURES native)
+    endif()
+    # The probe does not include C++23 core headers. C++17 keeps the build
+    # compatible with CUDA 11 and newer.
+    set(CMAKE_CUDA_STANDARD 17)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    set(CMAKE_CUDA_EXTENSIONS OFF)
+    enable_language(CUDA)
+    find_package(CUDAToolkit REQUIRED)
+endif()
+
 option(USE_CLANG_TIDY "use clang-tidy" OFF)
 option(LINT_AS_ERRORS "clang-tidy warnings as errors" OFF)
 message(STATUS "LINT_AS_ERRORS: ${LINT_AS_ERRORS}")
@@ -253,8 +271,12 @@ if(USE_SANITIZER)
         add_link_options(/INCREMENTAL:NO)
     else()
         set(SANITIZER_LIST "undefined,leak,address")
-        add_compile_options(-fsanitize=${SANITIZER_LIST})
-        add_link_options(-fsanitize=${SANITIZER_LIST})
+        add_compile_options(
+            "$<$<COMPILE_LANGUAGE:C,CXX,OBJCXX>:-fsanitize=${SANITIZER_LIST}>"
+        )
+        add_link_options(
+            "$<$<LINK_LANGUAGE:C,CXX,OBJCXX>:-fsanitize=${SANITIZER_LIST}>"
+        )
     endif()
 else()
     message(STATUS "not use sanitizer")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,6 +15,7 @@
         "USE_CLANG_TIDY": { "type": "BOOL", "value": "OFF" },
         "USE_SANITIZER": { "type": "BOOL", "value": "OFF" },
         "BUILD_METAL": { "type": "BOOL", "value": "OFF" },
+        "BUILD_CUDA": { "type": "BOOL", "value": "OFF" },
         "USE_GOOGLETEST": { "type": "BOOL", "value": "ON" },
         "CMAKE_EXPORT_COMPILE_COMMANDS": { "type": "BOOL", "value": "ON" },
         "CMAKE_LIBRARY_OUTPUT_DIRECTORY": {

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,9 @@ RUNENV += PYTHONPATH=$(SOLVCON_ROOT)
 # and nothing else is passed, so a make build and a preset build stay the same
 # build. Setting a knob to its preset value therefore costs nothing.
 CMAKE_KNOBS = SKIP_PYTHON_EXECUTABLE HIDE_SYMBOL SOLVCON_PROFILE \
-	SOLVCON_DEPS_CACHE BUILD_METAL BUILD_QT USE_CLANG_TIDY \
+	SOLVCON_DEPS_CACHE BUILD_METAL BUILD_CUDA BUILD_QT USE_CLANG_TIDY \
 	LINT_AS_ERRORS USE_GOOGLETEST USE_SANITIZER USE_CCACHE \
+	CMAKE_CUDA_ARCHITECTURES CMAKE_CUDA_HOST_COMPILER \
 	CMAKE_INSTALL_PREFIX CMAKE_LIBRARY_OUTPUT_DIRECTORY CMAKE_PREFIX_PATH
 CMAKE_OVERRIDES = $(strip $(foreach knob,$(CMAKE_KNOBS), \
 	$(if $(filter-out undefined default,$(origin $(knob))),\
@@ -269,7 +270,7 @@ AUTOPEP8_OPTS ?= --recursive --max-line-length=79 \
                  --ignore=E121,E123,E126,E201,E202,E203,E241,E301,E303,E501,W503,W504 \
                  --exclude=thirdparty,tmp,_deps
 
-CFFILES = $(shell find cpp gtests -type f \( -name '*.[ch]pp' -o -name '*.mm' \) | sort)
+CFFILES = $(shell find cpp gtests -type f \( -name '*.[ch]pp' -o -name '*.mm' -o -name '*.cu' \) | sort)
 ifeq ($(FORCE_CLANG_FORMAT),inplace)
 	CFCMD ?= $(CLANG_FORMAT) -i
 else

--- a/contrib/dependency/build-scdv.sh
+++ b/contrib/dependency/build-scdv.sh
@@ -42,9 +42,10 @@
 #       Print the system prerequisite commands (apt or brew) and exit.  The
 #       script never runs the package manager; copy, review, and run them
 #       yourself.  --print-apt is a backward-compatible alias.  The output
-#       ends with the two toolchains no build section installs: LaTeX, which
-#       the documentation needs to render its figures, then clang-format and
-#       clang-tidy for `make lint`, both from LLVM 22.
+#       includes CUDA 13.0 on Ubuntu.  It ends with the two toolchains no build
+#       section installs: LaTeX, which the documentation needs to render its
+#       figures, then clang-format and clang-tidy for `make lint`, both from
+#       LLVM 22.
 #   ./build-scdv.sh --allow-unsupported-platform
 #       Proceed on an unsupported OS/architecture for platform testing.
 #
@@ -176,7 +177,7 @@ scdv_apt_base_cmd() {
   cat <<'EOF'
 sudo apt install -y \
   build-essential gcc g++ make cmake ninja-build pkg-config \
-  git curl xz-utils gfortran libopenblas-dev \
+  ca-certificates gpg git curl wget xz-utils gfortran libopenblas-dev \
   libffi-dev libbz2-dev liblzma-dev libgdbm-dev \
   libncurses-dev uuid-dev tk-dev libedit-dev libexpat1-dev \
   doxygen
@@ -242,6 +243,18 @@ sudo apt install -y \
 EOF
 }
 
+scdv_apt_llvm_repo_cmd() {
+  # Configure the LLVM repository before either Qt's libclang development
+  # packages or the lint tools are installed.
+  cat <<'EOF'
+wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+  | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" \
+  | sudo tee /etc/apt/sources.list.d/llvm.list
+sudo apt-get -qqy update
+EOF
+}
+
 scdv_apt_clang_lint_cmd() {
   # Print the apt command for the C++ lint tools: clang-format for
   # `make cformat` and clang-tidy for `make USE_CLANG_TIDY=ON` and
@@ -253,11 +266,6 @@ scdv_apt_clang_lint_cmd() {
   # relative to the symlink's real path, so /usr/lib/llvm-22/share/clang is
   # still found.
   cat <<'EOF'
-wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
-  | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" \
-  | sudo tee /etc/apt/sources.list.d/llvm.list
-sudo apt-get -qqy update
 sudo apt install -y clang-format-22 clang-tidy-22
 sudo ln -fs "$(which clang-format-22)" /usr/local/bin/clang-format
 sudo ln -fs "$(which clang-tidy-22)" /usr/local/bin/clang-tidy
@@ -278,12 +286,28 @@ sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-16 100
 EOF
 }
 
+scdv_apt_cuda_cmd() {
+  # Print the CUDA commands used by the Linux CI build.  CUDA 13.0 supports
+  # GCC 14 as its host compiler; the rest of solvcon uses GCC 16.
+  cat <<'EOF'
+wget -qO cuda-keyring_1.1-1_all.deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+echo "d2a6b11c096396d868758b86dab1823b25e14d70333f1dfa74da5ddaf6a06dba  cuda-keyring_1.1-1_all.deb" | sha256sum --check - && \
+  sudo dpkg -i cuda-keyring_1.1-1_all.deb && \
+  sudo apt-get -qqy update && \
+  sudo apt-get -qy install cuda-nvcc-13-0 cuda-cudart-dev-13-0 g++-14
+EOF
+}
+
 plat_print_deps() {
-  # Ubuntu prints the apt base/GCC/QT/FFmpeg/LaTeX sets, then the lint
-  # toolchain.
+  # Ubuntu prints the apt base/GCC/CUDA sets, configures LLVM, then prints the
+  # QT/FFmpeg/LaTeX sets and lint toolchain.
   scdv_apt_base_cmd
   echo
   scdv_apt_gcc_cmd
+  echo
+  scdv_apt_cuda_cmd
+  echo
+  scdv_apt_llvm_repo_cmd
   echo
   scdv_apt_qt_cmd
   echo
@@ -437,6 +461,9 @@ export _SCDV_HAD_SOLVCON_DEPS_CACHE=${SOLVCON_DEPS_CACHE+1}
 # LD_LIBRARY_PATH will be loaded ahead of this scdv's freshly built Qt and
 # break with "version `Qt_6.x' not found". Strip those.
 PATH=$(printf '%s' "${PATH}" | tr ':' '\n' | grep -v '/var/Qt/' | paste -sd: -)
+if [ -d /usr/local/cuda-13.0/bin ] ; then
+  PATH=/usr/local/cuda-13.0/bin:${PATH}
+fi
 export PATH=${SCDV_USRDIR}/bin:${PATH}
 
 LD_LIBRARY_PATH=$(printf '%s' "${LD_LIBRARY_PATH-}" \

--- a/contrib/lint/check_ascii.py
+++ b/contrib/lint/check_ascii.py
@@ -56,7 +56,7 @@ def find_source_files(args):
     """Find all source code files in the project."""
     patterns = [
         '**/*.py', '**/*.cpp', '**/*.hpp', '**/*.c', '**/*.h',
-        '**/*.cxx', '**/*.hxx', '**/*.mm', '**/*.sh',
+        '**/*.cxx', '**/*.hxx', '**/*.mm', '**/*.cu', '**/*.sh',
         '**/Makefile', '**/makefile', '**/CMakeLists.txt',
         '.github/workflows/*.yml'
     ]
@@ -194,3 +194,6 @@ def main():
 
 if __name__ == '__main__':
     sys.exit(main())
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/cpp/solvcon/CMakeLists.txt
+++ b/cpp/solvcon/CMakeLists.txt
@@ -59,6 +59,15 @@ set(SOLVCON_ROOT_FILES
     ${SOLVCON_ROOT_HEADERS}
     CACHE FILEPATH "" FORCE)
 
+set(SOLVCON_DEVICE_HEADERS
+    CACHE FILEPATH "" FORCE)
+set(SOLVCON_DEVICE_SOURCES
+    CACHE FILEPATH "" FORCE)
+
+if (BUILD_CUDA)
+    add_subdirectory(device/cuda)
+endif () # BUILD_CUDA
+
 if (BUILD_METAL)
     add_subdirectory(device/metal)
     set(SOLVCON_DEVICE_HEADERS
@@ -68,11 +77,6 @@ if (BUILD_METAL)
     set(SOLVCON_DEVICE_SOURCES
         ${SOLVCON_DEVICE_SOURCES}
         ${SOLVCON_METAL_SOURCES}
-        CACHE FILEPATH "" FORCE)
-else () # BUILD_METAL
-    set(SOLVCON_DEVICE_HEADERS
-        CACHE FILEPATH "" FORCE)
-    set(SOLVCON_DEVICE_SOURCES
         CACHE FILEPATH "" FORCE)
 endif () #BUILD_METAL
 
@@ -130,6 +134,12 @@ set_source_files_properties(
 )
 
 set(SOLVCON_LIBRARIES solvcon_primary)
+
+if (BUILD_CUDA)
+    # Keep the probe out of the core link because CUDA may need a different
+    # host compiler from the C++ sources.
+    add_dependencies(solvcon_primary solvcon_cuda_probe)
+endif () # BUILD_CUDA
 
 if (BUILD_QT)
     qt_add_library(

--- a/cpp/solvcon/device/cuda/CMakeLists.txt
+++ b/cpp/solvcon/device/cuda/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2019, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+cmake_minimum_required(VERSION 4.0.1)
+
+add_library(
+    solvcon_cuda_probe
+    STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/cuda.cu
+)
+target_link_libraries(solvcon_cuda_probe PRIVATE CUDA::cudart)
+
+# vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/device/cuda/cuda.cu
+++ b/cpp/solvcon/device/cuda/cuda.cu
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace solvcon
+{
+
+namespace device
+{
+
+__global__ void cuda_build_probe() {}
+
+} /* end namespace device */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
This change adds an opt-in CUDA compile probe and a dedicated Ubuntu 24.04 CI lane with pinned CUDA 13.0 packages. The compile-only probe stays separate from the C++ core because nvcc uses a different supported host compiler.

Local verification passed with CUDA 13.0, GCC 16 for the C++ core, and GCC 14 for nvcc: `make lint`; the CUDA-enabled Release build; 1,867 Python tests with 606 skips and 3 expected failures; all 264 C++ tests; and the CUDA plus sanitizer compile probe.

Related to #1443.