### PR TITLE
Fix singleton CSV dimensions in DataFrame reader

### DIFF
--- a/solvcon/track/dataframe.py
+++ b/solvcon/track/dataframe.py
@@ -141,7 +141,7 @@ class DataFrame(object):
             table_header = [
                 x.strip() for x in next(fhd).strip().split(delimiter)
             ]
-            nd_arr = np.genfromtxt(fhd, delimiter=delimiter)
+            nd_arr = np.genfromtxt(fhd, delimiter=delimiter, ndmin=2)
 
             self._init_members()
 

--- a/tests/test_timeseries_dataframe.py
+++ b/tests/test_timeseries_dataframe.py
@@ -100,6 +100,21 @@ class TimeSeriesDataFrameTC(unittest.TestCase):
             self.assertEqual(tsdf._data[i].ndarray.shape[0], 10)
         self.assertEqual(tsdf._index_name, 'Index')
 
+    def test_read_from_text_file_preserves_singleton_dimensions(self):
+        cases = (
+            ('time,value\n1,2\n', True, ['value'], [2.0], [1]),
+            ('value\n1\n2\n', False, ['value'], [1.0, 2.0], [0, 1]),
+            ('value\n1\n', False, ['value'], [1.0], [0]),
+        )
+        for text, has_timestamp, columns, values, index in cases:
+            with self.subTest(text=text):
+                tsdf = dataframe.DataFrame()
+                tsdf.read_from_text_file(
+                    io.StringIO(text), timestamp_in_file=has_timestamp)
+                self.assertEqual(tsdf._columns, columns)
+                np.testing.assert_array_equal(tsdf['value'], values)
+                np.testing.assert_array_equal(tsdf.index, index)
+
     def test_dataframe_attribute_columns(self):
         tsdf = dataframe.DataFrame()
         tsdf.read_from_text_file(io.StringIO(self.dlc_data))


### PR DESCRIPTION
Pass ``ndmin=2`` to ``numpy.genfromtxt`` so CSV input retains separate row and column axes even when either dimension has length one. Add regression coverage for one-row, one-column, and one-cell inputs, including column names, indices, and values.

Related to #1521.

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
