### PR TITLE
Run benchmark worker tests with the active interpreter

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -7,14 +7,13 @@ import json
 import math
 import os
 import pathlib
-import shutil
 import subprocess
 import sys
 import tempfile
 import unittest
 import unittest.mock
 
-from solvcon import benchmark
+from solvcon import benchmark, clinfo
 from solvcon.benchmark import artifact
 from solvcon.benchmark import worker
 
@@ -363,10 +362,14 @@ class BenchmarkWorkerTC(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             path = pathlib.Path(directory) / 'artifact.json'
             request = make_request(path)
-            python = shutil.which('python3')
-            self.assertIsNotNone(python)
+            # A pilot-only build embeds _solvcon without a shared extension.
+            # Run the worker with that same binary in Python mode.
+            if clinfo.populated:
+                command = [clinfo.populated_argv[0], '--mode=python']
+            else:
+                command = [sys.executable]
             process = subprocess.run(
-                [python, '-m', 'solvcon.benchmark.worker'],
+                command + ['-m', 'solvcon.benchmark.worker'],
                 input=json.dumps(request) + '\n',
                 capture_output=True, text=True, check=False)
 


### PR DESCRIPTION
The pilot-only lint build embeds _solvcon without building a shared Python extension. The benchmark subprocess test introduced in #1487 launches python3 from PATH, which cannot load the embedded module. This causes both the macOS and Linux jobs in [run 33936323704](https://github.com/solvcon/solvcon/actions/runs/33936323704) to fail.

Launch the worker through the same pilot executable with --mode=python when running inside the embedded interpreter. Under ordinary pytest, use sys.executable. The test continues to verify the subprocess result and saved artifact.

Related to #1369

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
