### PR TITLE
Give cascaded windows a consistent size

### DIFF
--- a/solvcon/pilot/panel/_window_manager.py
+++ b/solvcon/pilot/panel/_window_manager.py
@@ -91,7 +91,7 @@ class WindowManager(_gui_common.PilotFeature):
     def _tile(self):
         self._mgr.mdiArea.tileSubWindows()
 
-    def _cascade(self):
+    def _cascade(self, width=400, height=300):
         mdi = self._mgr.mdiArea
         subwins = [s for s in mdi.subWindowList() if s.isVisible()]
         if not subwins:
@@ -101,7 +101,7 @@ class WindowManager(_gui_common.PilotFeature):
 
         for subwin in subwins:
             if not subwin.isMinimized():
-                subwin.resize(400, 300)
+                subwin.resize(width, height)
 
     def _set_tabbed(self, on):
         """Switch the MDI area between sub-window and tabbed view.

--- a/solvcon/pilot/panel/_window_manager.py
+++ b/solvcon/pilot/panel/_window_manager.py
@@ -92,7 +92,16 @@ class WindowManager(_gui_common.PilotFeature):
         self._mgr.mdiArea.tileSubWindows()
 
     def _cascade(self):
-        self._mgr.mdiArea.cascadeSubWindows()
+        mdi = self._mgr.mdiArea
+        subwins = [s for s in mdi.subWindowList() if s.isVisible()]
+        if not subwins:
+            return
+
+        mdi.cascadeSubWindows()
+
+        for subwin in subwins:
+            if not subwin.isMinimized():
+                subwin.resize(400, 300)
 
     def _set_tabbed(self, on):
         """Switch the MDI area between sub-window and tabbed view.

--- a/tests/gui/test_window_menu.py
+++ b/tests/gui/test_window_menu.py
@@ -205,12 +205,66 @@ class WindowLayoutTC(unittest.TestCase):
         one, two = [s.geometry() for s in self.area.subWindowList()]
         self.assertFalse(one.intersects(two))
 
-    def test_cascade_offsets_the_windows(self):
+    def test_cascade_preserves_qt_positions(self):
+        self._two_stacked_windows()
+        subwins = self.area.subWindowList()
+
+        self.area.cascadeSubWindows()
+        QtWidgets.QApplication.processEvents()
+        qt_positions = [subwin.pos() for subwin in subwins]
+        self.assertNotEqual(qt_positions[0], qt_positions[1])
+
+        for subwin in subwins:
+            subwin.setGeometry(0, 0, 200, 150)
+        QtWidgets.QApplication.processEvents()
+
+        self.model.action(WindowManager.CASCADE_ID).trigger()
+        QtWidgets.QApplication.processEvents()
+        positions = [subwin.pos() for subwin in subwins]
+
+        self.assertEqual(positions, qt_positions)
+
+    def test_cascade_resizes_the_windows(self):
         self._two_stacked_windows()
         self.model.action(WindowManager.CASCADE_ID).trigger()
         QtWidgets.QApplication.processEvents()
         one, two = [s.geometry() for s in self.area.subWindowList()]
-        self.assertNotEqual(one.topLeft(), two.topLeft())
+        self.assertEqual(one.size(), two.size())
+        self.assertEqual(one.width(), 400)
+        self.assertEqual(one.height(), 300)
+
+    def test_cascade_keeps_viewers_usable(self):
+        self._two_stacked_windows()
+        canvas_subwin, domain_subwin = self.area.subWindowList()
+
+        self.model.action(WindowManager.CASCADE_ID).trigger()
+        QtWidgets.QApplication.processEvents()
+
+        canvas = canvas_subwin.widget()
+        domain_host = domain_subwin.widget()
+        domain_viewer = domain_host.layout().itemAt(0).widget()
+
+        self.assertGreater(canvas.height(), 0)
+        self.assertGreater(domain_viewer.height(), 0)
+
+    def test_cascade_preserves_the_active_window(self):
+        self._two_stacked_windows()
+        active = self.area.activeSubWindow()
+        self.model.action(WindowManager.CASCADE_ID).trigger()
+        QtWidgets.QApplication.processEvents()
+        self.assertIs(self.area.activeSubWindow(), active)
+
+    def test_cascade_preserves_the_minimized_window(self):
+        self._two_stacked_windows()
+        minimized = self.area.subWindowList()[0]
+        minimized.showMinimized()
+        QtWidgets.QApplication.processEvents()
+        original_size = minimized.size()
+
+        self.model.action(WindowManager.CASCADE_ID).trigger()
+        QtWidgets.QApplication.processEvents()
+        self.assertTrue(minimized.isMinimized())
+        self.assertEqual(minimized.size(), original_size)
 
     def test_horizontal_tiling_forms_a_single_row(self):
         self._two_stacked_windows()

--- a/tests/gui/test_window_menu.py
+++ b/tests/gui/test_window_menu.py
@@ -233,6 +233,15 @@ class WindowLayoutTC(unittest.TestCase):
         self.assertEqual(one.width(), 400)
         self.assertEqual(one.height(), 300)
 
+    def test_cascade_allows_overriding_window_size(self):
+        self._two_stacked_windows()
+        _gui.controller.window_manager._cascade(width=320, height=240)
+        QtWidgets.QApplication.processEvents()
+        one, two = [s.geometry() for s in self.area.subWindowList()]
+        self.assertEqual(one.size(), two.size())
+        self.assertEqual(one.width(), 320)
+        self.assertEqual(one.height(), 240)
+
     def test_cascade_keeps_viewers_usable(self):
         self._two_stacked_windows()
         canvas_subwin, domain_subwin = self.area.subWindowList()


### PR DESCRIPTION
## Summary

This PR preserves the positions computed by Qt during Cascade and resizes each visible, non-minimized sub-window to `400` by `300`. The fixed size matches the initial dimensions used by the 2D and 3D viewer factories.

Minimized sub-windows retain both their state and size. The active sub-window remains unchanged, and the viewer content remains usable.

Manual verification used 2D and 3D viewers.
<img width="1511" height="694" alt="截圖 2026-09-10 14 45 43" src="https://github.com/user-attachments/assets/31b1d790-dcc5-4981-92d0-6cefb8e9db82" />

## Observation

On macOS 26 with Qt 6.11.1, sub-window titles are absent immediately after Cascade. Clicking the active sub-window displays only its title. Clicking an inactive sub-window, or switching away from and back to pilot, displays every title. The geometry and viewer content remain unchanged.

| Immediately after Cascade | After clicking the active sub-window | After clicking an inactive sub-window |
| --- | --- | --- |
| <img width="1512" height="693" alt="截圖 2026-09-09 23 00 52" src="https://github.com/user-attachments/assets/95dcd5fc-40bb-4da3-80d6-371f9a128c7e" /> | <img width="1512" height="693" alt="截圖 2026-09-09 23 01 11" src="https://github.com/user-attachments/assets/40fb4da4-7607-4ba8-8991-29878239ec24" /> | <img width="1511" height="692" alt="截圖 2026-09-09 23 01 28" src="https://github.com/user-attachments/assets/a4c496ae-573c-4c28-9963-75d3f9bf73dc" /> |

Calling `repaint()` after `resize()` did not make the missing titles appear. The cause remains unknown, and the behavior has not been verified on other platforms. Verification on Linux, Windows, or other Qt versions would help determine whether the behavior is specific to macOS, Qt 6.11.1, or their interaction.

This PR does not include the tested `repaint()` call because it did not change the observed behavior.

Does the macOS title-bar behavior block this change, or should it be tracked separately as a Qt/platform follow-up?

Related to #1245.