### PR TITLE
Fix segfault reopening a Canvas/Samples window

### DIFF
--- a/solvcon/pilot/apps/obsrefl/_viewer.py
+++ b/solvcon/pilot/apps/obsrefl/_viewer.py
@@ -18,6 +18,7 @@ close through the :attr:`closed` callback.
 
 from PySide6.QtCore import Qt, QObject, QEvent
 
+from ...base import _gui_common
 from ._colorbar import ColorBar
 from ._plots import AnalysisLinePlots
 
@@ -25,23 +26,6 @@ __all__ = [  # noqa: F822
     'DomainViewer',
     'LinePlotViewer',
 ]
-
-
-class _SubWindowCloseFilter(QObject):
-    """Report a watched sub-window's close synchronously.
-
-    A ``QMdiSubWindow`` has no close signal, so this filter is the only way
-    to stop the march before Qt frees the viewer.
-    """
-
-    def __init__(self, on_close, parent):
-        super().__init__(parent)
-        self._on_close = on_close
-
-    def eventFilter(self, obj, event):
-        if event.type() == QEvent.Type.Close:
-            self._on_close()
-        return False
 
 
 class _ResizeRelay(QObject):
@@ -109,7 +93,7 @@ class DomainViewer(object):
         self._subwin = self._mdi.activeSubWindow()
         if self._subwin is not None:
             self._subwin.setAttribute(Qt.WA_DeleteOnClose, True)
-            self._close_filter = _SubWindowCloseFilter(
+            self._close_filter = _gui_common.SubWindowCloseFilter(
                 self._on_subwin_closed, self._subwin)
             self._subwin.installEventFilter(self._close_filter)
             host = self._host()
@@ -273,7 +257,7 @@ class LinePlotViewer(object):
         self._subwin.setWindowTitle("reflection analysis")
         self._subwin.resize(*self.SIZE)
         self._mgr.addSubWindowGrip(self._subwin)
-        self._close_filter = _SubWindowCloseFilter(
+        self._close_filter = _gui_common.SubWindowCloseFilter(
             self._on_subwin_closed, self._subwin)
         self._subwin.installEventFilter(self._close_filter)
 

--- a/solvcon/pilot/base/_gui_common.py
+++ b/solvcon/pilot/base/_gui_common.py
@@ -70,6 +70,25 @@ class ToggleActionBridge(QtCore.QObject):
         self._store_changed.emit(tg.get(self._key, self._action.isChecked()))
 
 
+class SubWindowCloseFilter(QtCore.QObject):
+    """Report a watched sub-window's close synchronously.
+
+    A ``QMdiSubWindow`` has no close signal, so this filter is the only way
+    for an owner to drop its cached widget reference before Qt frees the
+    widget the sub-window wraps (``Qt.WA_DeleteOnClose`` runs the delete on
+    the next event-loop turn, not inside ``close()`` itself).
+    """
+
+    def __init__(self, on_close, parent):
+        super().__init__(parent)
+        self._on_close = on_close
+
+    def eventFilter(self, obj, event):
+        if event.type() == QtCore.QEvent.Type.Close:
+            self._on_close()
+        return False
+
+
 _SHORTCUT_CONTEXTS = {
     "application": QtCore.Qt.ApplicationShortcut,
     "window": QtCore.Qt.WindowShortcut,

--- a/solvcon/pilot/canvas/_canvas_gui.py
+++ b/solvcon/pilot/canvas/_canvas_gui.py
@@ -213,7 +213,9 @@ class Canvas(_gui_common.PilotFeature):
         super(Canvas, self).__init__(*args, **kw)
         self._world = core.WorldFp64()
         self._widget = None
+        self._widget_close_filter = None
         self._widget_2d = None
+        self._widget_2d_close_filter = None
         self._blank_worlds = []
 
     def populate_menu(self):
@@ -346,11 +348,40 @@ class Canvas(_gui_common.PilotFeature):
         self._draw_layer(self._world, layer)
         self._update_widget()
 
+    def _track_widget(self, clear):
+        """Watch the active sub-window and call ``clear`` before Qt frees
+        the widget it wraps.
+
+        Closing a canvas sub-window deletes the underlying C++ widget
+        (``QMdiArea.addSubWindow`` sets ``WA_DeleteOnClose`` by default), so
+        a reference cached across sample picks goes stale the moment the
+        window closes. ``clear`` runs before that happens, so the next
+        sample or open call rebuilds a fresh, live widget instead of
+        touching a freed one.
+        """
+        subwin = self._mgr.mdiArea.activeSubWindow()
+        if subwin is None:
+            return None
+        subwin.setAttribute(QtCore.Qt.WA_DeleteOnClose, True)
+        close_filter = _gui_common.SubWindowCloseFilter(clear, subwin)
+        subwin.installEventFilter(close_filter)
+        return close_filter
+
+    def _clear_widget(self):
+        self._widget = None
+        self._widget_close_filter = None
+
+    def _clear_widget_2d(self):
+        self._widget_2d = None
+        self._widget_2d_close_filter = None
+
     def _update_widget(self):
         # The canvas world is planar geometry, so it renders in the 2D canvas
         # (the 3D domain viewer is for meshes and fields).
         if self._widget is None:
             self._widget = self._mgr.add2DWidget()
+            self._widget_close_filter = self._track_widget(
+                self._clear_widget)
         self._widget.updateWorld(self._world)
         self._widget.resetView()
         # Keep a separately-opened 2D view in sync with the same world.
@@ -366,6 +397,8 @@ class Canvas(_gui_common.PilotFeature):
         """
         if self._widget_2d is None:
             self._widget_2d = self._mgr.add2DWidget()
+            self._widget_2d_close_filter = self._track_widget(
+                self._clear_widget_2d)
         self._widget_2d.updateWorld(self._world)
         self._widget_2d.resetView()
 

--- a/solvcon/pilot/canvas/_canvas_gui.py
+++ b/solvcon/pilot/canvas/_canvas_gui.py
@@ -217,6 +217,10 @@ class Canvas(_gui_common.PilotFeature):
         self._widget_2d = None
         self._widget_2d_close_filter = None
         self._blank_worlds = []
+        # Held for Canvas's lifetime: a throwaway mdiArea wrapper is
+        # garbage-collected right after use, invalidating any sub-window
+        # handle taken through it.
+        self._mdi = None
 
     def populate_menu(self):
         # Group the geometry samples under their own submenu, leaving the
@@ -358,8 +362,14 @@ class Canvas(_gui_common.PilotFeature):
         window closes. ``clear`` runs before that happens, so the next
         sample or open call rebuilds a fresh, live widget instead of
         touching a freed one.
+
+        Only called right after ``_update_widget``/``_open_2d`` create a
+        brand-new sub-window via ``add2DWidget()``, so a given sub-window
+        reaches ``installEventFilter`` at most once here.
         """
-        subwin = self._mgr.mdiArea.activeSubWindow()
+        if self._mdi is None:
+            self._mdi = self._mgr.mdiArea
+        subwin = self._mdi.activeSubWindow()
         if subwin is None:
             return None
         subwin.setAttribute(QtCore.Qt.WA_DeleteOnClose, True)


### PR DESCRIPTION
Fixes a segfault when closing a Canvas sample-pick window.

Canvas caches its 2D widget across sample picks, but never cleared that cache on window close. Since Qt frees the underlying widget on close, the cache was left pointing at freed memory — the next access segfaulted instead of raising a normal Python exception.

The fix adds a close filter that clears the cached reference before Qt deletes the widget, so the next pick rebuilds a fresh one. The filter itself moved from obsrefl/_viewer.py into the shared pilot/base/_gui_common.py; see inline comments for why.

Related to #1471.