### PR TITLE
Give the plot limits their named 2d type

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/canvas/RWorldRenderer2d.hpp
     # plot/
     ${CMAKE_CURRENT_SOURCE_DIR}/plot/plot_style.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/plot/PlotLimits2d.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/plot/RPlotSeries.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/plot/RPlotModel.hpp
     # app/

--- a/cpp/solvcon/pilot/plot/PlotLimits2d.hpp
+++ b/cpp/solvcon/pilot/plot/PlotLimits2d.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * The named rectangular limits shared by the native xy plot data and view.
+ *
+ * @ingroup group_domain
+ */
+
+#include <algorithm>
+
+namespace solvcon
+{
+
+/**
+ * One xy rectangle, with named bounds rather than positional array entries.
+ * The dimension suffix keeps this delivered type honestly 2d: a future 3d
+ * plot adds a sibling type instead of changing this one.
+ */
+struct PlotLimits2d
+{
+    double xmin = 0.0;
+    double xmax = 0.0;
+    double ymin = 0.0;
+    double ymax = 0.0;
+
+    constexpr PlotLimits2d() = default;
+
+    constexpr PlotLimits2d(double xmin, double xmax, double ymin, double ymax)
+        : xmin(xmin)
+        , xmax(xmax)
+        , ymin(ymin)
+        , ymax(ymax)
+    {
+    }
+
+    void merge(PlotLimits2d const & other);
+
+    constexpr bool operator==(PlotLimits2d const &) const = default;
+}; /* end struct PlotLimits2d */
+
+inline void PlotLimits2d::merge(PlotLimits2d const & other)
+{
+    xmin = std::min(xmin, other.xmin);
+    xmax = std::max(xmax, other.xmax);
+    ymin = std::min(ymin, other.ymin);
+    ymax = std::max(ymax, other.ymax);
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/plot/RPlotModel.cpp
+++ b/cpp/solvcon/pilot/plot/RPlotModel.cpp
@@ -74,12 +74,12 @@ std::shared_ptr<RPlotSeries> const & RPlotModel::series(std::size_t it) const
     return m_series[it];
 }
 
-std::optional<std::array<double, 4>> RPlotModel::data_limits() const
+std::optional<PlotLimits2d> RPlotModel::data_limits() const
 {
-    std::optional<std::array<double, 4>> limits;
+    std::optional<PlotLimits2d> limits;
     for (std::shared_ptr<RPlotSeries> const & ser : m_series)
     {
-        std::optional<std::array<double, 4>> const serlim = ser->data_limits();
+        std::optional<PlotLimits2d> const serlim = ser->data_limits();
         if (!serlim.has_value())
         {
             continue;
@@ -89,11 +89,7 @@ std::optional<std::array<double, 4>> RPlotModel::data_limits() const
             limits = serlim;
             continue;
         }
-        std::array<double, 4> & lim = *limits;
-        lim[0] = std::min(lim[0], (*serlim)[0]);
-        lim[1] = std::max(lim[1], (*serlim)[1]);
-        lim[2] = std::min(lim[2], (*serlim)[2]);
-        lim[3] = std::max(lim[3], (*serlim)[3]);
+        limits->merge(*serlim);
     }
     return limits;
 }
@@ -108,25 +104,25 @@ void RPlotModel::set_margin(double margin)
     m_margin = margin;
 }
 
-void RPlotModel::set_view_limits(double xmin, double xmax, double ymin, double ymax)
+void RPlotModel::set_view_limits(PlotLimits2d const & limits)
 {
-    validate_axis_limits(xmin, xmax, "x");
-    validate_axis_limits(ymin, ymax, "y");
-    m_view_limits = {xmin, xmax, ymin, ymax};
+    validate_axis_limits(limits.xmin, limits.xmax, "x");
+    validate_axis_limits(limits.ymin, limits.ymax, "y");
+    m_view_limits = limits;
 }
 
 void RPlotModel::autoscale()
 {
-    std::optional<std::array<double, 4>> const limits = data_limits();
+    std::optional<PlotLimits2d> const limits = data_limits();
     if (!limits.has_value())
     {
-        m_view_limits = {0.0, 1.0, 0.0, 1.0};
+        m_view_limits = PlotLimits2d{0.0, 1.0, 0.0, 1.0};
         return;
     }
 
-    auto const [xmin, xmax] = expand_axis((*limits)[0], (*limits)[1], m_margin);
-    auto const [ymin, ymax] = expand_axis((*limits)[2], (*limits)[3], m_margin);
-    m_view_limits = {xmin, xmax, ymin, ymax};
+    auto const [xmin, xmax] = expand_axis(limits->xmin, limits->xmax, m_margin);
+    auto const [ymin, ymax] = expand_axis(limits->ymin, limits->ymax, m_margin);
+    m_view_limits = PlotLimits2d{xmin, xmax, ymin, ymax};
 }
 
 ViewTransform2dFp64 RPlotModel::view(double width, double height) const
@@ -140,10 +136,10 @@ ViewTransform2dFp64 RPlotModel::view(double width, double height) const
                 height));
     }
 
-    double const zoom = std::min(width / (m_view_limits[1] - m_view_limits[0]),
-                                 height / (m_view_limits[3] - m_view_limits[2]));
-    double const center_x = 0.5 * (m_view_limits[0] + m_view_limits[1]);
-    double const center_y = 0.5 * (m_view_limits[2] + m_view_limits[3]);
+    double const zoom = std::min(width / (m_view_limits.xmax - m_view_limits.xmin),
+                                 height / (m_view_limits.ymax - m_view_limits.ymin));
+    double const center_x = 0.5 * (m_view_limits.xmin + m_view_limits.xmax);
+    double const center_y = 0.5 * (m_view_limits.ymin + m_view_limits.ymax);
 
     ViewTransform2dFp64 transform;
     transform.set_zoom(zoom);

--- a/cpp/solvcon/pilot/plot/RPlotModel.hpp
+++ b/cpp/solvcon/pilot/plot/RPlotModel.hpp
@@ -15,7 +15,6 @@
  * @ingroup group_domain
  */
 
-#include <array>
 #include <cstddef>
 #include <memory>
 #include <optional>
@@ -24,6 +23,7 @@
 #include <solvcon/universe/ViewTransform2d.hpp>
 
 #include <solvcon/pilot/plot/plot_style.hpp>
+#include <solvcon/pilot/plot/PlotLimits2d.hpp>
 #include <solvcon/pilot/plot/RPlotSeries.hpp>
 
 namespace solvcon
@@ -59,18 +59,18 @@ public:
     std::shared_ptr<RPlotSeries> const & series(std::size_t it) const;
 
     /**
-     * The union of every series' data limits as {xmin, xmax, ymin, ymax};
-     * nullopt when no series holds a finite sample.
+     * The union of every series' data limits; nullopt when no series holds a
+     * finite sample.
      */
-    std::optional<std::array<double, 4>> data_limits() const;
+    std::optional<PlotLimits2d> data_limits() const;
 
     double margin() const { return m_margin; }
 
     void set_margin(double margin);
 
-    std::array<double, 4> view_limits() const { return m_view_limits; }
+    PlotLimits2d view_limits() const { return m_view_limits; }
 
-    void set_view_limits(double xmin, double xmax, double ymin, double ymax);
+    void set_view_limits(PlotLimits2d const & limits);
 
     /**
      * Set the view limits to the data limits opened by the margin, guarding
@@ -92,7 +92,7 @@ private:
     std::vector<std::shared_ptr<RPlotSeries>> m_series;
     std::size_t m_cycle_index = 0;
     double m_margin = PLOT_DEFAULT_MARGIN;
-    std::array<double, 4> m_view_limits = {0.0, 1.0, 0.0, 1.0};
+    PlotLimits2d m_view_limits = {0.0, 1.0, 0.0, 1.0};
 }; /* end class RPlotModel */
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/plot/RPlotSeries.cpp
+++ b/cpp/solvcon/pilot/plot/RPlotSeries.cpp
@@ -86,14 +86,14 @@ double RPlotSeries::y_at(std::size_t it) const
     return y()[it];
 }
 
-std::optional<std::array<double, 4>> RPlotSeries::data_limits() const
+std::optional<PlotLimits2d> RPlotSeries::data_limits() const
 {
     if (!m_limits_stale)
     {
         return m_limits;
     }
 
-    std::optional<std::array<double, 4>> limits;
+    std::optional<PlotLimits2d> limits;
     std::span<double const> const xs = x();
     std::span<double const> const ys = y();
     for (std::size_t it = 0; it < xs.size(); ++it)
@@ -108,25 +108,25 @@ std::optional<std::array<double, 4>> RPlotSeries::data_limits() const
         }
         if (!limits.has_value())
         {
-            limits = std::array<double, 4>{xv, xv, yv, yv};
+            limits = PlotLimits2d{xv, xv, yv, yv};
             continue;
         }
-        std::array<double, 4> & lim = *limits;
-        if (xv < lim[0])
+        PlotLimits2d & lim = *limits;
+        if (xv < lim.xmin)
         {
-            lim[0] = xv;
+            lim.xmin = xv;
         }
-        if (xv > lim[1])
+        if (xv > lim.xmax)
         {
-            lim[1] = xv;
+            lim.xmax = xv;
         }
-        if (yv < lim[2])
+        if (yv < lim.ymin)
         {
-            lim[2] = yv;
+            lim.ymin = yv;
         }
-        if (yv > lim[3])
+        if (yv > lim.ymax)
         {
-            lim[3] = yv;
+            lim.ymax = yv;
         }
     }
 

--- a/cpp/solvcon/pilot/plot/RPlotSeries.hpp
+++ b/cpp/solvcon/pilot/plot/RPlotSeries.hpp
@@ -13,7 +13,6 @@
  * @ingroup group_domain
  */
 
-#include <array>
 #include <cstddef>
 #include <optional>
 #include <span>
@@ -24,6 +23,7 @@
 #include <solvcon/buffer/SimpleCollector.hpp>
 
 #include <solvcon/pilot/plot/plot_style.hpp>
+#include <solvcon/pilot/plot/PlotLimits2d.hpp>
 
 namespace solvcon
 {
@@ -52,7 +52,7 @@ public:
 
     double y_at(std::size_t it) const;
 
-    std::optional<std::array<double, 4>> data_limits() const;
+    std::optional<PlotLimits2d> data_limits() const;
 
     std::string const & label() const { return m_label; }
     void set_label(std::string label) { m_label = std::move(label); }
@@ -81,7 +81,7 @@ private:
     double m_line_width = PLOT_DEFAULT_LINE_WIDTH;
 
     mutable bool m_limits_stale = true;
-    mutable std::optional<std::array<double, 4>> m_limits;
+    mutable std::optional<PlotLimits2d> m_limits;
 }; /* end class RPlotSeries */
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/plot/wrap_plot.cpp
+++ b/cpp/solvcon/pilot/plot/wrap_plot.cpp
@@ -12,16 +12,15 @@
 
 #include <solvcon/buffer/pymod/SimpleArrayCaster.hpp>
 
-#include <solvcon/pilot/plot/plot_style.hpp>
+#include <solvcon/pilot/plot/PlotLimits2d.hpp>
 #include <solvcon/pilot/plot/RPlotModel.hpp>
 #include <solvcon/pilot/plot/RPlotSeries.hpp>
+#include <solvcon/pilot/plot/plot_style.hpp>
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <format>
 #include <memory>
-#include <optional>
 #include <span>
 #include <stdexcept>
 #include <vector>
@@ -34,17 +33,6 @@ namespace python
 
 namespace
 {
-
-/// A 4-tuple, not the list that an auto-cast std::array<double, 4> would give.
-pybind11::object limits_to_python(std::optional<std::array<double, 4>> const & limits)
-{
-    if (!limits.has_value())
-    {
-        return pybind11::none();
-    }
-    std::array<double, 4> const & lim = *limits;
-    return pybind11::make_tuple(lim[0], lim[1], lim[2], lim[3]);
-}
 
 /**
  * Reject a negative index with IndexError. A std::size_t parameter would raise
@@ -118,6 +106,57 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapPlotColor
 
 }; /* end class WrapPlotColor */
 
+class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapPlotLimits2d
+    : public WrapBase<WrapPlotLimits2d, PlotLimits2d>
+{
+
+    friend root_base_type;
+
+    WrapPlotLimits2d(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : root_base_type(mod, pyname, pydoc)
+    {
+        namespace py = pybind11;
+
+        (*this)
+            .def(py::init<>())
+            .def(
+                py::init<double, double, double, double>(),
+                py::arg("xmin"),
+                py::arg("xmax"),
+                py::arg("ymin"),
+                py::arg("ymax"))
+            //
+            ;
+
+        (*this)
+            .def_readwrite("xmin", &wrapped_type::xmin)
+            .def_readwrite("xmax", &wrapped_type::xmax)
+            .def_readwrite("ymin", &wrapped_type::ymin)
+            .def_readwrite("ymax", &wrapped_type::ymax)
+            .def("merge", &wrapped_type::merge, py::arg("other"))
+            .def(py::self == py::self) // NOLINT(misc-redundant-expression)
+            .def(py::self != py::self) // NOLINT(misc-redundant-expression)
+            .def(
+                "__iter__",
+                [](wrapped_type const & self)
+                { return py::make_tuple(self.xmin, self.xmax, self.ymin, self.ymax).attr("__iter__")(); })
+            .def(
+                "__repr__",
+                [](wrapped_type const & self)
+                {
+                    return std::format(
+                        "PlotLimits2d(xmin={}, xmax={}, ymin={}, ymax={})",
+                        self.xmin,
+                        self.xmax,
+                        self.ymin,
+                        self.ymax);
+                })
+            //
+            ;
+    }
+
+}; /* end class WrapPlotLimits2d */
+
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRPlotSeries
     : public WrapBase<WrapRPlotSeries, RPlotSeries, std::shared_ptr<RPlotSeries>>
 {
@@ -149,10 +188,7 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRPlotSeries
                 [](wrapped_type const & self, std::int64_t index)
                 { return self.y_at(checked_index(index, self.size(), "RPlotSeries::y_at", "size")); },
                 py::arg("index"))
-            .def(
-                "data_limits",
-                [](wrapped_type const & self)
-                { return limits_to_python(self.data_limits()); })
+            .def("data_limits", &wrapped_type::data_limits)
             .def_property("label", &wrapped_type::label, &wrapped_type::set_label)
             // A copy, not a reference into the series: `series.color.a = 128`
             // must fail rather than write to a temporary.
@@ -198,25 +234,10 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRPlotModel
                 [](wrapped_type const & self, std::int64_t index)
                 { return self.series(checked_index(index, self.size(), "RPlotModel::series", "size")); },
                 py::arg("index"))
-            .def(
-                "data_limits",
-                [](wrapped_type const & self)
-                { return limits_to_python(self.data_limits()); })
+            .def("data_limits", &wrapped_type::data_limits)
             .def_property("margin", &wrapped_type::margin, &wrapped_type::set_margin)
-            .def(
-                "view_limits",
-                [](wrapped_type const & self)
-                {
-                    std::array<double, 4> const lim = self.view_limits();
-                    return py::make_tuple(lim[0], lim[1], lim[2], lim[3]);
-                })
-            .def(
-                "set_view_limits",
-                &wrapped_type::set_view_limits,
-                py::arg("xmin"),
-                py::arg("xmax"),
-                py::arg("ymin"),
-                py::arg("ymax"))
+            .def("view_limits", &wrapped_type::view_limits)
+            .def("set_view_limits", &wrapped_type::set_view_limits, py::arg("limits"))
             .def("autoscale", &wrapped_type::autoscale)
             .def("view", &wrapped_type::view, py::arg("width"), py::arg("height"))
             //
@@ -234,6 +255,12 @@ void wrap_plot(pybind11::module & mod)
         "PlotColor",
         "One sRGB color with alpha, a byte per channel. An immutable value: "
         "the channels are read-only, so rebuild the color to change one.");
+    WrapPlotLimits2d::commit(
+        mod,
+        "PlotLimits2d",
+        "The mutable xmin, xmax, ymin, and ymax limits of one xy rectangle. "
+        "merge(other) expands this rectangle to contain the other one.");
+    mod.attr("PlotLimits2d").attr("__hash__") = py::none();
     WrapRPlotSeries::commit(
         mod,
         "RPlotSeries",

--- a/solvcon/pilot/__init__.py
+++ b/solvcon/pilot/__init__.py
@@ -19,6 +19,7 @@ from ._pilot_core import (  # noqa: F401
     RPythonConsoleDockWidget,
     RPythonTerminalDockWidget,
     RManager,
+    PlotLimits2d,
     PlotColor,
     RPlotSeries,
     RPlotModel,

--- a/solvcon/pilot/_pilot_core.py
+++ b/solvcon/pilot/_pilot_core.py
@@ -53,6 +53,11 @@ list_of_drawtool = [
     'default_draw_tool_name',
 ]
 
+# PlotLimits2d.hpp
+list_of_plotlimits = [
+    'PlotLimits2d',
+]
+
 # plot_style.hpp/.cpp
 list_of_plot_style = [
     'PlotColor',
@@ -78,6 +83,7 @@ _from_impl = (  # noqa: F822
     list_of_rpythonconsole +
     list_of_rpythonterminal +
     list_of_drawtool +
+    list_of_plotlimits +
     list_of_plot_style +
     list_of_rplotseries +
     list_of_rplotmodel
@@ -103,6 +109,7 @@ _load(list_of_rmanager)
 _load(list_of_rpythonconsole)
 _load(list_of_rpythonterminal)
 _load(list_of_drawtool)
+_load(list_of_plotlimits)
 _load(list_of_plot_style)
 _load(list_of_rplotseries)
 _load(list_of_rplotmodel)

--- a/solvcon/pilot/visual/_plot.py
+++ b/solvcon/pilot/visual/_plot.py
@@ -141,8 +141,8 @@ class LinePlotWidget(QWidget):
         self.update()
 
     def limits(self):
-        """The drawn limits as ``(xmin, xmax, ymin, ymax)``, or None while
-        there is nothing to draw.
+        """The drawn limits as a ``PlotLimits2d``, or None while there
+        is nothing to draw.
 
         The ordinate is in the mapped space, so a log plot reports the
         exponents it drew between.
@@ -205,14 +205,14 @@ class LinePlotWidget(QWidget):
                      max(1, self.height() - top - bottom))
 
     def _mapper(self, rect):
-        xmin, xmax, ymin, ymax = self._limits
-        xspan = xmax - xmin
-        yspan = ymax - ymin
+        limits = self._limits
+        xspan = limits.xmax - limits.xmin
+        yspan = limits.ymax - limits.ymin
 
         def to_screen(x, y):
             return QPointF(
-                rect.left() + (x - xmin) / xspan * rect.width(),
-                rect.bottom() - (y - ymin) / yspan * rect.height())
+                rect.left() + (x - limits.xmin) / xspan * rect.width(),
+                rect.bottom() - (y - limits.ymin) / yspan * rect.height())
 
         return to_screen
 

--- a/tests/test_pilot_plot.py
+++ b/tests/test_pilot_plot.py
@@ -2,7 +2,7 @@
 # BSD 3-Clause License, see COPYING
 
 """
-Tests for the native xy-plot core: PlotColor, the matplotlib C0-C9 cycle,
+Tests for the native xy-plot core: limits, colors, the matplotlib C0-C9 cycle,
 and RPlotSeries.
 
 The core is pure C++ with no Qt widget, so everything here is exercised
@@ -34,9 +34,14 @@ def _series(x_values, y_values):
     return ser
 
 
+def _limits(xmin, xmax, ymin, ymax):
+    """Build a PlotLimits2d with the given bounds."""
+    return pilot.PlotLimits2d(xmin, xmax, ymin, ymax)
+
+
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class PilotPlotTC(unittest.TestCase):
-    """The native plot vocabulary: the color cycle and the xy series."""
+    """The native plot limits, color cycle, and xy series."""
 
     def test_cycle_is_matplotlib_c0_to_c9(self):
         cycle = pilot.plot_color_cycle()
@@ -56,6 +61,33 @@ class PilotPlotTC(unittest.TestCase):
         self.assertTrue(color != None)  # noqa: E711
         self.assertNotIn(color, [1, 'a'])
         self.assertEqual('custom', {color: 'custom'}[pilot.PlotColor(1, 2, 3)])
+
+    def test_limits_is_a_mutable_value(self):
+        limits = _limits(0.0, 1.0, 2.0, 3.0)
+        self.assertEqual((0.0, 1.0, 2.0, 3.0), tuple(limits))
+        self.assertEqual(_limits(0.0, 1.0, 2.0, 3.0), limits)
+        self.assertNotEqual(_limits(0.0, 2.0, 2.0, 3.0), limits)
+        self.assertFalse(limits == None)  # noqa: E711
+        self.assertTrue(limits != None)  # noqa: E711
+        with self.assertRaises(TypeError):
+            hash(limits)
+        limits.xmin = -1.0
+        limits.ymax = 4.0
+        self.assertIsNone(limits.merge(_limits(-2.0, 3.0, 1.0, 5.0)))
+        self.assertEqual(_limits(-2.0, 3.0, 1.0, 5.0), limits)
+        self.assertEqual('PlotLimits2d(xmin=-2, xmax=3, ymin=1, ymax=5)',
+                         repr(limits))
+
+    def test_returned_limits_do_not_mutate_the_plot(self):
+        ser = _series([0.0, 1.0], [2.0, 3.0])
+        limits = ser.data_limits()
+        limits.xmin = -1.0
+        self.assertEqual(_limits(0.0, 1.0, 2.0, 3.0), ser.data_limits())
+
+        model = pilot.RPlotModel()
+        limits = model.view_limits()
+        limits.xmin = -1.0
+        self.assertEqual(_limits(0.0, 1.0, 0.0, 1.0), model.view_limits())
 
     def test_set_data_stores_the_samples(self):
         ser = _series([0.0, 1.0, 2.0, 3.0], [10.0, 11.0, 12.0, 13.0])
@@ -146,26 +178,28 @@ class PilotPlotTC(unittest.TestCase):
 
     def test_data_limits_are_the_raw_extent(self):
         ser = _series([3.0, -1.0, 2.0], [7.0, 9.0, -4.0])
-        self.assertEqual((-1.0, 3.0, -4.0, 9.0), ser.data_limits())
-        self.assertEqual((5.0, 5.0, 7.0, 7.0),
+        self.assertEqual(_limits(-1.0, 3.0, -4.0, 9.0), ser.data_limits())
+        self.assertEqual(_limits(5.0, 5.0, 7.0, 7.0),
                          _series([5.0], [7.0]).data_limits())
 
     def test_non_finite_sample_is_dropped_whole(self):
         for bad in (float('nan'), float('inf'), float('-inf')):
             with self.subTest(bad=bad):
                 ser = _series([0.0, 1.0, 2.0, 3.0], [10.0, 11.0, 12.0, bad])
-                self.assertEqual((0.0, 2.0, 10.0, 12.0), ser.data_limits())
+                self.assertEqual(_limits(0.0, 2.0, 10.0, 12.0),
+                                 ser.data_limits())
                 ser = _series([bad, 1.0, 2.0, 3.0], [10.0, 11.0, 12.0, 13.0])
-                self.assertEqual((1.0, 3.0, 11.0, 13.0), ser.data_limits())
+                self.assertEqual(_limits(1.0, 3.0, 11.0, 13.0),
+                                 ser.data_limits())
                 self.assertIsNone(_series([bad] * 4, [bad] * 4).data_limits())
 
     def test_limits_cache_is_stable_and_invalidates(self):
         ser = _series([0.0, 1.0], [2.0, 3.0])
         first = ser.data_limits()
-        self.assertEqual((0.0, 1.0, 2.0, 3.0), first)
+        self.assertEqual(_limits(0.0, 1.0, 2.0, 3.0), first)
         self.assertEqual(first, ser.data_limits())
         ser.set_data(_array([0.0, 4.0]), _array([2.0, 8.0]))
-        self.assertEqual((0.0, 4.0, 2.0, 8.0), ser.data_limits())
+        self.assertEqual(_limits(0.0, 4.0, 2.0, 8.0), ser.data_limits())
 
     def test_style_changes_do_not_disturb_the_limits(self):
         ser = _series([0.0, 1.0], [2.0, 3.0])
@@ -210,7 +244,8 @@ class PilotPlotModelTC(unittest.TestCase):
         ser.label = 'pressure'
         ser.set_data(_array([0.0, 1.0]), _array([2.0, 3.0]))
         self.assertEqual('pressure', model.series(0).label)
-        self.assertEqual((0.0, 1.0, 2.0, 3.0), model.series(0).data_limits())
+        self.assertEqual(_limits(0.0, 1.0, 2.0, 3.0),
+                         model.series(0).data_limits())
         self.assertEqual(1, model.size)
         self.assertEqual(1, len(model))
 
@@ -233,21 +268,21 @@ class PilotPlotModelTC(unittest.TestCase):
         self.assertIsNone(model.data_limits())
         model.add_series().set_data(_array([0.0, 1.0]), _array([5.0, 6.0]))
         model.add_series()
-        self.assertEqual((0.0, 1.0, 5.0, 6.0), model.data_limits())
+        self.assertEqual(_limits(0.0, 1.0, 5.0, 6.0), model.data_limits())
         model.add_series().set_data(_array([-3.0, 0.5]), _array([7.0, 8.0]))
-        self.assertEqual((-3.0, 1.0, 5.0, 8.0), model.data_limits())
+        self.assertEqual(_limits(-3.0, 1.0, 5.0, 8.0), model.data_limits())
 
     def test_autoscale_margins_the_data(self):
         model = pilot.RPlotModel()
-        self.assertEqual((0.0, 1.0, 0.0, 1.0), model.view_limits())
+        self.assertEqual(_limits(0.0, 1.0, 0.0, 1.0), model.view_limits())
         model.autoscale()
-        self.assertEqual((0.0, 1.0, 0.0, 1.0), model.view_limits())
+        self.assertEqual(_limits(0.0, 1.0, 0.0, 1.0), model.view_limits())
         model.add_series().set_data(_array([0.0, 10.0]),
                                     _array([0.0, 100.0]))
         self.assertEqual(0.05, model.margin)
         model.autoscale()
         for expected, actual in zip((-0.5, 10.5, -5.0, 105.0),
-                                    model.view_limits()):
+                                    tuple(model.view_limits())):
             self.assertAlmostEqual(expected, actual, places=12)
 
     def test_autoscale_guards_a_singular_span(self):
@@ -257,7 +292,7 @@ class PilotPlotModelTC(unittest.TestCase):
         # x: opened to 3 +- 0.15, then the 5% margin of the 0.3 span.
         # y: opened to +-0.5 around zero, then the margin of the 1.0 span.
         for expected, actual in zip((2.835, 3.165, -0.55, 0.55),
-                                    model.view_limits()):
+                                    tuple(model.view_limits())):
             self.assertAlmostEqual(expected, actual, places=12)
 
     def test_margin_and_view_limits_are_validated(self):
@@ -268,17 +303,17 @@ class PilotPlotModelTC(unittest.TestCase):
         model.margin = 0.0
         model.add_series().set_data(_array([0.0, 10.0]), _array([1.0, 2.0]))
         model.autoscale()
-        self.assertEqual((0.0, 10.0, 1.0, 2.0), model.view_limits())
+        self.assertEqual(_limits(0.0, 10.0, 1.0, 2.0), model.view_limits())
         for bad in ((1.0, 1.0, 0.0, 1.0), (0.0, 1.0, 2.0, 1.0),
                     (float('nan'), 1.0, 0.0, 1.0)):
             with self.assertRaises(ValueError):
-                model.set_view_limits(*bad)
-        model.set_view_limits(-2.0, 2.0, -4.0, 4.0)
-        self.assertEqual((-2.0, 2.0, -4.0, 4.0), model.view_limits())
+                model.set_view_limits(_limits(*bad))
+        model.set_view_limits(_limits(-2.0, 2.0, -4.0, 4.0))
+        self.assertEqual(_limits(-2.0, 2.0, -4.0, 4.0), model.view_limits())
 
     def test_view_fits_and_centers_the_limits(self):
         model = pilot.RPlotModel()
-        model.set_view_limits(0.0, 10.0, 0.0, 10.0)
+        model.set_view_limits(_limits(0.0, 10.0, 0.0, 10.0))
         transform = model.view(200.0, 100.0)
         self.assertEqual(10.0, transform.zoom)
         self.assertEqual((100.0, 50.0), transform.screen_from_world(5.0, 5.0))

--- a/tests/test_pilot_plot_widget.py
+++ b/tests/test_pilot_plot_widget.py
@@ -104,9 +104,9 @@ class LinePlotWidgetTC(unittest.TestCase):
         widget.resize(320, 240)
         rect = widget._lineplot_rect()
         to_screen = widget._mapper(rect)
-        xmin, xmax, ymin, ymax = widget.limits()
-        low = to_screen(xmin, ymin)
-        high = to_screen(xmax, ymax)
+        limits = widget.limits()
+        low = to_screen(limits.xmin, limits.ymin)
+        high = to_screen(limits.xmax, limits.ymax)
         self.assertAlmostEqual(rect.left(), low.x())
         self.assertAlmostEqual(rect.bottom(), low.y())
         self.assertAlmostEqual(rect.left() + rect.width(), high.x())
@@ -121,17 +121,17 @@ class LinePlotWidgetTC(unittest.TestCase):
         widget.model.margin = 0.5
         widget.refresh()
         loose = widget.limits()
-        self.assertLess(loose[2], tight[2])
-        self.assertGreater(loose[3], tight[3])
+        self.assertLess(loose.ymin, tight.ymin)
+        self.assertGreater(loose.ymax, tight.ymax)
 
     def test_a_log_lineplot_maps_the_exponents(self):
         widget = self._filled([1.0, 2.0, 3.0], [1e-1, 1e-3, 1e-5],
                               log_y=True)
-        _, _, ymin, ymax = widget.limits()
+        limits = widget.limits()
         # The limits are reported in the space that was drawn, so a decade
         # of data is a unit of ordinate.
-        self.assertLess(ymin, -5.0)
-        self.assertGreater(ymax, -1.0)
+        self.assertLess(limits.ymin, -5.0)
+        self.assertGreater(limits.ymax, -1.0)
 
     def test_a_log_lineplot_drops_what_it_cannot_place(self):
         # Zero and negative values have no logarithm; keeping them would


### PR DESCRIPTION
The xy plot moved its data and view limits around as std::optional<std::array<double, 4>>, so every consumer read the bounds by position and a swapped index would draw a wrong frame without a diagnostic.  The bounds now live in PlotLimits2d, a mutable value with named xmin, xmax, ymin, and ymax, the union as merge, and defaulted equality; the series, the model, and the Python binding all speak the type, and set_view_limits accepts it as an overload beside the four scalars.

The dimension suffix is the point of the name: the API cannot change once delivered, so a future 3d plot arrives as a sibling type and new overloads instead of a retrofit of this one, following the 2d and 3d naming of ViewTransform2d and the geometry types.

Related to #1331, #1049

<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
