### PR TITLE
Control `matmul` benchmark workers from Qt

### DIFF
--- a/solvcon/benchmark/collector.py
+++ b/solvcon/benchmark/collector.py
@@ -130,8 +130,13 @@ def _compare_result(execute, name, reference):
     }
 
 
-def _compare(spec, execute):
+def _ignore_progress(phase, name):
+    pass
+
+
+def _compare(spec, execute, progress=_ignore_progress):
     """Compare every requested kernel with the NumPy reference."""
+    progress('comparison', 'numpy')
     reference = np.atleast_1d(execute('numpy'))
     if reference.shape != spec.output_shape:
         raise RuntimeError('NumPy reference shape does not match spec')
@@ -147,10 +152,10 @@ def _compare(spec, execute):
             }
             for name in spec.kernels + ('numpy',)
         }
-    comparison = {
-        name: _compare_result(execute, name, reference)
-        for name in spec.kernels
-    }
+    comparison = {}
+    for name in spec.kernels:
+        progress('comparison', name)
+        comparison[name] = _compare_result(execute, name, reference)
     comparison['numpy'] = {
         'status': 'measured',
         'reason': None,
@@ -218,7 +223,8 @@ def _williams_rows(names):
     return tuple(named_rows)
 
 
-def _time_candidates(execute, names, sampling, clock):
+def _time_candidates(execute, names, sampling, clock,
+                     progress=_ignore_progress):
     """Time one repetition block per candidate in each scheduled round.
 
     A round selects one Williams row. Each candidate gets one clock interval
@@ -230,6 +236,7 @@ def _time_candidates(execute, names, sampling, clock):
     # both phases on one cyclic schedule.
     for warmup_index in range(-sampling.warmups, 0):
         for name in rows[warmup_index % len(rows)]:
+            progress('warmup', name)
             execute(name)
 
     elapsed_by_name = {name: [] for name in names}
@@ -238,6 +245,7 @@ def _time_candidates(execute, names, sampling, clock):
         row = rows[round_index % len(rows)]
         round_orders.append(list(row))
         for name in row:
+            progress('timing', name)
             start = clock()
             for _ in range(sampling.repetitions):
                 execute(name)
@@ -245,13 +253,13 @@ def _time_candidates(execute, names, sampling, clock):
     return round_orders, elapsed_by_name
 
 
-def _collect(spec, execute, clock):
+def _collect(spec, execute, clock, progress=_ignore_progress):
     names = spec.kernels + ('numpy',)
-    comparison = _compare(spec, execute)
+    comparison = _compare(spec, execute, progress)
     measured_names = tuple(
         name for name in names if comparison[name]['status'] == 'measured')
     round_orders, elapsed_by_name = _time_candidates(
-        execute, measured_names, spec.sampling, clock)
+        execute, measured_names, spec.sampling, clock, progress)
     results = []
     for name in names:
         result = {'name': name, **comparison[name]}
@@ -264,13 +272,13 @@ def _collect(spec, execute, clock):
     }
 
 
-def collect(spec):
-    """Collect one exact matmul comparison from a validated specification."""
+def collect(spec, *, progress=_ignore_progress):
+    """Collect a comparison, reporting (phase, kernel) outside timed blocks."""
 
     if not isinstance(spec, matmul.MatmulSpec):
         raise TypeError('spec must be a MatmulSpec')
     return _collect(
-        spec, _make_executor(spec), time.perf_counter_ns)
+        spec, _make_executor(spec), time.perf_counter_ns, progress)
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/benchmark/worker.py
+++ b/solvcon/benchmark/worker.py
@@ -39,7 +39,10 @@ def run(stdin, stdout):
     """Run one request and emit one terminal result or error event."""
     try:
         specification, output_path = _read_request(stdin)
-        comparison = collector.collect(specification)
+        comparison = collector.collect(
+            specification, progress=lambda phase, name: _emit({
+                'type': 'progress', 'phase': phase, 'kernel': name,
+            }, stdout))
         artifact_path = artifact.write_artifact(comparison, output_path)
         _emit({
             'type': 'result',

--- a/solvcon/pilot/_benchmark.py
+++ b/solvcon/pilot/_benchmark.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""Control one isolated matmul worker from a reusable Qt widget."""
+
+import json
+import os
+
+from PySide6 import QtCore, QtWidgets
+
+from solvcon import system
+
+
+class BenchmarkControl(QtWidgets.QWidget):
+    """Show progress and emit a terminal signal after the worker exits.
+
+    Call start with a MatmulSpec and an artifact path. A running control
+    rejects another start. Stop and close kill the worker asynchronously.
+    """
+
+    completed = QtCore.Signal(str)
+    failed = QtCore.Signal(str)
+    stopped = QtCore.Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.status = QtWidgets.QLabel('Idle', self)
+        self.status.setTextFormat(QtCore.Qt.TextFormat.PlainText)
+        self.elapsed = QtWidgets.QLabel('Elapsed: 0.0 s', self)
+        self.stop_button = QtWidgets.QPushButton('Stop', self)
+        self.stop_button.setEnabled(False)
+        self.stop_button.clicked.connect(self.stop)
+        layout = QtWidgets.QHBoxLayout(self)
+        for widget in (self.status, self.elapsed, self.stop_button):
+            layout.addWidget(widget)
+
+        self._process = QtCore.QProcess(self)
+        self._process.started.connect(self._send_request)
+        self._process.readyReadStandardOutput.connect(self._read_stdout)
+        self._process.readyReadStandardError.connect(self._read_stderr)
+        self._process.errorOccurred.connect(self._process_error)
+        self._process.finished.connect(self._finish)
+        self._clock = QtCore.QElapsedTimer()
+        self._timer = QtCore.QTimer(self)
+        self._timer.timeout.connect(self._update_elapsed)
+        self._running = False
+        self._closing = False
+
+    @property
+    def running(self):
+        return self._running
+
+    def start(self, specification, output_path):
+        if self.running:
+            raise RuntimeError('a benchmark is already running')
+        request = {'spec': specification.to_dict(),
+                   'output_path': os.fspath(output_path)}
+        self._request = (json.dumps(request, allow_nan=False) + '\n').encode()
+        self._kernels = specification.kernels + ('numpy',)
+        self._result = None
+        self._error = ''
+        self._stderr = b''
+        self._cancelled = False
+        self._running = True
+        self.status.setText('Preparing')
+        self.stop_button.setEnabled(True)
+        self._clock.start()
+        self._update_elapsed()
+        self._timer.start(100)
+        command = system.python_command('-m', 'solvcon.benchmark.worker')
+        self._process.start(command[0], command[1:])
+
+    def stop(self):
+        if self.running:
+            self._cancelled = True
+            self.status.setText('Stopping')
+            self.stop_button.setEnabled(False)
+            self._process.kill()
+
+    def closeEvent(self, event):
+        if self.running:
+            self._closing = True
+            self.stop()
+            event.ignore()
+        else:
+            super().closeEvent(event)
+
+    def _send_request(self):
+        if self._cancelled:
+            self._process.kill()
+            return
+        self._process.write(self._request)
+        self._process.closeWriteChannel()
+
+    def _update_elapsed(self):
+        seconds = self._clock.elapsed() / 1000
+        self.elapsed.setText(f'Elapsed: {seconds:.1f} s')
+
+    def _read_stdout(self):
+        while self._process.canReadLine():
+            line = bytes(self._process.readLine())
+            if self._cancelled or self._error:
+                continue
+            try:
+                self._handle_event(json.loads(line))
+            except ValueError as exc:
+                self._fail(f'Worker protocol error: {exc}')
+
+    def _handle_event(self, event):
+        if not isinstance(event, dict) or self._result is not None:
+            raise ValueError('unexpected worker event')
+        kind = event.get('type')
+        if kind == 'progress':
+            phase, kernel = event.get('phase'), event.get('kernel')
+            if (phase not in ('comparison', 'warmup', 'timing')
+                    or kernel not in self._kernels):
+                raise ValueError('invalid worker progress')
+            self.status.setText(f'{phase.capitalize()}: {kernel}')
+        elif kind == 'result':
+            path = event.get('artifact_path')
+            if not isinstance(path, str) or not path:
+                raise ValueError('invalid worker artifact path')
+            self._result = path
+            self.status.setText('Finishing')
+        elif kind == 'error':
+            self._fail(str(event.get('message', 'worker failed')))
+        else:
+            raise ValueError('unknown worker event')
+
+    def _read_stderr(self):
+        data = bytes(self._process.readAllStandardError())
+        self._stderr = (self._stderr + data)[-8192:]
+
+    def _fail(self, message):
+        if not self._error:
+            self._error = message or 'Worker failed'
+        self._process.kill()
+
+    def _process_error(self, error):
+        self._fail(self._process.errorString())
+        if error == QtCore.QProcess.ProcessError.FailedToStart:
+            # Qt finishes its startup cleanup after errorOccurred returns.
+            QtCore.QTimer.singleShot(
+                0, self,
+                lambda: self._finish(-1, QtCore.QProcess.ExitStatus.CrashExit))
+
+    def _finish(self, exit_code, exit_status):
+        if not self.running:
+            return
+        self._read_stdout()
+        self._read_stderr()
+        remaining = bytes(self._process.readAllStandardOutput())
+        if remaining and not self._error:
+            self._error = 'Worker protocol error: incomplete event'
+        normal_exit = exit_status == QtCore.QProcess.ExitStatus.NormalExit
+        if not self._error and (exit_code or not normal_exit):
+            self._error = f'Worker exited with code {exit_code}'
+        if not self._error and self._result is None:
+            self._error = 'Worker exited without a result'
+
+        self._running = False
+        self._timer.stop()
+        self._update_elapsed()
+        self.stop_button.setEnabled(False)
+        if self._closing:
+            self._closing = False
+            self.close()
+
+        if self._cancelled:
+            self.status.setText('Stopped')
+            self.stopped.emit()
+        elif self._error:
+            message = self._error
+            if self._stderr:
+                message += '\n' + self._stderr.decode('utf8', errors='replace')
+            self.status.setText(message)
+            self.failed.emit(message)
+        else:
+            self.status.setText('Completed')
+            self.completed.emit(self._result)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/system.py
+++ b/solvcon/system.py
@@ -18,12 +18,21 @@ from . import apputil
 
 
 __all__ = [
+    'python_command',
     'setup_process',
     'enter_main',
     'exec_code',
     'get_completions',
     'get_call_tip',
 ]
+
+
+def python_command(*args):
+    """Build an argument list for the active Python or embedded interpreter."""
+    clinfo = solvcon.clinfo
+    if clinfo.populated:
+        return [clinfo.populated_argv[0], '--mode=python', *args]
+    return [sys.executable, *args]
 
 
 class SolvconArgumentParser(argparse.ArgumentParser):

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -12,18 +12,27 @@ import pathlib
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 import unittest.mock
 
 import numpy as np
 
 import solvcon as sc
-from solvcon import benchmark, clinfo
+from solvcon import benchmark, system
 from solvcon.benchmark import artifact
 from solvcon.benchmark import collector
 from solvcon.benchmark import matmul
 from solvcon.benchmark import spec as benchmark_spec
 from solvcon.benchmark import worker
+
+
+try:
+    from PySide6 import QtCore, QtTest, QtWidgets
+except ImportError:
+    QtWidgets = None
+else:
+    from solvcon.pilot import _benchmark
 
 
 def make_matmul_spec(**updates):
@@ -806,25 +815,194 @@ class BenchmarkWorkerTC(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             path = pathlib.Path(directory) / 'artifact.json'
             request = make_request(path)
-            # A pilot-only build embeds _solvcon without a shared extension.
-            # Run the worker with that same binary in Python mode.
-            if clinfo.populated:
-                command = [clinfo.populated_argv[0], '--mode=python']
-            else:
-                command = [sys.executable]
             process = subprocess.run(
-                command + ['-m', 'solvcon.benchmark.worker'],
+                system.python_command('-m', 'solvcon.benchmark.worker'),
                 input=json.dumps(request) + '\n',
                 capture_output=True, text=True, check=False)
 
             self.assertEqual(
                 process.returncode, 0, process.stderr or process.stdout)
-            self.assertEqual(json.loads(process.stdout), {
+            events = [json.loads(line)
+                      for line in process.stdout.splitlines()]
+            self.assertEqual(events[:-1], [
+                {'type': 'progress', 'phase': phase, 'kernel': kernel}
+                for phase, kernel in (('comparison', 'numpy'),
+                                      ('comparison', 'naive'),
+                                      ('timing', 'naive'), ('timing', 'numpy'))
+            ])
+            self.assertEqual(events[-1], {
                 'type': 'result',
                 'artifact_path': str(path),
             })
             document = artifact.load_artifact(path)
             self.assertEqual(document['spec'], request['spec'])
+
+
+class BenchmarkProgressTC(unittest.TestCase):
+    def test_progress_stays_outside_timed_blocks(self):
+        sampling = make_matmul_spec(sampling={
+            'warmups': 1, 'repetitions': 2, 'rounds': 1,
+        }).sampling
+        events = []
+
+        def clock():
+            events.append('clock')
+            return len(events)
+
+        orders, elapsed = benchmark.collector._time_candidates(
+            lambda name: events.append(name), ('naive',), sampling, clock,
+            lambda phase, name: events.append((phase, name)))
+
+        self.assertEqual(events, [
+            ('warmup', 'naive'), 'naive', ('timing', 'naive'),
+            'clock', 'naive', 'naive', 'clock',
+        ])
+        self.assertEqual(orders, [['naive']])
+        self.assertEqual(elapsed, {'naive': [3]})
+
+
+@unittest.skipIf(QtWidgets is None, 'PySide6 is not installed')
+class BenchmarkControlTC(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = (QtWidgets.QApplication.instance()
+                   or QtWidgets.QApplication([]))
+
+    def setUp(self):
+        self.control = _benchmark.BenchmarkControl()
+        self.directory = tempfile.TemporaryDirectory()
+        self.path = pathlib.Path(self.directory.name) / 'result.json'
+        self.spec = make_matmul_spec(
+            kernels=['naive'],
+            sampling={'warmups': 1, 'repetitions': 2, 'rounds': 2})
+        self.events = []
+        self.control.completed.connect(
+            lambda path: self.events.append(('result', path)))
+        self.control.failed.connect(
+            lambda message: self.events.append(('error', message)))
+        self.control.stopped.connect(
+            lambda: self.events.append(('stopped', None)))
+
+    def tearDown(self):
+        self.control.stop()
+        self.wait_for(lambda: not self.control.running)
+        self.control.close()
+        self.control.deleteLater()
+        self.directory.cleanup()
+
+    def wait_for(self, predicate):
+        deadline = time.monotonic() + 15
+        while not predicate() and time.monotonic() < deadline:
+            QtTest.QTest.qWait(10)
+        self.assertTrue(predicate(), self.control.status.text())
+
+    def start_script(self, script):
+        script = 'import sys\nsys.stdin.readline()\n' + script
+        command = system.python_command('-c', script)
+        with unittest.mock.patch.object(
+                system, 'python_command', return_value=command):
+            self.control.start(self.spec, self.path)
+
+    def assert_finished(self, kind):
+        self.wait_for(lambda: not self.control.running)
+        self.assertEqual([event[0] for event in self.events], [kind])
+        self.assertEqual(self.control._process.state(),
+                         QtCore.QProcess.ProcessState.NotRunning)
+        self.assertFalse(self.control.stop_button.isEnabled())
+        self.assertFalse(self.control._timer.isActive())
+
+    def test_collect_and_repeat(self):
+        for _ in range(2):
+            self.events.clear()
+            self.control.start(self.spec, self.path)
+            with self.assertRaisesRegex(RuntimeError, 'already running'):
+                self.control.start(self.spec, self.path)
+            self.assert_finished('result')
+            self.assertEqual(self.events[0][1], str(self.path))
+            self.assertEqual(artifact.load_artifact(self.path)['spec'],
+                             self.spec.to_dict())
+
+    def test_progress_stop_and_recover(self):
+        event = json.dumps({'type': 'progress', 'phase': 'timing',
+                            'kernel': 'naive'})
+        self.start_script(
+            'import sys, time\n'
+            f'sys.stdout.write({event[:12]!r})\n'
+            'sys.stdout.flush()\n'
+            'time.sleep(0.15)\n'
+            f'print({event[12:]!r}, flush=True)\n'
+            'time.sleep(60)\n')
+        self.wait_for(lambda: self.control.status.text() == 'Timing: naive')
+        self.wait_for(
+            lambda: self.control.elapsed.text() != 'Elapsed: 0.0 s')
+        self.assertEqual(self.events, [])
+        self.control.stop_button.click()
+        self.assert_finished('stopped')
+        self.events.clear()
+        self.control.start(self.spec, self.path)
+        self.assert_finished('result')
+
+    def assert_error_recovery(self, cases):
+        for script, message in cases:
+            with self.subTest(message=message):
+                self.events.clear()
+                self.start_script(script)
+                self.assert_finished('error')
+                self.assertIn(message, self.events[0][1])
+        self.events.clear()
+        self.control.start(self.spec, self.path)
+        self.assert_finished('result')
+
+    def test_protocol_error_recovery(self):
+        self.assert_error_recovery((
+            ("print('not json', flush=True)\nimport time\ntime.sleep(60)",
+             'protocol'),
+            ("print('{}', flush=True)", 'unknown'),
+            ('print(\'{"type":"error","message":"bad spec"}\', '
+             'flush=True)\nimport time\ntime.sleep(60)', 'bad spec'),
+        ))
+
+    def test_exit_error_recovery(self):
+        self.assert_error_recovery((
+            ("print('{}', end='', flush=True)", 'incomplete'),
+            ('pass', 'without a result'),
+            ("import sys\nsys.stderr.write('native crash')\nsys.exit(3)",
+             'native crash'),
+            ('print(\'{"type":"result","artifact_path":"fake"}\', '
+             'flush=True)\nimport sys\nsys.exit(3)', 'code 3'),
+        ))
+
+    def test_crash(self):
+        self.start_script('import time\ntime.sleep(60)')
+        self.wait_for(lambda: self.control._process.state() ==
+                      QtCore.QProcess.ProcessState.Running)
+        self.control._process.kill()
+        self.assert_finished('error')
+
+    def test_failed_start_recovers_from_signal(self):
+        process_errors = []
+        self.control._process.errorOccurred.connect(process_errors.append)
+
+        def restart(message):
+            # Reentering QProcess inside its error signal can block Qt.
+            if not process_errors:
+                return
+            self.control.failed.disconnect(restart)
+            self.events.clear()
+            self.control.start(self.spec, self.path)
+
+        self.control.failed.connect(restart)
+        with unittest.mock.patch.object(system, 'python_command',
+                                        return_value=['/missing/worker']):
+            self.control.start(self.spec, self.path)
+        self.assert_finished('result')
+
+    def test_stop_during_start_and_close(self):
+        for action in (self.control.stop, self.control.close):
+            self.events.clear()
+            self.start_script('import time\ntime.sleep(60)')
+            action()
+            self.assert_finished('stopped')
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -297,6 +297,26 @@ class CallTipTC(unittest.TestCase):
         self.assertEqual(apputil.get_call_tip('boom()'), '')
 
 
+class PythonCommandTC(unittest.TestCase):
+    def test_uses_the_active_interpreter_and_preserves_arguments(self):
+        from unittest import mock
+        from solvcon import system
+
+        clinfo = mock.Mock(populated=False)
+        with mock.patch.object(solvcon, 'clinfo', clinfo), \
+                mock.patch.object(system.sys, 'executable', '/python path'):
+            self.assertEqual(
+                system.python_command('-c', 'print("hello world")'),
+                ['/python path', '-c', 'print("hello world")'])
+
+            clinfo.populated = True
+            clinfo.populated_argv = ['/pilot path', '--mode=pytest', '-v']
+            self.assertEqual(
+                system.python_command('-m', 'solvcon.benchmark.worker'),
+                ['/pilot path', '--mode=python', '-m',
+                 'solvcon.benchmark.worker'])
+
+
 class WorkerTC(unittest.TestCase):
     """The worker-thread helper for heavy console work."""
 


### PR DESCRIPTION
## Motivation

The worker from #1487 can collect and save one comparison, but Qt cannot yet control its lifetime. The Route Inspector needs kernel progress, elapsed time, and a responsive Stop action.

## Approach

Add a reusable `BenchmarkControl` widget that launches the worker through `QProcess`. Share interpreter selection through `system.python_command()`, including the pilot executable with `--mode=python` when Python is embedded. Both the Qt controller and subprocess tests use this helper.

```text
{spec, output_path} -> QProcess -> worker -> artifact
                         |
                         `-> JSON lines -> progress / result / error
QTimer + QElapsedTimer   -> elapsed time
```

Report progress before each comparison, warmup, and timed repetition block. Keep progress I/O outside the measured interval:

```text
progress -> clock start -> kernel x repetitions -> clock stop
```

Stop and close kill the worker without blocking the Qt event loop. Process and protocol errors report failure; completion requires a result event and a normal zero exit. Clear the running state and stop the timer before emitting a terminal signal.

Targeted benchmark and pilot tests: 71 passed, 336 skipped. `make lint` passes. Qt process tests run with the locally available PySide6. Full Pilot build verification remains blocked by Qt 6.6.3, which lacks `QRhiWidget`.

Related to #1369, task 6.
