### PR TITLE
Add a Python script to install `CMakeUserPresets.json`

### DIFF
--- a/.claude/skills/ide-user-presets/SKILL.md
+++ b/.claude/skills/ide-user-presets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ide-user-presets
-description: Install or refresh an IDE's CMakeUserPresets.json from the checked-in template, substituting the scdv prefix so the `ide-scdv-reldbg` preset carries a real path. Use when setting an IDE up on a checkout, when an IDE cannot find Qt6 or pybind11, or after the template changes. Not a build step; agents build with `make`.
+description: Install or refresh an IDE's CMakeUserPresets.json with contrib/cmake/install-user-presets.py, which substitutes the scdv prefix so the `ide-scdv-reldbg` preset carries a real path. Use when setting an IDE up on a checkout, when an IDE cannot find Qt6 or pybind11, or after the template changes. Not a build step; agents build with `make`.
 ---
 
 # IDE User Presets (solvcon)
@@ -11,10 +11,14 @@ shared presets in `CMakePresets.json`. Install it when an IDE needs it, never
 as preparation for a build: an agent builds with `make`, which selects a
 checked-in preset and layers the activated environment on top.
 
+`contrib/cmake/install-user-presets.py` does the whole job: it resolves the
+prefix, picks the template for the host, substitutes, and verifies. Read this
+page for what the script decides on your behalf and when to stop and ask.
+
 The `scdv` templates in `contrib/cmake/` name the prefix once, as
 `$penv{SCDV_USRDIR}` in the preset's `environment` map, and the three cache
-variables read it back from there as `$env{SCDV_USRDIR}`. Installing one is a
-copy with that single occurrence replaced by the prefix it names.
+variables read it back as `$env{SCDV_USRDIR}`. Installing is a copy with that
+single occurrence replaced by the prefix it names.
 
 Substituting rather than leaving the expansion in place is the whole point.
 An IDE started from the desktop inherits the session environment, not the
@@ -28,36 +32,74 @@ pybind11, or the template in `contrib/cmake/` changed and the installed copy
 is stale. Nothing else triggers it. Entering a worktree does not, and neither
 does a task that happens to build.
 
-## 1. Resolve the scdv prefix
-
-The substitution needs a prefix, so resolve one before touching the file:
-`$SCDV_USRDIR` when a shell has an scdv activated, `$SCDV_BASE/usr` when the
-user names an environment, or the `usr` directory of a build under
-`~/var/scdv/`. Do not invent a path and do not fall back to a system prefix.
-
-Carry the result in a shell variable, because only the first of those three is
-already one:
+## Install or refresh
 
 ```bash
-PREFIX=${SCDV_USRDIR:-${SCDV_BASE:?resolve an scdv prefix first}/usr}
+contrib/cmake/install-user-presets.py
 ```
+
+The script installs into the checkout it lives in, which in a worktree is the
+worktree, so it can be run from any directory. It writes the file, then
+reports the preset names and the prefix they carry. That is the whole
+procedure; the sections below cover the two decisions it hands back.
+
+Never commit the result and never move a machine path into
+`CMakePresets.json`.
+
+### The prefix
+
+The script resolves `$SCDV_USRDIR`, then `$SCDV_BASE/usr`, and takes
+`--prefix` over both. Pass `--prefix` when the shell has no scdv activated
+but the user names an environment, or to point at the `usr` directory of a
+build under `~/var/scdv/`.
+
+Nothing else is a candidate. Do not invent a path and do not fall back to a
+system prefix. When the script reports that no prefix resolved, stop and ask:
+an unsubstituted file is worse than no file, because CMake then reports
+missing packages rather than a missing environment.
 
 Report which environment was used. A machine often holds several, and the
 installed file pins the one that was resolved.
 
-Stop and ask when nothing resolves. An unsubstituted file is worse than no
-file: CMake reports missing packages rather than a missing environment.
+### An installed copy that differs
 
-## 2. Install or refresh
+The script refuses to overwrite a file that differs from the rendered
+template, and prints the diff instead. The diff tells the two causes apart: a
+stale template, or the user's own presets. Show it and ask before rerunning
+with `--force`.
 
-Work from the repository root (`git rev-parse --show-toplevel`), which in a
-worktree is the worktree, not the main checkout. Pick the template for the
-host: `CMakeUserPresets.scdv.json` on Linux and macOS,
-`CMakeUserPresets.win-scdv.json` on Windows. The `example` files beside them
-are for a prefix that is not an scdv and are hand-edited, not installed from
-here.
+`--check` renders and compares without writing, and exits non-zero when the
+installed copy is missing or stale. Use it to answer whether a refresh is
+needed.
+
+## What the script verifies
+
+It checks that the substituted `SCDV_USRDIR` names a directory that exists.
+Checking for a leftover `penv{` would not be enough: an empty prefix
+substitutes cleanly and leaves `"SCDV_USRDIR": ""`, which passes that grep and
+then fails a configure with missing packages instead of a missing environment.
+The remaining `$env{SCDV_USRDIR}` in the cache variables is correct, and
+resolves from the `environment` map above them.
+
+Then it runs `cmake --list-presets=configure` and `--list-presets=build` with
+`SCDV_USRDIR` removed from the environment, which is what an IDE sees, and
+requires `ide-scdv-reldbg` in the first and `ide-scdv-reldbg`,
+`ide-scdv-reldbg-module` and `ide-scdv-reldbg-gtest` in the second.
+
+Listing is the whole verification. Configuring or building through an `ide-*`
+preset is the IDE's job, and a build of your own is `make`. Report the preset
+names and the prefix they carry, then stop.
+
+## Doing it by hand
+
+Only when the script cannot run. Pick the template for the host,
+`CMakeUserPresets.scdv.json` on Linux and macOS,
+`CMakeUserPresets.win-scdv.json` on Windows, and substitute into the
+repository root. The `example` files beside them are for a prefix that is not
+an scdv; they are hand-edited, not installed from here.
 
 ```bash
+PREFIX=${SCDV_USRDIR:-${SCDV_BASE:?resolve an scdv prefix first}/usr}
 sed "s|\$penv{SCDV_USRDIR}|${PREFIX}|g" \
     contrib/cmake/CMakeUserPresets.scdv.json > CMakeUserPresets.json
 ```
@@ -68,34 +110,12 @@ sed "s|\$penv{SCDV_USRDIR}|${PREFIX}|g" \
     Set-Content CMakeUserPresets.json
 ```
 
-When the file already exists, render to a scratch path and compare. Identical
-output means the installed copy is current, so say so and stop. A difference
-is either a stale template or the user's own presets, which the diff tells
-apart: show it and ask before overwriting.
-
-Never commit the result and never move a machine path into
-`CMakePresets.json`.
-
-## 3. Verify
-
-The `SCDV_USRDIR` entry has to name a directory that exists. Checking for a
-leftover `penv{` is not enough: an empty `PREFIX` substitutes cleanly and
-leaves `"SCDV_USRDIR": ""`, which passes that grep and then fails a configure
-with missing packages instead of a missing environment.
+Then verify by hand what the script would have verified:
 
 ```bash
 test -d "$(sed -n 's/.*"SCDV_USRDIR": "\(.*\)".*/\1/p' CMakeUserPresets.json)"
+env -u SCDV_USRDIR cmake --list-presets
+env -u SCDV_USRDIR cmake --list-presets=build
 ```
-
-The remaining `$env{SCDV_USRDIR}` in the cache variables is correct, and
-resolves from the `environment` map above them. Then `cmake --list-presets`
-has to show `ide-scdv-reldbg`, and `cmake --list-presets=build` has to show
-`ide-scdv-reldbg`, `ide-scdv-reldbg-module`, and `ide-scdv-reldbg-gtest`. Report the
-preset names and the prefix they carry, then stop. Listing is the whole
-verification: configuring or building through an `ide-*` preset is the IDE's
-job, and a build of your own is `make`.
-
-Both listings have to work with the scdv deactivated, which is what an IDE
-sees. `env -u SCDV_USRDIR cmake --list-presets` is the cheap way to prove it.
 
 <!-- vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: -->

--- a/contrib/cmake/install-user-presets.py
+++ b/contrib/cmake/install-user-presets.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Install an IDE's CMakeUserPresets.json from the checked-in template.
+
+``CMakeUserPresets.json`` is gitignored and holds one machine's literal
+paths.  Its presets are named ``ide-*`` to keep them apart from the shared
+presets in ``CMakePresets.json``, which is where a build belongs.
+
+The scdv templates beside this script name the prefix once, as
+``$penv{SCDV_USRDIR}`` in the preset's ``environment`` map, and the cache
+variables read it back as ``$env{SCDV_USRDIR}``.  Installing is a copy with
+that single occurrence replaced by a resolved prefix.  The substitution is
+the point: an IDE started from the desktop inherits the session
+environment, not the shell where an scdv was activated, so the unexpanded
+form would configure the project against empty paths.
+
+The ``example`` templates beside the scdv ones are for a prefix that is not
+an scdv.  They are hand-edited and are not installed from here.
+
+Usage:
+    contrib/cmake/install-user-presets.py
+    contrib/cmake/install-user-presets.py --prefix ~/var/scdv/main/usr
+    contrib/cmake/install-user-presets.py --check
+"""
+
+import os
+import sys
+import json
+import shutil
+import difflib
+import pathlib
+import argparse
+import subprocess
+
+PLACEHOLDER = '$penv{SCDV_USRDIR}'
+TARGET = 'CMakeUserPresets.json'
+TEMPLATES = {
+    'nt': 'CMakeUserPresets.win-scdv.json',
+    'posix': 'CMakeUserPresets.scdv.json',
+}
+EXPECTED_PRESETS = (
+    ('configure', ('ide-scdv-reldbg',)),
+    ('build', ('ide-scdv-reldbg', 'ide-scdv-reldbg-module',
+               'ide-scdv-reldbg-gtest')),
+)
+
+
+def repo_root():
+    """Return the checkout holding this script.
+
+    A worktree gets its own, not the main checkout that spawned it.
+    """
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def template_path(root):
+    return root / 'contrib' / 'cmake' / TEMPLATES[os.name]
+
+
+def resolve_prefix(explicit):
+    """Resolve the scdv prefix that the template's placeholder names."""
+    if explicit:
+        prefix = pathlib.Path(explicit).expanduser()
+    elif os.environ.get('SCDV_USRDIR'):
+        prefix = pathlib.Path(os.environ['SCDV_USRDIR'])
+    elif os.environ.get('SCDV_BASE'):
+        prefix = pathlib.Path(os.environ['SCDV_BASE']) / 'usr'
+    else:
+        raise SystemExit(
+            'error: no scdv prefix resolved. Activate an scdv environment, '
+            'or pass --prefix naming the usr directory of one.')
+    prefix = prefix.expanduser().resolve()
+    if not prefix.is_dir():
+        raise SystemExit('error: prefix %s is not a directory' % prefix)
+    return prefix
+
+
+def render(root, prefix):
+    """Return the template text with the prefix substituted in."""
+    path = template_path(root)
+    text = path.read_text(encoding='utf-8')
+    if PLACEHOLDER not in text:
+        raise SystemExit('error: %s holds no %s to substitute'
+                         % (path, PLACEHOLDER))
+    # A Windows prefix goes in with forward slashes: a backslash would not
+    # survive the JSON string, and CMake accepts either separator.
+    return text.replace(PLACEHOLDER, prefix.as_posix())
+
+
+def diff(installed, rendered):
+    return ''.join(difflib.unified_diff(
+        installed.splitlines(keepends=True),
+        rendered.splitlines(keepends=True),
+        fromfile='%s (installed)' % TARGET,
+        tofile='%s (rendered)' % TARGET))
+
+
+def verify(root, target):
+    """Check that the installed file names a real prefix and lists presets."""
+    presets = json.loads(target.read_text(encoding='utf-8'))
+    named = presets['configurePresets'][0]['environment']['SCDV_USRDIR']
+    if not os.path.isdir(named):
+        print('error: SCDV_USRDIR "%s" is not a directory' % named,
+              file=sys.stderr)
+        return False
+    if shutil.which('cmake') is None:
+        print('note: cmake is not on PATH; presets were not listed')
+        return True
+    # An IDE sees the environment with no scdv activated, which is what the
+    # substitution exists to survive, so list the presets without it.
+    env = dict(os.environ)
+    env.pop('SCDV_USRDIR', None)
+    for kind, wanted in EXPECTED_PRESETS:
+        proc = subprocess.run(['cmake', '--list-presets=' + kind],
+                              cwd=str(root), env=env,
+                              capture_output=True, text=True)
+        missing = [name for name in wanted
+                   if '"%s"' % name not in proc.stdout]
+        if proc.returncode != 0 or missing:
+            sys.stderr.write(proc.stdout + proc.stderr)
+            print('error: cmake did not list %s preset %s'
+                  % (kind, ', '.join(missing or wanted)), file=sys.stderr)
+            return False
+        print('%s presets: %s' % (kind, ', '.join(wanted)))
+    return True
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description='Install CMakeUserPresets.json from the checked-in '
+        'scdv template, substituting the resolved prefix.'
+    )
+    parser.add_argument(
+        '--prefix',
+        help='scdv usr directory to substitute '
+        '(default: $SCDV_USRDIR, else $SCDV_BASE/usr)'
+    )
+    parser.add_argument(
+        '--check',
+        action='store_true',
+        help='report whether the installed copy is current; write nothing'
+    )
+    parser.add_argument(
+        '--force',
+        action='store_true',
+        help='overwrite an installed copy that differs from the template'
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    root = repo_root()
+    target = root / TARGET
+    prefix = resolve_prefix(args.prefix)
+    rendered = render(root, prefix)
+    installed = (target.read_text(encoding='utf-8')
+                 if target.exists() else None)
+    current = installed == rendered
+
+    if args.check:
+        if current:
+            print('%s is current (prefix %s)' % (TARGET, prefix))
+            return 0
+        state = 'missing' if installed is None else 'differs'
+        print('%s %s (prefix %s)' % (TARGET, state, prefix))
+        if installed is not None:
+            sys.stdout.write(diff(installed, rendered))
+        return 1
+
+    if current:
+        print('%s is current (prefix %s)' % (TARGET, prefix))
+    elif installed is not None and not args.force:
+        sys.stdout.write(diff(installed, rendered))
+        sys.stdout.flush()
+        print('error: %s differs from the template. Review the diff, then '
+              'rerun with --force to overwrite.' % TARGET, file=sys.stderr)
+        return 1
+    else:
+        target.write_text(rendered, encoding='utf-8')
+        print('wrote %s (prefix %s)' % (target, prefix))
+
+    return 0 if verify(root, target) else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/doc/source/devguide/cmake.md
+++ b/doc/source/devguide/cmake.md
@@ -209,11 +209,9 @@ interpreter to the configure step.  A CLion user can therefore drop the
 
 `CMakeUserPresets.scdv.json` and `CMakeUserPresets.win-scdv.json` sit beside
 the two templates above for a prefix that `build-scdv.sh` built (see
-{doc}`/start/build_dep`).  Their configure preset is `ide-scdv-reldbg`, and it
-names that prefix once rather than repeating it in three literal paths, so
-installing one substitutes a single value instead of editing three.  The
-`ide-user-presets` skill under `.claude/skills/` states the substitution and
-what has to hold for it.
+{doc}`/start/build_dep`). The script `contrib/cmake/install-user-presets.py`
+installs the template to the project root and uses the value in the environment
+variable `SCDV_USRDIR` for the placeholder in the template.
 
 ## IDE notes
 


### PR DESCRIPTION
Add `contrib/cmake/install-user-presets.py` to install `CMakeUserPresets.json` for IDE and worktree development.  Update the skill `.claude/skills/ide-user-presets/` to use the script.