### PR TITLE
Add the Qt Benchmark Inspector

### DIFF
--- a/doc/source/compute/profiling.md
+++ b/doc/source/compute/profiling.md
@@ -1,7 +1,21 @@
 # Profiling
 
-```{note}
-This page is a placeholder. Documentation for profiling is forthcoming.
-```
+## Benchmark Inspector
+
+In Pilot, select **Profiling > Benchmark Inspector** to open its MDI window.
+Reopening the menu returns to the same inspector and its last result.
+
+Choose Matmul, a dtype, and at least one kernel. Enter shapes and element strides
+exactly, including batch axes; changing a shape does not recompute its strides.
+
+Warmups are untimed calls. Each round times the requested calls per kernel,
+including NumPy. Worker threads requests BLAS/OpenMP threads only in the worker;
+libraries may use fewer. Unavailable kernels are recorded as `ineligible`.
+
+**Run** validates inputs and runs the comparison. The activity bar shows work
+is running; it does not estimate a percentage. **Save result...** exports the
+completed result as JSON. A new run replaces the result available for export.
+Completion, failure and **Stop** unlock the inputs. Closing the inspector or
+Pilot stops its worker.
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/solvcon/pilot/_benchmark.py
+++ b/solvcon/pilot/_benchmark.py
@@ -16,6 +16,7 @@ class BenchmarkControl(QtWidgets.QWidget):
 
     Call start with a MatmulSpec and an artifact path. A running control
     rejects another start. Stop and close kill the worker asynchronously.
+    Optional threads override only the new worker's BLAS/OpenMP environment.
     """
 
     completed = QtCore.Signal(str)
@@ -24,6 +25,10 @@ class BenchmarkControl(QtWidgets.QWidget):
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        self.progress = QtWidgets.QProgressBar(self)
+        self.progress.setRange(0, 1)
+        self.progress.setValue(0)
+        self.progress.setTextVisible(False)
         self.status = QtWidgets.QLabel('Idle', self)
         self.status.setTextFormat(QtCore.Qt.TextFormat.PlainText)
         self.elapsed = QtWidgets.QLabel('Elapsed: 0.0 s', self)
@@ -31,6 +36,7 @@ class BenchmarkControl(QtWidgets.QWidget):
         self.stop_button.setEnabled(False)
         self.stop_button.clicked.connect(self.stop)
         layout = QtWidgets.QHBoxLayout(self)
+        layout.addWidget(self.progress, 1)
         for widget in (self.status, self.elapsed, self.stop_button):
             layout.addWidget(widget)
 
@@ -40,6 +46,7 @@ class BenchmarkControl(QtWidgets.QWidget):
         self._process.readyReadStandardError.connect(self._read_stderr)
         self._process.errorOccurred.connect(self._process_error)
         self._process.finished.connect(self._finish)
+        QtWidgets.QApplication.instance().installEventFilter(self)
         self._clock = QtCore.QElapsedTimer()
         self._timer = QtCore.QTimer(self)
         self._timer.timeout.connect(self._update_elapsed)
@@ -50,9 +57,19 @@ class BenchmarkControl(QtWidgets.QWidget):
     def running(self):
         return self._running
 
-    def start(self, specification, output_path):
+    def start(self, specification, output_path, *, threads=None):
         if self.running:
             raise RuntimeError('a benchmark is already running')
+        env = QtCore.QProcessEnvironment.systemEnvironment()
+        if threads is not None:
+            if (isinstance(threads, bool) or not isinstance(threads, int)
+                    or threads < 1):
+                raise ValueError('threads must be a positive integer')
+            for name in ('OMP_NUM_THREADS', 'OPENBLAS_NUM_THREADS',
+                         'MKL_NUM_THREADS', 'BLIS_NUM_THREADS',
+                         'VECLIB_MAXIMUM_THREADS'):
+                env.insert(name, str(threads))
+        self._process.setProcessEnvironment(env)
         request = {'spec': specification.to_dict(),
                    'output_path': os.fspath(output_path)}
         self._request = (json.dumps(request, allow_nan=False) + '\n').encode()
@@ -62,6 +79,7 @@ class BenchmarkControl(QtWidgets.QWidget):
         self._stderr = b''
         self._cancelled = False
         self._running = True
+        self.progress.setRange(0, 0)
         self.status.setText('Preparing')
         self.stop_button.setEnabled(True)
         self._clock.start()
@@ -84,6 +102,13 @@ class BenchmarkControl(QtWidgets.QWidget):
             event.ignore()
         else:
             super().closeEvent(event)
+
+    def eventFilter(self, watched, event):
+        if event.type() == QtCore.QEvent.Type.Quit:
+            # Stop before closeEvent can defer and cancel QApplication.quit.
+            self.stop()
+            self._process.waitForFinished()
+        return super().eventFilter(watched, event)
 
     def _send_request(self):
         if self._cancelled:
@@ -159,6 +184,8 @@ class BenchmarkControl(QtWidgets.QWidget):
             self._error = 'Worker exited without a result'
 
         self._running = False
+        self.progress.setRange(0, 1)
+        self.progress.setValue(int(not (self._cancelled or self._error)))
         self._timer.stop()
         self._update_elapsed()
         self.stop_button.setEnabled(False)

--- a/solvcon/pilot/_benchmark_inspector.py
+++ b/solvcon/pilot/_benchmark_inspector.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""Edit and run one exact matmul comparison."""
+
+import pathlib
+import tempfile
+
+from PySide6 import QtCore, QtWidgets
+
+from solvcon.benchmark import artifact, matmul, spec
+from . import _benchmark
+
+
+def _integers(text, name):
+    try:
+        return tuple(int(item.strip()) for item in text.split(','))
+    except ValueError as exc:
+        raise spec.SpecError(
+            f'{name}: enter comma-separated integers') from exc
+
+
+class BenchmarkInspector(QtWidgets.QMdiSubWindow):
+    """Run one comparison in Pilot and export its last completed result."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle('Benchmark Inspector')
+        self._directory = tempfile.TemporaryDirectory()
+        self._path = pathlib.Path(self._directory.name) / 'result.json'
+        self.destroyed.connect(self._directory.cleanup)
+        self._closing = False
+        self._build_inputs()
+        self._build_controls()
+        self.resize(1000, 520)
+
+    def make_spec(self):
+        operands = []
+        for name in ('lhs', 'rhs'):
+            shape = _integers(self.fields[f'{name}_shape'].text(),
+                              f'{name} shape')
+            strides = _integers(self.fields[f'{name}_strides'].text(),
+                                f'{name} strides')
+            operands.append(spec.OperandSpec(shape, strides))
+        return matmul.MatmulSpec(
+            lhs=operands[0], rhs=operands[1],
+            dtype=self.dtype.currentText(), sampling=self._sampling(),
+            kernels=tuple(name for name, box in self.kernels.items()
+                          if box.isChecked()))
+
+    def _build_inputs(self):
+        self.inputs = QtWidgets.QWidget(self)
+        form = QtWidgets.QFormLayout(self.inputs)
+        form.setContentsMargins(0, 0, 0, 0)
+        form.setFormAlignment(QtCore.Qt.AlignmentFlag.AlignTop)
+        form.setFieldGrowthPolicy(
+            QtWidgets.QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
+        self.dtype = QtWidgets.QComboBox(self.inputs)
+        self.dtype.addItems(matmul.MATMUL_DTYPES)
+        self.dtype.setCurrentText('float64')
+        self.dtype.setToolTip('Element type for both inputs and the result.')
+        self.fields = {
+            name: QtWidgets.QLineEdit(value, self.inputs)
+            for name, value in (
+                ('lhs_shape', '64, 64'), ('lhs_strides', '64, 1'),
+                ('rhs_shape', '64, 64'), ('rhs_strides', '64, 1'),
+                ('threads', '1'), ('warmups', '2'),
+                ('repetitions', '5'), ('rounds', '5'))
+        }
+        form.addRow('Data type', self.dtype)
+        for name, label in (('lhs', 'A'), ('rhs', 'B')):
+            form.addRow(f'{label} shape', self.fields[f'{name}_shape'])
+            form.addRow(f'{label} element strides',
+                        self.fields[f'{name}_strides'])
+        form.addRow('Worker threads', self.fields['threads'])
+
+        for name in ('lhs_shape', 'rhs_shape'):
+            self.fields[name].setToolTip(
+                'Full shape, including batch axes: e.g. 2, 32, 64.')
+        for name in ('lhs_strides', 'rhs_strides'):
+            self.fields[name].setToolTip(
+                'One stride per axis, in elements. Negative and zero '
+                'strides are allowed. Values are used exactly as entered.')
+        self.fields['threads'].setToolTip(
+            'Requested BLAS/OpenMP threads in the worker. Libraries may '
+            'use fewer threads. Pilot keeps its current thread settings.')
+
+        sampling = QtWidgets.QGridLayout()
+        for col, (name, label, tooltip) in enumerate((
+                ('warmups', 'Warmups',
+                 'Untimed calls per kernel before timing; zero is allowed.'),
+                ('repetitions', 'Calls per round',
+                 'Consecutive calls timed together per round. '
+                 'Divide the block time by this count for time per call.'),
+                ('rounds', 'Rounds', 'Measurement rounds per kernel. '
+                 'Each round records one sample; '
+                 'kernel order is balanced across rounds.'))):
+            sampling.addWidget(QtWidgets.QLabel(label), 0, col)
+            sampling.addWidget(self.fields[name], 1, col)
+            sampling.setColumnStretch(col, 1)
+            self.fields[name].setToolTip(tooltip)
+            self.fields[name].textChanged.connect(self._update_help)
+        self.sampling_help = QtWidgets.QLabel(self.inputs)
+        self.sampling_help.setWordWrap(True)
+        sampling.addWidget(self.sampling_help, 2, 0, 1, 3)
+        form.addRow('Sampling', sampling)
+        self._update_help()
+        self._build_kernels(form)
+
+    def _build_kernels(self, form):
+        layout = QtWidgets.QGridLayout()
+        self.kernels = {}
+        choices = (
+            ('naive', 'Naive', 'Direct native loop for any valid input.'),
+            ('blas_dot', 'BLAS DOT', 'Vector @ vector.'),
+            ('blas_gevm', 'BLAS GEVM', 'Vector @ matrix.'),
+            ('blas_gemv', 'BLAS GEMV', 'Matrix @ vector.'),
+            ('blas_gemm', 'BLAS GEMM', 'Matrix @ matrix, including batches.'),
+            ('winograd', 'Winograd', 'Unbatched matrices with positive, '
+             'even M, K and N.'))
+        for index, (name, label, tooltip) in enumerate(choices):
+            box = QtWidgets.QCheckBox(label, self.inputs)
+            if name != 'naive':
+                tooltip += ' Requires a supported dtype and BLAS backend.'
+            box.setToolTip(tooltip)
+            box.setChecked(True)
+            layout.addWidget(box, index // 3, index % 3)
+            self.kernels[name] = box
+        form.addRow('Kernels', layout)
+        kernel_help = QtWidgets.QLabel(
+            'NumPy is always included for timing and numerical comparison. '
+            'Unavailable kernels are skipped and reported as ineligible.',
+            self.inputs)
+        kernel_help.setWordWrap(True)
+        layout.addWidget(kernel_help, 2, 0, 1, 3)
+
+    def _build_controls(self):
+        self.operation = QtWidgets.QComboBox(self)
+        self.operation.addItem('Matmul', 'matmul')
+        self.operation.setToolTip('Currently supports Matmul.')
+        self.error = QtWidgets.QLabel(self)
+        self.error.setTextFormat(QtCore.Qt.TextFormat.PlainText)
+        self.error.setWordWrap(True)
+        self.error.hide()
+        self.run_button = QtWidgets.QPushButton('Run', self)
+        self.control = _benchmark.BenchmarkControl(self)
+        self.control.status.setWordWrap(True)
+        self.control.layout().setContentsMargins(0, 0, 0, 0)
+        self.save_button = QtWidgets.QPushButton('Save result...', self)
+        self.save_button.setEnabled(False)
+
+        self.run_button.clicked.connect(self._run)
+        self.save_button.clicked.connect(self._save)
+        for signal in (self.control.completed, self.control.failed,
+                       self.control.stopped):
+            signal.connect(self._finished)
+        self.control.completed.connect(
+            lambda: self.save_button.setEnabled(True))
+
+        header = QtWidgets.QHBoxLayout()
+        header.addWidget(QtWidgets.QLabel('Operation'))
+        header.addWidget(self.operation)
+        header.addStretch(1)
+        header.addWidget(self.control.stop_button)
+
+        actions = QtWidgets.QHBoxLayout()
+        actions.addWidget(self.run_button)
+        actions.addWidget(self.save_button)
+        actions.addStretch(1)
+
+        content = QtWidgets.QWidget(self)
+        layout = QtWidgets.QVBoxLayout(content)
+        layout.addLayout(header)
+        layout.addWidget(self.inputs)
+        layout.addWidget(self.error)
+        layout.addLayout(actions)
+        layout.addWidget(self.control)
+        layout.addStretch(1)
+        self.setWidget(content)
+
+    def _save(self):
+        self._show_error('')
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, 'Save benchmark result', 'matmul-result.json',
+            'JSON files (*.json)')
+        if not path:
+            return
+        try:
+            artifact.write_artifact(artifact.load_artifact(self._path), path)
+        except (OSError, ValueError) as exc:
+            self._show_error(str(exc))
+
+    def _show_error(self, text):
+        self.error.setText(text)
+        self.error.setVisible(bool(text))
+
+    def _update_help(self):
+        try:
+            sampling = self._sampling()
+        except ValueError as exc:
+            text = str(exc)
+        else:
+            text = (
+                f'Each timed kernel runs {sampling.warmups} untimed warmups, '
+                f'then {sampling.rounds} rounds of '
+                f'{sampling.repetitions} calls each. '
+                'NumPy uses the same schedule.')
+        self.sampling_help.setText(text)
+
+    def _sampling(self):
+        return spec.Sampling(**{
+            name: self._count(name)
+            for name in ('warmups', 'repetitions', 'rounds')})
+
+    def _count(self, name):
+        values = _integers(self.fields[name].text(), name)
+        if len(values) != 1:
+            raise spec.SpecError(f'{name}: enter one integer')
+        return values[0]
+
+    def _run(self):
+        if self.control.running:
+            return
+        self._show_error('')
+        try:
+            request = self.make_spec()
+            threads = self._count('threads')
+            self.control.start(request, self._path, threads=threads)
+        except (ValueError, RuntimeError) as exc:
+            self._show_error(str(exc))
+            return
+        self.save_button.setEnabled(False)
+        self.operation.setEnabled(False)
+        self.inputs.setEnabled(False)
+        self.run_button.setEnabled(False)
+
+    def _finished(self):
+        self.operation.setEnabled(True)
+        self.inputs.setEnabled(True)
+        self.run_button.setEnabled(True)
+        if self._closing:
+            self.close()
+
+    def closeEvent(self, event):
+        if self.control.running:
+            self._closing = True
+            self.control.stop()
+            event.ignore()
+        else:
+            self._closing = False
+            super().closeEvent(event)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/pilot/base/_gui.py
+++ b/solvcon/pilot/base/_gui.py
@@ -15,6 +15,7 @@ from .. import airfoil
 
 if _pcore.enable:
     from . import _gui_common
+    from .. import _benchmark_inspector
     from ..visual import _mesh
     from ..panel import _tree_panel
     from ..apps import obsrefl
@@ -75,6 +76,7 @@ class _Controller(metaclass=_Singleton):
         self.save_2d_canvas = None
         self.openprofiledata = None
         self.runprofiling = None
+        self.benchmark = None
         self.mcap_panel = None
         self.agent = None
         self.theme_menu = None
@@ -148,6 +150,16 @@ class _Controller(metaclass=_Singleton):
         self._rmgr.pycon.writeToHistory(banner)
         self._rmgr.pyterm.writeToHistory(banner)
 
+    def _open_benchmark(self):
+        if self.benchmark is None:
+            self.benchmark = _benchmark_inspector.BenchmarkInspector()
+            self._rmgr.mdiArea.addSubWindow(self.benchmark)
+        self.benchmark.widget().show()
+        self.benchmark.show()
+        if self.benchmark.isMinimized():
+            self.benchmark.showNormal()
+        self._rmgr.mdiArea.setActiveSubWindow(self.benchmark)
+
     def _mesh_sample_dialog_entries(self):
         """Every example mesh as ``(category, label, tip, func)``, in menu
         order, gathered from the sample features for the sample dialog.  The
@@ -200,6 +212,13 @@ class _Controller(metaclass=_Singleton):
                 wm.toggleTerminal, id="window.terminal",
                 checkable=True, checked=False),
             35)
+        wm.menu_model.place(
+            "Profiling",
+            _gui_common.build_action(
+                wm.mainWindow, "Benchmark Inspector",
+                "Compare operation kernels", self._open_benchmark,
+                id="profiling.benchmark"),
+            60)
 
 
 controller = _Controller()

--- a/tests/gui/test_bar.py
+++ b/tests/gui/test_bar.py
@@ -8,6 +8,7 @@ import unittest
 import solvcon
 
 try:
+    from PySide6 import QtCore
     from solvcon import pilot
     from solvcon.pilot.base import _gui
 except ImportError:
@@ -60,5 +61,29 @@ class BarStructureTC(unittest.TestCase):
         window_items = [a.text() for a in model.menu("Window").actions()]
         self.assertNotIn("Console", window_items)
         self.assertNotIn("Terminal", window_items)
+
+    def test_benchmark_menu(self):
+        mgr = _gui.controller.build()
+        action = mgr.menu_model.action('profiling.benchmark')
+        self.assertIn(action, mgr.menu_model.menu('Profiling').actions())
+        action.trigger()
+        inspector = _gui.controller.benchmark
+        try:
+            self.assertIs(inspector.mdiArea(), mgr.mdiArea)
+            inspector.close()
+            action.trigger()
+            self.assertIs(_gui.controller.benchmark, inspector)
+            self.assertFalse(inspector.isHidden())
+            self.assertFalse(inspector.widget().isHidden())
+            inspector.showMinimized()
+            action.trigger()
+            self.assertFalse(inspector.isMinimized())
+        finally:
+            inspector.close()
+            mgr.mdiArea.removeSubWindow(inspector)
+            inspector.deleteLater()
+            QtCore.QCoreApplication.sendPostedEvents(
+                inspector, QtCore.QEvent.Type.DeferredDelete)
+            _gui.controller.benchmark = None
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -896,12 +896,12 @@ class BenchmarkControlTC(unittest.TestCase):
             QtTest.QTest.qWait(10)
         self.assertTrue(predicate(), self.control.status.text())
 
-    def start_script(self, script):
+    def start_script(self, script, **options):
         script = 'import sys\nsys.stdin.readline()\n' + script
         command = system.python_command('-c', script)
         with unittest.mock.patch.object(
                 system, 'python_command', return_value=command):
-            self.control.start(self.spec, self.path)
+            self.control.start(self.spec, self.path, **options)
 
     def assert_finished(self, kind):
         self.wait_for(lambda: not self.control.running)
@@ -910,6 +910,7 @@ class BenchmarkControlTC(unittest.TestCase):
                          QtCore.QProcess.ProcessState.NotRunning)
         self.assertFalse(self.control.stop_button.isEnabled())
         self.assertFalse(self.control._timer.isActive())
+        self.assertEqual(self.control.progress.value(), int(kind == 'result'))
 
     def test_collect_and_repeat(self):
         for _ in range(2):
@@ -941,6 +942,34 @@ class BenchmarkControlTC(unittest.TestCase):
         self.events.clear()
         self.control.start(self.spec, self.path)
         self.assert_finished('result')
+
+    def test_thread_isolation(self):
+        names = ('OMP_NUM_THREADS', 'OPENBLAS_NUM_THREADS', 'MKL_NUM_THREADS',
+                 'BLIS_NUM_THREADS', 'VECLIB_MAXIMUM_THREADS')
+        inherited = dict.fromkeys(names, '2')
+        event = json.dumps({'type': 'result', 'artifact_path': 'ok'})
+        for threads, expected in ((3, '3'), (None, '2')):
+            with self.subTest(threads=threads):
+                self.events.clear()
+                script = (
+                    'import os\n'
+                    f'assert all(os.environ[name] == {expected!r} '
+                    f'for name in {names!r})\n'
+                    f'print({event!r})')
+                with unittest.mock.patch.dict(os.environ, inherited):
+                    self.start_script(script, threads=threads)
+                    self.assert_finished('result')
+                    parent = {name: os.environ[name] for name in names}
+                    self.assertEqual(parent, inherited)
+
+    def test_invalid_threads(self):
+        for threads in (0, -1, True, 1.5, '2'):
+            with self.subTest(threads=threads):
+                with self.assertRaises(ValueError) as caught:
+                    self.control.start(self.spec, self.path, threads=threads)
+                self.assertEqual(str(caught.exception),
+                                 'threads must be a positive integer')
+                self.assertFalse(self.control.running)
 
     def assert_error_recovery(self, cases):
         for script, message in cases:

--- a/tests/test_benchmark_inspector.py
+++ b/tests/test_benchmark_inspector.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""Exercise the inspector without mapping a top-level window."""
+
+import time
+import unittest
+import unittest.mock
+
+from solvcon import system
+from solvcon.benchmark import artifact
+
+try:
+    from PySide6 import QtTest, QtWidgets
+except ImportError:
+    QtWidgets = None
+else:
+    from solvcon.pilot import _benchmark_inspector
+
+
+@unittest.skipIf(QtWidgets is None, 'PySide6 is not installed')
+class BenchmarkInspectorTC(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = (QtWidgets.QApplication.instance()
+                   or QtWidgets.QApplication([]))
+
+    def setUp(self):
+        self.widget = _benchmark_inspector.BenchmarkInspector()
+        self.path = self.widget._path
+        self.fields = self.widget.fields
+        self.set_fields(lhs_shape='2, 3', lhs_strides='-3, 1',
+                        rhs_shape='3, 2', rhs_strides='0, 1',
+                        warmups='0', repetitions='1', rounds='1')
+        for name, box in self.widget.kernels.items():
+            box.setChecked(name == 'naive')
+
+    def tearDown(self):
+        self.widget.control.stop()
+        self.wait_for_finish()
+        self.widget.close()
+        self.widget.deleteLater()
+
+    def set_fields(self, **values):
+        for name, value in values.items():
+            self.fields[name].setText(value)
+
+    def wait_for_finish(self):
+        deadline = time.monotonic() + 15
+        while self.widget.control.running and time.monotonic() < deadline:
+            QtTest.QTest.qWait(10)
+        self.assertFalse(self.widget.control.running)
+
+    def start_script(self, script):
+        script = 'import sys\nsys.stdin.readline()\n' + script
+        command = system.python_command('-c', script)
+        with unittest.mock.patch.object(
+                system, 'python_command', return_value=command):
+            self.widget.run_button.click()
+
+    def test_spec(self):
+        self.set_fields(lhs_shape='2, 4, 3', lhs_strides='20, -5, 0',
+                        rhs_shape='1, 3, 2', rhs_strides='0, 4, 1',
+                        warmups='0', repetitions=str(2**32), rounds='7')
+        self.widget.dtype.setCurrentText('complex64')
+        self.widget.kernels['blas_gemm'].setChecked(True)
+        self.assertEqual(self.widget.operation.count(), 1)
+        self.assertEqual(self.widget.operation.currentText(), 'Matmul')
+        self.assertEqual(self.widget.make_spec().to_dict(), {
+            'operation': 'matmul', 'dtype': 'complex64',
+            'lhs': {'shape': [2, 4, 3], 'strides': [20, -5, 0]},
+            'rhs': {'shape': [1, 3, 2], 'strides': [0, 4, 1]},
+            'sampling': {'warmups': 0, 'repetitions': 2**32, 'rounds': 7},
+            'kernels': ['naive', 'blas_gemm']})
+
+    def test_uncapped_shapes(self):
+        for extent, stride in ((0, 0), (2**32, -1)):
+            with self.subTest(extent=extent, stride=stride):
+                self.set_fields(lhs_shape=f'{extent}, 3',
+                                lhs_strides=f'{stride}, 0')
+                result = self.widget.make_spec()
+                self.assertEqual(result.lhs.shape, (extent, 3))
+                self.assertEqual(result.lhs.strides, (stride, 0))
+
+    def test_sampling_help(self):
+        self.set_fields(warmups='3', repetitions='7', rounds='2')
+        expected = (
+            'Each timed kernel runs 3 untimed warmups, then 2 rounds of '
+            '7 calls each. NumPy uses the same schedule.')
+        self.assertEqual(self.widget.sampling_help.text(), expected)
+        self.set_fields(rounds='0')
+        self.assertEqual(self.widget.sampling_help.text(),
+                         'sampling.rounds must be at least 1')
+        self.set_fields(rounds='2')
+        self.assertEqual(self.widget.sampling_help.text(), expected)
+
+    def test_reject_input(self):
+        cases = (
+            ('lhs_shape', '2,,3', 'lhs shape: enter comma-separated integers'),
+            ('lhs_shape', '2, 4',
+             'matmul contraction dimensions do not match'),
+            ('rounds', '1, 2', 'rounds: enter one integer'),
+            ('threads', '0', 'threads must be a positive integer'))
+        for field, value, error in cases:
+            with self.subTest(field=field, value=value):
+                previous = self.fields[field].text()
+                self.fields[field].setText(value)
+                self.widget.run_button.click()
+                self.assertEqual(self.widget.error.text(), error)
+                self.assertFalse(self.widget.control.running)
+                self.assertFalse(self.path.exists())
+                self.assertTrue(self.widget.run_button.isEnabled())
+                self.fields[field].setText(previous)
+        self.widget.kernels['naive'].setChecked(False)
+        self.widget.run_button.click()
+        self.assertEqual(self.widget.error.text(), 'kernels must not be empty')
+        self.assertFalse(self.widget.control.running)
+
+    def test_run_and_repeat(self):
+        for rounds in ('1', '2'):
+            self.fields['rounds'].setText(rounds)
+            expected = self.widget.make_spec().to_dict()
+            self.widget.run_button.click()
+            self.assertTrue(self.widget.control.running)
+            self.assertFalse(self.widget.inputs.isEnabled())
+            self.assertFalse(self.widget.run_button.isEnabled())
+            self.assertFalse(self.widget.save_button.isEnabled())
+            self.wait_for_finish()
+            self.assertEqual(self.widget.control.status.text(), 'Completed')
+            self.assertEqual(artifact.load_artifact(self.path)['spec'],
+                             expected)
+            self.assertTrue(self.widget.inputs.isEnabled())
+            self.assertTrue(self.widget.run_button.isEnabled())
+            self.assertTrue(self.widget.save_button.isEnabled())
+
+    def test_recovery(self):
+        control = self.widget.control
+        for action in ('stop', 'close', 'failure'):
+            with self.subTest(action=action):
+                script = ('sys.exit(1)' if action == 'failure' else
+                          'import time\ntime.sleep(60)')
+                self.start_script(script)
+                if action == 'stop':
+                    control.stop_button.click()
+                elif action == 'close':
+                    self.widget.close()
+                self.wait_for_finish()
+                self.assertTrue(self.widget.inputs.isEnabled())
+                self.assertTrue(self.widget.run_button.isEnabled())
+        self.widget.run_button.click()
+        self.wait_for_finish()
+        self.assertEqual(control.status.text(), 'Completed')
+
+    def test_save(self):
+        self.widget.run_button.click()
+        self.wait_for_finish()
+        path = self.path.with_name('saved.json')
+        with unittest.mock.patch.object(
+                QtWidgets.QFileDialog, 'getSaveFileName') as dialog:
+            dialog.return_value = ('', '')
+            with unittest.mock.patch.object(
+                    artifact, 'write_artifact') as write:
+                self.widget.save_button.click()
+                write.assert_not_called()
+            dialog.return_value = (str(path), '')
+            with unittest.mock.patch.object(
+                    artifact, 'write_artifact', side_effect=OSError('Full')):
+                self.widget.save_button.click()
+            self.assertEqual(self.widget.error.text(), 'Full')
+            self.fields['rounds'].setText('7')
+            self.widget.save_button.click()
+        self.assertEqual(self.widget.error.text(), '')
+        self.assertEqual(artifact.load_artifact(path),
+                         artifact.load_artifact(self.path))
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:


### PR DESCRIPTION
#1497 provides worker control. Add a reusable MDI Benchmark Inspector for Matmul under Profiling, following the prototype layout.

![Benchmark Inspector in Pilot after a completed run](https://raw.githubusercontent.com/ThreeMonth03/solvcon/prototype/benchmark-visualizer-assets/pr-assets/1516-pilot-benchmark-c2c037ab2ffa.png)

```text
Run                 -> validate inputs and run the worker
Save result         -> export the completed comparison as JSON
Stop / close / exit -> stop the worker
Open again          -> reuse the inspector and its last result
```

Shapes and element strides are used as entered. NumPy shares the sampling schedule; thread settings apply only to the worker.

Kernel eligibility remains Task 7b; result tables and charts remain Task 8.

Validation: full Pilot suite (2,494 passed), `make lint`, and manual Run/Save/close/reopen checks passed.

Related to #1369, task 7a.
