### PR TITLE
Raise `nightly_devbuild.yml`'s `issues` permission to `write`

### DIFF
--- a/.github/workflows/nightly_devbuild.yml
+++ b/.github/workflows/nightly_devbuild.yml
@@ -13,10 +13,6 @@ concurrency:
 
 # devbuild and lint both call check_skip_ci, which asks for these three, and
 # each also nests an open_issue_on_failure call that asks for issues: write.
-# A called workflow cannot hold more than its caller grants, and GitHub
-# checks that ceiling for the whole call graph before any job starts, so the
-# write scope is required here even though open_issue_on_failure's own `if`
-# keeps it from ever running under a schedule or workflow_dispatch trigger.
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/nightly_devbuild.yml
+++ b/.github/workflows/nightly_devbuild.yml
@@ -11,12 +11,16 @@ concurrency:
   group: nightly_devbuild
   cancel-in-progress: false
 
-# devbuild and lint both call check_skip_ci, which asks for these three, and a
-# called workflow cannot hold more than its caller grants.
+# devbuild and lint both call check_skip_ci, which asks for these three, and
+# each also nests an open_issue_on_failure call that asks for issues: write.
+# A called workflow cannot hold more than its caller grants, and GitHub
+# checks that ceiling for the whole call graph before any job starts, so the
+# write scope is required here even though open_issue_on_failure's own `if`
+# keeps it from ever running under a schedule or workflow_dispatch trigger.
 permissions:
   contents: read
   pull-requests: read
-  issues: read
+  issues: write
 
 # devbuild and lint lost their cron when the nightly workflows split off, so
 # this workflow calls them rather than restate their steps. Their job gates


### PR DESCRIPTION
This grants `issues: write` in `nightly_devbuild.yml`'s top-level `permissions` block instead of `issues: read`.

The `open_issue_on_failure` job that `devbuild.yml` and `lint.yml` each nest, added by #1528, declares `issues: write`. `nightly_devbuild.yml` calls both workflows through `workflow_call` but only granted `issues: read`, so GitHub rejected the whole call graph before any job could start. Every scheduled and `workflow_dispatch` run has failed with `startup_failure` since 2026-09-10.

The job's own `if` restricts it to `github.event_name == 'push'`, so it never actually runs under this workflow's triggers, but GitHub checks the permission ceiling for the full call graph up front regardless of that condition. Raising the grant satisfies the check without changing what the job does.

Related to #1536.