### PR TITLE
Use the initializer-list size in `small_vector`

### DIFF
--- a/cpp/solvcon/buffer/small_vector.hpp
+++ b/cpp/solvcon/buffer/small_vector.hpp
@@ -83,7 +83,7 @@ public:
     small_vector(std::initializer_list<T> init)
         : small_vector(init.size())
     {
-        std::copy_n(init.begin(), m_size, begin());
+        std::copy_n(init.begin(), init.size(), begin());
     }
 
     small_vector() { m_head = m_data.data(); }


### PR DESCRIPTION
Use `init.size()` instead of `m_size` as the copy count in the `small_vector` initializer-list constructor. This avoids a GCC 16 array-bounds false positive with `-fsanitize=undefined -O3 -std=c++23`.

For each affected one-element shape, the delegating constructor stores `init.size()` in `m_size`, so the copy count is one. Under UndefinedBehaviorSanitizer instrumentation, GCC loses the connection between that store and the subsequent read of `m_size`. In the inline-storage branch, GCC only retains the bound `m_size <= N`, where `N` is three. GCC therefore considers a copy beyond the one-element source possible, and `-Werror=array-bounds` rejects the build.

Using `init.size()` directly lets GCC fold the copy count to one at the call site without tracking the member's store and load. The affected copies retain the same count and behavior.

UndefinedBehaviorSanitizer triggers the warning; builds without sanitizers or with AddressSanitizer alone pass. `USE_SANITIZER=ON` enables undefined, leak, and address sanitizers together, which explains the failure in the combined sanitizer build.
