### PR TITLE
Use collector size in `as_array()`

### DIFF
--- a/cpp/solvcon/buffer/SimpleCollector.hpp
+++ b/cpp/solvcon/buffer/SimpleCollector.hpp
@@ -119,7 +119,7 @@ public:
 
     SimpleArray<T> as_array()
     {
-        return SimpleArray<T>(expander().as_concrete());
+        return SimpleArray<T>({static_cast<ssize_t>(size())}, {1}, expander().as_concrete());
     }
 
     void push_back(value_type const & value)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -6168,10 +6168,45 @@ class SimpleCollectorTC(unittest.TestCase):
         for it in range(5):
             self.assertEqual(it * 1.1, arr[it])
 
+        empty = ct.as_array()
+        self.assertEqual((0,), empty.shape)
+        self.assertEqual([], empty.ndarray.tolist())
+        self.assertEqual(old_capacity, ct.capacity)
+
         # Collector can be reused after clear.
         ct.push_back(42.0)
         self.assertEqual(1, len(ct))
         self.assertEqual(42.0, ct[0])
+
+        reused = ct.as_array()
+        self.assertEqual((1,), reused.shape)
+        self.assertEqual([42.0], reused.ndarray.tolist())
+        self.assertTrue(np.shares_memory(arr.ndarray, reused.ndarray))
+        self.assertEqual((0,), empty.shape)
+
+    def test_as_array_after_shrink(self):
+        classes = (solvcon.SimpleCollectorInt32,
+                   solvcon.SimpleCollectorFloat64)
+        for cls, length, alignment in itertools.product(
+                classes, (0, 1, 3), (0, 16)):
+            with self.subTest(cls=cls, length=length, alignment=alignment):
+                collector = cls(4, alignment)
+                for index in range(4):
+                    collector[index] = index
+                original = collector.as_array()
+
+                collector.expand(length)
+                result = collector.as_array()
+
+                self.assertEqual((length,), result.shape)
+                self.assertEqual(list(range(length)), result.ndarray.tolist())
+                self.assertEqual(alignment, result.alignment)
+                self.assertEqual(4, collector.capacity)
+                self.assertEqual((4,), original.shape)
+                self.assertEqual(list(range(4)), original.ndarray.tolist())
+                if length:
+                    self.assertTrue(np.shares_memory(
+                        original.ndarray, result.ndarray))
 
     def test_alignment_preserved_in_as_concrete(self):
         ep = solvcon.BufferExpander(128, 16)


### PR DESCRIPTION
The buffer-only constructor derives the exported shape from the cached buffer, which can be larger than the collector after clearing or shrinking:

```python
import solvcon as sc

collector = sc.SimpleCollectorFloat64()
for value in (10, 20, 30):
    collector.push_back(value)
original = collector.as_array()

collector.clear()
collector.as_array().ndarray.tolist()  # Before: [10, 20, 30]; after: []
collector.push_back(99)
collector.as_array().ndarray.tolist()  # Before: [99, 20, 30]; after: [99]
```

Pass the current element count and unit stride to the existing view constructor. This limits the new array without resizing or copying the shared buffer:

```cpp
// Before: shape comes from the entire buffer.
SimpleArray<T>(expander().as_concrete());

// After: shape comes from the collector's current size.
SimpleArray<T>({static_cast<ssize_t>(size())}, {1}, expander().as_concrete());
```

The regressions cover clear/reuse and shrinking across integer and floating-point collectors, with and without alignment. They also check that earlier exports keep their shapes and nonempty exports still share memory.

No-Qt buffer, mesh, and universe tests: 680 passed, 5 skipped. `make lint` passes.

Related to #1508.
