### PR TITLE
Skip the Winograd boundary case on the macOS runner

### DIFF
--- a/.github/workflows/nightly_profiling.yml
+++ b/.github/workflows/nightly_profiling.yml
@@ -42,8 +42,15 @@ jobs:
         include:
           - os: ubuntu-24.04
             cmake_build_type: Release
+            pyprof_matrix_opts: ''
           - os: macos-26
             cmake_build_type: RelWithDebInfo
+            # The float64 case at the Winograd threshold peaks near 7 GiB.
+            # The macOS runner swaps on it, which ran the job past its
+            # 30-minute timeout on two consecutive nightly builds. The
+            # float32 case peaks near 4 GiB and still runs here. The ubuntu
+            # runner has the memory and keeps measuring both dtypes.
+            pyprof_matrix_opts: '--skip-winograd-boundary float64'
       fail-fast: false
 
     steps:
@@ -88,7 +95,8 @@ jobs:
       - name: make pyprof
         run: |
           echo "::group::make pyprof"
-          make pyprof
+          make pyprof \
+            PYPROF_OPTS_profile_matrix_ops="${{ matrix.pyprof_matrix_opts }}"
           echo "::endgroup::"
 
   send_email_on_failure:

--- a/Makefile
+++ b/Makefile
@@ -169,18 +169,22 @@ pytest-gui: buildext
 PROFFILES = $(shell find profiling -type f -name 'profile_*.py' | sort)
 PROFRESDIR = profiling/results
 
+prof_name = $(basename $(notdir $(1)))
+prof_out = $(PROFRESDIR)/$(call prof_name,$(1)).output
+# Options reach one profiling script through PYPROF_OPTS_<script>, e.g.
+#   make pyprof PYPROF_OPTS_profile_matrix_ops=--skip-winograd-boundary
+prof_opts = $(PYPROF_OPTS_$(call prof_name,$(1)))
+
 .PHONY: pyprof
 pyprof: buildext $(PROFFILES)
-	@mkdir -p profiling/results
-	@mkdir -p profiling/results/png
-	@for fn in $(PROFFILES); \
-	do \
-		outfn=$${fn%%.py}; \
-		outfn=profiling/results/$${outfn##profiling/}.output; \
-		echo "$(WHICH_PYTHON) $${fn} > $${outfn}"; \
+	@mkdir -p $(PROFRESDIR)
+	@mkdir -p $(PROFRESDIR)/png
+	@$(foreach fn,$(PROFFILES), \
+		echo "$(WHICH_PYTHON) $(fn) $(call prof_opts,$(fn)) > $(call prof_out,$(fn))"; \
 		env $(RUNENV) \
-			$(WHICH_PYTHON) $${fn} > $${outfn} || exit 1; \
-	done
+			$(WHICH_PYTHON) $(fn) $(call prof_opts,$(fn)) \
+			> $(call prof_out,$(fn)) || exit 1; \
+	)
 
 .PHONY: pilot
 pilot: cmake

--- a/profiling/profile_matrix_ops.py
+++ b/profiling/profile_matrix_ops.py
@@ -204,6 +204,12 @@ def profile_matmul_suite(dtype, warmups=1, samples=1, rounds=3):
                 warmups, samples, rounds)
 
 
+# Mirror MatmulTuning::Winograd::minimum_side in
+# cpp/solvcon/buffer/matmul_executor.hpp.  A smaller square matrix falls
+# back to the BLAS kernel and stops measuring the Winograd route.
+WINOGRAD_BOUNDARY_SIDE = 16_384
+
+
 def profile_winograd_boundary(dtype, side, rng):
     dtype = np.dtype(dtype)
     shape = (side, side)
@@ -258,6 +264,12 @@ def parse_arguments(argv=None):
     parser.add_argument(
         "--rounds", type=parse_positive_count, default=3,
         help="matmul profiling rounds; use 5 or more for stable results")
+    parser.add_argument(
+        "--skip-winograd-boundary", action="append", default=[],
+        choices=("float32", "float64"), metavar="DTYPE",
+        help="skip the square case at the Winograd threshold for this "
+             "dtype; repeat to skip both. float32 peaks near 4 GiB and "
+             "float64 near 7 GiB")
     return parser.parse_args(argv)
 
 
@@ -274,8 +286,15 @@ def main(argv=None):
             rounds=args.rounds)
 
     rng = np.random.default_rng(20260812)
+    skipped = args.skip_winograd_boundary
+    if skipped:
+        print("## Winograd boundary: skipped for "
+              f"`{'`, `'.join(skipped)}`\n")
+
     for dtype in (np.float32, np.float64):
-        profile_winograd_boundary(dtype, side=16_384, rng=rng)
+        if np.dtype(dtype).name in skipped:
+            continue
+        profile_winograd_boundary(dtype, side=WINOGRAD_BOUNDARY_SIDE, rng=rng)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The nightly_profiling macOS job dies at its 30-minute timeout, which reports as `cancelled` and mails a failure. It did so on two consecutive nights. Almost all of that time goes to `profiling/profile_matrix_ops.py`, and almost all of that to the square case at the Winograd threshold. That case needs a 16384-square operand because `MatmulTuning::Winograd::minimum_side` is 16384, so the float64 pair peaks near 7 GiB and the runner swaps. The float32 pair peaks near 4 GiB and fits. The ubuntu runner has the memory for both and finishes the same script in about 11 minutes.

This change adds `--skip-winograd-boundary`, which names one dtype and repeats to skip both, and sets it to `float64` on the macOS matrix entry. The macOS job keeps the float32 measurement and the ubuntu entry keeps both.

`make pyprof` ran every profiling script bare, so the options `profile_matrix_ops.py` already parses could not reach it from CI. The target now forwards options per script through `PYPROF_OPTS_<script>`, the way `pytest` forwards `PYTEST_OPTS`. A flag for one script does not reach the other six.

I ran `make pyprof PROFFILES=profiling/profile_matrix_ops.py` on macOS four ways. The default takes 1m34s and reports both dtypes. `--skip-winograd-boundary float64` takes 28s and reports float32 alone. Repeating the flag for both dtypes takes 4s. An unknown dtype fails at argument parsing. `make lint` passes.
