### PR TITLE
MCAP: Decode a named string, sequence, or array as a column

### DIFF
--- a/solvcon/track/mcap/_decodeplan.py
+++ b/solvcon/track/mcap/_decodeplan.py
@@ -11,14 +11,19 @@ typedefs, and integer constants.
 
 ``DecodePlan`` turns the root struct into a tree and walks it over the
 CDR body of each message.  A scalar or enum leaf reached through nested
-structs is a column.  The walk steps over a string, a sequence, an
-array, or a union, so a leaf inside one is not a column.  A union reads
-its discriminator to find the case the payload carries.
+structs is a column.  A string is a column when the field list names
+it, and so is a sequence or array of scalars, enums, or strings.  Such
+a field decodes to a ``str`` or a ``list`` per message.  The walk steps
+over a union and over a container of any other element, so a leaf
+inside one is not a column.  A union reads its discriminator to find
+the case the payload carries.
 """
 
 import re
 import struct
 import collections
+
+import numpy as np
 
 import solvcon as sc
 
@@ -80,6 +85,8 @@ _ORDERS = (">", "<")
 _SCALARS = tuple({dtype: struct.Struct(order + code)
                   for dtype, (code, _) in COLUMN_TYPES.items()}
                  for order in _ORDERS)
+_DTYPES = tuple({dtype: np.dtype(dtype).newbyteorder(order)
+                 for dtype in COLUMN_TYPES} for order in _ORDERS)
 _TRUNCATED = "the payload ends before the fields do"
 
 
@@ -373,27 +380,37 @@ class DecodePlan:
     ``fields`` are the selected dotted paths, ``types`` their column
     dtypes, and ``enums`` the member names of each enum-typed field.
     Without ``fields`` the plan selects every scalar leaf in declaration
-    order.  An enum reads as its ``uint32`` ordinal.
+    order.  An enum reads as its ``uint32`` ordinal.  A string field has
+    the type ``str``.  A sequence or array field has the element type
+    followed by ``[]``.  ``fields`` may also name a string or container
+    field, which decodes to a Python ``str`` or ``list``.
     """
 
     def __init__(self, schema, fields=None):
         self.schema = schema
         registry = parse_schema(schema)
-        self._tree = _tree(registry, ("named", schema.name.replace("/", "::"),
-                                      ()), ())
-        leaves = _leaves(self._tree, ())
+        tree = _tree(registry, ("named", schema.name.replace("/", "::"),
+                                ()), ())
+        leaves = _leaves(tree, ())
         types = {path: dtype for path, dtype, _ in leaves}
 
-        self.fields = tuple(types if fields is None else fields)
+        if fields is None:
+            fields = [path for path, dtype in types.items()
+                      if dtype in COLUMN_TYPES]
+        self.fields = tuple(fields)
         unknown = [path for path in self.fields if path not in types]
         if unknown:
-            raise McapError("unknown or non-scalar fields {}".format(unknown))
+            raise McapError("unknown or unsupported fields {}".format(
+                unknown))
         if len(set(self.fields)) != len(self.fields):
             raise McapError("duplicate fields in {}".format(self.fields))
         self.types = tuple(types[path] for path in self.fields)
         self.enums = {path: members for path, _, members in leaves
                       if members and path in self.fields}
-        paths = [path for path, _, _ in leaves]
+
+        self._tree = _mark(tree, (), set(self.fields))
+        paths = [path for path, dtype, _ in leaves
+                 if dtype in COLUMN_TYPES or path in self.fields]
         self._select = tuple(paths.index(path) for path in self.fields)
 
     def decode(self, payload):
@@ -458,13 +475,37 @@ def _union_tree(registry, name, visiting):
 
 
 def _leaves(node, path):
-    """Return ``(path, dtype, enum members)`` per scalar leaf, in order."""
+    """
+    Return ``(path, dtype, enum members)`` per leaf, in order.
+
+    A leaf is a scalar, a string, or a sequence or array of scalars or
+    strings.  The dtype of a container ends with ``[]``.
+    """
     if node[0] == "scalar":
         return [(".".join(path), node[1], node[2])]
+    if node[0] == "string":
+        return [(".".join(path), "str", None)]
     if node[0] == "struct":
         return [leaf for field, child in node[1]
                 for leaf in _leaves(child, path + (field,))]
+    if node[0] not in ("sequence", "array"):
+        return []
+    child = node[1]
+    if child[0] == "scalar":
+        return [(".".join(path), child[1] + "[]", child[2])]
+    if child[0] == "string":
+        return [(".".join(path), "str[]", None)]
     return []
+
+
+def _mark(node, path, fields):
+    """Flag each string or container node with whether ``fields`` names it."""
+    if node[0] == "struct":
+        return ("struct", [(field, _mark(child, path + (field,), fields))
+                           for field, child in node[1]])
+    if node[0] in ("string", "sequence", "array"):
+        return node + (".".join(path) in fields,)
+    return node
 
 
 def _walk(node, body, pos, order, values):
@@ -472,9 +513,9 @@ def _walk(node, body, pos, order, values):
     Walk ``node`` over the CDR ``body`` from ``pos`` and return the end.
 
     ``body`` starts after the encapsulation header, at the origin of CDR
-    alignment.  ``values`` collects every scalar leaf in the order of
-    ``_leaves``, or is ``None`` inside a container, whose scalars are not
-    columns.
+    alignment.  ``values`` collects every scalar and every selected
+    string or container in the order of ``_leaves``, or is ``None``
+    inside a union or a non-leaf container, whose leaves are not columns.
     """
     kind = node[0]
     if kind == "scalar":
@@ -492,8 +533,6 @@ def _walk(node, body, pos, order, values):
         pos = _walk(node[1], body, pos, order, discriminator)
         child = node[2].get(discriminator[0], node[2].get(None))
         return pos if child is None else _walk(child, body, pos, order, None)
-    # TODO: a string, a sequence, or an array is only skipped; none of them
-    # produces a column yet.
     if kind == "array":
         count = node[2]
     else:
@@ -502,14 +541,38 @@ def _walk(node, body, pos, order, values):
         pos += 4
     if count > len(body) - pos:
         raise McapError(_TRUNCATED)
+    selected = values is not None and node[-1]
     if kind == "string":
+        if selected:
+            values.append(_text(body, pos, count))
         return pos + count
-    if node[1][0] == "scalar":
-        size = _SCALARS[order][node[1][1]].size
-        return pos + (-pos % size if count else 0) + size * count
+    child = node[1]
+    if child[0] == "scalar":
+        size = _SCALARS[order][child[1]].size
+        pos += -pos % size if count else 0
+        if selected:
+            if size * count > len(body) - pos:
+                raise McapError(_TRUNCATED)
+            values.append(np.frombuffer(body, _DTYPES[order][child[1]],
+                                        count, pos).tolist())
+        return pos + size * count
+    items = [] if selected and child[0] == "string" else None
     for _ in range(count):
-        pos = _walk(node[1], body, pos, order, None)
+        pos = _walk(child, body, pos, order, items)
+    if items is not None:
+        values.append(items)
     return pos
+
+
+def _text(body, pos, count):
+    """Decode the CDR string at ``pos``; ``count`` includes the NUL."""
+    end = pos + count - 1
+    if count == 0 or body[end] != 0:
+        raise McapError("a string lacks its NUL terminator")
+    try:
+        return str(body[pos:end], "utf-8")
+    except UnicodeDecodeError:
+        raise McapError("a string is not UTF-8") from None
 
 
 def _resolve(registry, type_):

--- a/solvcon/track/mcap/_reader.py
+++ b/solvcon/track/mcap/_reader.py
@@ -45,11 +45,16 @@ class Extraction(collections.namedtuple("Extraction", "time columns")):
     The columns of one topic sorted by log time.
 
     ``time`` is a ``SimpleArrayUint64`` of log times in nanoseconds, and
-    ``columns`` maps each selected field to its ``SimpleArray``.
+    ``columns`` maps each selected field to its ``SimpleArray``.  A string
+    or container field maps to a NumPy ``object`` array of Python values
+    instead, which ``to_frame`` rejects.
     """
 
     def to_frame(self):
-        return dataframe.DataFrame.from_columns(self.time, **self.columns)
+        try:
+            return dataframe.DataFrame.from_columns(self.time, **self.columns)
+        except TypeError as error:
+            raise McapError("not a frame column: {}".format(error)) from error
 
 
 def unpack(fmt, buf, pos):
@@ -308,6 +313,8 @@ class Reader:
 
 
 def _column(values, dtype):
+    if dtype not in COLUMN_TYPES:
+        return np.fromiter(values, dtype='object', count=len(values))
     return COLUMN_TYPES[dtype][1](array=np.array(values, dtype=dtype))
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_track_mcap.py
+++ b/tests/test_track_mcap.py
@@ -207,11 +207,13 @@ class CdrPacker:
         self.body += struct.pack(self.order + code * len(values), *values)
         return self
 
-    def string(self, text):
-        data = text.encode() + b"\0"
+    def blob(self, data):
         self.scalar("I", len(data))
         self.body += data
         return self
+
+    def string(self, text):
+        return self.blob(text.encode() + b"\0")
 
     def payload(self):
         return b"\0" + (b"\x01" if self.order == "<" else b"\0") + b"\0\0" + \
@@ -248,7 +250,7 @@ class SchemaParseTC(unittest.TestCase):
         self.assertEqual(plan.types, ("uint32", "uint32", "bool", "float64"))
         self.assertEqual(plan.enums, {"kind": ("A", "B", "C")})
         for fields in (["extra.number"], ["extra.value"]):
-            with self.assertRaisesRegex(mcap.McapError, "non-scalar"):
+            with self.assertRaisesRegex(mcap.McapError, "unsupported"):
                 mcap.DecodePlan(schema, fields)
 
         for order in "<>":
@@ -320,35 +322,73 @@ class SchemaParseTC(unittest.TestCase):
                                         ("monitor_msgs", "msg")))))
 
     def test_walk_steps_over_containers(self):
-        """The walk steps over a string, a sequence, or an array."""
+        """The auto plan steps over a string, a sequence, or an array."""
         schema = mcap.Schema(1, "monitor_msgs/msg/Summary", "ros2idl",
                              SUMMARY_IDL)
         plan = mcap.DecodePlan(schema)
         self.assertEqual(plan.fields, ("header.sequence_number",
                                        "version.major", "version.minor",
                                        "v_target"))
-        for fields in (["reasons"], ["header.module_name"], ["flags"]):
-            with self.assertRaisesRegex(mcap.McapError, "non-scalar"):
+        for fields in (["reasons"], ["polygon_point"], ["polygon"]):
+            with self.assertRaisesRegex(mcap.McapError, "unsupported"):
                 mcap.DecodePlan(schema, fields)
         for order in "<>":
-            packer = CdrPacker(order).string("mod").scalar("I", 3)
-            packer.scalar("H", 1, 2)
-            packer.scalar("I", 2).scalar("Q", 10).string("a")
-            packer.scalar("Q", 11).string("bb")
-            packer.scalar("I", 1).string("n")
-            packer.scalar("B", 7, 8, 9)
-            packer.scalar("I", 1).scalar("d", 0.5)
-            packer.scalar("d", *range(6))
-            packer.scalar("I", 1).scalar("d", 1.0, 2.0, 3.0)
-            packer.scalar("d", 22.5)
-            self.assertEqual(plan.decode(packer.payload()), (3, 1, 2, 22.5),
-                             order)
+            self.assertEqual(plan.decode(pack_summary(order)),
+                             (3, 1, 2, 22.5), order)
+        payload = pack_summary("<")
         with self.assertRaisesRegex(mcap.McapError, "ends before"):
-            plan.decode(packer.payload()[:-3])
+            plan.decode(payload[:-3])
         with self.assertRaisesRegex(mcap.McapError, "ends before"):
             plan.decode(CdrPacker("<").scalar("I", 999).payload())
         with self.assertRaisesRegex(mcap.McapError, "encapsulation"):
-            plan.decode(b"\0\x02\0\0" + packer.payload()[4:])
+            plan.decode(b"\0\x02\0\0" + payload[4:])
+
+    def test_named_containers_decode(self):
+        """A named string, sequence, or array of scalars is a column."""
+        schema = mcap.Schema(1, "monitor_msgs/msg/Summary", "ros2idl",
+                             SUMMARY_IDL)
+        plan = mcap.DecodePlan(schema, ["header.module_name", "notes",
+                                        "flags", "brake_duration",
+                                        "v_target"])
+        self.assertEqual(plan.types, ("str", "str[]", "uint8[]",
+                                      "float64[]", "float64"))
+        for order in "<>":
+            self.assertEqual(plan.decode(pack_summary(order)),
+                             ("mod", ["n"], [7, 8, 9], [0.5], 22.5), order)
+
+        schema = mcap.Schema(1, "demo_msgs/msg/Signals", "ros2idl",
+                             SIGNALS_IDL)
+        plan = mcap.DecodePlan(schema, ["frame_id", "cov", "samples"])
+        self.assertEqual(plan.types, ("str", "float64[]", "float32[]"))
+        self.assertEqual(plan.decode(pack_signals(">", 1)),
+                         ("abc", [1.0, 2.0, 3.0, 4.0], [1.5, 2.5, 3.5]))
+        with self.assertRaisesRegex(mcap.McapError, "ends before"):
+            mcap.DecodePlan(schema, ["samples"]).decode(
+                pack_signals("<", 1)[:-40])
+
+    def test_string_edges(self):
+        """An empty, NUL-bearing, or non-UTF-8 string, and an empty list."""
+        schema = mcap.Schema(1, "x/msg/Y", "ros2idl",
+                             b"module x { module msg { enum E { P, Q };"
+                             b" struct Y { sequence<E> es; string s;"
+                             b" sequence<string> ss; }; }; };")
+        plan = mcap.DecodePlan(schema, ["es", "s", "ss"])
+        self.assertEqual(plan.fields, ("es", "s", "ss"))
+        self.assertEqual(plan.types, ("uint32[]", "str", "str[]"))
+        self.assertEqual(plan.enums, {"es": ("P", "Q")})
+        packer = CdrPacker("<").scalar("I", 0).string("a\0b").scalar("I", 0)
+        self.assertEqual(plan.decode(packer.payload()), ([], "a\0b", []))
+        packer = CdrPacker("<").scalar("I", 2, 1, 0).blob(b"\0")
+        self.assertEqual(plan.decode(packer.scalar("I", 0).payload()),
+                         ([1, 0], "", []))
+        packer = CdrPacker("<").scalar("I", 0).blob(b"\xff\0")
+        with self.assertRaisesRegex(mcap.McapError, "not UTF-8"):
+            plan.decode(packer.scalar("I", 0).payload())
+        self.assertEqual(mcap.DecodePlan(schema).decode(packer.payload()), ())
+        for data in (b"", b"abc"):
+            packer = CdrPacker("<").scalar("I", 0).blob(data).scalar("I", 0)
+            with self.assertRaisesRegex(mcap.McapError, "NUL terminator"):
+                plan.decode(packer.payload())
 
     def test_huge_array_bound_fails_fast(self):
         """A short payload fails before the walk iterates a huge array."""
@@ -468,6 +508,20 @@ def pack_signals(order, kind):
     else:
         packer.scalar("i", 7).scalar("d", 8.5)
     return packer.scalar("d", 3.5).payload()
+
+
+def pack_summary(order):
+    """Pack a ``Summary`` message with ``sequence_number`` 3."""
+    packer = CdrPacker(order).string("mod").scalar("I", 3)
+    packer.scalar("H", 1, 2)
+    packer.scalar("I", 2).scalar("Q", 10).string("a")
+    packer.scalar("Q", 11).string("bb")
+    packer.scalar("I", 1).string("n")
+    packer.scalar("B", 7, 8, 9)
+    packer.scalar("I", 1).scalar("d", 0.5)
+    packer.scalar("d", *range(6))
+    packer.scalar("I", 1).scalar("d", 1.0, 2.0, 3.0)
+    return packer.scalar("d", 22.5).payload()
 
 
 def pack_status(seq, speed, brake_active, mode):
@@ -595,6 +649,33 @@ class McapInOutTC(unittest.TestCase):
         self.assertEqual(brake.columns, ["active"])
         self.assertEqual(brake.index.tolist(), [15, 35])
         self.assertEqual(brake["active"].tolist(), [False, True])
+
+    def test_extract_container_columns(self):
+        """A string or container column is an object array, not a frame."""
+        path = os.path.join(self.tmpdir.name, "signals.mcap")
+        with open(path, "wb") as fp:
+            writer = foxglove_mcap_writer.Writer(fp)
+            writer.start(profile="ros2")
+            schema_id = writer.register_schema("demo_msgs/msg/Signals",
+                                               "ros2idl", SIGNALS_IDL)
+            channel_id = writer.register_channel("/signals", "cdr",
+                                                 schema_id)
+            for log_time, kind in ((20, 0), (10, 1)):
+                writer.add_message(channel_id, log_time,
+                                   pack_signals("<", kind), log_time)
+            writer.finish()
+
+        with mcap.Reader(path) as reader:
+            ext = reader.extract("/signals", ["frame_id", "samples",
+                                              "count"])
+        self.assertEqual(ext.time.ndarray.tolist(), [10, 20])
+        self.assertIsInstance(ext.columns["count"], sc.SimpleArrayUint32)
+        self.assertEqual(ext.columns["frame_id"].dtype, object)
+        self.assertEqual(ext.columns["frame_id"].tolist(), ["abc", "abc"])
+        self.assertEqual(ext.columns["samples"].tolist(),
+                         [[1.5, 2.5, 3.5], [1.5, 2.5, 3.5]])
+        with self.assertRaisesRegex(mcap.McapError, "frame_id has unsup"):
+            ext.to_frame()
 
     def test_messages_match_foxglove(self):
         for compression in ("none", "lz4", "zstd"):


### PR DESCRIPTION
This PR lets a `DecodePlan` in `solvcon.track.mcap` decode a string, a sequence, or an array into a column. A field list may name a string field, whose type is `str`. A sequence or array of scalars, enums, or strings has the element type followed by `[]`. Each decodes to a Python `str` or `list` per message. The reader stacks them into a NumPy `object` array, and `Extraction.to_frame` rejects such a column with `McapError`.

Before this PR the walk only stepped over these fields, so no such field could reach a column. The auto plan still selects scalar leaves only, so a recording full of `frame_id` strings extracts a frame without a field list. The walk decodes a string or container only when the plan selects it. A container of structs, unions, or nested containers is still not a column. A string without its NUL terminator, or with bytes that are not UTF-8, raises `McapError`.

Related to #1438.
