### PR TITLE
Fix transpose ownership and axis validation

### DIFF
--- a/cpp/solvcon/buffer/SimpleArray.hpp
+++ b/cpp/solvcon/buffer/SimpleArray.hpp
@@ -3020,7 +3020,8 @@ void SimpleArray<T>::transpose(shape_type const & axis, bool copy)
     {
         throw std::runtime_error("SimpleArray::transpose: axis size mismatch");
     }
-    shape_type new_shape(m_shape.size(), -1);
+    small_vector<bool> seen(m_shape.size(), false);
+    shape_type new_shape(m_shape.size());
     shape_type new_stride(m_stride.size());
     for (ssize_t it = 0; it < ndim(); ++it)
     {
@@ -3028,10 +3029,11 @@ void SimpleArray<T>::transpose(shape_type const & axis, bool copy)
         {
             throw std::runtime_error("SimpleArray::transpose: axis out of range");
         }
-        if (new_shape[it] != -1)
+        if (seen[axis[it]])
         {
             throw std::runtime_error("SimpleArray::transpose: axis already set");
         }
+        seen[axis[it]] = true;
         new_shape[it] = m_shape[axis[it]];
         new_stride[it] = m_stride[axis[it]];
     }

--- a/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
+++ b/cpp/solvcon/buffer/pymod/wrap_SimpleArray.hpp
@@ -11,6 +11,7 @@
 
 #include <cctype>
 #include <cstdint>
+#include <memory>
 #include <string>
 
 namespace solvcon
@@ -145,16 +146,17 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSimpleArray
                 "transpose",
                 [](wrapped_type & self, py::object const & axis, bool inplace, bool copy)
                 {
-                    wrapped_type * ret = inplace ? &self : new wrapped_type(self);
+                    auto owner = inplace ? nullptr : std::make_unique<wrapped_type>(self);
+                    wrapped_type & ret = inplace ? self : *owner;
                     if (axis.is_none())
                     {
-                        ret->transpose(copy);
+                        ret.transpose(copy);
                     }
                     else
                     {
-                        ret->transpose(make_shape(axis), copy);
+                        ret.transpose(make_shape(axis), copy);
                     }
-                    return *ret;
+                    return ret;
                 },
                 py::arg("axis") = py::none(),
                 py::arg("inplace") = true,

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -2,6 +2,7 @@
 # BSD 3-Clause License, see COPYING
 
 
+import itertools
 import operator
 import unittest
 
@@ -512,6 +513,44 @@ class SimpleArrayBasicTC(unittest.TestCase):
         check_equal(sarr, ndarr)
         check_equal(sarr2, ndarrT)
         self.assertNotEqual(memoryview(sarr), memoryview(sarr2))
+
+    def test_SimpleArray_transpose_invalid_axes(self):
+        ndarr = np.arange(24, dtype='float64').reshape(2, 3, 4)
+        cases = [
+            ((0, 0, 2), 'axis already set'),
+            ((2, 1, 2), 'axis already set'),
+            ((0, 1), 'axis size mismatch'),
+            ((0, 1, 3), 'axis out of range'),
+        ]
+        for inplace, copy, (axes, message) in itertools.product(
+                (False, True), (False, True), cases):
+            with self.subTest(inplace=inplace, copy=copy, axes=axes):
+                sarr = solvcon.SimpleArrayFloat64(array=ndarr.copy())
+                original_stride = sarr.stride
+
+                with self.assertRaisesRegex(RuntimeError, message):
+                    sarr.transpose(axis=axes, inplace=inplace, copy=copy)
+
+                self.assertEqual(sarr.shape, ndarr.shape)
+                self.assertEqual(sarr.stride, original_stride)
+                np.testing.assert_array_equal(sarr.ndarray, ndarr)
+
+    def test_SimpleArray_transpose_modes(self):
+        ndarr = np.arange(24, dtype='float64').reshape(2, 3, 4)
+        for inplace, copy, axes in itertools.product(
+                (False, True), (False, True), (None, (2, 0, 1))):
+            with self.subTest(inplace=inplace, copy=copy, axes=axes):
+                sarr = solvcon.SimpleArrayFloat64(array=ndarr.copy())
+                expected = ndarr.transpose(axes)
+
+                result = sarr.transpose(axis=axes, inplace=inplace, copy=copy)
+
+                np.testing.assert_array_equal(result.ndarray, expected)
+                np.testing.assert_array_equal(
+                    sarr.ndarray, expected if inplace else ndarr)
+                if not inplace:
+                    result.ndarray.flat[0] = -1
+                    np.testing.assert_array_equal(sarr.ndarray, ndarr)
 
     def test_SimpleArray_transpose_copy(self):
         # Physical (deep-copy) transpose variants.  Cover 1D, 2D, 3D, 4D;


### PR DESCRIPTION
## Motivation

A repeated axis returns an invalid shape:

```python
import numpy as np
import solvcon as sc

a = sc.SimpleArrayFloat64(
    array=np.arange(6, dtype="float64").reshape(2, 3))
a.transpose(axis=(1, 1), inplace=False)
# Before: returns an array with shape (3, 3)
# After:  RuntimeError: SimpleArray::transpose: axis already set
```

The old out-of-place path leaks the allocated array:

```cpp
auto *ret = new wrapped_type(self);
ret->transpose(copy);
return *ret; // Copies the result; never deletes ret.
```

## Approach

For `axis=(1, 1)`, track source axis `1` instead of separate output positions:

```text
        old check                   new check
it=0    new_shape[0] == -1: accept   seen[1] == false: mark true
it=1    new_shape[1] == -1: accept   seen[1] == true: throw
```

Own the temporary copy with `unique_ptr`. It releases the copy on return and on exceptions:

```cpp
auto owner = inplace ? nullptr : std::make_unique<wrapped_type>(self);
wrapped_type &ret = inplace ? self : *owner;
ret.transpose(copy); // Default-axis path.
return ret;         // Copies the result; owner then frees the temporary.
```

No-Qt tests: 552 passed, 2 skipped, 2 xfailed. `make lint` passes. The allocator probe drops from ~48 MiB retained to 0-64 bytes after six calls.

Related to #1505.
