### PR TITLE
Build the standalone extension for the pilot test lane

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -359,6 +359,10 @@ class BenchmarkWorkerTC(unittest.TestCase):
         self.assertEqual(event['error_type'], 'RuntimeError')
         self.assertEqual(event['message'], 'native failure')
 
+    @unittest.skipIf(
+        '_solvcon' in sys.builtin_module_names,
+        'the pilot carries _solvcon in the executable, so the interpreter '
+        'this test spawns cannot import it')
     def test_process_writes_artifact(self):
         with tempfile.TemporaryDirectory() as directory:
             path = pathlib.Path(directory) / 'artifact.json'


### PR DESCRIPTION
The benchmark worker test spawns a `python3` interpreter and asserts that the interpreter writes the artifact. The spawned interpreter must import the `_solvcon` extension, and it could not do that in the pilot test lane. The test therefore failed on master in the `lint` and `devbuild_windows` jobs.

`cpp/binary/pymod_solvcon/module.cpp` builds `_solvcon` as an extension file on disk. `cpp/binary/pilot/pilot.cpp` builds it a second time, as an embedded module inside the pilot executable. The suite that runs inside the pilot imports the embedded copy, which a spawned interpreter cannot reach. The `run_pilot_pytest` target built only the pilot, so the tree held no extension file for that interpreter to import.

The target now builds the extension as well. It builds the extension in its own step, not as a second prerequisite. A prerequisite may run beside the pilot build under a parallel make, and the two would then share one build directory.

Windows needs the second change. An interpreter there does not find the DLLs that the extension needs, so it cannot load the extension at all. The test skips on Windows and names that reason. Every other platform runs the test, and fails when the extension is absent or does not load.

Related to #1369.
