### PR TITLE
MCAP: Walk a union case by its discriminator

### DIFF
--- a/solvcon/track/mcap/_decodeplan.py
+++ b/solvcon/track/mcap/_decodeplan.py
@@ -11,9 +11,9 @@ typedefs, and integer constants.
 
 ``DecodePlan`` turns the root struct into a tree and walks it over the
 CDR body of each message.  A scalar or enum leaf reached through nested
-structs is a column.  The walk steps over a string, a sequence, or an
-array, so a leaf inside one is not a column.  A union field raises
-``McapError`` when a plan reaches it.
+structs is a column.  The walk steps over a string, a sequence, an
+array, or a union, so a leaf inside one is not a column.  A union reads
+its discriminator to find the case the payload carries.
 """
 
 import re
@@ -227,10 +227,7 @@ class _IdlParser:
         discriminator = self.type(modules)
         self.expect(")")
         self.expect("{")
-        members = None
-        if discriminator[0] == "named":
-            scoped = _lookup(self.registry.enums, discriminator[1], modules)
-            members = self.registry.enums.get(scoped)
+        members = self.enum_members(discriminator)
         cases = []
         values = []
         while self.peek() not in ("}", None):
@@ -255,6 +252,21 @@ class _IdlParser:
         self.expect("}")
         self.skip_optional(";")
         self.registry.unions[_scoped(modules, name)] = (discriminator, cases)
+
+    def enum_members(self, type_):
+        """Return the members of the enum ``type_`` names, else ``None``."""
+        seen = set()
+        while type_[0] == "named":
+            _, name, modules = type_
+            scoped = _lookup(self.registry.enums, name, modules)
+            if scoped is not None:
+                return self.registry.enums[scoped]
+            scoped = _lookup(self.registry.typedefs, name, modules)
+            if scoped is None or scoped in seen:
+                return None
+            seen.add(scoped)
+            type_ = self.registry.typedefs[scoped]
+        return None
 
     def label_value(self, label, members, modules):
         """Return the discriminator value a union case label names."""
@@ -404,8 +416,9 @@ def _tree(registry, type_, visiting):
     Return the tree that ``_walk`` runs over ``type_``.
 
     A node is ``("scalar", dtype, enum members)``, ``("struct", [(field,
-    node), ...])``, ``("string",)``, ``("sequence", node)``, or
-    ``("array", node, count)``.
+    node), ...])``, ``("string",)``, ``("sequence", node)``, ``("array",
+    node, count)``, or ``("union", discriminator node, {value: node})``.
+    The ``None`` key of the union map holds the ``default`` case.
     """
     type_ = _resolve(registry, type_)
     kind = type_[0]
@@ -413,12 +426,13 @@ def _tree(registry, type_, visiting):
         return ("scalar", type_[1], None)
     if kind == "enum":
         return ("scalar", ENUM_TYPE, registry.enums[type_[1]])
-    if kind == "struct":
+    if kind in ("struct", "union"):
         name = type_[1]
         if name in visiting:
-            raise McapError("struct {} contains itself".format(name))
-        return ("struct", [(field, _tree(registry, field_type,
-                                         visiting + (name,)))
+            raise McapError("{} {} contains itself".format(kind, name))
+        visiting += (name,)
+    if kind == "struct":
+        return ("struct", [(field, _tree(registry, field_type, visiting))
                            for field, field_type in registry.structs[name]])
     if kind == "string":
         return ("string",)
@@ -426,7 +440,21 @@ def _tree(registry, type_, visiting):
         return ("sequence", _tree(registry, type_[1], visiting))
     if kind == "array":
         return ("array", _tree(registry, type_[1], visiting), type_[2])
+    if kind == "union":
+        return _union_tree(registry, type_[1], visiting)
     raise McapError("unsupported type {!r}".format(type_[1]))
+
+
+def _union_tree(registry, name, visiting):
+    discriminator, cases = registry.unions[name]
+    switch = _tree(registry, discriminator, visiting)
+    if switch[0] != "scalar" or switch[1] in ("float32", "float64"):
+        raise McapError("bad discriminator of union {}".format(name))
+    branches = {}
+    for values, case_type in cases:
+        branches.update(dict.fromkeys(values,
+                                      _tree(registry, case_type, visiting)))
+    return ("union", switch, branches)
 
 
 def _leaves(node, path):
@@ -459,6 +487,11 @@ def _walk(node, body, pos, order, values):
         for _, child in node[1]:
             pos = _walk(child, body, pos, order, values)
         return pos
+    if kind == "union":
+        discriminator = []
+        pos = _walk(node[1], body, pos, order, discriminator)
+        child = node[2].get(discriminator[0], node[2].get(None))
+        return pos if child is None else _walk(child, body, pos, order, None)
     # TODO: a string, a sequence, or an array is only skipped; none of them
     # produces a column yet.
     if kind == "array":

--- a/tests/test_track_mcap.py
+++ b/tests/test_track_mcap.py
@@ -242,7 +242,66 @@ class SchemaParseTC(unittest.TestCase):
         self.assertEqual(registry.unions["demo_msgs::msg::Tail"][1],
                          [((-1, 120), ("scalar", "uint8")),
                           ((7,), ("scalar", "float64"))])
-        with self.assertRaisesRegex(mcap.McapError, "unsupported type"):
+
+        plan = mcap.DecodePlan(schema)
+        self.assertEqual(plan.fields, ("count", "kind", "ok", "speed"))
+        self.assertEqual(plan.types, ("uint32", "uint32", "bool", "float64"))
+        self.assertEqual(plan.enums, {"kind": ("A", "B", "C")})
+        for fields in (["extra.number"], ["extra.value"]):
+            with self.assertRaisesRegex(mcap.McapError, "non-scalar"):
+                mcap.DecodePlan(schema, fields)
+
+        for order in "<>":
+            for kind in range(3):
+                self.assertEqual(plan.decode(pack_signals(order, kind)),
+                                 (7, kind, True, 3.5), (order, kind))
+        with self.assertRaisesRegex(mcap.McapError, "ends before"):
+            plan.decode(pack_signals("<", 2)[:-12])
+
+    def test_union_cases(self):
+        """A union walks the case its discriminator selects, or none."""
+        schema = mcap.Schema(1, "x/msg/Y", "ros2idl", b"""
+            module x { module msg {
+              union Flag switch(boolean) {
+                case TRUE: double when;
+                case FALSE: octet why;
+              };
+              union Bare switch(short) { case 1: double d; };
+              struct Y { Flag flag; Bare bare; uint8 tail; };
+            }; };""")
+        plan = mcap.DecodePlan(schema)
+        self.assertEqual(plan.fields, ("tail",))
+        packer = CdrPacker("<").scalar("?", True).scalar("d", 1.5)
+        packer.scalar("h", 1).scalar("d", 2.5).scalar("B", 9)
+        self.assertEqual(plan.decode(packer.payload()), (9,))
+        packer = CdrPacker("<").scalar("?", False).scalar("B", 3)
+        packer.scalar("h", 2).scalar("B", 8)
+        self.assertEqual(plan.decode(packer.payload()), (8,))
+
+        schema = mcap.Schema(1, "x/msg/Y", "ros2idl",
+                             b"module x { module msg { enum Kind { A, B };"
+                             b" typedef Kind Switch;"
+                             b" union U switch(Switch) { case Kind::B:"
+                             b" double d; }; struct Y { U u; uint8 t; };"
+                             b" }; };")
+        plan = mcap.DecodePlan(schema)
+        packer = CdrPacker("<").scalar("I", 1).scalar("d", 1.5)
+        self.assertEqual(plan.decode(packer.scalar("B", 6).payload()), (6,))
+
+        for switch in (b"struct S { long v; }; union U switch(S)",
+                       b"union U switch(double)"):
+            schema = mcap.Schema(1, "x/msg/Y", "ros2idl",
+                                 b"module x { module msg { " + switch +
+                                 b" { case 1: long a; };"
+                                 b" struct Y { U u; }; }; };")
+            with self.assertRaisesRegex(mcap.McapError, "bad discriminator"):
+                mcap.DecodePlan(schema)
+        schema = mcap.Schema(1, "x/msg/Y", "ros2idl",
+                             b"module x { module msg {"
+                             b" struct S { U u; };"
+                             b" union U switch(long) { case 1: S s; };"
+                             b" struct Y { U u; }; }; };")
+        with self.assertRaisesRegex(mcap.McapError, "union .* contains"):
             mcap.DecodePlan(schema)
 
     def test_bundle(self):
@@ -384,6 +443,31 @@ class SchemaParseTC(unittest.TestCase):
         self.assertNotIn("x::msg::N", registry.consts)
         self.assertEqual(registry.structs["x::msg::Y"][0][1],
                          ("array", ("scalar", "float64"), 3))
+
+
+def pack_signals(order, kind):
+    """Pack a ``Signals`` message with ``count`` 7 and ``speed`` 3.5."""
+    packer = CdrPacker(order).string("abc")
+    packer.scalar("I", 2).string("x").scalar("B", 9)
+    packer.string("yz").scalar("B", 8)
+    packer.scalar("d", 1.0, 2.0, 3.0, 4.0).scalar("I", 7).scalar("I", kind)
+    packer.scalar("I", kind)
+    if kind == 0:
+        packer.scalar("i", -5)
+    elif kind == 1:
+        packer.string("h")
+    else:
+        packer.scalar("d", 6.5)
+    packer.scalar("I", 3).scalar("f", 1.5, 2.5, 3.5)
+    packer.string("p").scalar("B", 1).string("q").scalar("B", 2)
+    packer.scalar("?", True)
+    if kind == 0:
+        packer.scalar("i", -1).scalar("B", 4)
+    elif kind == 1:
+        packer.scalar("i", ord("x")).scalar("B", 4)
+    else:
+        packer.scalar("i", 7).scalar("d", 8.5)
+    return packer.scalar("d", 3.5).payload()
 
 
 def pack_status(seq, speed, brake_active, mode):


### PR DESCRIPTION
This PR lets the decode plan in `solvcon.track.mcap` walk an IDL union. The plan turns a union into a tree node that holds the discriminator and a map from case value to case subtree. The walk reads the discriminator and steps into the case it selects. When no case matches and no default exists, the walk steps past the discriminator alone.

A schema with a union could not build a plan before this PR, so no field of that message, union or not, reached a column. A leaf inside a union is not a column, the same rule as a leaf inside a sequence or an array. A union that contains itself, or that switches on a non-integral type, raises `McapError`. The parser follows a typedef to the enum it names, so a case label of an enum typedef resolves to its ordinal.

Related to #1438.
