### PR TITLE
Validate NumPy contiguity in `ConcreteBuffer`

### DIFF
--- a/cpp/solvcon/buffer/pymod/wrap_ConcreteBuffer.cpp
+++ b/cpp/solvcon/buffer/pymod/wrap_ConcreteBuffer.cpp
@@ -38,6 +38,10 @@ WrapConcreteBuffer::WrapConcreteBuffer(pybind11::module & mod, char const * pyna
             py::init(
                 [](py::array & arr_in, size_t alignment)
                 {
+                    if ((arr_in.flags() & (py::array::c_style | py::array::f_style)) == 0)
+                    {
+                        throw std::invalid_argument("ConcreteBuffer: input array must be C- or F-contiguous");
+                    }
                     return wrapped_type::construct(
                         arr_in.nbytes(), arr_in.mutable_data(), std::make_unique<ConcreteBufferNdarrayRemover>(arr_in), alignment);
                 }),

--- a/doc/source/compute/buffer/memory.md
+++ b/doc/source/compute/buffer/memory.md
@@ -79,15 +79,15 @@ buf = solvcon.ConcreteBuffer(array=ndarr)
 assert buf.nbytes == ndarr.nbytes
 ```
 
-The dtype and shape of the source array do not matter, but the array must be
-contiguous; the buffer covers its `nbytes` bytes and shares them zero-copy, so
-writing through one side is visible on the other. The constructor also accepts
-the optional `alignment` keyword, validated against the same set (0, 16, 32,
-or 64); no size-multiple check applies because nothing is allocated. The
-buffer holds a reference to the source array, tying the lifetime of the memory
-to the Python object. The `is_from_python` property reports the provenance: it
-is `True` for a buffer wrapping a numpy array and `False` for a buffer that
-allocated its own memory.
+The dtype and shape of the source array do not matter, but the array must be C-
+or F-contiguous; other layouts raise `ValueError`. The buffer covers its
+`nbytes` bytes and shares them zero-copy, so writing through one side is
+visible on the other. The constructor also accepts the optional `alignment`
+keyword, validated against the same set (0, 16, 32, or 64); no size-multiple
+check applies because nothing is allocated. The buffer holds a reference to the
+source array, tying the lifetime of the memory to the Python object. The
+`is_from_python` property reports the provenance: it is `True` for a buffer
+wrapping a numpy array and `False` for a buffer that allocated its own memory.
 
 ## BufferExpander
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -79,6 +79,44 @@ class ConcreteBufferBasicTC(unittest.TestCase):
         buf.ndarray.fill(0)
         self.assertTrue((ndarr == 0).all())
 
+    def test_from_ndarray_rejects_noncontiguous(self):
+        storage = np.arange(64, dtype='int8')
+        cases = (
+            ('step', storage[:8:2]),
+            ('reverse', storage[:8][::-1]),
+            ('columns', storage.reshape(8, 8)[:, ::2]),
+            ('zero', np.ndarray((4,), dtype='int8', buffer=storage,
+                                strides=(0,))),
+        )
+        for layout, source in cases:
+            with self.subTest(layout=layout):
+                with self.assertRaisesRegex(
+                        ValueError,
+                        'input array must be C- or F-contiguous'):
+                    solvcon.ConcreteBuffer(array=source)
+
+    def test_from_ndarray_contiguous_layouts(self):
+        shapes = ((2, 3), (1, 3), (0, 3), ())
+        for shape, order, dtype in itertools.product(
+                shapes, ('C', 'F'), ('int8', 'float64')):
+            with self.subTest(shape=shape, order=order, dtype=dtype):
+                source = np.empty(shape, dtype=dtype, order=order)
+                source.flat = np.arange(source.size, dtype=dtype)
+                expected = np.frombuffer(source.tobytes(order='A'),
+                                         dtype='int8')
+
+                buffer = solvcon.ConcreteBuffer(array=source)
+
+                self.assertEqual(source.nbytes, buffer.nbytes)
+                self.assertTrue(buffer.is_from_python)
+                np.testing.assert_array_equal(expected, buffer.ndarray)
+                self.assertEqual(source.ctypes.data,
+                                 buffer.ndarray.ctypes.data)
+                if source.size:
+                    self.assertTrue(np.shares_memory(source, buffer.ndarray))
+                    buffer.ndarray.fill(0)
+                    self.assertFalse(np.any(source))
+
 
 class ConcreteBufferAlignmentTC(unittest.TestCase):
     """


### PR DESCRIPTION
A non-contiguous NumPy view is currently treated as a contiguous byte range, so the returned buffer exposes bytes outside the view:

```python
import numpy as np
import solvcon as sc

base = np.arange(8, dtype='int8')
source = base[::2]  # [0, 2, 4, 6]
buffer = sc.ConcreteBuffer(array=source)
# Before: exposes [0, 1, 2, 3].
# After:  ValueError: ConcreteBuffer: input array must be C- or F-contiguous
```

Check NumPy's C/F-contiguous flags before wrapping the data pointer. Either flag is sufficient because `ConcreteBuffer` exposes physical bytes and carries no shape or strides:

```text
C-contiguous     -> share bytes in their existing order
F-contiguous     -> share bytes in their existing order
neither          -> reject before constructing the buffer
```

The regressions reject stepped, reversed, column-sliced and zero-stride inputs. They also check byte order and sharing for accepted C/F layouts, including singleton axes, empty arrays and scalars. Update the constructor documentation to state the accepted layouts and exception.

No-Qt buffer, mesh, grid, and multidimensional solver tests: 467 passed, 8 skipped. `make lint` passes.

Related to #1512.
