### PR TITLE
Prepare Windows CUDA builds

### DIFF
--- a/.github/actions/setup_windows/action.yml
+++ b/.github/actions/setup_windows/action.yml
@@ -72,15 +72,19 @@ runs:
           throw "CUDA installer hash mismatch: expected $cuda_expected_hash got $cuda_hash"
         }
         $cuda_install = Start-Process -FilePath $cuda_installer `
-          -ArgumentList '-s', '-n', 'nvcc_13.0', 'cudart_13.0' `
+          -ArgumentList '-s', '-n', 'nvcc_13.0', 'crt_13.0', `
+            'cudart_13.0' `
           -NoNewWindow -PassThru -Wait
         if ($cuda_install.ExitCode -ne 0) {
           throw "CUDA installer exited with code $($cuda_install.ExitCode)"
         }
         $cuda_root = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0'
         $nvcc = Join-Path $cuda_root 'bin\nvcc.exe'
-        if (-not (Test-Path -LiteralPath $nvcc)) {
-          throw "CUDA compiler not found at $nvcc"
+        $cuda_header = Join-Path $cuda_root 'include\crt\host_config.h'
+        foreach ($cuda_file in @($nvcc, $cuda_header)) {
+          if (-not (Test-Path -LiteralPath $cuda_file -PathType Leaf)) {
+            throw "CUDA file not found at $cuda_file"
+          }
         }
         echo "CUDA_PATH=$cuda_root" |
           Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/actions/setup_windows/action.yml
+++ b/.github/actions/setup_windows/action.yml
@@ -31,6 +31,7 @@ runs:
       uses: lukka/get-cmake@latest
 
     - name: install qt
+      if: ${{ inputs.workflow != 'build_cuda' }}
       uses: jurplel/install-qt-action@v4
       with:
         # aqtinstall 3.3.0 cannot resolve Qt 6.11's new split Windows
@@ -52,13 +53,51 @@ runs:
       with:
         python-version: '3.14.7'
 
+    - name: install CUDA toolkit
+      if: ${{ inputs.workflow == 'build_cuda' }}
+      shell: pwsh
+      run: |
+        echo "::group::install CUDA toolkit"
+        $cuda_installer = Join-Path $env:RUNNER_TEMP `
+          'cuda_13.0.0_windows_network.exe'
+        $cuda_url = ('https://developer.download.nvidia.com/compute/cuda/' +
+          '13.0.0/network_installers/' +
+          'cuda_13.0.0_windows_network.exe')
+        Invoke-WebRequest -Uri $cuda_url -OutFile $cuda_installer
+        $cuda_hash = (Get-FileHash -LiteralPath $cuda_installer `
+          -Algorithm SHA256).Hash.ToLower()
+        $cuda_expected_hash = `
+          '69e2b033ead25c64280424d7e899a9155953d90d8e06e315d27e6999ad4a7419'
+        if ($cuda_hash -ne $cuda_expected_hash) {
+          throw "CUDA installer hash mismatch: expected $cuda_expected_hash got $cuda_hash"
+        }
+        $cuda_install = Start-Process -FilePath $cuda_installer `
+          -ArgumentList '-s', '-n', 'nvcc_13.0', 'cudart_13.0' `
+          -NoNewWindow -PassThru -Wait
+        if ($cuda_install.ExitCode -ne 0) {
+          throw "CUDA installer exited with code $($cuda_install.ExitCode)"
+        }
+        $cuda_root = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0'
+        $nvcc = Join-Path $cuda_root 'bin\nvcc.exe'
+        if (-not (Test-Path -LiteralPath $nvcc)) {
+          throw "CUDA compiler not found at $nvcc"
+        }
+        echo "CUDA_PATH=$cuda_root" |
+          Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "CUDAToolkit_ROOT=$cuda_root" |
+          Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo (Join-Path $cuda_root 'bin') |
+          Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        & $nvcc --version
+        echo "::endgroup::"
+
     - name: sccache
-      if: ${{ inputs.workflow == 'build' }}
+      if: ${{ inputs.workflow == 'build' || inputs.workflow == 'build_cuda' }}
       uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         variant: sccache
-        key: ${{ runner.os }}-sccache-${{ inputs.cmake-build-type }}
-        restore-keys: ${{ runner.os }}-sccache-${{ inputs.cmake-build-type }}
+        key: ${{ runner.os }}-sccache-${{ inputs.workflow == 'build_cuda' && 'cuda-Release' || inputs.cmake-build-type }}
+        restore-keys: ${{ runner.os }}-sccache-${{ inputs.workflow == 'build_cuda' && 'cuda-Release' || inputs.cmake-build-type }}
         save: ${{ github.event_name != 'pull_request' }}
         # Bound the cache so it does not grow without limit across the rolling
         # key. A master push and the nightly (both build types) save under this
@@ -124,7 +163,16 @@ runs:
         echo "$vcpkg_bin_path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "::endgroup::"
 
+    - name: dependency by pip (CUDA)
+      if: ${{ inputs.workflow == 'build_cuda' }}
+      shell: pwsh
+      run: |
+        echo "::group::dependency by pip (CUDA)"
+        pip3 install -U numpy pytest flake8 pybind11
+        echo "::endgroup::"
+
     - name: dependency by pip
+      if: ${{ inputs.workflow != 'build_cuda' }}
       shell: pwsh
       run: |
         echo "::group::dependency by pip"

--- a/.github/actions/setup_windows/action.yml
+++ b/.github/actions/setup_windows/action.yml
@@ -73,15 +73,16 @@ runs:
         }
         $cuda_install = Start-Process -FilePath $cuda_installer `
           -ArgumentList '-s', '-n', 'nvcc_13.0', 'crt_13.0', `
-            'cudart_13.0' `
+            'cudart_13.0', 'nvvm_13.0' `
           -NoNewWindow -PassThru -Wait
         if ($cuda_install.ExitCode -ne 0) {
           throw "CUDA installer exited with code $($cuda_install.ExitCode)"
         }
         $cuda_root = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0'
         $nvcc = Join-Path $cuda_root 'bin\nvcc.exe'
+        $cicc = Join-Path $cuda_root 'nvvm\bin\cicc.exe'
         $cuda_header = Join-Path $cuda_root 'include\crt\host_config.h'
-        foreach ($cuda_file in @($nvcc, $cuda_header)) {
+        foreach ($cuda_file in @($nvcc, $cicc, $cuda_header)) {
           if (-not (Test-Path -LiteralPath $cuda_file -PathType Leaf)) {
             throw "CUDA file not found at $cuda_file"
           }

--- a/.github/workflows/devbuild_windows.yml
+++ b/.github/workflows/devbuild_windows.yml
@@ -107,8 +107,52 @@ jobs:
           cmake --workflow --preset ci-win-rel
           echo "::endgroup::"
 
+  # Hosted Windows runners have no NVIDIA GPU.  Compile the CUDA-enabled
+  # extension without trying to execute the probe.
+  build_cuda_windows:
+
+    needs: [check_skip]
+
+    if: |
+      needs.check_skip.outputs.skip != 'true' &&
+      needs.check_skip.outputs.cpp != 'false' && (
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' &&
+       ((vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH) == '*' ||
+        contains(vars.SCGH_PUSH_RUN_BRANCH || vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))))
+
+    name: build_cuda_windows-2022
+
+    runs-on: windows-2022
+
+    timeout-minutes: ${{ fromJSON(vars.SCGH_TIMEOUT_BUILD || vars.MMGH_TIMEOUT_BUILD || '60') }}
+
+    steps:
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: event name
+        run: |
+          echo "github.event_name: ${{ github.event_name }}"
+
+      - name: setup
+        uses: ./.github/actions/setup_windows
+        with:
+          workflow: build_cuda
+
+      - name: build extension with CUDA
+        run: |
+          echo "::group::build extension with CUDA"
+          $env:PYBIND11_DIR = "$(pybind11-config --cmakedir)"
+          nvcc --version
+          cmake --preset ci-win-cuda
+          cmake --build --preset ci-win-cuda --verbose
+          echo "::endgroup::"
+
   send_email_on_failure:
-    needs: [check_skip, build_windows]
+    needs: [check_skip, build_windows, build_cuda_windows]
     # Mail a master push failure only. A `timeout-minutes` kill reports
     # `cancelled`, not `failure`.
     if: |
@@ -123,6 +167,7 @@ jobs:
       job_results: |
         - check_skip: ${{ needs.check_skip.result }}
         - build_windows: ${{ needs.build_windows.result }}
+        - build_cuda_windows: ${{ needs.build_cuda_windows.result }}
     secrets:
       EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
       EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -165,13 +165,20 @@
       }
     },
     {
-      "name": "ci-win-mkl",
+      "name": "ci-win-sccache",
       "hidden": true,
       "inherits": "ci-win-base",
       "cacheVariables": {
         "CMAKE_C_COMPILER_LAUNCHER": "sccache",
         "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
-        "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded",
+        "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded"
+      }
+    },
+    {
+      "name": "ci-win-mkl",
+      "hidden": true,
+      "inherits": "ci-win-sccache",
+      "cacheVariables": {
         "SOLVCON_USE_MKL": { "type": "BOOL", "value": "ON" },
         "CMAKE_INCLUDE_PATH": "$env{MKL_INCLUDE_DIR}",
         "CMAKE_LIBRARY_PATH": "$env{MKL_LIBRARY_DIR}"
@@ -193,6 +200,23 @@
       "description": "For the Windows CI job. A developer wants win-dbg instead.",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Debug" }
+      }
+    },
+    {
+      "name": "ci-win-cuda",
+      "inherits": "ci-win-sccache",
+      "displayName": "CI: Windows CUDA Release",
+      "description": "For the Windows CUDA CI job.",
+      "cacheVariables": {
+        "BUILD_CUDA": { "type": "BOOL", "value": "ON" },
+        "BUILD_QT": { "type": "BOOL", "value": "OFF" },
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" },
+        "CMAKE_CUDA_COMPILER_LAUNCHER": "sccache",
+        "CMAKE_CUDA_ARCHITECTURES": {
+          "type": "STRING",
+          "value": "all-major"
+        },
+        "USE_GOOGLETEST": { "type": "BOOL", "value": "OFF" }
       }
     },
     {
@@ -410,6 +434,14 @@
       "configurePreset": "ci-win-dbg",
       "displayName": "CI: Windows Debug",
       "description": "Build everything the Windows CI job builds."
+    },
+    {
+      "name": "ci-win-cuda",
+      "inherits": "win-base",
+      "configurePreset": "ci-win-cuda",
+      "displayName": "CI: Windows CUDA Release",
+      "description": "Build the extension and its CUDA compile probe.",
+      "targets": ["_solvcon"]
     },
     {
       "name": "ci-win-asan",

--- a/contrib/dependency/windows/build-scdv-windows.ps1
+++ b/contrib/dependency/windows/build-scdv-windows.ps1
@@ -50,7 +50,8 @@
 #       is safe to capture: $prefix = .\build-scdv-windows.ps1 -PrintPrefix.
 #   .\build-scdv-windows.ps1 -PrintPrereq
 #       Print the prerequisite install commands and manual notes, then exit.
-#       Nothing is built and no directories are created.
+#       This includes the CUDA 13.0 compiler and runtime used by CI.  Nothing
+#       is built and no directories are created.
 #   .\build-scdv-windows.ps1 -PrintVsInstall
 #       Print just the elevated command to install the VS 2022 Build Tools
 #       (the v143 MSVC toolset), then exit.  Run it from an administrator
@@ -268,6 +269,26 @@ winget install --id NASM.NASM -e
 '@
     Show-VsInstall
     @'
+
+# CUDA 13.0 matches the Linux CI compiler/runtime pair.  NVIDIA's network
+# installer fetches only nvcc and cudart here; no display driver or GPU is
+# needed to compile solvcon's CUDA probe.  The install itself is machine-wide,
+# so Start-Process requests elevation:
+$cuda_installer = Join-Path $env:TEMP 'cuda_13.0.0_windows_network.exe'
+$cuda_url = 'https://developer.download.nvidia.com/compute/cuda/13.0.0/network_installers/cuda_13.0.0_windows_network.exe'
+curl.exe -fL -o $cuda_installer $cuda_url
+$cuda_hash = (Get-FileHash -LiteralPath $cuda_installer -Algorithm SHA256).Hash.ToLower()
+$cuda_expected_hash = '69e2b033ead25c64280424d7e899a9155953d90d8e06e315d27e6999ad4a7419'
+if ($cuda_hash -ne $cuda_expected_hash) {
+    throw "CUDA installer hash mismatch: expected $cuda_expected_hash got $cuda_hash"
+}
+$cuda_install = Start-Process -FilePath $cuda_installer -Verb RunAs -PassThru -Wait -ArgumentList '-s', '-n', 'nvcc_13.0', 'cudart_13.0'
+if ($cuda_install.ExitCode -ne 0) {
+    throw "CUDA installer exited with code $($cuda_install.ExitCode)"
+}
+$env:CUDA_PATH = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0'
+$env:CUDAToolkit_ROOT = $env:CUDA_PATH
+$env:PATH = "$(Join-Path $env:CUDA_PATH 'bin');$env:PATH"
 
 # scipy needs a Fortran compiler.  WinLibs supplies gfortran through winget:
 winget install --id BrechtSanders.WinLibs.POSIX.UCRT -e --scope user
@@ -612,6 +633,14 @@ $_sp = Join-Path $usr 'Lib\site-packages'
 $env:PATH = "$usr;$(Join-Path $usr 'Scripts');$(Join-Path $usr 'bin');" +
             "$(Join-Path $_sp 'PySide6');$(Join-Path $_sp 'shiboken6');" +
             $env:PATH
+$cuda = if ($env:CUDA_PATH) {
+    $env:CUDA_PATH
+} else {
+    'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0'
+}
+if (Test-Path -LiteralPath (Join-Path $cuda 'bin') -PathType Container) {
+    $env:PATH = "$(Join-Path $cuda 'bin');$env:PATH"
+}
 $env:QT_PLUGIN_PATH = Join-Path $usr 'plugins'
 
 # So a downstream CMake build finds this scdv's Qt, pybind11, and BLAS/LAPACK.

--- a/contrib/dependency/windows/build-scdv-windows.ps1
+++ b/contrib/dependency/windows/build-scdv-windows.ps1
@@ -271,9 +271,9 @@ winget install --id NASM.NASM -e
     @'
 
 # CUDA 13.0 matches the Linux CI compiler/runtime pair.  NVIDIA's network
-# installer fetches only nvcc, its compiler support files, and cudart here; no
-# display driver or GPU is needed to compile solvcon's CUDA probe.  The install
-# itself is machine-wide, so Start-Process requests elevation:
+# installer fetches only nvcc, its compiler support and backend, and cudart
+# here; no display driver or GPU is needed to compile solvcon's CUDA probe.
+# The install itself is machine-wide, so Start-Process requests elevation:
 $cuda_installer = Join-Path $env:TEMP 'cuda_13.0.0_windows_network.exe'
 $cuda_url = 'https://developer.download.nvidia.com/compute/cuda/13.0.0/network_installers/cuda_13.0.0_windows_network.exe'
 curl.exe -fL -o $cuda_installer $cuda_url
@@ -282,14 +282,15 @@ $cuda_expected_hash = '69e2b033ead25c64280424d7e899a9155953d90d8e06e315d27e6999a
 if ($cuda_hash -ne $cuda_expected_hash) {
     throw "CUDA installer hash mismatch: expected $cuda_expected_hash got $cuda_hash"
 }
-$cuda_install = Start-Process -FilePath $cuda_installer -Verb RunAs -PassThru -Wait -ArgumentList '-s', '-n', 'nvcc_13.0', 'crt_13.0', 'cudart_13.0'
+$cuda_install = Start-Process -FilePath $cuda_installer -Verb RunAs -PassThru -Wait -ArgumentList '-s', '-n', 'nvcc_13.0', 'crt_13.0', 'cudart_13.0', 'nvvm_13.0'
 if ($cuda_install.ExitCode -ne 0) {
     throw "CUDA installer exited with code $($cuda_install.ExitCode)"
 }
 $cuda_root = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0'
 $nvcc = Join-Path $cuda_root 'bin\nvcc.exe'
+$cicc = Join-Path $cuda_root 'nvvm\bin\cicc.exe'
 $cuda_header = Join-Path $cuda_root 'include\crt\host_config.h'
-foreach ($cuda_file in @($nvcc, $cuda_header)) {
+foreach ($cuda_file in @($nvcc, $cicc, $cuda_header)) {
     if (-not (Test-Path -LiteralPath $cuda_file -PathType Leaf)) {
         throw "CUDA file not found at $cuda_file"
     }

--- a/contrib/dependency/windows/build-scdv-windows.ps1
+++ b/contrib/dependency/windows/build-scdv-windows.ps1
@@ -271,9 +271,9 @@ winget install --id NASM.NASM -e
     @'
 
 # CUDA 13.0 matches the Linux CI compiler/runtime pair.  NVIDIA's network
-# installer fetches only nvcc and cudart here; no display driver or GPU is
-# needed to compile solvcon's CUDA probe.  The install itself is machine-wide,
-# so Start-Process requests elevation:
+# installer fetches only nvcc, its compiler support files, and cudart here; no
+# display driver or GPU is needed to compile solvcon's CUDA probe.  The install
+# itself is machine-wide, so Start-Process requests elevation:
 $cuda_installer = Join-Path $env:TEMP 'cuda_13.0.0_windows_network.exe'
 $cuda_url = 'https://developer.download.nvidia.com/compute/cuda/13.0.0/network_installers/cuda_13.0.0_windows_network.exe'
 curl.exe -fL -o $cuda_installer $cuda_url
@@ -282,11 +282,19 @@ $cuda_expected_hash = '69e2b033ead25c64280424d7e899a9155953d90d8e06e315d27e6999a
 if ($cuda_hash -ne $cuda_expected_hash) {
     throw "CUDA installer hash mismatch: expected $cuda_expected_hash got $cuda_hash"
 }
-$cuda_install = Start-Process -FilePath $cuda_installer -Verb RunAs -PassThru -Wait -ArgumentList '-s', '-n', 'nvcc_13.0', 'cudart_13.0'
+$cuda_install = Start-Process -FilePath $cuda_installer -Verb RunAs -PassThru -Wait -ArgumentList '-s', '-n', 'nvcc_13.0', 'crt_13.0', 'cudart_13.0'
 if ($cuda_install.ExitCode -ne 0) {
     throw "CUDA installer exited with code $($cuda_install.ExitCode)"
 }
-$env:CUDA_PATH = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0'
+$cuda_root = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0'
+$nvcc = Join-Path $cuda_root 'bin\nvcc.exe'
+$cuda_header = Join-Path $cuda_root 'include\crt\host_config.h'
+foreach ($cuda_file in @($nvcc, $cuda_header)) {
+    if (-not (Test-Path -LiteralPath $cuda_file -PathType Leaf)) {
+        throw "CUDA file not found at $cuda_file"
+    }
+}
+$env:CUDA_PATH = $cuda_root
 $env:CUDAToolkit_ROOT = $env:CUDA_PATH
 $env:PATH = "$(Join-Path $env:CUDA_PATH 'bin');$env:PATH"
 


### PR DESCRIPTION
## Summary

- add a Windows CUDA CI job that installs the minimal CUDA 13.0 compiler/runtime components and builds the CUDA probe without Qt
- add matching `ci-win-cuda` configure and build presets with a dedicated sccache key
- extend `build-scdv-windows.ps1` prerequisite guidance and activation support for CUDA 13.0
- validate `nvcc`, the NVVM `cicc` backend, and CUDA CRT headers after installation

## Notes

GitHub-hosted Windows runners do not have an NVIDIA GPU, so this verifies CUDA compilation and linking rather than runtime execution.

Related to #1443.