### PR TITLE
Release old heap storage in `small_vector` move assignment

### DIFF
--- a/cpp/solvcon/buffer/small_vector.hpp
+++ b/cpp/solvcon/buffer/small_vector.hpp
@@ -175,6 +175,10 @@ public:
             }
             else
             {
+                if (m_head != m_data.data())
+                {
+                    delete[] m_head;
+                }
                 m_size = other.m_size;
                 m_capacity = other.m_capacity;
                 m_head = other.m_head;

--- a/gtests/test_nopython_buffer.cpp
+++ b/gtests/test_nopython_buffer.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <memory>
 #include <random>
 #include <type_traits>
 #ifdef Py_PYTHON_H
@@ -659,6 +660,23 @@ TEST(SimpleCollector, pop_back)
     coll.pop_back();
     EXPECT_TRUE(coll.empty());
     EXPECT_THROW(coll.pop_back(), std::out_of_range);
+}
+
+TEST(small_vector, heap_move_assignment_releases_destination)
+{
+    solvcon::small_vector<std::shared_ptr<int>> destination(4, std::make_shared<int>(7));
+    std::weak_ptr<int> previous = destination[0];
+    solvcon::small_vector<std::shared_ptr<int>> source(5, std::make_shared<int>(42));
+    auto * const source_data = source.data();
+
+    destination = std::move(source);
+
+    EXPECT_TRUE(previous.expired());
+    EXPECT_EQ(source_data, destination.data());
+    EXPECT_EQ(5, destination.size());
+    EXPECT_EQ(5, destination.capacity());
+    EXPECT_EQ(42, *destination[0]);
+    EXPECT_TRUE(source.empty());
 }
 
 TEST(small_vector, select_kth)


### PR DESCRIPTION
`small_vector` move assignment forgot to delete the destination's old heap storage before taking the source pointer. This PR adds the missing `delete[]` when the destination owns heap storage.

```text
heap-to-heap move assignment
  -> delete destination's old storage
  -> take source pointer, size, and capacity
  -> reset source to empty inline storage
```

The regression uses `weak_ptr::expired()` to detect whether the old elements were released. It also checks that the destination takes the source allocation.

The C++ suite passes 265 tests with Qt and Metal disabled. `make lint` passes.

Related to #1502.