### PR TITLE
Add open_issue_on_failure workflow for post-merge failures

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -363,3 +363,25 @@ jobs:
     secrets:
       EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
       EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
+
+  open_issue_on_failure:
+    needs: [check_skip, standalone_buffer, build, build_cuda]
+    # Report a master push failure only, on the same gate as
+    # send_email_on_failure above.
+    if: |
+      always() &&
+      (contains(needs.*.result, 'failure') ||
+       contains(needs.*.result, 'cancelled')) &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      github.event.repository.fork == false
+    permissions:
+      issues: write
+      pull-requests: read
+    uses: ./.github/workflows/open_issue_on_failure.yml
+    with:
+      job_results: |
+        - check_skip: ${{ needs.check_skip.result }}
+        - standalone_buffer: ${{ needs.standalone_buffer.result }}
+        - build: ${{ needs.build.result }}
+        - build_cuda: ${{ needs.build_cuda.result }}

--- a/.github/workflows/devbuild_windows.yml
+++ b/.github/workflows/devbuild_windows.yml
@@ -171,3 +171,23 @@ jobs:
     secrets:
       EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
       EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
+
+  open_issue_on_failure:
+    needs: [check_skip, build_windows]
+    # Report a master push failure only, on the same gate as
+    # send_email_on_failure above.
+    if: |
+      always() &&
+      (contains(needs.*.result, 'failure') ||
+       contains(needs.*.result, 'cancelled')) &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      github.event.repository.fork == false
+    permissions:
+      issues: write
+      pull-requests: read
+    uses: ./.github/workflows/open_issue_on_failure.yml
+    with:
+      job_results: |
+        - check_skip: ${{ needs.check_skip.result }}
+        - build_windows: ${{ needs.build_windows.result }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -224,3 +224,23 @@ jobs:
     secrets:
       EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
       EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
+
+  open_issue_on_failure:
+    needs: [check_skip, lint]
+    # Report a master push failure only, on the same gate as
+    # send_email_on_failure above.
+    if: |
+      always() &&
+      (contains(needs.*.result, 'failure') ||
+       contains(needs.*.result, 'cancelled')) &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      github.event.repository.fork == false
+    permissions:
+      issues: write
+      pull-requests: read
+    uses: ./.github/workflows/open_issue_on_failure.yml
+    with:
+      job_results: |
+        - check_skip: ${{ needs.check_skip.result }}
+        - lint: ${{ needs.lint.result }}

--- a/.github/workflows/open_issue_on_failure.yml
+++ b/.github/workflows/open_issue_on_failure.yml
@@ -43,7 +43,7 @@ jobs:
           existing_issue=$(gh issue list \
             --repo "$GITHUB_REPOSITORY" \
             --state open \
-            --limit 100 \
+            --search "$title" \
             --json number,title \
             --jq "map(select(.title == \"$title\")) | .[0].number // empty")
 

--- a/.github/workflows/open_issue_on_failure.yml
+++ b/.github/workflows/open_issue_on_failure.yml
@@ -1,0 +1,91 @@
+name: open_issue_on_failure
+
+on:
+  workflow_call:
+    inputs:
+      job_results:
+        description: 'String of job results'
+        required: true
+        type: string
+
+jobs:
+  open_issue_on_failure:
+    name: open_issue_for_pr_that_broke_master
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Find and notify the pull request that broke master
+        env:
+          GH_TOKEN: ${{ github.token }}
+          JOB_RESULTS: ${{ inputs.job_results }}
+        run: |
+          echo "::group::Resolve the pull request for ${{ github.sha }}"
+          pr_number=$(gh api "repos/$GITHUB_REPOSITORY/commits/${{ github.sha }}/pulls" --jq '.[0].number // empty')
+          pr_author=$(gh api "repos/$GITHUB_REPOSITORY/commits/${{ github.sha }}/pulls" --jq '.[0].user.login // empty')
+          echo "pr_number=${pr_number:-<none>} pr_author=${pr_author:-<none>}"
+          echo "::endgroup::"
+
+          if [ -z "$pr_number" ]; then
+            echo 'No pull request is associated with this commit; nothing to report.'
+            exit 0
+          fi
+
+          # The title carries only the PR number so that any post-merge
+          # workflow failing on this PR lands on the same tracking issue.
+          title="CI failure after merging #${pr_number}"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # The fixed pair triages post-merge CI regardless of who broke it;
+          # the pull request author is still named in the issue text below.
+          assignees='chestercheng,rockleona'
+
+          existing_issue=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --limit 100 \
+            --json number,title \
+            --jq "map(select(.title == \"$title\")) | .[0].number // empty")
+
+          if [ -n "$existing_issue" ]; then
+            echo "An open failure report already exists (#${existing_issue}); commenting instead."
+            gh issue comment "$existing_issue" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "$(cat <<EOF
+          CI failed again on \`${{ github.workflow }}\` for this pull request.
+
+          **Job status**
+
+          ${JOB_RESULTS}
+
+          **Run:** ${run_url}
+          EOF
+          )"
+            exit 0
+          fi
+
+          pr_url="${{ github.server_url }}/${GITHUB_REPOSITORY}/pull/${pr_number}"
+          body=$(cat <<EOF
+          Pull request #${pr_number} by @${pr_author} merged into master, and the
+          \`${{ github.workflow }}\` workflow failed on the resulting push.
+
+          **Job status**
+
+          ${JOB_RESULTS}
+
+          **Run:** ${run_url}
+          **Pull request:** ${pr_url}
+          EOF
+          )
+
+          issue_url=$(gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$title" \
+            --body "$body" \
+            --label build)
+          echo "Opened $issue_url"
+
+          # An assignee not on the repo would otherwise fail the whole job;
+          # assignment is separate from creation so that only fails softly.
+          gh issue edit "$issue_url" --add-assignee "$assignees" || \
+            echo "Could not assign ${assignees}; left the issue unassigned."


### PR DESCRIPTION
Add `open_issue_on_failure` workflow for post-merge failures

`send_email_on_fail.yml` mails `solvcon@googlegroups.com` when a master push breaks CI, but the mail never says which merged pull request caused it or who to ask to fix it. Add `.github/workflows/report_ci_failure.yml`, a reusable workflow that resolves the pull request for the failing commit via `gh api repos/{repo}/commits/{sha}/pulls`, then `gh issue create`s an issue naming the pull request and labels it `build`. The issue is assigned to a fixed pair (`chestercheng`, `rockleona`) rather than the pull request author, so post-merge failures always reach whoever triages them; the author is still named in the issue text. A repeat failure on a pull request that already has an open report gets a `gh issue comment` on that issue instead of a duplicate. Both the issue and the comment are formatted with GitHub markdown.

Call the new workflow from `devbuild.yml`, `lint.yml`, and `devbuild_windows.yml` as a job alongside the existing `send_email_on_failure` job, reusing its `needs`/`if` gate verbatim so it fires under the same push-to-master-failure conditions.

Related to #1479