### PR TITLE
Table the topics of an MCAP recording in the pilot

### DIFF
--- a/solvcon/pilot/track/__init__.py
+++ b/solvcon/pilot/track/__init__.py
@@ -2,7 +2,8 @@
 # BSD 3-Clause License, see COPYING
 
 
-"""The MCAP viewer of the pilot: a dock that lists the open recording."""
+"""The MCAP viewer of the pilot: a dock that lists the open recording and
+a main window that tables one of its topics."""
 
 from .. import _pilot_core as _pcore
 
@@ -11,15 +12,18 @@ if _pcore.enable:
 
     McapDock = _mcap_viewer.McapDock
     McapPanel = _mcap_viewer.McapPanel
+    McapMainWindow = _mcap_viewer.McapMainWindow
 else:
     # Bind only the public names: a None module attribute would shadow the
     # real submodule import in no-GUI builds.
     McapDock = None
     McapPanel = None
+    McapMainWindow = None
 
 __all__ = [
     'McapDock',
     'McapPanel',
+    'McapMainWindow',
 ]
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/track/_mcap_viewer.py
+++ b/solvcon/pilot/track/_mcap_viewer.py
@@ -3,8 +3,9 @@
 
 
 """
-Open an MCAP recording in the pilot: the Track menu opens a file, and the
-dock on the right shows what the reader gets without decoding a message.
+Open an MCAP recording in the pilot: the Track menu opens a file, the dock
+on the right shows what the reader gets without decoding a message, and the
+main window decodes the topic picked in the dock.
 """
 
 import os
@@ -19,9 +20,10 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QGridLayout,
 from ...track import mcap
 from .._style import PaletteStyled
 from ..base import _gui_common
-from ._style import (Rules, font, row_colors, BODY_TEXT_PIXEL_SIZE,
-                     CAPTION_TEXT_PIXEL_SIZE, TOPIC_NAME_PIXEL_SIZE,
-                     TOPIC_TYPE_PIXEL_SIZE)
+from ._style import (Rules, font, row_colors, ROW_PAD, ROW_GAP,
+                     BODY_TEXT_PIXEL_SIZE, CAPTION_TEXT_PIXEL_SIZE,
+                     TOPIC_NAME_PIXEL_SIZE, TOPIC_TYPE_PIXEL_SIZE)
+from ._mcap_viewer_main_window import McapMainWindow, WINDOW_SIZE
 
 __all__ = [
     "McapDock",
@@ -31,8 +33,6 @@ __all__ = [
 _TOPIC_ROLE = Qt.UserRole
 _COUNT_ROLE = Qt.UserRole + 1
 _TYPE_ROLE = Qt.UserRole + 2
-_ROW_PAD = 4
-_ROW_GAP = 8
 
 
 def format_size(nbytes):
@@ -96,7 +96,7 @@ class _TopicDelegate(QStyledItemDelegate):
         self._type_height = QFontMetrics(font(TOPIC_TYPE_PIXEL_SIZE)).height()
 
     def sizeHint(self, option, index):
-        height = self._name_height + self._type_height + 2 * _ROW_PAD
+        height = self._name_height + self._type_height + 2 * ROW_PAD
         return QSize(option.rect.width(), height)
 
     def paint(self, painter, option, index):
@@ -106,14 +106,14 @@ class _TopicDelegate(QStyledItemDelegate):
                                           painter, option.widget)
         text, sub = row_colors(self.parent(),
                                option.state & QStyle.State_Selected)
-        rect = option.rect.adjusted(_ROW_GAP, _ROW_PAD, -_ROW_GAP, -_ROW_PAD)
+        rect = option.rect.adjusted(ROW_GAP, ROW_PAD, -ROW_GAP, -ROW_PAD)
 
         painter.save()
         painter.setPen(text)
         top = QRect(rect.left(), rect.top(), rect.width(), self._name_height)
         painter.setFont(font(CAPTION_TEXT_PIXEL_SIZE, mono=True))
         count = index.data(_COUNT_ROLE)
-        width = painter.fontMetrics().horizontalAdvance(count) + _ROW_GAP
+        width = painter.fontMetrics().horizontalAdvance(count) + ROW_GAP
         painter.drawText(top, Qt.AlignRight | Qt.AlignVCenter, count)
         painter.setFont(font(TOPIC_NAME_PIXEL_SIZE, mono=True))
         name = painter.fontMetrics().elidedText(
@@ -133,6 +133,7 @@ class McapDock(PaletteStyled):
     """The file summary and the topic list of the open recording."""
 
     open_requested = Signal()
+    topic_selected = Signal(str)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -189,7 +190,7 @@ class McapDock(PaletteStyled):
         head = QWidget()
         head.setObjectName("header")
         header = QHBoxLayout(head)
-        header.setContentsMargins(_ROW_GAP, 4, _ROW_GAP, 4)
+        header.setContentsMargins(ROW_GAP, 4, ROW_GAP, 4)
         self._columns = [QLabel("Topic"), QLabel("Count")]
         for label in self._columns:
             label.setFont(font(CAPTION_TEXT_PIXEL_SIZE, bold=True))
@@ -200,6 +201,8 @@ class McapDock(PaletteStyled):
         self._topics.setUniformItemSizes(True)
         self._topics.setItemDelegate(_TopicDelegate(self))
         self._topics.setFrameShape(QFrame.NoFrame)
+        self._topics.itemClicked.connect(self._on_item_chosen)
+        self._topics.itemActivated.connect(self._on_item_chosen)
         box.addWidget(self._topics, 1)
         layout.addWidget(self._box, 1)
 
@@ -230,6 +233,9 @@ class McapDock(PaletteStyled):
             item.setToolTip(topic)
             self._topics.addItem(item)
 
+    def _on_item_chosen(self, item):
+        self.topic_selected.emit(item.data(_TOPIC_ROLE))
+
     def set_error(self, path, message):
         """Report that ``path`` would not open, and clear the summary."""
         self.set_reader(None)
@@ -249,13 +255,17 @@ class McapDock(PaletteStyled):
 
 
 class McapPanel(_gui_common.PilotFeature):
-    """Open MCAP files from the Track menu into the dock."""
+    """Open MCAP files from the Track menu into the dock and a window."""
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
         self._action = None
         self._dock = None
         self._reader = None
+        self._subwin = None
+        # PySide does not see the sub-window take the window as its child,
+        # and would delete the window with the last Python reference.
+        self._viewer = None
         self._diag = QFileDialog()
         self._diag.setFileMode(QFileDialog.ExistingFile)
         self._diag.setWindowTitle("Open MCAP file")
@@ -270,6 +280,11 @@ class McapPanel(_gui_common.PilotFeature):
     def panel(self):
         return None if self._dock is None else self._dock.widget()
 
+    @property
+    def viewer(self):
+        """The main window of the open recording, or ``None`` when closed."""
+        return None if self._subwin is None else self._viewer
+
     def populate_menu(self):
         self.add_action(
             "Track", "Open MCAP", "Open an MCAP recording",
@@ -280,13 +295,41 @@ class McapPanel(_gui_common.PilotFeature):
         self._action.toggled.connect(self._on_toggled)
 
     def open_file(self, path):
-        """Read the summary of ``path`` into the dock."""
+        """Read ``path`` into the dock and a fresh main window."""
         reader = mcap.Reader(path)
+        if self._subwin is not None:
+            self._subwin.close()
         if self._reader is not None:
             self._reader.close()
         self._reader = reader
         self._shown_panel().set_reader(reader)
+        self._open_window()
         return reader
+
+    def _open_window(self):
+        self._viewer = McapMainWindow(self._reader)
+        self._viewer.closed.connect(self._on_window_closed)
+        self._subwin = self._mgr.addSubWindow(self._viewer)
+        self._subwin.setWindowTitle(self._viewer.title)
+        self._subwin.resize(*WINDOW_SIZE)
+        self._mgr.addSubWindowGrip(self._subwin)
+
+    def _on_window_closed(self):
+        self._subwin = None
+
+    def _on_topic_selected(self, topic):
+        """Show ``topic`` in the main window; reopen it after a close.
+
+        The topic already on the table turns back to its first page
+        instead of being decoded again.
+        """
+        if self._subwin is None:
+            self._open_window()
+        viewer = self.viewer
+        if viewer.topic == topic and viewer.model is not None:
+            viewer.page(1)
+        else:
+            viewer.table(topic)
 
     def _on_selected(self, path):
         """Open what the dialog chose, and report a file that will not open.
@@ -317,6 +360,7 @@ class McapPanel(_gui_common.PilotFeature):
             return
         panel = McapDock()
         panel.open_requested.connect(self._diag.open)
+        panel.topic_selected.connect(self._on_topic_selected)
         self._dock = QDockWidget("MCAP")
         self._dock.setWidget(panel)
         self._mainWindow.addDockWidget(Qt.RightDockWidgetArea, self._dock)

--- a/solvcon/pilot/track/_mcap_viewer_main_window.py
+++ b/solvcon/pilot/track/_mcap_viewer_main_window.py
@@ -1,0 +1,412 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+The main window of the open recording: one topic at a time, every scalar
+leaf decoded once and paged through a table.
+"""
+
+import os
+import datetime
+
+from PySide6.QtCore import (Qt, Signal, QAbstractTableModel, QModelIndex,
+                            QRect, QSize)
+from PySide6.QtGui import QFontMetrics, QIntValidator
+from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
+                               QPushButton, QLineEdit, QTableView,
+                               QHeaderView, QStackedWidget, QAbstractItemView)
+
+from ...track import mcap
+from .._style import PaletteStyled
+from ._style import (Rules, font, header_colors, row_colors, ROW_PAD,
+                     ROW_GAP, CAPTION_TEXT_PIXEL_SIZE, TOPIC_NAME_PIXEL_SIZE,
+                     TOPIC_TYPE_PIXEL_SIZE)
+
+__all__ = [
+    "McapMainWindow",
+    "TopicTableModel",
+    "CellFormat",
+    "PAGE_SIZE",
+    "WINDOW_SIZE",
+]
+
+PAGE_SIZE = 50
+ROW_HEIGHT = 22
+WINDOW_SIZE = (900, 580)
+
+_EPOCH = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+_INDEX_ALIGN = int(Qt.AlignRight | Qt.AlignVCenter)
+_CELL_ALIGN = int(Qt.AlignLeft | Qt.AlignVCenter)
+
+
+class CellFormat:
+    """
+    The text of a table cell, one formatter per column dtype.
+
+    :meth:`of` picks the formatter a dtype needs, falling back to ``str``
+    for the dtypes that read well on their own.  :meth:`time` is not in
+    that table: the log time is a column the plan does not describe.
+    """
+
+    FLOAT_DIGITS = 4
+
+    @staticmethod
+    def time(ns):
+        """Return ``ns`` since the epoch as ``YYYY-MM-DD HH:MM:SS.ffffff``."""
+        seconds, rest = divmod(int(ns), 1_000_000_000)
+        when = _EPOCH + datetime.timedelta(seconds=seconds,
+                                           microseconds=rest // 1000)
+        return when.strftime("%Y-%m-%d %H:%M:%S.%f")
+
+    @staticmethod
+    def boolean(value):
+        return "true" if value else "false"
+
+    @classmethod
+    def real(cls, value):
+        return "{:.{}f}".format(value, cls.FLOAT_DIGITS)
+
+    @classmethod
+    def of(cls, dtype):
+        """Return the formatter for a column of ``dtype``."""
+        return {"bool": cls.boolean,
+                "float32": cls.real,
+                "float64": cls.real}.get(dtype, str)
+
+
+class TopicTableModel(QAbstractTableModel):
+    """
+    The extracted leaves of one topic, ``PAGE_SIZE`` messages at a time.
+
+    Column 0 is the message index and column 1 the log time; the rest are
+    the leaves in plan order, each typed by the plan and named in the
+    header with the type as its tool tip. Pages count from 1, the way the
+    footer shows them, and the cells of a page are formatted once when it
+    is turned to.
+    """
+
+    def __init__(self, extraction, plan, parent=None):
+        super().__init__(parent)
+        self._time = extraction.time
+        self._columns = [(extraction.columns[field], CellFormat.of(dtype))
+                         for field, dtype in zip(plan.fields, plan.types)]
+        self._headers = [("#", ""), ("log_time", "")] + \
+            list(zip(plan.fields, plan.types))
+        self._page = 1
+        self._fill()
+
+    @property
+    def message_count(self):
+        return len(self._time)
+
+    @property
+    def page_count(self):
+        return max(1, -(-self.message_count // PAGE_SIZE))
+
+    @property
+    def page(self):
+        return self._page
+
+    @property
+    def start(self):
+        """The message index of the first row on the page."""
+        return (self._page - 1) * PAGE_SIZE
+
+    def set_page(self, page):
+        """Turn to ``page``, clamped to the pages there are; return it."""
+        page = min(max(1, int(page)), self.page_count)
+        if page != self._page:
+            self.beginResetModel()
+            self._page = page
+            self._fill()
+            self.endResetModel()
+        return page
+
+    def _fill(self):
+        stop = min(self.start + PAGE_SIZE, self.message_count)
+        self._cells = [
+            [str(i), CellFormat.time(self._time[i])] +
+            [fmt(column[i]) for column, fmt in self._columns]
+            for i in range(self.start, stop)]
+
+    def rowCount(self, parent=QModelIndex()):
+        return 0 if parent.isValid() else len(self._cells)
+
+    def columnCount(self, parent=QModelIndex()):
+        return 0 if parent.isValid() else len(self._headers)
+
+    def headerData(self, section, orientation, role=Qt.DisplayRole):
+        if orientation != Qt.Horizontal:
+            return None
+        if role == Qt.DisplayRole:
+            return self._headers[section][0]
+        if role == Qt.ToolTipRole:
+            return self._headers[section][1]
+        return None
+
+    def data(self, index, role=Qt.DisplayRole):
+        if role == Qt.DisplayRole:
+            return self._cells[index.row()][index.column()]
+        if role == Qt.TextAlignmentRole:
+            return _INDEX_ALIGN if index.column() == 0 else _CELL_ALIGN
+        return None
+
+
+class _FieldHeader(QHeaderView):
+    """
+    Paint a column header: the leaf's dotted path over its type.
+
+    For example, ``vehicle_msgs/Status.speed`` over ``float64``.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(Qt.Horizontal, parent)
+        self._path_font = font(TOPIC_NAME_PIXEL_SIZE, mono=True, bold=True)
+        self._type_font = font(TOPIC_TYPE_PIXEL_SIZE)
+        self._path_metrics = QFontMetrics(self._path_font)
+        self._type_metrics = QFontMetrics(self._type_font)
+        self.setHighlightSections(False)
+        self.setSectionsClickable(False)
+
+    def _height(self):
+        return (self._path_metrics.height() + self._type_metrics.height()
+                + 2 * ROW_PAD)
+
+    def sizeHint(self):
+        return QSize(super().sizeHint().width(), self._height())
+
+    def _texts(self, section):
+        """The ``(path, type)`` of ``section``, blank without a model."""
+        model = self.model()
+        if model is None:
+            return "", ""
+        return (model.headerData(section, Qt.Horizontal, Qt.DisplayRole),
+                model.headerData(section, Qt.Horizontal, Qt.ToolTipRole))
+
+    def sectionSizeFromContents(self, section):
+        path, type_ = self._texts(section)
+        width = max(self._path_metrics.horizontalAdvance(path),
+                    self._type_metrics.horizontalAdvance(type_))
+        return QSize(width + 2 * ROW_GAP, self._height())
+
+    def paintSection(self, painter, rect, index):
+        surface, line = header_colors(self)
+        path_color, type_color = row_colors(self, False)
+        path, type_ = self._texts(index)
+        inner = rect.adjusted(ROW_GAP, ROW_PAD, -ROW_GAP, -ROW_PAD)
+
+        painter.save()
+        painter.fillRect(rect, surface)
+        painter.setPen(line)
+        painter.drawLine(rect.bottomLeft(), rect.bottomRight())
+        painter.drawLine(rect.topRight(), rect.bottomRight())
+        top = QRect(inner.left(), inner.top(), inner.width(),
+                    self._path_metrics.height())
+        painter.setFont(self._path_font)
+        painter.setPen(path_color)
+        painter.drawText(top, Qt.AlignLeft | Qt.AlignVCenter, path)
+        bottom = QRect(inner.left(), top.bottom() + 1, inner.width(),
+                       self._type_metrics.height())
+        painter.setFont(self._type_font)
+        painter.setPen(type_color)
+        painter.drawText(bottom, Qt.AlignLeft | Qt.AlignVCenter, type_)
+        painter.restore()
+
+
+class McapMainWindow(PaletteStyled):
+    """One topic of the open recording, decoded into a paged table.
+
+    The sub-window forwards its close here, so ``closed`` is the one
+    signal the owner needs to learn the window went away.
+    """
+
+    closed = Signal()
+
+    def __init__(self, reader, parent=None):
+        super().__init__(parent)
+        self._reader = reader
+        self._topic = None
+        self._model = None
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        self._build_toolbar(layout)
+        self._pages = QStackedWidget()
+        self._notice = QLabel("Select a topic in the MCAP dock")
+        self._notice.setAlignment(Qt.AlignCenter)
+        self._notice.setWordWrap(True)
+        self._notice.setFont(font(CAPTION_TEXT_PIXEL_SIZE))
+        self._pages.addWidget(self._notice)
+        self._pages.addWidget(self._build_table())
+        layout.addWidget(self._pages, 1)
+        self._apply_style()
+
+    @property
+    def topic(self):
+        """The topic shown, or ``None`` before the first ``table()``."""
+        return self._topic
+
+    @property
+    def model(self):
+        """The table model, or ``None`` until ``table()`` decodes a topic."""
+        return self._model
+
+    @property
+    def title(self):
+        return "MCAP viewer - {}".format(os.path.basename(self._reader.path))
+
+    def _build_toolbar(self, layout):
+        toolbar = QWidget()
+        toolbar.setObjectName("toolbar")
+        bar = QHBoxLayout(toolbar)
+        bar.setContentsMargins(12, 6, 12, 6)
+        bar.setSpacing(10)
+        self._name = QLabel()
+        self._name.setFont(font(TOPIC_NAME_PIXEL_SIZE, mono=True, bold=True))
+        self._type = QLabel()
+        self._type.setFont(font(CAPTION_TEXT_PIXEL_SIZE))
+        self._type.hide()
+        self._summary = QLabel()
+        self._summary.setFont(font(CAPTION_TEXT_PIXEL_SIZE))
+        bar.addWidget(self._name)
+        bar.addWidget(self._type)
+        bar.addStretch(1)
+        bar.addWidget(self._summary)
+        layout.addWidget(toolbar)
+
+    def _build_table(self):
+        self._table_page = QWidget()
+        page = QVBoxLayout(self._table_page)
+        page.setContentsMargins(0, 0, 0, 0)
+        page.setSpacing(0)
+        self._table = QTableView()
+        self._table.setHorizontalHeader(_FieldHeader(self._table))
+        self._table.verticalHeader().hide()
+        self._table.verticalHeader().setDefaultSectionSize(ROW_HEIGHT)
+        self._table.setFont(font(CAPTION_TEXT_PIXEL_SIZE, mono=True))
+        self._table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self._table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self._table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._table.setAlternatingRowColors(True)
+        self._table.setShowGrid(False)
+        self._table.setWordWrap(False)
+        page.addWidget(self._table, 1)
+
+        footer = QWidget()
+        footer.setObjectName("footer")
+        strip = QHBoxLayout(footer)
+        strip.setContentsMargins(12, 4, 12, 4)
+        strip.setSpacing(8)
+        self._range = QLabel()
+        self._prev = QPushButton("<")
+        self._prev.clicked.connect(self._on_prev)
+        self._page_word = QLabel("Page")
+        self._page_input = QLineEdit()
+        self._page_input.setValidator(QIntValidator(1, 10 ** 9))
+        self._page_input.setFixedWidth(52)
+        self._page_input.setAlignment(Qt.AlignRight)
+        self._page_input.setToolTip("Page number, Enter to jump")
+        self._page_input.setFont(font(CAPTION_TEXT_PIXEL_SIZE, mono=True))
+        self._page_input.returnPressed.connect(self._on_jump)
+        self._page_total = QLabel()
+        self._next = QPushButton(">")
+        self._next.clicked.connect(self._on_next)
+        for widget in (self._range, self._prev, self._page_word,
+                       self._page_total, self._next):
+            widget.setFont(font(CAPTION_TEXT_PIXEL_SIZE))
+        strip.addWidget(self._range)
+        strip.addStretch(1)
+        for widget in (self._prev, self._page_word, self._page_input,
+                       self._page_total, self._next):
+            strip.addWidget(widget)
+        page.addWidget(footer)
+        return self._table_page
+
+    def table(self, topic):
+        """Show every scalar leaf of ``topic`` from its first page.
+
+        Return the table model, or ``None`` when the decoder cannot read
+        the topic; the body then says why.
+        """
+        self._topic = topic
+        # The view does not own its model; dropping the reference after
+        # detaching it is what frees the previous topic's columns.
+        self._table.setModel(None)
+        self._model = None
+        self._name.setText(topic)
+        self._type.hide()
+        self._summary.setText("")
+        try:
+            schema = self._reader.schema(topic)
+            if schema is not None:
+                self._type.setText(schema.name)
+                self._type.show()
+
+            # Without a schema there is no plan, and the reader says so.
+            plan = None if schema is None else mcap.DecodePlan(schema)
+
+            # TODO: (1) the extraction runs on the GUI thread.
+            # (2) the extraction is not paged, so it can be huge.
+            extraction = self._reader.extract(topic, plan)
+        except mcap.McapError as error:
+            self._notice.setText("Cannot decode {}: {}".format(topic, error))
+            self._pages.setCurrentWidget(self._notice)
+            return None
+
+        self._model = TopicTableModel(extraction, plan)
+        self._table.setModel(self._model)
+        self._table.resizeColumnsToContents()
+        # The first page sizes the columns, so make room for the last index.
+        widest = self._table.fontMetrics().horizontalAdvance(
+            str(self._model.message_count)) + 2 * ROW_GAP
+        self._table.setColumnWidth(0, max(widest, self._table.columnWidth(0)))
+        self._summary.setText("{:,} messages \u00b7 {} columns".format(
+            self._model.message_count, len(plan.fields)))
+        self._pages.setCurrentWidget(self._table_page)
+        self.page(1)
+        return self._model
+
+    def page(self, number):
+        """Turn to page ``number``; out of range clamps to the ends.
+
+        Return the page shown, or ``None`` until ``table()`` decodes a topic.
+        """
+        if self._model is None:
+            return None
+        number = self._model.set_page(number)
+        self._table.scrollToTop()
+        rows = self._model.rowCount()
+        first = self._model.start + 1 if rows else 0
+        self._range.setText("Rows {:,}\u2013{:,} of {:,}".format(
+            first, self._model.start + rows, self._model.message_count))
+        self._page_input.setText(str(number))
+        self._page_total.setText("of {:,}".format(self._model.page_count))
+        self._prev.setEnabled(number > 1)
+        self._next.setEnabled(number < self._model.page_count)
+        return number
+
+    def _on_prev(self):
+        self.page(self._model.page - 1)
+
+    def _on_next(self):
+        self.page(self._model.page + 1)
+
+    def _on_jump(self):
+        self.page(int(self._page_input.text() or 1))
+
+    def closeEvent(self, event):
+        self.closed.emit()
+        super().closeEvent(event)
+
+    def _apply_style(self):
+        self.setStyleSheet(Rules.sheet(self, "bar", "table", "button",
+                                       "field"))
+        self._type.setStyleSheet(Rules.sheet(self, "badge"))
+        self._notice.setStyleSheet(Rules.sheet(self, "faint"))
+        sheet = Rules.sheet(self, "label")
+        for label in (self._summary, self._range, self._page_word,
+                      self._page_total):
+            label.setStyleSheet(sheet)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/track/_style.py
+++ b/solvcon/pilot/track/_style.py
@@ -19,6 +19,9 @@ __all__ = [
     'Rules',
     'font',
     'row_colors',
+    'header_colors',
+    'ROW_PAD',
+    'ROW_GAP',
     'BODY_TEXT_PIXEL_SIZE',
     'CAPTION_TEXT_PIXEL_SIZE',
     'TOPIC_NAME_PIXEL_SIZE',
@@ -29,12 +32,14 @@ BODY_TEXT_PIXEL_SIZE = 12
 CAPTION_TEXT_PIXEL_SIZE = 11
 TOPIC_NAME_PIXEL_SIZE = 12
 TOPIC_TYPE_PIXEL_SIZE = 10
+ROW_PAD = 4
+ROW_GAP = 8
 
 # How far the hairlines, the header, and the faint text sit from the
 # surface each is mixed against.
 _HAIRLINE_STEP_TOWARD_TEXT = 0.10
 _HEADER_UNDERLINE_STEP_TOWARD_TEXT = 0.06
-_BUTTON_BORDER_STEP_TOWARD_TEXT = 0.17
+_CONTROL_BORDER_STEP_TOWARD_TEXT = 0.17
 _HEADER_SURFACE_STEP_TOWARD_TEXT = 0.05
 _HOVERED_ROW_STEP_TOWARD_ACCENT_ON_LIGHT = 0.06
 _HOVERED_ROW_STEP_TOWARD_ACCENT_ON_DARK = 0.2
@@ -44,6 +49,9 @@ _TOPIC_NAME_COLOR_ON_DARK = QColor(Qt.white)
 _TOPIC_TYPE_STEP_TOWARD_SURFACE_ON_LIGHT = 0.5
 _TOPIC_TYPE_STEP_TOWARD_SURFACE_ON_DARK = 0.5
 _SELECTED_TYPE_STEP_TOWARD_ACCENT = 0.2
+_BAR_SURFACE_STEP_TOWARD_TEXT = 0.02
+_ALTERNATE_ROW_STEP_TOWARD_TEXT = 0.02
+_BADGE_SURFACE_STEP_TOWARD_TEXT = 0.08
 
 
 def _is_dark(shades):
@@ -82,6 +90,31 @@ def row_colors(widget, selected):
     return name, type_
 
 
+def _header_surface(shades):
+    return Shades.blend(shades.base, shades.on_base,
+                        _HEADER_SURFACE_STEP_TOWARD_TEXT)
+
+
+def header_colors(widget):
+    """The ``(surface, line)`` colors a column header paints in."""
+    shades = Shades(widget)
+    return _header_surface(shades), shades.raised(_HAIRLINE_STEP_TOWARD_TEXT)
+
+
+def _control(shades, selector, radius, padding):
+    """A control on the base surface: the button and the field share it."""
+    border = shades.raised(_CONTROL_BORDER_STEP_TOWARD_TEXT)
+    return f"""
+        {selector} {{
+            background: {shades.base.name()};
+            color: {shades.on_base.name()};
+            border: 1px solid {border.name()};
+            border-radius: {radius}px;
+            padding: {padding};
+        }}
+        """
+
+
 class Rules(RuleCatalog):
     """One method per role the pilot's track panels draw."""
 
@@ -98,6 +131,61 @@ class Rules(RuleCatalog):
                 f" letter-spacing: 1px; }}")
 
     @staticmethod
+    def faint(shades):
+        """A hint the reader can do without."""
+        return f"QLabel {{ color: {shades.greyed.name()}; }}"
+
+    @staticmethod
+    def badge(shades):
+        """The schema type beside the topic name."""
+        line = shades.raised(_HAIRLINE_STEP_TOWARD_TEXT)
+        chip = shades.raised(_BADGE_SURFACE_STEP_TOWARD_TEXT)
+        return f"""
+            QLabel {{
+                color: {shades.muted.name()};
+                background: {chip.name()};
+                border: 1px solid {line.name()};
+                border-radius: 4px;
+                padding: 1px 6px;
+            }}
+            """
+
+    @staticmethod
+    def bar(shades):
+        """The strips over and under the body of the main window."""
+        line = shades.raised(_HEADER_UNDERLINE_STEP_TOWARD_TEXT)
+        surface = shades.raised(_BAR_SURFACE_STEP_TOWARD_TEXT)
+        return f"""
+            QWidget#toolbar, QWidget#footer {{
+                background: {surface.name()};
+            }}
+            QWidget#toolbar {{ border-bottom: 1px solid {line.name()}; }}
+            QWidget#footer {{ border-top: 1px solid {line.name()}; }}
+            """
+
+    @staticmethod
+    def field(shades):
+        """The field that takes the page number."""
+        return _control(shades, "QLineEdit", 4, "1px 4px")
+
+    @staticmethod
+    def table(shades):
+        """The paged table of one topic; the header paints itself."""
+        alternate = Shades.blend(shades.base, shades.on_base,
+                                 _ALTERNATE_ROW_STEP_TOWARD_TEXT)
+        return f"""
+            QTableView {{
+                background: {shades.base.name()};
+                alternate-background-color: {alternate.name()};
+                border: none;
+            }}
+            QTableView::item:selected {{
+                background-color: {shades.accent.name()};
+                color: {shades.on_accent.name()};
+            }}
+            """
+
+    @staticmethod
     def rule(shades):
         """The hairline the summary is closed with."""
         line = shades.raised(_HAIRLINE_STEP_TOWARD_TEXT)
@@ -106,16 +194,7 @@ class Rules(RuleCatalog):
     @staticmethod
     def button(shades):
         """The control the file dialog is opened from."""
-        border = shades.raised(_BUTTON_BORDER_STEP_TOWARD_TEXT)
-        return f"""
-            QPushButton {{
-                background: {shades.base.name()};
-                color: {shades.on_base.name()};
-                border: 1px solid {border.name()};
-                border-radius: 5px;
-                padding: 2px 12px;
-            }}
-            """
+        return _control(shades, "QPushButton", 5, "2px 12px")
 
     @staticmethod
     def topics(shades):
@@ -126,8 +205,7 @@ class Rules(RuleCatalog):
         """
         line = shades.raised(_HAIRLINE_STEP_TOWARD_TEXT)
         underline = shades.raised(_HEADER_UNDERLINE_STEP_TOWARD_TEXT)
-        head = Shades.blend(shades.base, shades.on_base,
-                            _HEADER_SURFACE_STEP_TOWARD_TEXT)
+        head = _header_surface(shades)
         if _is_dark(shades):
             hover_step = _HOVERED_ROW_STEP_TOWARD_ACCENT_ON_DARK
         else:

--- a/tests/gui/test_mcap_viewer.py
+++ b/tests/gui/test_mcap_viewer.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2026, solvcon team <contact@solvcon.net>
 # BSD 3-Clause License, see COPYING
 
-"""The MCAP panel feature on the pilot window: the menu and the dock."""
+"""The MCAP panel feature on the pilot window: the menu, the dock, and the
+main window."""
 
 import os
 import tempfile
@@ -28,15 +29,26 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 TOPIC = "/vehicle/brake"
+BRAKE_IDL = b"""
+module vehicle_msgs {
+  module msg {
+    struct Brake {
+      boolean active;
+    };
+  };
+};
+"""
 
 
 def write_fixture(path):
-    """One schemaless topic: the feature tests only list it."""
+    """One topic of one message, decodable so the main window fills."""
     with open(path, "wb") as fp:
         writer = foxglove_mcap_writer.Writer(fp)
         writer.start(profile="ros2")
-        channel_id = writer.register_channel(TOPIC, "cdr", 0)
-        writer.add_message(channel_id, 10, b"\0\x01\0\0", 10)
+        schema_id = writer.register_schema("vehicle_msgs/msg/Brake",
+                                           "ros2idl", BRAKE_IDL)
+        channel_id = writer.register_channel(TOPIC, "cdr", schema_id)
+        writer.add_message(channel_id, 10, b"\0\x01\0\0\x01", 10)
         writer.finish()
 
 
@@ -55,6 +67,9 @@ class McapPanelTC(unittest.TestCase):
         self.feature.populate_menu()
 
     def tearDown(self):
+        if self.feature._subwin is not None:
+            self.feature._subwin.close()
+        QApplication.processEvents()
         if self.feature.reader is not None:
             self.feature.reader.close()
         self.tmpdir.cleanup()
@@ -94,5 +109,45 @@ class McapPanelTC(unittest.TestCase):
         QApplication.processEvents()
         self.assertIs(self.feature.reader, second)
         self.assertEqual(self.feature.panel._error.text(), "bad magic")
+
+    def _mcap_windows(self):
+        return [w for w in self.mgr.mdiArea.subWindowList()
+                if isinstance(w.widget(), _mcap_viewer.McapMainWindow)]
+
+    def test_open_file_opens_the_window_and_a_topic_fills_it(self):
+        self.feature.open_file(self.path)
+        QApplication.processEvents()
+        viewer = self.feature.viewer
+        self.assertIsInstance(viewer, _mcap_viewer.McapMainWindow)
+        self.assertEqual([w.windowTitle() for w in self._mcap_windows()],
+                         ["MCAP viewer - drive.mcap"])
+        self.assertIsNone(viewer.topic)
+
+        topics = self.feature.panel._topics
+        topics.itemClicked.emit(topics.item(0))
+        self.assertEqual(viewer.topic, TOPIC)
+        self.assertEqual(viewer.model.rowCount(), 1)
+        self.assertEqual(viewer.model.data(viewer.model.index(0, 2)), "true")
+
+        # The same topic again keeps its table instead of decoding anew.
+        model = viewer.model
+        topics.itemClicked.emit(topics.item(0))
+        self.assertIs(viewer.model, model)
+
+        # Another file replaces the window; the new one waits for a topic.
+        self.feature.open_file(self.path)
+        QApplication.processEvents()
+        self.assertIsNot(self.feature.viewer, viewer)
+        self.assertEqual(len(self._mcap_windows()), 1)
+        self.assertIsNone(self.feature.viewer.topic)
+
+        # A closed window comes back for the next topic.
+        self.feature._subwin.close()
+        QApplication.processEvents()
+        self.assertIsNone(self.feature.viewer)
+        self.assertEqual(self._mcap_windows(), [])
+        topics.itemClicked.emit(topics.item(0))
+        self.assertEqual(self.feature.viewer.topic, TOPIC)
+        self.assertEqual(len(self._mcap_windows()), 1)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_mcap_viewer.py
+++ b/tests/test_pilot_mcap_viewer.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2026, solvcon team <contact@solvcon.net>
 # BSD 3-Clause License, see COPYING
 
-"""The MCAP dock filled from a generated recording."""
+"""The MCAP dock and main window filled from a generated recording."""
 
 import os
+import struct
 import tempfile
 import unittest
 
@@ -13,6 +14,8 @@ from solvcon.track import mcap
 try:
     from solvcon import pilot
     from solvcon.pilot.track import _mcap_viewer
+    from solvcon.pilot.track import _mcap_viewer_main_window as _main_window
+    from PySide6.QtCore import Qt
 except ImportError:
     pilot = None
 
@@ -31,10 +34,25 @@ module vehicle_msgs {
 };
 """
 
+STATUS_IDL = b"""
+module vehicle_msgs {
+  module msg {
+    struct Status {
+      uint32 seq;
+      double speed;
+      boolean active;
+    };
+  };
+};
+"""
+
 BRAKE_TOPIC = "/vehicle/brake"
 BRAKE_PAYLOAD = b"\0\x01\0\0\x01"
 DIAG_TOPIC = "/diagnostics"
+STATUS_TOPIC = "/vehicle/status"
+STATUS_COUNT = 120
 SECOND_NS = 1_000_000_000
+START_NS = 10 * SECOND_NS
 
 
 def write_fixture(path):
@@ -51,13 +69,22 @@ def write_fixture(path):
                                            b"{}")
         channel_id = writer.register_channel(DIAG_TOPIC, "json", schema_id)
         writer.add_message(channel_id, 4 * SECOND_NS, b"{}", 4 * SECOND_NS)
+        schema_id = writer.register_schema("vehicle_msgs/msg/Status",
+                                           "ros2idl", STATUS_IDL)
+        channel_id = writer.register_channel(STATUS_TOPIC, "cdr", schema_id)
+        for i in range(STATUS_COUNT):
+            log_time = START_NS + i * 10_000_000
+            fields = struct.pack("<I4xd?", i, i / 4, i % 2 == 0)
+            payload = b"\0\x01\0\0" + fields
+            writer.add_message(channel_id, log_time, payload, log_time)
         writer.finish()
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 @unittest.skipIf(foxglove_mcap_writer is None,
                  "the Foxglove mcap package is not installed")
-class McapDockTC(unittest.TestCase):
+class _RecordingTC(unittest.TestCase):
+    """A generated recording open in a reader for the length of a test."""
 
     @classmethod
     def setUpClass(cls):
@@ -73,6 +100,9 @@ class McapDockTC(unittest.TestCase):
         self.reader.close()
         self.tmpdir.cleanup()
 
+
+class McapDockTC(_RecordingTC):
+
     def test_dock_lists_the_file_its_topics_and_the_one_selected(self):
         dock = _mcap_viewer.McapDock()
         dock.set_reader(self.reader)
@@ -80,9 +110,9 @@ class McapDockTC(unittest.TestCase):
         self.assertEqual(dock._file.toolTip(), self.path)
         self.assertEqual(dock._size.text(),
                          _mcap_viewer.format_size(self.reader.size))
-        self.assertEqual(dock._duration.text(), "5s")
-        self.assertEqual(dock._messages.text(), "4")
-        self.assertEqual(dock._caption.text(), "TOPICS \u00b7 2")
+        self.assertEqual(dock._duration.text(), "8s")
+        self.assertEqual(dock._messages.text(), "124")
+        self.assertEqual(dock._caption.text(), "TOPICS \u00b7 3")
 
         topics = dock._topics
         self.assertEqual(
@@ -91,7 +121,13 @@ class McapDockTC(unittest.TestCase):
                 _mcap_viewer._TYPE_ROLE)]
              for i in range(topics.count())],
             [[BRAKE_TOPIC, "3", "vehicle_msgs/msg/Brake"],
-             [DIAG_TOPIC, "1", "diagnostics"]])
+             [DIAG_TOPIC, "1", "diagnostics"],
+             [STATUS_TOPIC, "120", "vehicle_msgs/msg/Status"]])
+        selected = []
+        dock.topic_selected.connect(selected.append)
+        topics.itemClicked.emit(topics.item(1))
+        topics.itemActivated.emit(topics.item(2))
+        self.assertEqual(selected, [DIAG_TOPIC, STATUS_TOPIC])
 
         dock.set_reader(None)
         self.assertEqual([label.text() for label in dock._values], ["-"] * 4)
@@ -135,5 +171,73 @@ class McapDockTC(unittest.TestCase):
         self.assertEqual(dock._topics.count(), 0)
         dock.set_reader(self.reader)
         self.assertTrue(dock._error.isHidden())
+
+
+class McapMainWindowTC(_RecordingTC):
+
+    def test_go_through(self):
+        window = _main_window.McapMainWindow(self.reader)
+        self.assertEqual(window.title, "MCAP viewer - drive.mcap")
+        self.assertIsNone(window.model)
+        self.assertIsNone(window.page(1))
+        self.assertIs(window._pages.currentWidget(), window._notice)
+
+        # The topic table, its headers, and its first page.
+        model = window.table(STATUS_TOPIC)
+        self.assertEqual(window.topic, STATUS_TOPIC)
+        self.assertEqual(window._type.text(), "vehicle_msgs/msg/Status")
+        self.assertEqual(window._summary.text(),
+                         "120 messages \u00b7 3 columns")
+        self.assertEqual(
+            [(model.headerData(i, Qt.Horizontal),
+              model.headerData(i, Qt.Horizontal, Qt.ToolTipRole))
+             for i in range(model.columnCount())],
+            [("#", ""), ("log_time", ""), ("seq", "uint32"),
+             ("speed", "float64"), ("active", "bool")])
+
+        def row(irow):
+            return [model.data(model.index(irow, i))
+                    for i in range(model.columnCount())]
+
+        self.assertEqual(model.rowCount(), 50)
+        self.assertEqual(row(0), ["0", "1970-01-01 00:00:10.000000", "0",
+                                  "0.0000", "true"])
+        self.assertEqual(row(49), ["49", "1970-01-01 00:00:10.490000", "49",
+                                   "12.2500", "false"])
+        self.assertEqual(window._range.text(), "Rows 1\u201350 of 120")
+        self.assertEqual(window._page_total.text(), "of 3")
+        self.assertFalse(window._prev.isEnabled())
+
+        # Paging by API, by the input field, and by the buttons.
+        self.assertEqual(window.page(3), 3)
+        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(row(0)[:2], ["100", "1970-01-01 00:00:11.000000"])
+        self.assertEqual(window._range.text(), "Rows 101\u2013120 of 120")
+        self.assertFalse(window._next.isEnabled())
+        self.assertEqual(window.page(99), 3)
+        self.assertEqual(window.page(0), 1)
+        window._page_input.setText("2")
+        window._page_input.returnPressed.emit()
+        self.assertEqual(model.page, 2)
+        window._next.click()
+        self.assertEqual(model.page, 3)
+        window._prev.click()
+        self.assertEqual(model.page, 2)
+        self.assertEqual(window._page_input.text(), "2")
+
+        # A topic the decoder cannot read says why.
+        self.assertIsNone(window.table(DIAG_TOPIC))
+        self.assertIsNone(window.model)
+        self.assertEqual(window._type.text(), "diagnostics")
+        self.assertIs(window._pages.currentWidget(), window._notice)
+        self.assertEqual(
+            window._notice.text(),
+            "Cannot decode /diagnostics: "
+            "schema encoding 'jsonschema' of diagnostics")
+
+        self.assertEqual(
+            _main_window.CellFormat.time(
+                1755765120 * SECOND_NS + 123_456_789),
+            "2025-08-21 08:32:00.123456")
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
A click on a topic in the MCAP dock opens a sub-window that tables every scalar leaf of the topic, 50 messages per page. When the reader cannot decode a topic, the window shows the reader's message in place of a table.

Related to #1454.


<img width="1349" height="961" alt="Screenshot 2026-09-05 at 9 12 45 PM" src="https://github.com/user-attachments/assets/ad96fbfa-007a-47cd-aa79-2eb3e4ff9687" />