### PR TITLE
Keep CI logic in contrib/ci scripts instead of workflow YAML

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,18 @@ any dependency requires user review and consent.
 **macOS**: System Integrity Protection (SIP) may interfere with
 `DYLD_LIBRARY_PATH`. The Makefile sets `PYTHONPATH` as a workaround.
 
+## Continuous Integration
+
+Workflows live in `.github/workflows/`; helper scripts live in `contrib/ci/`.
+Keep a workflow step's `run:` block short: a single command or a few lines of
+glue. When a step needs real logic (loops, conditionals, more than roughly ten
+lines, or anything you would want to run locally), put it in a script under
+`contrib/ci/` and have the workflow call that script, as `cache_cleanup.yml`
+calls `contrib/ci/prune-caches.sh`. YAML-embedded scripts cannot be linted,
+tested, or run outside CI, so a long inline block is a maintenance liability.
+When you touch an existing step that already carries a long inline script,
+move that script into `contrib/ci/` as part of the change.
+
 ## Profiling System
 
 solvcon includes an integrated runtime profiler:

--- a/contrib/prompt/general-rule.md
+++ b/contrib/prompt/general-rule.md
@@ -75,4 +75,10 @@ re-check with a direct command first. Before declaring a task blocked or
 impossible, try at least two different approaches and report exactly what was
 tried and the errors seen.
 
+## Rule 14 -- Keep CI logic in scripts, not in YAML
+A workflow step's `run:` block is glue, not a program. If the logic grows past
+a few lines, or you would want to run it locally, put it in a script under
+`contrib/ci/` and call the script from the workflow. See `AGENTS.md`
+"Continuous Integration".
+
 <!-- vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79: -->


### PR DESCRIPTION
Adds a "Continuous Integration" section to CLAUDE.md and Rule 14 to contrib/prompt/general-rule.md. A workflow step's run block stays a few lines of glue. When the logic needs loops, conditionals, more than about ten lines, or a local run, the agent puts that logic in a script under contrib/ci/ and the workflow calls the script, as cache_cleanup.yml calls contrib/ci/prune-caches.sh.

A script in YAML cannot be linted, tested, or run outside CI, so long inline blocks are a maintenance liability. The rule also asks an agent that edits a step with a long inline script to move that script into contrib/ci/ as part of the change.

Codex reviewed the diff and reported no issues. make checkascii and make checktws pass.

[skip-ci]
