### PR TITLE
Retry the toolchain PPA add in CI setup

### DIFF
--- a/.github/actions/setup_linux/action.yml
+++ b/.github/actions/setup_linux/action.yml
@@ -108,7 +108,7 @@ runs:
       shell: bash
       run: |
         echo "::group::Install and configure gcc-16"
-        sudo add-apt-repository -y -n ppa:ubuntu-toolchain-r/test
+        sudo contrib/ci/add-ppa.sh ppa:ubuntu-toolchain-r/test
         sudo contrib/ci/apt-update.sh -qq
         sudo apt-get -qy install gcc-16 g++-16
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-16 100

--- a/contrib/ci/add-ppa.sh
+++ b/contrib/ci/add-ppa.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+#
+# Add a PPA with `add-apt-repository` and retry it. add-apt-repository asks
+# Launchpad for the PPA signing key over its REST API, and Launchpad answers
+# with HTTP 500 GPGKeyTemporarilyNotFoundError now and then. A retry sends a
+# new request, which Launchpad answers once the key is available again.
+# Driven by .github/actions/setup_linux/action.yml, and runnable by hand:
+#
+#   sudo contrib/ci/add-ppa.sh ppa:ubuntu-toolchain-r/test
+#
+# Every argument goes to `add-apt-repository` after `-y -n`. ATTEMPTS is how
+# many attempts to make before the script gives up.
+
+set -euo pipefail
+
+ATTEMPTS="${ATTEMPTS:-3}"
+
+for ((attempt = 1; attempt <= ATTEMPTS; attempt++)) ; do
+    if [ "$attempt" -gt 1 ] ; then
+        sleep 10
+    fi
+    if add-apt-repository -y -n "$@" ; then
+        exit 0
+    fi
+    echo "add-apt-repository attempt $attempt of $ATTEMPTS failed"
+done
+
+exit 1
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
This PR wraps the toolchain PPA add in the Linux CI setup with a retry, so that a transient Launchpad error does not fail the whole run.

The devbuild run for the merge of #1500 on master failed in the `standalone_buffer_ubuntu-24.04` job before the build started. `add-apt-repository` fetches the PPA signing key from the Launchpad REST API, and Launchpad answered with HTTP 500 `GPGKeyTemporarilyNotFoundError` (run https://github.com/solvcon/solvcon/actions/runs/33972147424). The step had no retry, so one such answer was fatal.

The new script `contrib/ci/add-ppa.sh` runs `add-apt-repository -y -n` up to three times with a 10 second pause between attempts. It follows the shape of `contrib/ci/apt-update.sh`, which already protects the `apt-get update` calls in the same action.
